### PR TITLE
ssa: prune abitypes by callgraph

### DIFF
--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -447,69 +447,6 @@ func TestErrVarOf(t *testing.T) {
 	ctx.varOf(nil, g)
 }
 
-func TestContextResolveLinkname(t *testing.T) {
-	tests := []struct {
-		name   string
-		link   map[string]string
-		input  string
-		want   string
-		panics bool
-	}{
-		{
-			name: "Normal",
-			link: map[string]string{
-				"foo": "C.bar",
-			},
-			input: "foo",
-			want:  "bar",
-		},
-		{
-			name: "MultipleLinks",
-			link: map[string]string{
-				"foo1": "C.bar1",
-				"foo2": "C.bar2",
-			},
-			input: "foo2",
-			want:  "bar2",
-		},
-		{
-			name:  "NoLink",
-			link:  map[string]string{},
-			input: "foo",
-			want:  "foo",
-		},
-		{
-			name: "InvalidLink",
-			link: map[string]string{
-				"foo": "invalid.bar",
-			},
-			input:  "foo",
-			panics: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.panics {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Error("want panic")
-					}
-				}()
-			}
-			ctx := &context{prog: llssa.NewProgram(nil)}
-			for k, v := range tt.link {
-				ctx.prog.SetLinkname(k, v)
-			}
-			got := ctx.resolveLinkname(tt.input)
-			if !tt.panics {
-				if got != tt.want {
-					t.Errorf("got %q, want %q", got, tt.want)
-				}
-			}
-		})
-	}
-}
-
 func TestInstantiate(t *testing.T) {
 	obj := types.NewTypeName(0, nil, "T", nil)
 	named := types.NewNamed(obj, types.Typ[types.Int], nil)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1222,7 +1222,7 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 	ctx.initFiles(pkgPath, files, pkgName == "C")
 	ctx.prog.SetPatch(ctx.patchType)
 	ctx.prog.SetCompileMethods(ctx.checkCompileMethods)
-	ret.SetResolveLinkname(ctx.resolveLinkname)
+	ret.SetResolveLinkname(ctx.prog.ResolveLinkname)
 
 	if hasPatch {
 		skips := ctx.skips
@@ -1352,17 +1352,6 @@ func (p *context) _patchType(typ types.Type) (types.Type, bool) {
 func instantiate(orig types.Type, t *types.Named) (typ types.Type) {
 	typ, _ = llssa.Instantiate(orig, t)
 	return
-}
-
-func (p *context) resolveLinkname(name string) string {
-	if link, ok := p.prog.Linkname(name); ok {
-		prefix, ltarget, _ := strings.Cut(link, ".")
-		if prefix != "C" {
-			panic("resolveLinkname: invalid link: " + link)
-		}
-		return ltarget
-	}
-	return name
 }
 
 // checkCompileMethods ensures that all methods attached to the given type

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -683,6 +683,7 @@ func (p *context) pkgNoInit(pkg *types.Package) bool {
 func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon) (ret llssa.Expr) {
 	cv := call.Value
 	if mthd := call.Method; mthd != nil {
+		p.prog.AddInvoke(mthd)
 		o := p.compileValue(b, cv)
 		fn := b.Imethod(o, mthd)
 		hasVArg := fnNormal

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -994,6 +994,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	entryPkg := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
 		rtInit:        needRuntime,
 		pyInit:        needPyInit,
+		abiPrune:      !IsDbgEnabled(),
 		abiInit:       needAbiInit,
 		methodByIndex: methodByIndex,
 		methodByName:  methodByName,

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -31,13 +31,13 @@ import (
 	"go/token"
 	"go/types"
 
+	"golang.org/x/tools/go/callgraph/rta"
+
 	"github.com/goplus/llgo/internal/packages"
+	llssa "github.com/goplus/llgo/ssa"
 	llvm "github.com/goplus/llvm"
 	"golang.org/x/tools/go/callgraph"
-	"golang.org/x/tools/go/callgraph/cha"
 	"golang.org/x/tools/go/ssa"
-
-	llssa "github.com/goplus/llgo/ssa"
 )
 
 type genConfig struct {
@@ -98,8 +98,8 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 
 	if cfg.abiPrune {
 		progSSA := ctx.progSSA
-		chaGraph := cha.CallGraph(progSSA)
-		invoked := buildInvokeIndex(chaGraph)
+		res := buildRTAResult(progSSA)
+		invoked := buildInvokeIndex(res.CallGraph)
 		mainPkg.PruneAbiTypes(cfg.abiInit, func(index int, method *types.Selection) bool {
 			if cfg.abiInit != 0 && ast.IsExported(method.Obj().Name()) {
 				return true
@@ -108,12 +108,14 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 			if _, ok := invoked[mth]; ok {
 				return true
 			}
+			mtyp := method.Type()
 			for v := range invoked {
 				if v.Name() == mth.Name() {
-					if !types.Identical(prog.Patch(v.Type().(*types.Signature).Recv().Type()), method.Type().(*types.Signature).Recv().Type()) {
+					vtyp := v.Type()
+					if !types.Identical(prog.Patch(vtyp.(*types.Signature).Recv().Type()), mtyp.(*types.Signature).Recv().Type()) {
 						continue
 					}
-					if !types.Identical(prog.Patch(v.Type()), method.Type()) {
+					if !types.Identical(prog.Patch(vtyp), mtyp) {
 						continue
 					}
 					return true
@@ -180,6 +182,22 @@ func filterAbiSymbol(abiInit int, sym *llssa.AbiSymbol) bool {
 		}
 	}
 	return false
+}
+
+func buildRTAResult(progSSA *ssa.Program) *rta.Result {
+	var roots []*ssa.Function
+	for _, pkg := range progSSA.AllPackages() {
+		if pkg.Pkg.Name() == "main" {
+			if fn := pkg.Func("main"); fn != nil {
+				roots = append(roots, fn)
+			}
+		}
+		if fn := pkg.Func("init"); fn != nil {
+			roots = append(roots, fn)
+		}
+	}
+	res := rta.Analyze(roots, true)
+	return res
 }
 
 func buildInvokeIndex(cg *callgraph.Graph) map[*ssa.Function]bool {

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -32,6 +32,9 @@ import (
 
 	"github.com/goplus/llgo/internal/packages"
 	llvm "github.com/goplus/llvm"
+	"golang.org/x/tools/go/callgraph"
+	"golang.org/x/tools/go/callgraph/cha"
+	"golang.org/x/tools/go/ssa"
 
 	llssa "github.com/goplus/llgo/ssa"
 )
@@ -91,6 +94,32 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 		rtInit = declareNoArgFunc(mainPkg, rtPkgPath+".init")
 	}
 
+	if !IsDbgEnabled() {
+		progSSA := ctx.progSSA
+		chaGraph := cha.CallGraph(progSSA)
+		//vtaGraph := vta.CallGraph(ssautil.AllFunctions(progSSA), chaGraph)
+		//_ = vtaGraph
+		invoked := buildInvokeIndex(chaGraph)
+		mainPkg.PruneAbiTypes(func(sel *types.Selection) bool {
+			method := progSSA.MethodValue(sel)
+			if _, ok := invoked[method]; ok {
+				return true
+			}
+			for v := range invoked {
+				if v.Name() == method.Name() {
+					if !types.Identical(prog.PatchType(v.Type().(*types.Signature).Recv().Type()), sel.Type().(*types.Signature).Recv().Type()) {
+						continue
+					}
+					if !types.Identical(prog.PatchType(v.Type()), sel.Type()) {
+						continue
+					}
+					return true
+				}
+			}
+			return false
+		})
+	}
+
 	var abiInit llssa.Function
 	if cfg.abiInit != 0 {
 		abiInit = mainPkg.InitAbiTypesFor("init$abitypes", func(sym *llssa.AbiSymbol) bool {
@@ -148,6 +177,20 @@ func filterAbiSymbol(abiInit int, sym *llssa.AbiSymbol) bool {
 		}
 	}
 	return false
+}
+
+func buildInvokeIndex(cg *callgraph.Graph) map[*ssa.Function]bool {
+	invoked := make(map[*ssa.Function]bool)
+	for _, node := range cg.Nodes {
+		for _, out := range node.Out {
+			if out.Callee != nil && out.Callee.Func != nil {
+				if out.Site != nil && out.Site.Common().IsInvoke() {
+					invoked[out.Callee.Func] = true
+				}
+			}
+		}
+	}
+	return invoked
 }
 
 // defineEntryFunction creates the program's entry function. The name is

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -31,12 +31,11 @@ import (
 	"go/token"
 	"go/types"
 
-	"golang.org/x/tools/go/callgraph/rta"
-
 	"github.com/goplus/llgo/internal/packages"
 	llssa "github.com/goplus/llgo/ssa"
 	llvm "github.com/goplus/llvm"
 	"golang.org/x/tools/go/callgraph"
+	"golang.org/x/tools/go/callgraph/rta"
 	"golang.org/x/tools/go/ssa"
 )
 

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -27,6 +27,7 @@
 package build
 
 import (
+	"go/ast"
 	"go/token"
 	"go/types"
 
@@ -42,6 +43,7 @@ import (
 type genConfig struct {
 	rtInit        bool
 	pyInit        bool
+	abiPrune      bool
 	abiInit       int
 	methodByIndex map[int]none
 	methodByName  map[string]none
@@ -94,23 +96,24 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 		rtInit = declareNoArgFunc(mainPkg, rtPkgPath+".init")
 	}
 
-	if !IsDbgEnabled() {
+	if cfg.abiPrune {
 		progSSA := ctx.progSSA
 		chaGraph := cha.CallGraph(progSSA)
-		//vtaGraph := vta.CallGraph(ssautil.AllFunctions(progSSA), chaGraph)
-		//_ = vtaGraph
 		invoked := buildInvokeIndex(chaGraph)
-		mainPkg.PruneAbiTypes(func(sel *types.Selection) bool {
-			method := progSSA.MethodValue(sel)
-			if _, ok := invoked[method]; ok {
+		mainPkg.PruneAbiTypes(cfg.abiInit, func(index int, method *types.Selection) bool {
+			if cfg.abiInit != 0 && ast.IsExported(method.Obj().Name()) {
+				return true
+			}
+			mth := progSSA.MethodValue(method)
+			if _, ok := invoked[mth]; ok {
 				return true
 			}
 			for v := range invoked {
-				if v.Name() == method.Name() {
-					if !types.Identical(prog.PatchType(v.Type().(*types.Signature).Recv().Type()), sel.Type().(*types.Signature).Recv().Type()) {
+				if v.Name() == mth.Name() {
+					if !types.Identical(prog.Patch(v.Type().(*types.Signature).Recv().Type()), method.Type().(*types.Signature).Recv().Type()) {
 						continue
 					}
-					if !types.Identical(prog.PatchType(v.Type()), sel.Type()) {
+					if !types.Identical(prog.Patch(v.Type()), method.Type()) {
 						continue
 					}
 					return true

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -426,7 +426,7 @@ func (b Builder) abiUncommonMethods(t types.Type, name string, mset *types.Metho
 		}
 		mSig := m.Type().(*types.Signature)
 		var tfn, ifn llvm.Value
-		if prog.abiTypePruning && !prog.methodIsInvoke(m) {
+		if prog.abiTypePruning && !prog.methodIsInvoke(i, m) {
 			tfn = prog.Nil(prog.VoidPtr()).impl
 			ifn = tfn
 		} else {
@@ -548,9 +548,12 @@ func (p Package) getAbiTypesFor(name string, filter func(sym *AbiSymbol) bool) E
 	sort.Strings(names)
 	fields := make([]llvm.Value, len(names))
 	for i, name := range names {
-		g := p.doNewVar(name, prog.abiSymbol[name].Typ)
-		g.impl.SetLinkage(llvm.ExternalLinkage)
-		g.impl.SetGlobalConstant(true)
+		g := p.VarOf(name)
+		if g == nil {
+			g = p.doNewVar(name, prog.abiSymbol[name].Typ)
+			g.impl.SetLinkage(llvm.ExternalLinkage)
+			g.impl.SetGlobalConstant(true)
+		}
 		ptr := Expr{llvm.ConstGEP(g.impl.GlobalValueType(), g.impl, []llvm.Value{
 			llvm.ConstInt(prog.Int32().ll, 0, false),
 			llvm.ConstInt(prog.Int32().ll, 0, false),
@@ -596,7 +599,7 @@ func (p Package) InitAbiTypes(fname string) Function {
 	return p.InitAbiTypesFor(fname, nil)
 }
 
-func (p Package) PruneAbiTypes(methodIsInvoke func(method *types.Selection) bool) {
+func (p Package) PruneAbiTypes(needAbiInit int, methodIsInvoke func(index int, method *types.Selection) bool) {
 	prog := p.Prog
 	var names []string
 	for k, sym := range prog.abiSymbol {
@@ -606,10 +609,14 @@ func (p Package) PruneAbiTypes(methodIsInvoke func(method *types.Selection) bool
 		names = append(names, k)
 	}
 	sort.Strings(names)
-	p.SetResolveLinkname(prog.resolveLinkname)
+	p.SetResolveLinkname(prog.ResolveLinkname)
 	if methodIsInvoke == nil {
-		methodIsInvoke = func(method *types.Selection) bool {
-			if ms, ok := prog.invokeMethods[method.Obj().Name()]; ok {
+		methodIsInvoke = func(index int, method *types.Selection) bool {
+			name := method.Obj().Name()
+			if needAbiInit != 0 && ast.IsExported(name) {
+				return true
+			}
+			if ms, ok := prog.invokeMethods[name]; ok {
 				for m := range ms {
 					if types.Identical(m, method.Type()) {
 						return true

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -346,14 +346,14 @@ func (b Builder) abiUncommonMethodSet(t types.Type) (mset *types.MethodSet, ok b
 		}
 		mset := types.NewMethodSet(t)
 		if mset.Len() != 0 {
-			if prog.compileMethods != nil {
+			if prog.compileMethods != nil && !prog.abiTypePruning {
 				prog.compileMethods(b.Pkg, t)
 			}
 		}
 		return mset, true
 	case *types.Struct, *types.Pointer:
 		if mset := types.NewMethodSet(t); mset.Len() != 0 {
-			if prog.compileMethods != nil {
+			if prog.compileMethods != nil && !prog.abiTypePruning {
 				prog.compileMethods(b.Pkg, t)
 			}
 			return mset, true
@@ -400,7 +400,7 @@ type Method struct {
 }
 */
 
-func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Value {
+func (b Builder) abiUncommonMethods(t types.Type, name string, mset *types.MethodSet) llvm.Value {
 	prog := b.Prog
 	ft := prog.rtType("Method")
 	n := mset.Len()
@@ -408,7 +408,13 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 	pkg, _ := b.abiUncommonPkg(t)
 	anonymous := pkg == nil
 	if anonymous {
-		pkg = types.NewPackage(b.Pkg.Path(), "")
+		pkgPath := b.Pkg.Path()
+		if prog.abiTypePruning {
+			if sym, ok := prog.abiSymbol[name]; ok {
+				pkgPath = sym.PkgPath
+			}
+		}
+		pkg = types.NewPackage(pkgPath, "")
 	}
 	for i := 0; i < n; i++ {
 		m := mset.At(i)
@@ -420,12 +426,17 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		}
 		mSig := m.Type().(*types.Signature)
 		var tfn, ifn llvm.Value
-		tfn = b.abiMethodFunc(anonymous, pkg, mName, mSig)
-		ifn = tfn
-		if _, ok := m.Recv().Underlying().(*types.Pointer); !ok {
-			pRecv := types.NewVar(token.NoPos, pkg, "", types.NewPointer(mSig.Recv().Type()))
-			pSig := types.NewSignature(pRecv, mSig.Params(), mSig.Results(), mSig.Variadic())
-			ifn = b.abiMethodFunc(anonymous, pkg, mName, pSig)
+		if prog.abiTypePruning && !prog.methodIsInvoke(m) {
+			tfn = prog.Nil(prog.VoidPtr()).impl
+			ifn = tfn
+		} else {
+			tfn = b.abiMethodFunc(anonymous, pkg, mName, mSig)
+			ifn = tfn
+			if _, ok := m.Recv().Underlying().(*types.Pointer); !ok {
+				pRecv := types.NewVar(token.NoPos, pkg, "", types.NewPointer(mSig.Recv().Type()))
+				pSig := types.NewSignature(pRecv, mSig.Params(), mSig.Results(), mSig.Variadic())
+				ifn = b.abiMethodFunc(anonymous, pkg, mName, pSig)
+			}
 		}
 		var values []llvm.Value
 		values = append(values, name)
@@ -447,7 +458,7 @@ func funcType(prog Program, typ types.Type) types.Type {
 func (b Builder) abiMethodFunc(anonymous bool, mPkg *types.Package, mName string, mSig *types.Signature) (tfn llvm.Value) {
 	var fullName string
 	if anonymous {
-		fullName = b.Pkg.Path() + "." + mSig.Recv().Type().String() + "." + mName
+		fullName = mPkg.Path() + "." + mSig.Recv().Type().String() + "." + mName
 	} else {
 		fullName = FuncName(mPkg, mName, mSig.Recv(), false)
 	}
@@ -502,13 +513,15 @@ func (b Builder) abiType(t types.Type) Expr {
 			fields = []llvm.Value{
 				llvm.ConstNamedStruct(prog.Type(rt, InGo).ll, fields),
 				b.abiUncommonType(t, mset),
-				b.abiUncommonMethods(t, mset),
+				b.abiUncommonMethods(t, name, mset),
 			}
 		}
 		g.impl.SetInitializer(llvm.ConstNamedStruct(g.impl.GlobalValueType(), fields))
 		g.impl.SetGlobalConstant(true)
-		g.impl.SetLinkage(llvm.WeakODRLinkage)
-		prog.abiSymbol[name] = &AbiSymbol{Name: name, PkgPath: pkg.Path(), Raw: t, Typ: g.Type, MSet: mset}
+		if !prog.abiTypePruning {
+			g.impl.SetLinkage(llvm.WeakODRLinkage)
+			prog.abiSymbol[name] = &AbiSymbol{Name: name, PkgPath: pkg.Path(), Raw: t, Typ: g.Type, MSet: mset}
+		}
 	}
 	return Expr{llvm.ConstGEP(g.impl.GlobalValueType(), g.impl, []llvm.Value{
 		llvm.ConstInt(prog.Int32().ll, 0, false),
@@ -581,6 +594,41 @@ func (p Package) InitAbiTypesFor(fname string, filter func(sym *AbiSymbol) bool)
 
 func (p Package) InitAbiTypes(fname string) Function {
 	return p.InitAbiTypesFor(fname, nil)
+}
+
+func (p Package) PruneAbiTypes(methodIsInvoke func(method *types.Selection) bool) {
+	prog := p.Prog
+	var names []string
+	for k, sym := range prog.abiSymbol {
+		if sym.MSet == nil {
+			continue
+		}
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	p.SetResolveLinkname(prog.resolveLinkname)
+	if methodIsInvoke == nil {
+		methodIsInvoke = func(method *types.Selection) bool {
+			if ms, ok := prog.invokeMethods[method.Obj().Name()]; ok {
+				for m := range ms {
+					if types.Identical(m, method.Type()) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+	}
+	prog.abiTypePruning = true
+	defer func() {
+		prog.abiTypePruning = false
+	}()
+	prog.methodIsInvoke = methodIsInvoke
+	b := (&aFunction{Pkg: p, Prog: prog}).NewBuilder()
+	for _, name := range names {
+		sym := prog.abiSymbol[name]
+		b.abiType(sym.Raw)
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -213,7 +213,7 @@ type aProgram struct {
 	linkname       map[string]string     // pkgPath.nameInPkg => linkname
 	abiSymbol      map[string]*AbiSymbol // abi symbol name => AbiSymbol
 	abiTypePruning bool
-	methodIsInvoke func(method *types.Selection) bool
+	methodIsInvoke func(index int, method *types.Selection) bool
 
 	invokeMethods map[string]map[types.Type]none
 
@@ -241,7 +241,7 @@ func (p Program) AddInvoke(fn *types.Func) {
 		m = make(map[types.Type]none)
 		p.invokeMethods[name] = m
 	}
-	m[p.patch(fn.Type())] = none{}
+	m[p.Patch(fn.Type())] = none{}
 }
 
 // A Program presents a program.
@@ -315,11 +315,7 @@ func (p Program) SetPatch(patchType func(types.Type) types.Type) {
 	p.patchType = patchType
 }
 
-func (p Program) PatchType(typ types.Type) types.Type {
-	return p.patch(typ)
-}
-
-func (p Program) patch(typ types.Type) types.Type {
+func (p Program) Patch(typ types.Type) types.Type {
 	if p.patchType != nil {
 		return p.patchType(typ)
 	}
@@ -354,7 +350,7 @@ func (p Program) Linkname(name string) (link string, ok bool) {
 	return
 }
 
-func (p Program) resolveLinkname(name string) string {
+func (p Program) ResolveLinkname(name string) string {
 	if link, ok := p.linkname[name]; ok {
 		prefix, ltarget, _ := strings.Cut(link, ".")
 		if prefix != "C" {

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -22,6 +22,7 @@ import (
 	"go/types"
 	"runtime"
 	"strconv"
+	"strings"
 	"unsafe"
 
 	"github.com/goplus/llgo/internal/env"
@@ -208,9 +209,13 @@ type aProgram struct {
 
 	printfTy *types.Signature
 
-	paramObjPtr_ *types.Var
-	linkname     map[string]string     // pkgPath.nameInPkg => linkname
-	abiSymbol    map[string]*AbiSymbol // abi symbol name => AbiSymbol
+	paramObjPtr_   *types.Var
+	linkname       map[string]string     // pkgPath.nameInPkg => linkname
+	abiSymbol      map[string]*AbiSymbol // abi symbol name => AbiSymbol
+	abiTypePruning bool
+	methodIsInvoke func(method *types.Selection) bool
+
+	invokeMethods map[string]map[types.Type]none
 
 	ptrSize int
 
@@ -225,6 +230,18 @@ type AbiSymbol struct {
 	Raw     types.Type
 	Typ     Type
 	MSet    *types.MethodSet
+}
+
+type none struct{}
+
+func (p Program) AddInvoke(fn *types.Func) {
+	name := fn.Name()
+	m, ok := p.invokeMethods[name]
+	if !ok {
+		m = make(map[types.Type]none)
+		p.invokeMethods[name] = m
+	}
+	m[p.patch(fn.Type())] = none{}
 }
 
 // A Program presents a program.
@@ -272,6 +289,7 @@ func NewProgram(target *Target) Program {
 		target: target, td: td, tm: tm, is32Bits: is32Bits,
 		ptrSize: td.PointerSize(), named: make(map[string]Type), fnnamed: make(map[string]int),
 		linkname: make(map[string]string), abiSymbol: make(map[string]*AbiSymbol),
+		invokeMethods: make(map[string]map[types.Type]none),
 	}
 	prog.abi.Init(uintptr(prog.ptrSize), (*goProgram)(unsafe.Pointer(prog)))
 	return prog
@@ -295,6 +313,10 @@ func (p Program) DataLayout() string {
 
 func (p Program) SetPatch(patchType func(types.Type) types.Type) {
 	p.patchType = patchType
+}
+
+func (p Program) PatchType(typ types.Type) types.Type {
+	return p.patch(typ)
 }
 
 func (p Program) patch(typ types.Type) types.Type {
@@ -330,6 +352,17 @@ func (p Program) SetLinkname(name, link string) {
 func (p Program) Linkname(name string) (link string, ok bool) {
 	link, ok = p.linkname[name]
 	return
+}
+
+func (p Program) resolveLinkname(name string) string {
+	if link, ok := p.linkname[name]; ok {
+		prefix, ltarget, _ := strings.Cut(link, ".")
+		if prefix != "C" {
+			panic("resolveLinkname: invalid link: " + link)
+		}
+		return ltarget
+	}
+	return name
 }
 
 func (p Program) runtime() *types.Package {
@@ -718,8 +751,6 @@ type aPackage struct {
 	preserveSyms   map[string]struct{} // set of exported symbol names
 	llvmUsedValues []llvm.Value
 }
-
-type none struct{}
 
 type Package = *aPackage
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1395,7 +1395,7 @@ func TestAbiPrune(t *testing.T) {
 	bNE.Return(bNE.MakeInterface(nonEmptyType, prog.Zero(prog.Type(named, InGo))))
 
 	mainpkg := prog.NewPackage("main", "")
-	mainpkg.PruneAbiTypes(nil)
+	mainpkg.PruneAbiTypes(0, nil)
 	s := mainpkg.String()
 	if !strings.Contains(s, `@"*_llgo_foo/bar.Point" = constant { %"github.com/goplus/llgo/runtime/abi.PtrType",`) {
 		t.Fatal("error puretype", s)
@@ -1452,7 +1452,8 @@ func TestAbiTables(t *testing.T) {
 	bNE := fnNE.MakeBody(1)
 	bNE.Return(bNE.MakeInterface(nonEmptyType, prog.Val(7)))
 
-	fn := pkg.InitAbiTypes(pkg.Path() + ".init$abitables")
+	mainpkg := prog.NewPackage("main", "")
+	fn := mainpkg.InitAbiTypes(pkg.Path() + ".init$abitables")
 	s := fn.impl.String()
 	if !strings.Contains(s, `define void @"foo/bar.init$abitables"()`) ||
 		!strings.Contains(s, `@"foo/bar.init$abitables$slice"`) ||
@@ -1561,5 +1562,68 @@ func TestRtFuncResolvesLinkname(t *testing.T) {
 
 	if got := pkg.rtFunc("Sigsetjmp").impl.Name(); got != "sigsetjmp" {
 		t.Fatalf("rtFunc linkname = %q, want %q", got, "sigsetjmp")
+	}
+}
+
+func TestResolveLinkname(t *testing.T) {
+	tests := []struct {
+		name   string
+		link   map[string]string
+		input  string
+		want   string
+		panics bool
+	}{
+		{
+			name: "Normal",
+			link: map[string]string{
+				"foo": "C.bar",
+			},
+			input: "foo",
+			want:  "bar",
+		},
+		{
+			name: "MultipleLinks",
+			link: map[string]string{
+				"foo1": "C.bar1",
+				"foo2": "C.bar2",
+			},
+			input: "foo2",
+			want:  "bar2",
+		},
+		{
+			name:  "NoLink",
+			link:  map[string]string{},
+			input: "foo",
+			want:  "foo",
+		},
+		{
+			name: "InvalidLink",
+			link: map[string]string{
+				"foo": "invalid.bar",
+			},
+			input:  "foo",
+			panics: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.panics {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Error("want panic")
+					}
+				}()
+			}
+			prog := NewProgram(nil)
+			for k, v := range tt.link {
+				prog.SetLinkname(k, v)
+			}
+			got := prog.ResolveLinkname(tt.input)
+			if !tt.panics {
+				if got != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+			}
+		})
 	}
 }

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1326,6 +1326,82 @@ func TestTargetMachineAndDataLayout(t *testing.T) {
 	}
 }
 
+func TestAbiPrune(t *testing.T) {
+	prog := NewProgram(nil)
+	prog.sizes = types.SizesFor("gc", runtime.GOARCH)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	emptyIface := types.NewInterfaceType(nil, nil)
+	emptyIface.Complete()
+	emptyType := prog.Type(emptyIface, InGo)
+
+	makeFn := func(name string, x Expr) {
+		sig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", emptyIface)), false)
+		fn := pkg.NewFunc(name, sig, InGo)
+		b := fn.MakeBody(1)
+		iface := b.MakeInterface(emptyType, x)
+		b.Return(iface)
+	}
+
+	makeFn("intIface", prog.Val(1))
+	makeFn("ptrIface", prog.Nil(prog.VoidPtr()))
+	makeFn("floatIface", prog.FloatVal(3.5, prog.Float32()))
+
+	st := types.NewStruct([]*types.Var{
+		types.NewVar(0, nil, "a", types.Typ[types.Int]),
+		types.NewVar(0, nil, "b", types.Typ[types.Int]),
+	}, nil)
+	makeFn("structIface", prog.Zero(prog.Type(st, InGo)))
+
+	single := types.NewStruct([]*types.Var{
+		types.NewVar(0, nil, "v", types.Typ[types.Int]),
+	}, nil)
+	makeFn("singleFieldIface", prog.Zero(prog.Type(single, InGo)))
+
+	pkgTypes := types.NewPackage("foo/bar", "bar")
+	obj := types.NewTypeName(token.NoPos, pkgTypes, "Point", nil)
+	named := types.NewNamed(obj, types.Typ[types.Int], nil)
+	msig := types.NewSignatureType(types.NewVar(0, pkgTypes, "", named), nil, nil, nil, nil, false)
+	mthd := types.NewFunc(0, pkgTypes, "M", msig)
+	mthd2 := types.NewFunc(0, pkgTypes, "m2", msig)
+	named.AddMethod(mthd)
+	named.AddMethod(mthd2)
+	prog.AddInvoke(mthd)
+	pkgTypes.Scope().Insert(obj)
+
+	anonStruct := types.NewStruct(
+		[]*types.Var{
+			types.NewField(0, pkgTypes, "", named, true),
+			types.NewField(0, pkgTypes, "Age", types.Typ[types.Int], false),
+			types.NewField(0, pkgTypes, "Tags", types.NewSlice(types.Typ[types.String]), false),
+		}, nil,
+	)
+	rawSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	rawMeth := types.NewFunc(0, pkgTypes, "M", rawSig)
+	nonEmpty := types.NewInterfaceType([]*types.Func{rawMeth}, nil)
+	nonEmpty.Complete()
+	nonEmptyType := prog.Type(nonEmpty, InGo)
+	sigNE := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", nonEmpty)), false)
+	fnNE := pkg.NewFunc("nonEmptyIface", sigNE, InGo)
+	bNE := fnNE.MakeBody(1)
+	bNE.MakeInterface(nonEmptyType, prog.Zero(prog.Type(anonStruct, InGo)))
+	bNE.Return(bNE.MakeInterface(nonEmptyType, prog.Zero(prog.Type(named, InGo))))
+
+	mainpkg := prog.NewPackage("main", "")
+	mainpkg.PruneAbiTypes(nil)
+	s := mainpkg.String()
+	if !strings.Contains(s, `@"*_llgo_foo/bar.Point" = constant { %"github.com/goplus/llgo/runtime/abi.PtrType",`) {
+		t.Fatal("error puretype", s)
+	}
+}
+
 func TestAbiTables(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -448,7 +448,7 @@ func (p Program) toLLVMFields(raw *types.Struct) (fields []llvm.Type) {
 	if n > 0 {
 		fields = make([]llvm.Type, n)
 		for i := 0; i < n; i++ {
-			fields[i] = p.rawType(p.patch(raw.Field(i).Type())).ll
+			fields[i] = p.rawType(p.Patch(raw.Field(i).Type())).ll
 		}
 	}
 	return
@@ -462,7 +462,7 @@ func (p Program) toLLVMTypes(t *types.Tuple, n int) (ret []llvm.Type) {
 	if n > 0 {
 		ret = make([]llvm.Type, n)
 		for i := 0; i < n; i++ {
-			ret[i] = p.rawType(p.patch(t.At(i).Type())).ll
+			ret[i] = p.rawType(p.Patch(t.At(i).Type())).ll
 		}
 	}
 	return


### PR DESCRIPTION
- prune abitypes by RTA callgraph ( needAbiInit disable prune )

```
func main() { fmt.Println("hello world") }
```
go build:      2358096
llgo build:    1903800
llgo prune (RTA) :   1324856

