### PR TITLE
fix(pclntab): preserve Darwin line sites with DWARF

### DIFF
--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1585,7 +1585,7 @@ func (p *context) emitPCLineLabel(b llssa.Builder, pos token.Pos) {
 		pushSection = ".pushsection __DATA,__llgo_pcl,regular,live_support"
 		recordSymbol = "l_llgo_pcline_rec_${:uid}:\n"
 	}
-	b.InlineAsm(
+	b.InlineAsmNoDebug(
 		asmLabel + ":\n" +
 			pushSection + "\n" +
 			".p2align " + align + "\n" +

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1603,7 +1603,7 @@ func (p *context) emitPCLineLabel(b llssa.Builder, pos token.Pos) {
 		pushSection = ".pushsection __DATA,__llgo_pcl,regular,live_support"
 		recordSymbol = "l_llgo_pcline_rec_${:uid}:\n"
 	}
-	b.InlineAsm(
+	b.InlineAsmNoDebug(
 		asmLabel + ":\n" +
 			pushSection + "\n" +
 			".p2align " + align + "\n" +

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -471,12 +471,10 @@ func Build(inv Invocation) ([]Package, error) {
 	prog.EnableLTOPluginMarkers(conf.LTOPlugin.Enabled())
 	funcInfo := conf.Mode != ModeGen && conf.PCLNMode != PCLNNone
 	prog.EnableFuncInfoMetadata(funcInfo)
-	// Site records are inline-asm fragments inside function bodies. Darwin
-	// DWARF builds avoid them because they disturb LLDB lexical scopes; Linux
-	// still needs them because its restricted dynamic symbol table cannot
-	// reconstruct every Go entry PC through dlsym. External mode always needs
-	// final-PC sites for sidecar construction.
-	prog.EnableFuncInfoSites(shouldEnablePCLNSites(conf, funcInfo, emitDebugInfo))
+	// PC-line sites stay enabled with DWARF so runtime source locations remain
+	// precise. The link table emitter separately suppresses Darwin address sites
+	// when their entry-block assembly would disturb LLDB lexical scopes.
+	prog.EnableFuncInfoSites(shouldEnablePCLNSites(conf, funcInfo))
 	sizes := func(sizes types.Sizes, compiler, arch string) types.Sizes {
 		if arch == "wasm" {
 			sizes = &types.StdSizes{WordSize: 4, MaxAlign: 4}
@@ -1275,7 +1273,7 @@ func compileExtraFiles(ctx *context, verbose bool) ([]string, error) {
 // internal/pclnpost and doc/design/pclntab-linkphase.md). Any failure leaves
 // the binary fully functional on the first-use construction fallback.
 func rewritePrebuiltFuncTab(ctx *context, out string, verbose bool) {
-	if ctx == nil || ctx.prog == nil || !ctx.prog.FuncInfoSitesEnabled() || !shouldEmitRuntimeSites(ctx) {
+	if !shouldEmitRuntimeAddressSites(ctx) {
 		return
 	}
 	if ctx.buildConf.BuildMode != BuildModeExe {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -472,12 +472,10 @@ func Build(inv Invocation) ([]Package, error) {
 	prog.EnableLTOPluginMarkers(conf.LTOPlugin.Enabled())
 	funcInfo := conf.Mode != ModeGen && conf.PCLNMode != PCLNNone
 	prog.EnableFuncInfoMetadata(funcInfo)
-	// Site records are inline-asm fragments inside function bodies. Darwin
-	// DWARF builds avoid them because they disturb LLDB lexical scopes; Linux
-	// still needs them because its restricted dynamic symbol table cannot
-	// reconstruct every Go entry PC through dlsym. External mode always needs
-	// final-PC sites for sidecar construction.
-	prog.EnableFuncInfoSites(shouldEnablePCLNSites(conf, funcInfo, emitDebugInfo))
+	// PC-line sites stay enabled with DWARF so runtime source locations remain
+	// precise. The link table emitter separately suppresses Darwin address sites
+	// when their entry-block assembly would disturb LLDB lexical scopes.
+	prog.EnableFuncInfoSites(shouldEnablePCLNSites(conf, funcInfo))
 	sizes := func(sizes types.Sizes, compiler, arch string) types.Sizes {
 		if arch == "wasm" {
 			sizes = &types.StdSizes{WordSize: 4, MaxAlign: 4}
@@ -1330,7 +1328,7 @@ func compileExtraFiles(ctx *context, verbose bool) ([]string, error) {
 // internal/pclnpost and doc/design/pclntab-linkphase.md). Any failure leaves
 // the binary fully functional on the first-use construction fallback.
 func rewritePrebuiltFuncTab(ctx *context, out string, verbose bool) {
-	if ctx == nil || ctx.prog == nil || !ctx.prog.FuncInfoSitesEnabled() || !shouldEmitRuntimeSites(ctx) {
+	if !shouldEmitRuntimeAddressSites(ctx) {
 		return
 	}
 	if ctx.buildConf.BuildMode != BuildModeExe {

--- a/internal/build/funcinfo_table.go
+++ b/internal/build/funcinfo_table.go
@@ -412,7 +412,7 @@ func emitFuncInfoTable(ctx *context, pkg llssa.Package, records []funcInfoRecord
 			llvm.ConstInt(countType, 0, false),
 		}))
 		pcLineCount.SetInitializer(llvm.ConstInt(countType, uint64(len(encoded.PCLines)), false))
-		if shouldEmitRuntimeSites(ctx) {
+		if shouldEmitRuntimePCLineSites(ctx) {
 			startName, endName := pcLineSiteSectionInfo.boundary(shouldEmitRuntimeMachOSites(ctx))
 			pcSiteStart := llvm.AddGlobal(mod, pcSiteRecordType, startName)
 			pcSiteEnd := llvm.AddGlobal(mod, pcSiteRecordType, endName)
@@ -424,9 +424,10 @@ func emitFuncInfoTable(ctx *context, pkg llssa.Package, records []funcInfoRecord
 		}
 	}
 	machOSites := shouldEmitRuntimeMachOSites(ctx)
-	emitSites := shouldEmitRuntimeSites(ctx)
-	emitEntrySites := shouldEmitRuntimeEntryELFSites(ctx) && len(encoded.Records) != 0
-	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machOSites, emitSites && len(pcLineValues) != 0, emitEntrySites)
+	emitPCLineSites := shouldEmitRuntimePCLineSites(ctx)
+	emitAddressSites := shouldEmitRuntimeAddressSites(ctx)
+	emitEntrySites := emitAddressSites && len(encoded.Records) != 0
+	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machOSites, emitPCLineSites && len(pcLineValues) != 0, emitEntrySites)
 	if emitEntrySites {
 		startName, endName := entrySiteSectionInfo.boundary(machOSites)
 		entryStart := llvm.AddGlobal(mod, funcEntryRecordType, startName)
@@ -601,9 +602,10 @@ func emitExternalFuncInfoTable(ctx *context, mod llvm.Module, records []funcInfo
 	used.SetSection("llvm.metadata")
 
 	machO := shouldEmitRuntimeMachOSites(ctx)
-	emitSites := shouldEmitRuntimeSites(ctx)
-	emitPCSites := emitSites && len(encoded.PCLines) != 0
-	emitEntrySites := shouldEmitRuntimeEntryELFSites(ctx) && len(encoded.Records) != 0
+	emitPCLineSites := shouldEmitRuntimePCLineSites(ctx)
+	emitAddressSites := shouldEmitRuntimeAddressSites(ctx)
+	emitPCSites := emitPCLineSites && len(encoded.PCLines) != 0
+	emitEntrySites := emitAddressSites && len(encoded.Records) != 0
 	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machO, emitPCSites, emitEntrySites)
 	if emitPCSites {
 		start, end := pcLineSiteSectionInfo.boundary(machO)
@@ -635,25 +637,34 @@ func shouldEmitRuntimeMachOSites(ctx *context) bool {
 		ctx.buildConf.Target == ""
 }
 
-// shouldEmitRuntimeSites reports whether the target object format has a
+// shouldEmitRuntimePCLineSites reports whether the target object format has a
 // DCE-safe section story for metadata site records. ELF uses SHF_LINK_ORDER
 // associated sections (honored by --gc-sections). The ELF sections are also
 // writable because shared libraries need dynamic relative relocations for the
 // absolute pointers stored in each record. Mach-O uses live_support sections:
 // under ld64/lld -dead_strip a live_support atom survives only if the atom it
 // references (the anchor inside the function body) is live, which is the same
-// records-follow-function semantics. Sites are additionally gated per Program:
-// debug builds keep the funcinfo tables but drop the body-embedded site records
-// (see Program.EnableFuncInfoSites).
-func shouldEmitRuntimeSites(ctx *context) bool {
+// records-follow-function semantics. Sites are additionally gated per Program.
+func shouldEmitRuntimePCLineSites(ctx *context) bool {
 	if ctx == nil || ctx.prog == nil || !ctx.prog.FuncInfoSitesEnabled() {
 		return false
 	}
 	return shouldEmitRuntimeELFSites(ctx) || shouldEmitRuntimeMachOSites(ctx)
 }
 
-func shouldEmitRuntimeEntryELFSites(ctx *context) bool {
-	return shouldEmitRuntimeSites(ctx)
+// shouldEmitRuntimeAddressSites controls function-entry address records. Their
+// entry-block inline assembly changes Darwin's initial
+// line row and makes LLDB expose inner lexical scopes too early. PC-line sites
+// do not have that problem when emitted without a debug location, so embedded
+// Darwin DWARF builds suppress only address sites. External PCLN still needs
+// final address records to construct its sidecar.
+func shouldEmitRuntimeAddressSites(ctx *context) bool {
+	if !shouldEmitRuntimePCLineSites(ctx) {
+		return false
+	}
+	conf := ctx.buildConf
+	return conf.Goos != "darwin" || conf.PCLNMode == PCLNExternal ||
+		!shouldEmitDebugInfo(conf, &ctx.crossCompile)
 }
 
 // siteSectionInfo names one metadata site section in both object formats.
@@ -727,7 +738,7 @@ func siteAnchorLabel(machO bool, kind string) string {
 }
 
 func emitFuncInfoEntrySites(ctx *context, pkg llssa.Package) {
-	if !shouldEmitRuntimeEntryELFSites(ctx) || pkg == nil || !ctx.prog.FuncInfoMetadataEnabled() {
+	if !shouldEmitRuntimeAddressSites(ctx) || pkg == nil || !ctx.prog.FuncInfoMetadataEnabled() {
 		return
 	}
 	mod := pkg.Module()

--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -416,6 +416,74 @@ func TestFuncInfoTableIgnoresInvalidMetadata(t *testing.T) {
 	}
 }
 
+func TestRuntimeSitePolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		conf        Config
+		enableSites bool
+		wantPCLine  bool
+		wantAddress bool
+	}{
+		{
+			name:        "linux embedded dwarf",
+			conf:        Config{Goos: "linux", PCLNMode: PCLNEmbedded},
+			enableSites: true,
+			wantPCLine:  true,
+			wantAddress: true,
+		},
+		{
+			name:        "darwin embedded dwarf",
+			conf:        Config{Goos: "darwin", PCLNMode: PCLNEmbedded},
+			enableSites: true,
+			wantPCLine:  true,
+		},
+		{
+			name: "darwin embedded without dwarf",
+			conf: Config{
+				Goos:        "darwin",
+				PCLNMode:    PCLNEmbedded,
+				LinkOptions: LinkOptions{DWARF: DWARFOmit},
+			},
+			enableSites: true,
+			wantPCLine:  true,
+			wantAddress: true,
+		},
+		{
+			name:        "darwin external dwarf",
+			conf:        Config{Goos: "darwin", PCLNMode: PCLNExternal},
+			enableSites: true,
+			wantPCLine:  true,
+			wantAddress: true,
+		},
+		{
+			name:        "fixed target",
+			conf:        Config{Goos: "darwin", Target: "rp2040", PCLNMode: PCLNEmbedded},
+			enableSites: true,
+		},
+		{
+			name: "program sites disabled",
+			conf: Config{Goos: "linux", PCLNMode: PCLNEmbedded},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prog := llssa.NewProgram(nil)
+			defer prog.Dispose()
+			prog.EnableFuncInfoSites(tt.enableSites)
+			ctx := &context{prog: prog, buildConf: &tt.conf}
+			if got := shouldEmitRuntimePCLineSites(ctx); got != tt.wantPCLine {
+				t.Fatalf("shouldEmitRuntimePCLineSites() = %v, want %v", got, tt.wantPCLine)
+			}
+			if got := shouldEmitRuntimeAddressSites(ctx); got != tt.wantAddress {
+				t.Fatalf("shouldEmitRuntimeAddressSites() = %v, want %v", got, tt.wantAddress)
+			}
+		})
+	}
+	if shouldEmitRuntimePCLineSites(nil) || shouldEmitRuntimeAddressSites(nil) {
+		t.Fatal("nil context enabled runtime sites")
+	}
+}
+
 // TestFuncInfoTableEmissionMatrix sweeps the OS / pointer-size / content
 // combinations so both the ELF and Mach-O directive branches, the 32-bit
 // pointer directives, and the empty-table initializers stay covered on every
@@ -454,6 +522,9 @@ func TestFuncInfoTableEmissionMatrix(t *testing.T) {
 					BuildMode: BuildModeExe,
 					Goos:      c.goos,
 					Goarch:    c.goarch,
+					LinkOptions: LinkOptions{
+						DWARF: DWARFOmit,
+					},
 				},
 			}
 			records := collectFuncInfo([]Package{{LPkg: src}})

--- a/internal/build/pcln_mode.go
+++ b/internal/build/pcln_mode.go
@@ -70,7 +70,8 @@ func effectivePCLNMode(conf *Config) PCLNMode {
 }
 
 // shouldEnablePCLNSites reports whether compiler-emitted PC anchor records are
-// required for this build.
+// globally enabled for this build. Target-specific filtering of address-site
+// categories happens when the runtime tables are emitted.
 func shouldEnablePCLNSites(conf *Config, funcInfo bool) bool {
 	if conf == nil || !funcInfo || !IsFuncInfoSitesEnabled() {
 		return false

--- a/internal/build/pcln_mode.go
+++ b/internal/build/pcln_mode.go
@@ -70,15 +70,12 @@ func effectivePCLNMode(conf *Config) PCLNMode {
 }
 
 // shouldEnablePCLNSites reports whether compiler-emitted PC anchor records are
-// required for this build. Darwin DWARF builds keep the historical site-free
-// path because inline anchors disturb LLDB lexical scopes there. ELF cannot
-// reconstruct all Go entry PCs with dlsym: most Go symbols are intentionally
-// absent from .dynsym, so Linux keeps sites even when it emits DWARF.
-func shouldEnablePCLNSites(conf *Config, funcInfo, emitDebugInfo bool) bool {
+// required for this build.
+func shouldEnablePCLNSites(conf *Config, funcInfo bool) bool {
 	if conf == nil || !funcInfo || !IsFuncInfoSitesEnabled() {
 		return false
 	}
-	return !emitDebugInfo || conf.Goos == "linux" || conf.PCLNMode == PCLNExternal
+	return true
 }
 
 // validatePCLNMode checks whether the selected build can produce the requested

--- a/internal/build/pcln_mode_test.go
+++ b/internal/build/pcln_mode_test.go
@@ -121,27 +121,26 @@ func TestEffectivePCLNModeLegacyPrecedence(t *testing.T) {
 func TestShouldEnablePCLNSites(t *testing.T) {
 	t.Setenv(llgoFuncInfoSites, "1")
 	tests := []struct {
-		name      string
-		conf      Config
-		funcInfo  bool
-		debugInfo bool
-		want      bool
+		name     string
+		conf     Config
+		funcInfo bool
+		want     bool
 	}{
 		{name: "embedded without debug", conf: Config{Goos: "darwin", PCLNMode: PCLNEmbedded}, funcInfo: true, want: true},
-		{name: "darwin embedded debug", conf: Config{Goos: "darwin", PCLNMode: PCLNEmbedded}, funcInfo: true, debugInfo: true},
-		{name: "linux embedded debug", conf: Config{Goos: "linux", PCLNMode: PCLNEmbedded}, funcInfo: true, debugInfo: true, want: true},
-		{name: "external debug", conf: Config{Goos: "darwin", PCLNMode: PCLNExternal}, funcInfo: true, debugInfo: true, want: true},
-		{name: "metadata disabled", conf: Config{Goos: "linux", PCLNMode: PCLNEmbedded}, debugInfo: true},
+		{name: "darwin embedded debug", conf: Config{Goos: "darwin", PCLNMode: PCLNEmbedded}, funcInfo: true, want: true},
+		{name: "linux embedded debug", conf: Config{Goos: "linux", PCLNMode: PCLNEmbedded}, funcInfo: true, want: true},
+		{name: "external debug", conf: Config{Goos: "darwin", PCLNMode: PCLNExternal}, funcInfo: true, want: true},
+		{name: "metadata disabled", conf: Config{Goos: "linux", PCLNMode: PCLNEmbedded}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldEnablePCLNSites(&tt.conf, tt.funcInfo, tt.debugInfo); got != tt.want {
+			if got := shouldEnablePCLNSites(&tt.conf, tt.funcInfo); got != tt.want {
 				t.Fatalf("shouldEnablePCLNSites() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 	t.Setenv(llgoFuncInfoSites, "0")
-	if shouldEnablePCLNSites(&Config{Goos: "linux", PCLNMode: PCLNExternal}, true, true) {
+	if shouldEnablePCLNSites(&Config{Goos: "linux", PCLNMode: PCLNExternal}, true) {
 		t.Fatal("LLGO_FUNCINFO_SITES=0 did not disable sites")
 	}
 }

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -213,6 +213,50 @@ func f() {}
 	}
 }
 
+func TestInlineAsmNoDebugPreservesBuilderLocation(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "asm.go", `package p
+func f() {}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typesPkg, err := (&types.Config{}).Check("example.com/p", fset, []*ast.File{file}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prog := NewProgram(&Target{OptLevel: optlevel.O0})
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	pkg := prog.NewPackage("p", "example.com/p")
+	pkg.InitDebug("p", "example.com/p", fset)
+	decl := file.Decls[0].(*ast.FuncDecl)
+	object := typesPkg.Scope().Lookup("f").(*types.Func)
+	fn := pkg.NewFunc("example.com/p.f", object.Type().(*types.Signature), InGo)
+	b := fn.MakeBody(1)
+	defer b.Dispose()
+	pos := fset.Position(decl.Body.Lbrace)
+	b.DebugFunction(fn, object.Scope(), fset.Position(object.Pos()), pos)
+	b.DISetCurrentDebugLocation(fn, pos)
+	b.InlineAsmNoDebug("nop")
+	b.Return()
+	b.EndBuild()
+	pkg.FinalizeDebug()
+
+	asm := fn.impl.EntryBasicBlock().FirstInstruction()
+	if !asm.InstructionDebugLoc().IsNil() {
+		t.Fatal("inline assembly retained the current debug location")
+	}
+	ret := llvm.NextInstruction(asm)
+	if ret.IsNil() || ret.InstructionDebugLoc().IsNil() {
+		t.Fatal("inline assembly cleared the builder debug location")
+	}
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("inline assembly debug metadata is invalid: %v\n%s", err, pkg.Module().String())
+	}
+}
+
 func newDebugRuntimePackage() *types.Package {
 	pkg := types.NewPackage(PkgRuntime, "runtime")
 	unsafePointer := types.Typ[types.UnsafePointer]

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -296,6 +296,17 @@ func (b Builder) InlineAsm(instruction string) {
 	b.impl.CreateCall(typ, asm, nil, "")
 }
 
+// InlineAsmNoDebug emits inline assembly without attaching the builder's
+// current source location. The builder location itself is left unchanged.
+func (b Builder) InlineAsmNoDebug(instruction string) {
+	dbgInstrf("InlineAsm %s\n", instruction)
+
+	typ := llvm.FunctionType(b.Prog.tyVoid(), nil, false)
+	asm := llvm.InlineAsm(typ, instruction, "", true, false, llvm.InlineAsmDialectATT, false)
+	call := b.impl.CreateCall(typ, asm, nil, "")
+	call.InstructionSetDebugLoc(llvm.Metadata{})
+}
+
 func (b Builder) InlineAsmFull(instruction, constraints string, retType Type, exprs []Expr) Expr {
 	typs := make([]llvm.Type, len(exprs))
 	vals := make([]llvm.Value, len(exprs))

--- a/ssa/funcinfo.go
+++ b/ssa/funcinfo.go
@@ -38,8 +38,8 @@ func (p Program) FuncInfoMetadataEnabled() bool {
 }
 
 // EnableFuncInfoSites controls emission of per-function site records. The build
-// layer may apply a narrower target policy to function-entry address records while
-// retaining PC-line records.
+// layer may apply a narrower target policy to function-entry address records
+// while retaining PC-line records.
 func (p Program) EnableFuncInfoSites(enable bool) {
 	p.enableFuncInfoSites = enable
 }

--- a/ssa/funcinfo.go
+++ b/ssa/funcinfo.go
@@ -37,12 +37,9 @@ func (p Program) FuncInfoMetadataEnabled() bool {
 	return p.enableFuncInfoMetadata
 }
 
-// EnableFuncInfoSites controls emission of the per-function site records
-// (entry and PC-line inline-asm fragments inside function bodies). They are
-// gated separately from the funcinfo metadata tables because the
-// body-embedded anchors shift instruction/scope layout enough to confuse
-// debuggers; debug builds keep the tables (FuncForPC name/FileLine fidelity
-// via the dlsym path) but drop the sites.
+// EnableFuncInfoSites controls emission of per-function site records. The build
+// layer may apply a narrower target policy to function-entry address records while
+// retaining PC-line records.
 func (p Program) EnableFuncInfoSites(enable bool) {
 	p.enableFuncInfoSites = enable
 }

--- a/test/go/dwarf_pcln_acceptance_test.go
+++ b/test/go/dwarf_pcln_acceptance_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const dwarfPCLNProbe = `package main
+
+import (
+	"log"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func checkCaller() {
+	_, file, line, ok := runtime.Caller(0) // CALLER_MARK
+	if !ok || !strings.HasSuffix(file, "main.go") || line != CALLER_LINE {
+		panic("bad caller: " + file + ":" + strconv.Itoa(line))
+	}
+}
+
+func checkFrames() {
+	var pcs [8]uintptr
+	n := runtime.Callers(0, pcs[:]) // FRAMES_MARK
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		if frame.Function == "main.checkFrames" {
+			if !strings.HasSuffix(frame.File, "main.go") || frame.Line != FRAMES_LINE {
+				panic("bad frame: " + frame.File + ":" + strconv.Itoa(frame.Line))
+			}
+			break
+		}
+		if !more {
+			panic("checkFrames frame missing")
+		}
+	}
+}
+
+func main() {
+	var out strings.Builder
+	logger := log.New(&out, "", log.Lshortfile)
+	logger.Print("site") // LOG_MARK
+	want := "main.go:" + strconv.Itoa(LOG_LINE) + ":"
+	if !strings.HasPrefix(out.String(), want) {
+		panic("bad log site: " + out.String())
+	}
+
+	checkCaller()
+	checkFrames()
+	os.Stdout.WriteString("PCLN_DWARF_OK\n")
+}
+`
+
+func TestDWARFPCLNLineSites(t *testing.T) {
+	source := dwarfPCLNProbe
+	for _, marker := range []string{"CALLER", "FRAMES", "LOG"} {
+		source = strings.ReplaceAll(source, marker+"_LINE", strconv.Itoa(markerLine(source, marker+"_MARK")))
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := findStringConversionRepoRoot(t)
+	t.Setenv("LLGO_ROOT", repoRoot)
+	cmd := exec.Command("go", "run", "-p=1", "./cmd/llgo", "run", "-a", "-ldflags=-w=false", file)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("DWARF PCLN probe failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "PCLN_DWARF_OK") {
+		t.Fatalf("DWARF PCLN probe is missing its success marker:\n%s", out)
+	}
+}

--- a/test/go/dwarf_pcln_acceptance_test.go
+++ b/test/go/dwarf_pcln_acceptance_test.go
@@ -86,7 +86,7 @@ func TestDWARFPCLNLineSites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	cmd := exec.Command("go", "run", "-p=1", "./cmd/llgo", "run", "-a", "-ldflags=-w=false", file)
 	cmd.Dir = repoRoot


### PR DESCRIPTION
## Problem

Darwin builds with DWARF currently disable every compiler-emitted funcinfo site record. That avoids an LLDB lexical-scope regression from inline assembly at function entry, but also removes final-PC anchors used for precise runtime line tables. `runtime.Caller`, `runtime.CallersFrames`, logging prefixes, and panic locations can then fall back to an earlier address.

Function-entry address records and PC-line anchors have different debugger effects: entry records alter the initial line-table row, while a PC-line anchor is safe when its inline-assembly call has no debug location.

## Changes

- add `ssa.Builder.InlineAsmNoDebug`, clearing only the emitted call location while preserving the builder location;
- emit PC-line anchors whenever funcinfo sites are enabled, including Darwin DWARF builds;
- split runtime policy between PC-line and function-entry address records;
- suppress only function-entry address records for embedded pclntab + Darwin + DWARF;
- retain address records for Darwin without DWARF, external pclntab, and ELF targets;
- add explicit `-ldflags=-w=false` execution coverage for `runtime.Caller`, `runtime.CallersFrames`, and `log.Lshortfile`;
- clarify the global site gate and use explicit PC-line naming.

This does not change pclntab mode selection, default `-w`, runtime table format, or LLDB language behavior.

Fixes #2115.

## Dependency update

#2143 and #2215 are merged. This branch is rebased directly onto current `main`.

## Verification

- `go test ./internal/build ./ssa ./cl`;
- `go test ./test/go -run 'TestDWARF.*PCLN|TestPCLN.*DWARF' -count=1`;
- the complete `go test ./...` passes on the dependent #2142 stack;
- `git diff --check`.