### PR TITLE
build: stabilize Darwin DWARF debug maps across cache hits

### DIFF
--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -728,6 +728,56 @@ func TestLinkOptionsControlDarwinDebugSymbols(t *testing.T) {
 	}
 }
 
+func TestDarwinDWARFCacheUsesStableArchivePaths(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Mach-O debug-map integration test")
+	}
+
+	cacheDir := t.TempDir()
+	oldCacheRootFunc := cacheRootFunc
+	cacheRootFunc = func() string { return cacheDir }
+	t.Cleanup(func() { cacheRootFunc = oldCacheRootFunc })
+
+	binPath := filepath.Join(t.TempDir(), "ldflagsstrip")
+	buildCachedArchivePaths := func() []string {
+		cfg := &Config{
+			Mode:        ModeBuild,
+			OutFile:     binPath,
+			LinkOptions: LinkOptions{DWARF: DWARFPreserve},
+		}
+		if _, err := Do([]string{"./testdata/ldflagsstrip"}, cfg); err != nil {
+			t.Fatalf("ModeBuild with DWARF failed: %v", err)
+		}
+		f, err := macho.Open(binPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if f.Symtab == nil {
+			t.Fatal("Mach-O has no symbol table")
+		}
+
+		const nOSO = 0x66
+		cachePrefix := filepath.Join(cacheDir, cacheBuildDirName) + string(os.PathSeparator)
+		var paths []string
+		for _, sym := range f.Symtab.Syms {
+			if sym.Type == nOSO && strings.HasPrefix(sym.Name, cachePrefix) {
+				paths = append(paths, sym.Name)
+			}
+		}
+		return paths
+	}
+
+	coldPaths := buildCachedArchivePaths()
+	warmPaths := buildCachedArchivePaths()
+	if len(coldPaths) == 0 {
+		t.Fatal("cold build has no cache-backed N_OSO paths")
+	}
+	if !slices.Equal(coldPaths, warmPaths) {
+		t.Fatalf("cold and warm N_OSO paths differ:\ncold: %q\nwarm: %q", coldPaths, warmPaths)
+	}
+}
+
 func machoHasStabs(t *testing.T, path string) bool {
 	t.Helper()
 	f, err := macho.Open(path)

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -460,6 +460,56 @@ func TestLinkOptionsControlDarwinDebugSymbols(t *testing.T) {
 	}
 }
 
+func TestDarwinDWARFCacheUsesStableArchivePaths(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Mach-O debug-map integration test")
+	}
+
+	cacheDir := t.TempDir()
+	oldCacheRootFunc := cacheRootFunc
+	cacheRootFunc = func() string { return cacheDir }
+	t.Cleanup(func() { cacheRootFunc = oldCacheRootFunc })
+
+	binPath := filepath.Join(t.TempDir(), "ldflagsstrip")
+	buildCachedArchivePaths := func() []string {
+		cfg := &Config{
+			Mode:        ModeBuild,
+			OutFile:     binPath,
+			LinkOptions: LinkOptions{DWARF: DWARFPreserve},
+		}
+		if _, err := Do([]string{"./testdata/ldflagsstrip"}, cfg); err != nil {
+			t.Fatalf("ModeBuild with DWARF failed: %v", err)
+		}
+		f, err := macho.Open(binPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if f.Symtab == nil {
+			t.Fatal("Mach-O has no symbol table")
+		}
+
+		const nOSO = 0x66
+		cachePrefix := filepath.Join(cacheDir, cacheBuildDirName) + string(os.PathSeparator)
+		var paths []string
+		for _, sym := range f.Symtab.Syms {
+			if sym.Type == nOSO && strings.HasPrefix(sym.Name, cachePrefix) {
+				paths = append(paths, sym.Name)
+			}
+		}
+		return paths
+	}
+
+	coldPaths := buildCachedArchivePaths()
+	warmPaths := buildCachedArchivePaths()
+	if len(coldPaths) == 0 {
+		t.Fatal("cold build has no cache-backed N_OSO paths")
+	}
+	if !slices.Equal(coldPaths, warmPaths) {
+		t.Fatalf("cold and warm N_OSO paths differ:\ncold: %q\nwarm: %q", coldPaths, warmPaths)
+	}
+}
+
 func machoHasStabs(t *testing.T, path string) bool {
 	t.Helper()
 	f, err := macho.Open(path)

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -532,6 +532,9 @@ func (c *context) saveToCache(pkg *aPackage) error {
 		return err
 	}
 
+	// Link a cache miss from the same stable archive path used by a cache hit.
+	// Darwin records this path in its N_OSO debug map.
+	pkg.ArchiveFile = paths.Archive
 	return nil
 }
 

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -522,6 +522,9 @@ func (c *context) saveToCache(pkg *aPackage) error {
 		return err
 	}
 
+	// Link a cache miss from the same stable archive path used by a cache hit.
+	// Darwin records this path in its N_OSO debug map.
+	pkg.ArchiveFile = paths.Archive
 	return nil
 }
 

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -1001,6 +1001,9 @@ func TestSaveToCache_Success(t *testing.T) {
 	// Check cache was created
 	cm := ctx.ensureCacheManager()
 	paths := cm.PackagePaths("arm64-apple-darwin", "example.com/lib", "def456")
+	if pkg.ArchiveFile != paths.Archive {
+		t.Fatalf("ArchiveFile = %q, want stable cache path %q", pkg.ArchiveFile, paths.Archive)
+	}
 
 	// Check manifest contains original content and metadata in Package section
 	content, err := readManifest(paths.Manifest)

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -1047,6 +1047,9 @@ func TestSaveToCache_Success(t *testing.T) {
 	// Check cache was created
 	cm := ctx.ensureCacheManager()
 	paths := cm.PackagePaths("arm64-apple-darwin", "example.com/lib", "def456")
+	if pkg.ArchiveFile != paths.Archive {
+		t.Fatalf("ArchiveFile = %q, want stable cache path %q", pkg.ArchiveFile, paths.Archive)
+	}
 
 	// Check manifest contains original content and metadata in Package section
 	content, err := readManifest(paths.Manifest)


### PR DESCRIPTION
Fixes #2119.

## Problem

On a package-cache miss, LLGo normalizes a dependency into a temporary archive, copies it into the persistent cache, and continues linking the temporary path. A cache hit links the persistent archive instead.

Darwin records linker input paths in `N_OSO` debug-map entries. Identical code therefore produces different cold and warm `LC_SYMTAB` string tables, and the cold binary refers to temporary archives that disappear after the build.

## Fix

After the archive, metadata, and manifest are written successfully, use the cached archive as the current package link input. Cache misses and hits then use the same stable path. Cache-disabled builds, main packages, and failed cache writes retain their existing behavior.

The regression test builds the same Mach-O twice with an isolated cache and verifies that both debug maps contain the same cache-backed `N_OSO` paths. A unit assertion fixes the link-input transition at the cache boundary.

## Validation

- Rebased cleanly onto `xgo-dev/llgo/main` at `e82e95fbe84dd66f82e0dd6bb4c6db59eb7e40b2` (the single implementation commit is now `55fbc292c6e0af9f422a5c7f0fd6a3e3ab462e56`).
- Local `GOMAXPROCS=4 GOMEMLIMIT=8GiB GOFLAGS=-p=1 go test -vet=off -count=1 -timeout=20m ./internal/build` passes.
- GitHub Actions: 41 checks passed, 1 dependency-gated check was skipped, and no checks failed.
