### PR TITLE
cmd/compile: validate noescape function bodies

### DIFF
--- a/cmd/internal/compile/compile_test.go
+++ b/cmd/internal/compile/compile_test.go
@@ -180,6 +180,63 @@ func TestRunCmdBuildsAndReportsErrors(t *testing.T) {
 	if code != 1 || !strings.Contains(stderr, "go:uintptrkeepalive requires go:nosplit") {
 		t.Fatalf("-std compile exit code = %d, stderr=%q; want code 1 and pragma diagnostic", code, stderr)
 	}
+
+	invalidNoescape := dir + "/invalid_noescape.go"
+	if err := os.WriteFile(invalidNoescape, []byte(`package compilecase
+//go:unknown
+func External()
+
+//go:noescape
+// compiler directives remain pending across ordinary comments and blank lines.
+
+func HasBody() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, code = runCompileCommand(t, []string{"-C", "-e", "-std", invalidNoescape})
+	if code != 1 ||
+		!strings.Contains(stderr, "//go:unknown is not allowed in the standard library") ||
+		!strings.Contains(stderr, "can only use //go:noescape with external func implementations") {
+		t.Fatalf("-std compile exit code = %d, stderr=%q; want both standard-library pragma diagnostics", code, stderr)
+	}
+
+	for _, invalid := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "type error",
+			source: `package compilecase
+//go:unknown
+func External()
+
+//go:noescape
+func HasBody() { _ = missing }
+`,
+			want: "undefined: missing",
+		},
+		{
+			name: "parse error",
+			source: `package compilecase
+var x = )
+
+//go:noescape
+func HasBody() {}
+`,
+			want: "syntax error",
+		},
+	} {
+		invalidPath := dir + "/invalid_noescape_" + strings.ReplaceAll(invalid.name, " ", "_") + ".go"
+		if err := os.WriteFile(invalidPath, []byte(invalid.source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, stderr, code = runCompileCommand(t, []string{"-C", "-e", "-std", invalidPath})
+		if code != 1 || !strings.Contains(stderr, invalid.want) ||
+			strings.Contains(stderr, "can only use //go:noescape with external func implementations") {
+			t.Fatalf("%s exit code = %d, stderr=%q; want code 1, %q, and no noescape-body diagnostic", invalid.name, code, stderr, invalid.want)
+		}
+	}
 }
 
 func runCompileCommand(t *testing.T, args []string) (stdout, stderr string, exitCode int) {

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -492,7 +492,9 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	// cmd/compile reaches compiler-directive body checks only after parsing and
 	// type-checking the complete package and its imports. Do not gate on
 	// ListError: an earlier compiler-directive diagnostic may itself be why go
-	// list stopped early.
+	// list stopped early. When function bodies are deliberately ignored, their
+	// type-check phase is incomplete, so writer-only checks cannot be safely
+	// synthesized.
 	hasSourceErrors := tc.IgnoreFuncBodies || len(errs) != 0 || typErr != nil ||
 		len(lpkg.TypeErrors) != 0 || hasIllTypedImport
 	if !hasSourceErrors {

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -481,17 +481,38 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 		appendError(typErr)
 	}
 
-	// Record accumulated errors.
-	illTyped := len(lpkg.Errors) > 0
-	if !illTyped {
-		for _, imp := range lpkg.Imports {
-			if imp.IllTyped {
-				illTyped = true
+	hasIllTypedImport := false
+	for _, imp := range lpkg.Imports {
+		if imp.IllTyped {
+			hasIllTypedImport = true
+			break
+		}
+	}
+
+	// cmd/compile reaches compiler-directive body checks only after parsing and
+	// type-checking the complete package and its imports. Do not gate on
+	// ListError: an earlier compiler-directive diagnostic may itself be why go
+	// list stopped early.
+	hasSourceErrors := tc.IgnoreFuncBodies || len(errs) != 0 || typErr != nil ||
+		len(lpkg.TypeErrors) != 0 || hasIllTypedImport
+	if !hasSourceErrors {
+		for _, err := range lpkg.Errors {
+			if err.Kind == packages.ParseError || err.Kind == packages.TypeError {
+				hasSourceErrors = true
 				break
 			}
 		}
 	}
-	lpkg.IllTyped = illTyped
+	if !hasSourceErrors {
+		for _, err := range validateCompilerDirectives(ld.Fset, lpkg.Syntax) {
+			if !packageHasCompilerDiagnostic(lpkg.Errors, err) {
+				appendError(err)
+			}
+		}
+	}
+
+	// Record accumulated errors.
+	lpkg.IllTyped = len(lpkg.Errors) > 0 || hasIllTypedImport
 }
 
 func packageGoVersion(ld *loader, lpkg *loaderPackage) string {

--- a/internal/packages/pragma.go
+++ b/internal/packages/pragma.go
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packages
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+)
+
+const noescapeBodyDiagnostic = "can only use //go:noescape with external func implementations"
+
+// validateCompilerDirectives applies compiler-only semantic checks that are
+// outside go/types. The go command may report these checks while loading export
+// data, but it can stop before reaching them when an earlier compiler error is
+// present, so the source frontend must validate them independently.
+func validateCompilerDirectives(fset *token.FileSet, files []*ast.File) []types.Error {
+	if fset == nil {
+		return nil
+	}
+	var errs []types.Error
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+		previousEnd := file.Name.End()
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			directiveEnd := decl.Pos()
+			var declarationToken token.Pos
+			if ok {
+				declarationToken = fn.Pos()
+				directiveEnd = compilerFunctionPos(fn)
+			}
+			hasNoescape := hasCompilerDirectiveBetween(
+				fset, file.Comments, previousEnd, directiveEnd, declarationToken, "go:noescape",
+			)
+			previousEnd = decl.End()
+			if !ok || fn.Body == nil || !hasNoescape {
+				continue
+			}
+			errs = append(errs, types.Error{
+				Fset: fset,
+				Pos:  directiveEnd,
+				Msg:  noescapeBodyDiagnostic,
+			})
+		}
+	}
+	return errs
+}
+
+func compilerFunctionPos(fn *ast.FuncDecl) token.Pos {
+	if fn.Recv != nil && fn.Recv.Opening.IsValid() {
+		return fn.Recv.Opening
+	}
+	if fn.Name != nil {
+		return fn.Name.Pos()
+	}
+	return fn.Pos()
+}
+
+// hasCompilerDirectiveBetween reports whether a standalone directive occurs
+// between two declarations. cmd/compile keeps directives pending across blank
+// lines and ordinary comments, then consumes them at the next declaration. A
+// function directive may also occur between the func keyword and its name (or
+// receiver).
+func hasCompilerDirectiveBetween(
+	fset *token.FileSet, groups []*ast.CommentGroup, start, end, declarationToken token.Pos, directive string,
+) bool {
+	previous := start
+	for _, group := range groups {
+		if group == nil || group.End() <= start || group.Pos() >= end {
+			continue
+		}
+		for _, comment := range group.List {
+			if comment == nil || comment.End() <= start || comment.Pos() >= end {
+				continue
+			}
+			if declarationToken > previous && declarationToken < comment.Pos() {
+				previous = declarationToken
+			}
+			standalone := physicalLine(fset, previous) != physicalLine(fset, comment.Pos())
+			previous = comment.End()
+			if !standalone || !strings.HasPrefix(comment.Text, "//") {
+				continue
+			}
+			text := strings.TrimPrefix(comment.Text, "//")
+			if text == directive {
+				return true
+			}
+			if strings.HasPrefix(text, directive) && len(text) > len(directive) {
+				next := text[len(directive)]
+				if next == ' ' {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func physicalLine(fset *token.FileSet, pos token.Pos) int {
+	return fset.PositionFor(pos, false).Line
+}
+
+func packageHasCompilerDiagnostic(errs []Error, want types.Error) bool {
+	position := want.Fset.Position(want.Pos)
+	for _, err := range errs {
+		if err.Msg == want.Msg && sameDiagnosticLine(err.Pos, position) {
+			return true
+		}
+		for _, line := range strings.Split(err.Msg, "\n") {
+			pos, msg, ok := strings.Cut(line, ": ")
+			if ok && msg == want.Msg && sameDiagnosticLine(pos, position) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/packages/pragma.go
+++ b/internal/packages/pragma.go
@@ -25,10 +25,10 @@ import (
 
 const noescapeBodyDiagnostic = "can only use //go:noescape with external func implementations"
 
-// validateCompilerDirectives applies compiler-only semantic checks that are
-// outside go/types. The go command may report these checks while loading export
-// data, but it can stop before reaching them when an earlier compiler error is
-// present, so the source frontend must validate them independently.
+// validateCompilerDirectives applies cmd/compile's //go:noescape body check,
+// which is outside go/types. The go command may report this check while loading
+// export data, but it can stop before reaching it when an earlier compiler error
+// is present, so the source frontend must validate it independently.
 func validateCompilerDirectives(fset *token.FileSet, files []*ast.File) []types.Error {
 	if fset == nil {
 		return nil

--- a/internal/packages/pragma_test.go
+++ b/internal/packages/pragma_test.go
@@ -1,0 +1,267 @@
+//go:build !llgo
+
+package packages
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+func TestValidateCompilerDirectives(t *testing.T) {
+	tests := []struct {
+		name            string
+		source          string
+		allowParseError bool
+		wantFile        string
+		wantLine        int
+		wantColumn      int
+	}{
+		{
+			name: "noescape function body",
+			source: `package p
+//go:noescape
+func f() {}
+`,
+			wantLine:   3,
+			wantColumn: 6,
+		},
+		{
+			name: "noescape directive argument",
+			source: `package p
+//go:noescape ignored
+func f() {}
+`,
+			wantLine: 3,
+		},
+		{
+			name: "blank line before function",
+			source: `package p
+//go:noescape
+
+func f() {}
+`,
+			wantLine: 4,
+		},
+		{
+			name: "ordinary comment before function",
+			source: `package p
+//go:noescape
+// ordinary
+
+func f() {}
+`,
+			wantLine: 5,
+		},
+		{
+			name: "between func keyword and name",
+			source: `package p
+func
+//go:noescape
+f() {}
+`,
+			wantLine:   4,
+			wantColumn: 1,
+		},
+		{
+			name: "method body",
+			source: `package p
+type T int
+//go:noescape
+func (T) f() {}
+`,
+			wantLine:   4,
+			wantColumn: 6,
+		},
+		{
+			name: "between func keyword and receiver",
+			source: `package p
+type T int
+func
+//go:noescape
+(T) f() {}
+`,
+			wantLine:   5,
+			wantColumn: 1,
+		},
+		{
+			name: "between receiver and method name",
+			source: `package p
+type T int
+func (T)
+//go:noescape
+f() {}
+`,
+			allowParseError: true,
+		},
+		{
+			name: "external implementation",
+			source: `package p
+//go:noescape
+func f()
+`,
+		},
+		{
+			name: "spaced comment",
+			source: `package p
+// go:noescape
+func f() {}
+`,
+		},
+		{
+			name: "lookalike directive",
+			source: `package p
+//go:noescapex
+func f() {}
+`,
+		},
+		{
+			name:   "tab argument",
+			source: "package p\n//go:noescape\tignored\nfunc f() {}\n",
+		},
+		{
+			name: "block comment",
+			source: `package p
+/*go:noescape*/
+func f() {}
+`,
+		},
+		{
+			name: "intervening variable declaration",
+			source: `package p
+//go:noescape
+var (
+	x int
+)
+func f() {}
+`,
+		},
+		{
+			name: "intervening type declaration",
+			source: `package p
+//go:noescape
+type T int
+func f() {}
+`,
+		},
+		{
+			name: "misplaced on previous declaration line",
+			source: `package p
+var x int //go:noescape
+func f() {}
+`,
+		},
+		{
+			name: "ordinary block comment on directive line",
+			source: `package p
+/* ordinary */ //go:noescape
+func f() {}
+`,
+		},
+		{
+			name: "after func keyword on same line",
+			source: `package p
+func //go:noescape
+f() {}
+`,
+		},
+		{
+			name: "before package declaration",
+			source: `//go:noescape
+package p
+func f() {}
+`,
+		},
+		{
+			name: "physical line with logical line remapping",
+			source: `package p
+var x int
+//line remapped.go:2:1
+//go:noescape
+func f() {}
+`,
+			wantFile:   "remapped.go",
+			wantLine:   3,
+			wantColumn: 6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "pragma.go", tt.source, parser.ParseComments)
+			if err != nil && !tt.allowParseError {
+				t.Fatal(err)
+			}
+			errs := validateCompilerDirectives(fset, []*ast.File{nil, file})
+			if tt.wantLine == 0 {
+				if len(errs) != 0 {
+					t.Fatalf("validateCompilerDirectives returned %+v, want no errors", errs)
+				}
+				return
+			}
+			if len(errs) != 1 {
+				t.Fatalf("validateCompilerDirectives returned %d errors, want 1: %+v", len(errs), errs)
+			}
+			if errs[0].Msg != noescapeBodyDiagnostic {
+				t.Fatalf("diagnostic = %q, want %q", errs[0].Msg, noescapeBodyDiagnostic)
+			}
+			got := fset.Position(errs[0].Pos)
+			if got.Line != tt.wantLine {
+				t.Fatalf("diagnostic line = %d, want %d", got.Line, tt.wantLine)
+			}
+			if tt.wantColumn != 0 && got.Column != tt.wantColumn {
+				t.Fatalf("diagnostic column = %d, want %d", got.Column, tt.wantColumn)
+			}
+			if tt.wantFile != "" && got.Filename != tt.wantFile {
+				t.Fatalf("diagnostic file = %q, want %q", got.Filename, tt.wantFile)
+			}
+		})
+	}
+
+	if errs := validateCompilerDirectives(nil, nil); len(errs) != 0 {
+		t.Fatalf("nil file set returned %+v, want no errors", errs)
+	}
+}
+
+func TestPackageHasCompilerDiagnostic(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "/tmp/pragma.go", "package p\n\nfunc f() {}\n", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fn := file.Decls[0].(*ast.FuncDecl)
+	want := types.Error{Fset: fset, Pos: fn.Pos(), Msg: noescapeBodyDiagnostic}
+	tests := []struct {
+		name string
+		errs []Error
+		want bool
+	}{
+		{
+			name: "structured diagnostic",
+			errs: []Error{{Pos: "/tmp/pragma.go:3:1", Msg: noescapeBodyDiagnostic}},
+			want: true,
+		},
+		{
+			name: "driver diagnostic",
+			errs: []Error{{Msg: "# p\n/tmp/pragma.go:3: " + noescapeBodyDiagnostic}},
+			want: true,
+		},
+		{
+			name: "wrong line",
+			errs: []Error{{Pos: "/tmp/pragma.go:2:1", Msg: noescapeBodyDiagnostic}},
+		},
+		{
+			name: "wrong message",
+			errs: []Error{{Pos: "/tmp/pragma.go:3:1", Msg: "other error"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := packageHasCompilerDiagnostic(tt.errs, want); got != tt.want {
+				t.Fatalf("packageHasCompilerDiagnostic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1803,10 +1803,6 @@ xfails:
     reason: gc-specific nil-check elimination diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue18331.go
-    reason: gc standard-library pragma validation is not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue41635.go
     reason: gc-specific -m optimization diagnostics are not implemented by llgo
   - version: go1.26


### PR DESCRIPTION
## Summary

- validate the gc-only `//go:noescape` body restriction in the source loader when an earlier compiler diagnostic makes `go list` stop before reporting it
- preserve cmd/compile pragma association across blank lines and ordinary comments, including method and `//line` position semantics
- suppress the writer-only diagnostic when parsing, complete type checking, or imported packages have already failed
- remove `fixedbugs/issue18331.go` from the Go 1.26 GOROOT xfail list

## Tests and coverage

- added focused pragma association, placement, deduplication, method-position, and phase-order unit tests
- added end-to-end compile tests for the review counterexamples: blank/comment separation, preceding unknown pragma, type error, and parse error
- Go 1.26.5: `go test ./internal/packages ./internal/build ./cmd/internal/compile -count=1`
- Go 1.24.11, 1.25.0, and 1.26.0: `go test ./internal/packages ./cmd/internal/compile -count=1`
- `go test ./test/goroot -count=1`
- Go 1.24.11, 1.25.0, and 1.26.0: `fixedbugs/issue18331.go` and `fixedbugs/issue48097.go`
- Go 1.26.0: target case plus all remaining 148 compile/errorcheck xfails

No functional dependency on another PR. #2201 only has a separate test-file overlap; #2218 and #2219 touch different `xfail.yaml` entries.

CI environment note: #2215 has landed on `main` with the isolated Ubuntu ESP QEMU package-install fix. This PR does not contain any CI changes.
