### PR TITLE
test/goroot: match malformed package clause diagnostics

### DIFF
--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1170,7 +1170,8 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			} else if _, suffix, found := strings.Cut(message, " "); found {
 				message = suffix
 			}
-			parserAlias := sourceOK && matchesParserDiagnosticAlias(expected.regexp, sourceDiagnostic, expected.source)
+			parserAlias := sourceOK && physicalDiagnosticSources[sourceDiagnostic.file] &&
+				matchesParserDiagnosticAlias(expected.regexp, sourceDiagnostic, expected.source)
 			if matchesExpectedDiagnostic(expected.regexp, message) || parserAlias {
 				matched = true
 				if ok && isScopedLexicalDiagnostic(message) {

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1698,6 +1698,9 @@ func parserRecoverySecondaries(primary string) []string {
 // unrelated malformed programs. Exact source matching keeps those allowances
 // scoped to the GOROOT cases that require them.
 func parserRecoverySourceSecondaries(primary, source string) []string {
+	if _, secondaries := packageClauseParserMapping(primary, source); len(secondaries) != 0 {
+		return secondaries
+	}
 	source = parserRecoverySourceCode(source)
 	switch primary {
 	// GOROOT/test/fixedbugs/bug050.go. go/parser omits the "syntax error:"
@@ -1751,18 +1754,27 @@ func parserRecoverySecondaryGroups(primary, source string) [][]string {
 				{"illegal character U+003F '?'"},
 			}
 		}
+	}
+	return nil
+}
+
+// packageClauseParserMapping keeps each diagnostic alias and its recovery
+// secondary under one exact source-shape guard.
+func packageClauseParserMapping(primary, source string) (canonical string, secondaries []string) {
+	source = parserRecoverySourceCode(source)
+	switch primary {
 	// GOROOT/test/fixedbugs/issue4776.go
 	case "expected 'package', found 'type'":
 		if source == "type MyInt int32" {
-			return [][]string{{"expected ';', found int32"}}
+			return "syntax error: package statement must be first", []string{"expected ';', found int32"}
 		}
 	// GOROOT/test/fixedbugs/issue13266.go
 	case "expected 'IDENT', found '%'":
 		if source == "package%" {
-			return [][]string{{"expected ';', found 'EOF'"}}
+			return "syntax error: unexpected %, expected name", []string{"expected ';', found 'EOF'"}
 		}
 	}
-	return nil
+	return "", nil
 }
 
 func parserRecoverySourceCode(source string) string {
@@ -1832,16 +1844,10 @@ nextLine:
 }
 
 func matchesParserDiagnosticAlias(expected *regexp.Regexp, diagnostic sourceDiagnostic, source string) bool {
-	source = parserRecoverySourceCode(source)
+	if canonical, _ := packageClauseParserMapping(diagnostic.message, source); canonical != "" {
+		return expected.MatchString(canonical)
+	}
 	switch diagnostic.message {
-	// GOROOT/test/fixedbugs/issue4776.go
-	case "expected 'package', found 'type'":
-		return source == "type MyInt int32" &&
-			expected.MatchString("syntax error: package statement must be first")
-	// GOROOT/test/fixedbugs/issue13266.go
-	case "expected 'IDENT', found '%'":
-		return source == "package%" &&
-			expected.MatchString("syntax error: unexpected %, expected name")
 	case "expected ';', found ','":
 		return expected.MatchString("unexpected comma") &&
 			isParenthesizedImportLine(diagnostic.file, diagnostic.line)

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1121,6 +1121,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 	lines = preferSpecificDiagnostics(lines)
 	var wanted []wantedError
 	sourceLines := make(map[string][]string, len(sources))
+	physicalDiagnosticSources := make(map[string]bool, len(sources))
 	for _, source := range sources {
 		expected, err := wantedErrors(source.full, source.short)
 		if err != nil {
@@ -1132,6 +1133,14 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			return err
 		}
 		sourceLines[normalizeDiagnosticPath(source.short)] = strings.Split(string(data), "\n")
+		file := canonicalDiagnosticPath(source.full)
+		// Pairing is keyed by physical source lines. A line directive makes that
+		// relationship ambiguous, so leave every recovery diagnostic visible.
+		physical := !hasLineDirective(data)
+		if previous, ok := physicalDiagnosticSources[file]; ok {
+			physical = previous && physical
+		}
+		physicalDiagnosticSources[file] = physical
 	}
 	pathResolver := newDiagnosticPathResolver(sources)
 	lexicalLocations := make(map[string]bool)
@@ -1165,12 +1174,8 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 				if ok && isScopedLexicalDiagnostic(message) {
 					lexicalLocations[diagnostic.locationKey()] = true
 				}
-				if sourceOK {
-					secondaries := parserRecoverySecondaries(message)
-					if len(secondaries) == 0 {
-						secondaries = parserRecoverySourceSecondaries(message, expected.source)
-					}
-					if len(secondaries) != 0 {
+				if sourceOK && physicalDiagnosticSources[sourceDiagnostic.file] {
+					for _, secondaries := range parserRecoverySecondaryGroups(message, expected.source) {
 						parserRecoveryPairs = append(parserRecoveryPairs, parserRecoveryPair{
 							file: sourceDiagnostic.file, line: sourceDiagnostic.line, secondaries: secondaries,
 						})
@@ -1634,7 +1639,14 @@ func (resolver diagnosticPathResolver) resolve(file string) (string, bool) {
 		return full, full != ""
 	}
 	if filepath.IsAbs(file) {
-		return canonicalDiagnosticPath(file), true
+		full := canonicalDiagnosticPath(file)
+		// An absolute path is not sufficient by itself: it must still identify
+		// one of the sources whose ERROR comments are being checked.
+		for _, source := range resolver {
+			if source == full {
+				return full, true
+			}
+		}
 	}
 	return "", false
 }
@@ -1698,6 +1710,43 @@ func parserRecoverySourceSecondaries(primary, source string) []string {
 	return nil
 }
 
+// parserRecoverySecondaryGroups returns independent one-use allowances for an
+// exact primary. Source-independent pairs are checked first; all other pairs
+// require an exact ERROR source shape. Most recovery spellings are alternatives
+// in one group; issue11610 deterministically emits two separate follow-ons, so
+// each receives its own group.
+func parserRecoverySecondaryGroups(primary, source string) [][]string {
+	if secondaries := parserRecoverySecondaries(primary); len(secondaries) != 0 {
+		return [][]string{secondaries}
+	}
+	if secondaries := parserRecoverySourceSecondaries(primary, source); len(secondaries) != 0 {
+		return [][]string{secondaries}
+	}
+	source = parserRecoverySourceCode(source)
+	switch primary {
+	case "syntax error: ... is missing type":
+		if source == "func g(x int, y float32) (...)" {
+			return [][]string{{"expected type, found ')'"}}
+		}
+	case "syntax error: cannot use c <- v as value":
+		if source == "if c <- v {" {
+			return [][]string{{"expected boolean expression, found simple statement (missing parentheses around composite literal?)"}}
+		}
+	case "syntax error: unexpected <- after top level declaration":
+		if source == "var _ = c <- v" {
+			return [][]string{{"expected ';', found '<-'"}}
+		}
+	case "invalid character U+003F '?'":
+		if source == "var?" {
+			return [][]string{
+				{"expected 'IDENT', found 'ILLEGAL'"},
+				{"illegal character U+003F '?'"},
+			}
+		}
+	}
+	return nil
+}
+
 func parserRecoverySourceCode(source string) string {
 	// Prefer the last recognized marker so marker-like text in the source
 	// expression cannot truncate the shape before the actual ERROR comment.
@@ -1711,6 +1760,15 @@ func parserRecoverySourceCode(source string) string {
 		source = source[:comment]
 	}
 	return strings.TrimSpace(source)
+}
+
+func hasLineDirective(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "//line") || strings.Contains(line, "/*line") {
+			return true
+		}
+	}
+	return false
 }
 
 func discardPairedParserDiagnostics(lines []string, resolver diagnosticPathResolver, pairs []parserRecoveryPair) []string {

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1170,7 +1170,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			} else if _, suffix, found := strings.Cut(message, " "); found {
 				message = suffix
 			}
-			parserAlias := sourceOK && matchesParserDiagnosticAlias(expected.regexp, sourceDiagnostic)
+			parserAlias := sourceOK && matchesParserDiagnosticAlias(expected.regexp, sourceDiagnostic, expected.source)
 			if matchesExpectedDiagnostic(expected.regexp, message) || parserAlias {
 				matched = true
 				if ok && isScopedLexicalDiagnostic(message) {
@@ -1750,6 +1750,16 @@ func parserRecoverySecondaryGroups(primary, source string) [][]string {
 				{"illegal character U+003F '?'"},
 			}
 		}
+	// GOROOT/test/fixedbugs/issue4776.go
+	case "expected 'package', found 'type'":
+		if source == "type MyInt int32" {
+			return [][]string{{"expected ';', found int32"}}
+		}
+	// GOROOT/test/fixedbugs/issue13266.go
+	case "expected 'IDENT', found '%'":
+		if source == "package%" {
+			return [][]string{{"expected ';', found 'EOF'"}}
+		}
 	}
 	return nil
 }
@@ -1820,10 +1830,22 @@ nextLine:
 	return out
 }
 
-func matchesParserDiagnosticAlias(expected *regexp.Regexp, diagnostic sourceDiagnostic) bool {
-	return diagnostic.message == "expected ';', found ','" &&
-		expected.MatchString("unexpected comma") &&
-		isParenthesizedImportLine(diagnostic.file, diagnostic.line)
+func matchesParserDiagnosticAlias(expected *regexp.Regexp, diagnostic sourceDiagnostic, source string) bool {
+	source = parserRecoverySourceCode(source)
+	switch diagnostic.message {
+	// GOROOT/test/fixedbugs/issue4776.go
+	case "expected 'package', found 'type'":
+		return source == "type MyInt int32" &&
+			expected.MatchString("syntax error: package statement must be first")
+	// GOROOT/test/fixedbugs/issue13266.go
+	case "expected 'IDENT', found '%'":
+		return source == "package%" &&
+			expected.MatchString("syntax error: unexpected %, expected name")
+	case "expected ';', found ','":
+		return expected.MatchString("unexpected comma") &&
+			isParenthesizedImportLine(diagnostic.file, diagnostic.line)
+	}
+	return false
 }
 
 func isParenthesizedImportLine(file string, line int) bool {

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1662,6 +1662,10 @@ func parserRecoverySecondaries(primary string) []string {
 		return []string{"expected type, found '}'", "expected type, found ')'", "expected type, found ','"}
 	case "syntax error: else must be followed by if or statement block":
 		return []string{"expected if statement or block, found ';'"}
+	case "expected 'package', found 'func'":
+		return []string{"expected ';', found '('"}
+	case "syntax error: unexpected { after top level declaration":
+		return []string{"expected ';', found '{'"}
 	case "syntax error: unexpected newline in type declaration", "syntax error: unexpected EOF in type declaration":
 		return []string{"expected type, found newline"}
 	case "syntax error: unexpected newline in composite literal; possibly missing comma or }":

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1662,6 +1662,7 @@ func parserRecoverySecondaries(primary string) []string {
 		return []string{"expected type, found '}'", "expected type, found ')'", "expected type, found ','"}
 	case "syntax error: else must be followed by if or statement block":
 		return []string{"expected if statement or block, found ';'"}
+	// go/parser omits the "syntax error:" prefix when the package clause is missing.
 	case "expected 'package', found 'func'":
 		return []string{"expected ';', found '('"}
 	case "syntax error: unexpected { after top level declaration":

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1166,7 +1166,11 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 					lexicalLocations[diagnostic.locationKey()] = true
 				}
 				if sourceOK {
-					if secondaries := parserRecoverySecondaries(message); len(secondaries) != 0 {
+					secondaries := parserRecoverySecondaries(message)
+					if len(secondaries) == 0 {
+						secondaries = parserRecoverySourceSecondaries(message, expected.source)
+					}
+					if len(secondaries) != 0 {
 						parserRecoveryPairs = append(parserRecoveryPairs, parserRecoveryPair{
 							file: sourceDiagnostic.file, line: sourceDiagnostic.line, secondaries: secondaries,
 						})
@@ -1649,7 +1653,8 @@ func parseSourceDiagnostic(line string, resolver diagnosticPathResolver) (source
 }
 
 // parserRecoverySecondaries is deliberately limited to exact diagnostic pairs
-// emitted by GOROOT cases enabled with this compatibility shim.
+// whose secondary does not depend on the source shape. Source-dependent pairs
+// belong in parserRecoverySourceSecondaries.
 func parserRecoverySecondaries(primary string) []string {
 	switch primary {
 	case "syntax error: cannot use a := 10 as value":
@@ -1662,11 +1667,6 @@ func parserRecoverySecondaries(primary string) []string {
 		return []string{"expected type, found '}'", "expected type, found ')'", "expected type, found ','"}
 	case "syntax error: else must be followed by if or statement block":
 		return []string{"expected if statement or block, found ';'"}
-	// go/parser omits the "syntax error:" prefix when the package clause is missing.
-	case "expected 'package', found 'func'":
-		return []string{"expected ';', found '('"}
-	case "syntax error: unexpected { after top level declaration":
-		return []string{"expected ';', found '{'"}
 	case "syntax error: unexpected newline in type declaration", "syntax error: unexpected EOF in type declaration":
 		return []string{"expected type, found newline"}
 	case "syntax error: unexpected newline in composite literal; possibly missing comma or }":
@@ -1675,6 +1675,42 @@ func parserRecoverySecondaries(primary string) []string {
 		return []string{"missing ',' before newline in parameter list"}
 	}
 	return nil
+}
+
+// parserRecoverySourceSecondaries handles diagnostic spellings shared by
+// unrelated malformed programs. Exact source matching keeps those allowances
+// scoped to the GOROOT cases that require them.
+func parserRecoverySourceSecondaries(primary, source string) []string {
+	source = parserRecoverySourceCode(source)
+	switch primary {
+	// GOROOT/test/fixedbugs/bug050.go. go/parser omits the "syntax error:"
+	// prefix when the package clause is missing.
+	case "expected 'package', found 'func'":
+		if source == "func main() {" {
+			return []string{"expected ';', found '('"}
+		}
+	// GOROOT/test/syntax/vareq1.go
+	case "syntax error: unexpected { after top level declaration":
+		if source == `var x map[string]string{"a":"b"}` {
+			return []string{"expected ';', found '{'"}
+		}
+	}
+	return nil
+}
+
+func parserRecoverySourceCode(source string) string {
+	// Prefer the last recognized marker so marker-like text in the source
+	// expression cannot truncate the shape before the actual ERROR comment.
+	comment := -1
+	for _, marker := range []string{"// ERROR", "// GC_ERROR"} {
+		if index := strings.LastIndex(source, marker); index > comment {
+			comment = index
+		}
+	}
+	if comment >= 0 {
+		source = source[:comment]
+	}
+	return strings.TrimSpace(source)
 }
 
 func discardPairedParserDiagnostics(lines []string, resolver diagnosticPathResolver, pairs []parserRecoveryPair) []string {

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"go/constant"
 	"go/format"
 	"go/parser"
+	"go/scanner"
 	"go/token"
 	"io"
 	"io/fs"
@@ -1159,6 +1160,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			continue
 		}
 		matched := false
+		parserRecoveryAuthorized := false
 		for _, candidate := range candidates {
 			diagnostic, ok := parseCompilerDiagnostic(candidate)
 			sourceDiagnostic, sourceOK := parseSourceDiagnostic(candidate, pathResolver)
@@ -1174,12 +1176,14 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 				if ok && isScopedLexicalDiagnostic(message) {
 					lexicalLocations[diagnostic.locationKey()] = true
 				}
-				if sourceOK && physicalDiagnosticSources[sourceDiagnostic.file] {
-					for _, secondaries := range parserRecoverySecondaryGroups(message, expected.source) {
+				if !parserRecoveryAuthorized && sourceOK && physicalDiagnosticSources[sourceDiagnostic.file] {
+					groups := parserRecoverySecondaryGroups(message, expected.source)
+					for _, secondaries := range groups {
 						parserRecoveryPairs = append(parserRecoveryPairs, parserRecoveryPair{
 							file: sourceDiagnostic.file, line: sourceDiagnostic.line, secondaries: secondaries,
 						})
 					}
+					parserRecoveryAuthorized = len(groups) != 0
 				}
 				if !ok {
 					diagnostic = compilerDiagnostic{
@@ -1724,18 +1728,22 @@ func parserRecoverySecondaryGroups(primary, source string) [][]string {
 	}
 	source = parserRecoverySourceCode(source)
 	switch primary {
+	// GOROOT/test/fixedbugs/bug228.go
 	case "syntax error: ... is missing type":
 		if source == "func g(x int, y float32) (...)" {
 			return [][]string{{"expected type, found ')'"}}
 		}
+	// GOROOT/test/syntax/chan1.go: channel send in an if condition.
 	case "syntax error: cannot use c <- v as value":
 		if source == "if c <- v {" {
 			return [][]string{{"expected boolean expression, found simple statement (missing parentheses around composite literal?)"}}
 		}
+	// GOROOT/test/syntax/chan1.go: channel send in a top-level declaration.
 	case "syntax error: unexpected <- after top level declaration":
 		if source == "var _ = c <- v" {
 			return [][]string{{"expected ';', found '<-'"}}
 		}
+	// GOROOT/test/fixedbugs/issue11610.go
 	case "invalid character U+003F '?'":
 		if source == "var?" {
 			return [][]string{
@@ -1763,12 +1771,29 @@ func parserRecoverySourceCode(source string) string {
 }
 
 func hasLineDirective(data []byte) bool {
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "//line") || strings.Contains(line, "/*line") {
+	file := token.NewFileSet().AddFile("", -1, len(data))
+	var sourceScanner scanner.Scanner
+	sourceScanner.Init(file, data, func(token.Position, string) {}, scanner.ScanComments)
+	for {
+		position, kind, literal := sourceScanner.Scan()
+		if kind == token.EOF {
+			return false
+		}
+		if kind != token.COMMENT {
+			continue
+		}
+		if strings.HasPrefix(literal, "/*line ") {
+			return true
+		}
+		if !strings.HasPrefix(literal, "//line ") {
+			continue
+		}
+		offset := file.Offset(position)
+		lineStart := bytes.LastIndexByte(data[:offset], '\n') + 1
+		if len(bytes.TrimSpace(data[lineStart:offset])) == 0 {
 			return true
 		}
 	}
-	return false
 }
 
 func discardPairedParserDiagnostics(lines []string, resolver diagnosticPathResolver, pairs []parserRecoveryPair) []string {

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1710,15 +1710,29 @@ func parserRecoverySourceSecondaries(primary, source string) []string {
 		if source == `var x map[string]string{"a":"b"}` {
 			return []string{"expected ';', found '{'"}
 		}
+	// GOROOT/test/fixedbugs/bug228.go
+	case "syntax error: ... is missing type":
+		if source == "func g(x int, y float32) (...)" {
+			return []string{"expected type, found ')'"}
+		}
+	// GOROOT/test/syntax/chan1.go: channel send in an if condition.
+	case "syntax error: cannot use c <- v as value":
+		if source == "if c <- v {" {
+			return []string{"expected boolean expression, found simple statement (missing parentheses around composite literal?)"}
+		}
+	// GOROOT/test/syntax/chan1.go: channel send in a top-level declaration.
+	case "syntax error: unexpected <- after top level declaration":
+		if source == "var _ = c <- v" {
+			return []string{"expected ';', found '<-'"}
+		}
 	}
 	return nil
 }
 
 // parserRecoverySecondaryGroups returns independent one-use allowances for an
-// exact primary. Source-independent pairs are checked first; all other pairs
-// require an exact ERROR source shape. Most recovery spellings are alternatives
-// in one group; issue11610 deterministically emits two separate follow-ons, so
-// each receives its own group.
+// exact primary. Source-independent pairs are checked first, followed by
+// source-dependent single groups. issue11610 deterministically emits two
+// separate follow-ons, so each receives its own group here.
 func parserRecoverySecondaryGroups(primary, source string) [][]string {
 	if secondaries := parserRecoverySecondaries(primary); len(secondaries) != 0 {
 		return [][]string{secondaries}
@@ -1728,21 +1742,6 @@ func parserRecoverySecondaryGroups(primary, source string) [][]string {
 	}
 	source = parserRecoverySourceCode(source)
 	switch primary {
-	// GOROOT/test/fixedbugs/bug228.go
-	case "syntax error: ... is missing type":
-		if source == "func g(x int, y float32) (...)" {
-			return [][]string{{"expected type, found ')'"}}
-		}
-	// GOROOT/test/syntax/chan1.go: channel send in an if condition.
-	case "syntax error: cannot use c <- v as value":
-		if source == "if c <- v {" {
-			return [][]string{{"expected boolean expression, found simple statement (missing parentheses around composite literal?)"}}
-		}
-	// GOROOT/test/syntax/chan1.go: channel send in a top-level declaration.
-	case "syntax error: unexpected <- after top level declaration":
-		if source == "var _ = c <- v" {
-			return [][]string{{"expected ';', found '<-'"}}
-		}
 	// GOROOT/test/fixedbugs/issue11610.go
 	case "invalid character U+003F '?'":
 		if source == "var?" {
@@ -1782,7 +1781,7 @@ func hasLineDirective(data []byte) bool {
 		if kind != token.COMMENT {
 			continue
 		}
-		if strings.HasPrefix(literal, "/*line ") {
+		if strings.HasPrefix(literal, "/*line ") && strings.Contains(literal[len("/*line "):], ":") {
 			return true
 		}
 		if !strings.HasPrefix(literal, "//line ") {
@@ -1790,7 +1789,8 @@ func hasLineDirective(data []byte) bool {
 		}
 		offset := file.Offset(position)
 		lineStart := bytes.LastIndexByte(data[:offset], '\n') + 1
-		if len(bytes.TrimSpace(data[lineStart:offset])) == 0 {
+		if len(bytes.TrimSpace(data[lineStart:offset])) == 0 &&
+			strings.Contains(literal[len("//line "):], ":") {
 			return true
 		}
 	}

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -726,6 +726,51 @@ func TestCheckExpectedErrorsDiscardsExactParserPair(t *testing.T) {
 	}
 }
 
+func TestCheckExpectedErrorsDiscardsPairedDeclarationRecoveryDiagnostics(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		line      int
+		primary   string
+		secondary string
+	}{
+		{
+			name:      "missing package clause",
+			source:    "func main() { // ERROR \"package\"\n}\n",
+			line:      1,
+			primary:   "expected 'package', found 'func'",
+			secondary: "expected ';', found '('",
+		},
+		{
+			name: "top-level composite literal",
+			source: `package p
+var x map[string]string{"a":"b"} // ERROR "unexpected { at end of statement|unexpected { after top level declaration|expected ';' or newline after top level declaration"
+`,
+			line:      2,
+			primary:   "syntax error: unexpected { after top level declaration",
+			secondary: "expected ';', found '{'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			output := fmt.Sprintf("%s:%d: %s\n%s:%d: %s\n", file, tt.line, tt.primary, file, tt.line, tt.secondary)
+			if err := checkExpectedErrors(output, file, "case.go"); err != nil {
+				t.Fatal(err)
+			}
+			if err := checkExpectedErrors(fmt.Sprintf("%s:%d: %s\n", file, tt.line, tt.secondary), file, "case.go"); err == nil {
+				t.Fatal("secondary diagnostic passed without its primary")
+			}
+			if got := parserRecoverySecondaries(tt.primary + "."); got != nil {
+				t.Fatalf("near-match primary activated parser recovery: %v", got)
+			}
+		})
+	}
+}
+
 func TestCheckExpectedErrorsScopesImportAlias(t *testing.T) {
 	tests := []struct {
 		name, src string

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -789,6 +789,208 @@ var y map[string]string{"a":"b"} // ERROR "unexpected { at end of statement|unex
 	}
 }
 
+func TestCheckExpectedErrorsDiscardsAdditionalParserRecoveryDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		output func(file string) string
+	}{
+		{
+			name: "variadic result Go 1.24",
+			source: `package p
+func g(x int, y float32) (...) // ERROR "[.][.][.]"
+`,
+			output: func(file string) string {
+				return file + ":2: syntax error: ... is missing type\n" +
+					file + ":2: expected type, found ')'\n"
+			},
+		},
+		{
+			name: "variadic result Go 1.25 and newer",
+			source: `package p
+func g(x int, y float32) (...) // ERROR "[.][.][.]"
+`,
+			output: func(file string) string {
+				return file + ":2: syntax error: ... is missing type\n" +
+					file + ":2: invalid use of ...\n" +
+					file + ":2: expected type, found ')'\n"
+			},
+		},
+		{
+			name: "channel send in if condition",
+			source: `package p
+var c chan int
+var v int
+func f() {
+	if c <- v { // ERROR "cannot use c <- v as value|send statement used as value"
+	}
+}
+`,
+			output: func(file string) string {
+				return file + ":5: syntax error: cannot use c <- v as value\n" +
+					file + ":5: expected boolean expression, found simple statement (missing parentheses around composite literal?)\n"
+			},
+		},
+		{
+			name: "channel send at top level",
+			source: `package p
+var c chan int
+var v int
+var _ = c <- v // ERROR "unexpected <-|send statement used as value"
+`,
+			output: func(file string) string {
+				return file + ":4: syntax error: unexpected <- after top level declaration\n" +
+					file + ":4: expected ';', found '<-'\n"
+			},
+		},
+		{
+			name: "illegal declaration character",
+			source: `package p
+var? // ERROR "invalid character U\+003F '\?'|invalid character 0x3f in input file"
+`,
+			output: func(file string) string {
+				return file + ":2: invalid character U+003F '?'\n" +
+					file + ":2: expected 'IDENT', found 'ILLEGAL'\n" +
+					file + ":2: illegal character U+003F '?'\n"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := checkExpectedErrors(tt.output(file), file, "case.go"); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestAdditionalParserRecoveryDiagnosticsFailOpen(t *testing.T) {
+	t.Run("missing primary", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+var? // ERROR "invalid character U\+003F '\?'"
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":2: expected 'IDENT', found 'ILLEGAL'\n" +
+			file + ":2: illegal character U+003F '?'\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), `no match for "invalid character`) {
+			t.Fatalf("err=%v, want missing primary to fail", err)
+		}
+	})
+
+	t.Run("primary does not match ERROR", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+var? // ERROR "different diagnostic"
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":2: invalid character U+003F '?'\n" +
+			file + ":2: expected 'IDENT', found 'ILLEGAL'\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), "expected 'IDENT', found 'ILLEGAL'") {
+			t.Fatalf("err=%v, want unmatched primary to leave recovery diagnostic visible", err)
+		}
+	})
+
+	t.Run("same line different illegal token", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+var _ = ?; var@ // ERROR "invalid character U\+003F '\?'"
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":2: invalid character U+003F '?'\n" +
+			file + ":2: expected 'IDENT', found 'ILLEGAL'\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), "expected 'IDENT', found 'ILLEGAL'") {
+			t.Fatalf("err=%v, want the unrelated @ recovery diagnostic to remain", err)
+		}
+	})
+
+	t.Run("wrong line", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+var? // ERROR "invalid character U\+003F '\?'"
+
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":2: invalid character U+003F '?'\n" +
+			file + ":3: expected 'IDENT', found 'ILLEGAL'\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), ":3: expected 'IDENT', found 'ILLEGAL'") {
+			t.Fatalf("err=%v, want wrong-line recovery to remain", err)
+		}
+	})
+
+	t.Run("near match primary", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+var? // ERROR "invalid character U\+003F '\?'"
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":2: invalid character U+003F '?'.\n" +
+			file + ":2: expected 'IDENT', found 'ILLEGAL'\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), "expected 'IDENT', found 'ILLEGAL'") {
+			t.Fatalf("err=%v, want recovery after near-match primary to remain", err)
+		}
+	})
+
+	t.Run("wrong file", func(t *testing.T) {
+		dir := t.TempDir()
+		primaryFile := filepath.Join(dir, "primary.go")
+		otherFile := filepath.Join(dir, "other.go")
+		if err := os.WriteFile(primaryFile, []byte(`package p
+var? // ERROR "invalid character U\+003F '\?'"
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(otherFile, []byte("package p\nvar x int\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := primaryFile + ":2: invalid character U+003F '?'\n" +
+			otherFile + ":2: expected 'IDENT', found 'ILLEGAL'\n"
+		err := checkExpectedErrorsForFiles(output, []diagnosticSource{
+			{full: primaryFile, short: "primary.go"},
+			{full: otherFile, short: "other.go"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "other.go:2: expected 'IDENT', found 'ILLEGAL'") {
+			t.Fatalf("err=%v, want wrong-file recovery to remain", err)
+		}
+	})
+
+	t.Run("line directive", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+//line remapped.go:2
+var? // ERROR "invalid character U\+003F '\?'"
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":3: invalid character U+003F '?'\n" +
+			file + ":3: expected 'IDENT', found 'ILLEGAL'\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), "expected 'IDENT', found 'ILLEGAL'") {
+			t.Fatalf("err=%v, want line-remapped recovery to remain", err)
+		}
+	})
+}
+
 func TestCheckExpectedErrorsScopesImportAlias(t *testing.T) {
 	tests := []struct {
 		name, src string
@@ -830,6 +1032,37 @@ func TestDiscardPairedParserDiagnosticsIsExactMultiset(t *testing.T) {
 	want := []string{exact, wrongLine, wrongFile, similar}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("discardPairedParserDiagnostics()=%v, want %v", got, want)
+	}
+
+	identifier := fileA + ":2: expected 'IDENT', found 'ILLEGAL'"
+	illegal := fileA + ":2: illegal character U+003F '?'"
+	pairs = []parserRecoveryPair{
+		{file: canonicalDiagnosticPath(fileA), line: 2, secondaries: []string{"expected 'IDENT', found 'ILLEGAL'"}},
+		{file: canonicalDiagnosticPath(fileA), line: 2, secondaries: []string{"illegal character U+003F '?'"}},
+	}
+	got = discardPairedParserDiagnostics([]string{identifier, identifier, illegal, illegal}, resolver, pairs)
+	want = []string{identifier, illegal}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("independent groups=%v, want %v", got, want)
+	}
+}
+
+func TestDiagnosticPathResolverRejectsUnknownAndAmbiguousSources(t *testing.T) {
+	dir := t.TempDir()
+	left := filepath.Join(dir, "left", "case.go")
+	right := filepath.Join(dir, "right", "case.go")
+	resolver := newDiagnosticPathResolver([]diagnosticSource{
+		{full: left, short: "case.go"},
+		{full: right, short: "case.go"},
+	})
+	if _, ok := resolver.resolve("case.go"); ok {
+		t.Fatal("ambiguous short path resolved")
+	}
+	if _, ok := resolver.resolve(filepath.Join(dir, "unknown", "case.go")); ok {
+		t.Fatal("unknown absolute path resolved")
+	}
+	if got, ok := resolver.resolve(left); !ok || got != canonicalDiagnosticPath(left) {
+		t.Fatalf("known absolute path resolved to %q, %v", got, ok)
 	}
 }
 

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -1130,8 +1130,16 @@ func TestCheckExpectedErrorsScopesPackageClauseAliases(t *testing.T) {
 			name:   "different declaration",
 			source: "type Other int32 // ERROR \"package statement must be first|package clause\"\n",
 			output: func(file string) string {
-				return file + ":1: expected 'package', found 'type'\n" +
-					file + ":1: expected ';', found int32"
+				return file + ":1: expected 'package', found 'type'"
+			},
+		},
+		{
+			name: "line directive physical logical collision",
+			source: "type MyInt int32 // ERROR \"package statement must be first|package clause\"\n" +
+				"//line case.go:1\n" +
+				"type Other int32\n",
+			output: func(file string) string {
+				return file + ":1: expected 'package', found 'type'"
 			},
 		},
 		{
@@ -1147,8 +1155,7 @@ func TestCheckExpectedErrorsScopesPackageClauseAliases(t *testing.T) {
 			name:   "different malformed token",
 			source: "package@ // ERROR \"unexpected %|package name must be an identifier|after package clause|expected declaration\"\n",
 			output: func(file string) string {
-				return file + ":1: expected 'IDENT', found '%'\n" +
-					file + ":1: expected ';', found 'EOF'"
+				return file + ":1: expected 'IDENT', found '%'"
 			},
 		},
 	}

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -730,6 +730,7 @@ func TestCheckExpectedErrorsDiscardsPairedDeclarationRecoveryDiagnostics(t *test
 	tests := []struct {
 		name      string
 		source    string
+		wrong     string
 		line      int
 		primary   string
 		secondary string
@@ -737,6 +738,7 @@ func TestCheckExpectedErrorsDiscardsPairedDeclarationRecoveryDiagnostics(t *test
 		{
 			name:      "missing package clause",
 			source:    "func main() { // ERROR \"package\"\n}\n",
+			wrong:     "func other() { // ERROR \"package\"\n}\n",
 			line:      1,
 			primary:   "expected 'package', found 'func'",
 			secondary: "expected ';', found '('",
@@ -745,6 +747,9 @@ func TestCheckExpectedErrorsDiscardsPairedDeclarationRecoveryDiagnostics(t *test
 			name: "top-level composite literal",
 			source: `package p
 var x map[string]string{"a":"b"} // ERROR "unexpected { at end of statement|unexpected { after top level declaration|expected ';' or newline after top level declaration"
+`,
+			wrong: `package p
+var y map[string]string{"a":"b"} // ERROR "unexpected { at end of statement|unexpected { after top level declaration|expected ';' or newline after top level declaration"
 `,
 			line:      2,
 			primary:   "syntax error: unexpected { after top level declaration",
@@ -764,8 +769,21 @@ var x map[string]string{"a":"b"} // ERROR "unexpected { at end of statement|unex
 			if err := checkExpectedErrors(fmt.Sprintf("%s:%d: %s\n", file, tt.line, tt.secondary), file, "case.go"); err == nil {
 				t.Fatal("secondary diagnostic passed without its primary")
 			}
+			if got := parserRecoverySecondaries(tt.primary); got != nil {
+				t.Fatalf("source-dependent primary activated source-independent recovery: %v", got)
+			}
 			if got := parserRecoverySecondaries(tt.primary + "."); got != nil {
 				t.Fatalf("near-match primary activated parser recovery: %v", got)
+			}
+
+			wrongFile := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(wrongFile, []byte(tt.wrong), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			wrongOutput := fmt.Sprintf("%s:%d: %s\n%s:%d: %s\n", wrongFile, tt.line, tt.primary, wrongFile, tt.line, tt.secondary)
+			err := checkExpectedErrors(wrongOutput, wrongFile, "case.go")
+			if err == nil || !strings.Contains(err.Error(), tt.secondary) {
+				t.Fatalf("wrong source shape discarded secondary: %v", err)
 			}
 		})
 	}

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -1110,6 +1110,62 @@ func TestCheckExpectedErrorsScopesImportAlias(t *testing.T) {
 	}
 }
 
+func TestCheckExpectedErrorsScopesPackageClauseAliases(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		output func(string) string
+		wantOK bool
+	}{
+		{
+			name:   "missing package clause",
+			source: "type MyInt int32 // ERROR \"package statement must be first|package clause\"\n",
+			output: func(file string) string {
+				return file + ":1: expected 'package', found 'type'\n" +
+					file + ":1: expected ';', found int32"
+			},
+			wantOK: true,
+		},
+		{
+			name:   "different declaration",
+			source: "type Other int32 // ERROR \"package statement must be first|package clause\"\n",
+			output: func(file string) string {
+				return file + ":1: expected 'package', found 'type'\n" +
+					file + ":1: expected ';', found int32"
+			},
+		},
+		{
+			name:   "malformed package clause",
+			source: "package% // ERROR \"unexpected %|package name must be an identifier|after package clause|expected declaration\"\n",
+			output: func(file string) string {
+				return file + ":1: expected 'IDENT', found '%'\n" +
+					file + ":1: expected ';', found 'EOF'"
+			},
+			wantOK: true,
+		},
+		{
+			name:   "different malformed token",
+			source: "package@ // ERROR \"unexpected %|package name must be an identifier|after package clause|expected declaration\"\n",
+			output: func(file string) string {
+				return file + ":1: expected 'IDENT', found '%'\n" +
+					file + ":1: expected ';', found 'EOF'"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := checkExpectedErrors(tt.output(file), file, "case.go")
+			if tt.wantOK && err != nil || !tt.wantOK && err == nil {
+				t.Fatalf("err=%v, wantOK=%v", err, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestDiscardPairedParserDiagnosticsIsExactMultiset(t *testing.T) {
 	dir := t.TempDir()
 	fileA := filepath.Join(dir, "a", "case.go")

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -869,6 +869,27 @@ var? // ERROR "invalid character U\+003F '\?'|invalid character 0x3f in input fi
 }
 
 func TestAdditionalParserRecoveryDiagnosticsFailOpen(t *testing.T) {
+	t.Run("one ERROR authorizes one recovery group", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+func f() {
+	if a := 10 { // ERROR "cannot use [ab] := 10 as value"
+	}
+}
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":3: syntax error: cannot use a := 10 as value\n" +
+			file + ":3: syntax error: cannot use b := 10 as value\n" +
+			file + ":3: expected boolean expression, found assignment (missing parentheses around composite literal?)\n" +
+			file + ":3: expected boolean or range expression, found assignment (missing parentheses around composite literal?)\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), "expected boolean or range expression") {
+			t.Fatalf("err=%v, want the second matching primary's recovery diagnostic to remain", err)
+		}
+	})
+
 	t.Run("missing primary", func(t *testing.T) {
 		file := filepath.Join(t.TempDir(), "case.go")
 		source := `package p
@@ -950,6 +971,27 @@ var? // ERROR "invalid character U\+003F '\?'"
 		}
 	})
 
+	t.Run("wrong channel source shape", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "case.go")
+		source := `package p
+var c chan int
+var v int
+func f() {
+	if (c <- v) { // ERROR "cannot use c <- v as value"
+	}
+}
+`
+		if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output := file + ":5: syntax error: cannot use c <- v as value\n" +
+			file + ":5: expected boolean expression, found simple statement (missing parentheses around composite literal?)\n"
+		err := checkExpectedErrors(output, file, "case.go")
+		if err == nil || !strings.Contains(err.Error(), "expected boolean expression") {
+			t.Fatalf("err=%v, want recovery for a different source shape to remain", err)
+		}
+	})
+
 	t.Run("wrong file", func(t *testing.T) {
 		dir := t.TempDir()
 		primaryFile := filepath.Join(dir, "primary.go")
@@ -989,6 +1031,59 @@ var? // ERROR "invalid character U\+003F '\?'"
 			t.Fatalf("err=%v, want line-remapped recovery to remain", err)
 		}
 	})
+}
+
+func TestParserRecoverySourceCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "URL before ERROR comment",
+			source: `var _ = "http://example.com" // ERROR "broken"`,
+			want:   `var _ = "http://example.com"`,
+		},
+		{
+			name:   "URL without ERROR comment",
+			source: `var _ = "http://example.com"`,
+			want:   `var _ = "http://example.com"`,
+		},
+		{
+			name:   "GC ERRORAUTO comment",
+			source: `var _ = "http://example.com" // GC_ERRORAUTO "broken"`,
+			want:   `var _ = "http://example.com"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parserRecoverySourceCode(tt.source); got != tt.want {
+				t.Fatalf("parserRecoverySourceCode(%q)=%q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasLineDirective(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{name: "line comment", data: "\t//line remapped.go:1\n", want: true},
+		{name: "block comment", data: "  /*line remapped.go:1*/\n", want: true},
+		{name: "block comment after source", data: "x /*line remapped.go:1*/\n", want: true},
+		{name: "missing separator", data: "//linefoo.go:1\n", want: false},
+		{name: "after source", data: "x //line remapped.go:1\n", want: false},
+		{name: "inside string", data: `var _ = "/*line remapped.go:1*/"` + "\n", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasLineDirective([]byte(tt.data)); got != tt.want {
+				t.Fatalf("hasLineDirective(%q)=%v, want %v", tt.data, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestCheckExpectedErrorsScopesImportAlias(t *testing.T) {

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -1074,6 +1074,8 @@ func TestHasLineDirective(t *testing.T) {
 		{name: "block comment", data: "  /*line remapped.go:1*/\n", want: true},
 		{name: "block comment after source", data: "x /*line remapped.go:1*/\n", want: true},
 		{name: "missing separator", data: "//linefoo.go:1\n", want: false},
+		{name: "line comment without line number", data: "//line remapped\n", want: false},
+		{name: "block comment without line number", data: "/*line remapped*/\n", want: false},
 		{name: "after source", data: "x //line remapped.go:1\n", want: false},
 		{name: "inside string", data: `var _ = "/*line remapped.go:1*/"` + "\n", want: false},
 	}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2103,10 +2103,6 @@ xfails:
     reason: gc-specific pragma optimization diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug050.go
-    reason: llgo parser emits an additional malformed-declaration diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: devirt.go
     reason: gc-specific SSA devirtualization diagnostics are not implemented by llgo
   - version: go1.26
@@ -2309,10 +2305,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue34723.go
     reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
-  - version: go1.26
-    directive: errorcheck
-    case: syntax/vareq1.go
-    reason: llgo parser recovery emits an additional diagnostic after the expected syntax error
   - version: go1.26
     directive: errorcheck
     case: escape_bloop.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1867,10 +1867,6 @@ xfails:
     reason: llgo parser recovery emits additional malformed-channel diagnostics
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue4776.go
-    reason: llgo parser uses a different missing-package-clause diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: escape2n.go
     reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
   - version: go1.26
@@ -1985,10 +1981,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/notinheap2.go
     reason: gc-specific notinheap allocation diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue13266.go
-    reason: llgo parser uses a different malformed-package-clause diagnostic
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue19667.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2203,14 +2203,6 @@ xfails:
     reason: llgo parser recovery emits additional malformed-declaration diagnostics
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug228.go
-    reason: llgo parser emits an additional malformed-parameter diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: syntax/chan1.go
-    reason: llgo parser recovery emits additional malformed-channel diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: escape_field.go
     reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
   - version: go1.26
@@ -2269,10 +2261,6 @@ xfails:
     directive: errorcheck
     case: internal/runtime/sys/inlinegcpc.go
     reason: gc runtime inlining diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue11610.go
-    reason: llgo parser reports additional illegal-character diagnostics
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue22164.go


### PR DESCRIPTION
## Summary

- recognize the equivalent go/parser spellings for the missing and malformed package-clause cases
- pair only the exact follow-on diagnostics for `fixedbugs/issue4776.go` and `fixedbugs/issue13266.go`
- remove those two Go 1.26 errorcheck xfails

## Correctness

Both aliases require the exact primary and ERROR source shape. Recovery diagnostics remain canonical-file, physical-line, and one-use scoped. Files with line directives fail open; only-primary counterexamples verify that a different declaration/token and a physical/logical line collision cannot activate an alias.

## Validation

- `go test ./test/goroot -count=1`
- both GOROOT cases on Go 1.24.11, 1.25.0, 1.26.0, and 1.26.5
- the remaining 141 Go 1.26 compile/errorcheck xfails
- `git diff --check`

## Scope and dependencies

This PR depends on #2222 for exact grouped parser-recovery handling. The dependency is recorded here rather than in the title. It is intentionally separate from #2223 and the malformed-receiver work, does not overlap #2218/#2219/#2220/#2201 cases, and contains no CI, wasm, or DWARF changes.