### PR TITLE
ssa: saturate float-to-uint32 conversions

### DIFF
--- a/cl/float_int_conversion_compile_test.go
+++ b/cl/float_int_conversion_compile_test.go
@@ -1,0 +1,44 @@
+//go:build !llgo
+
+package cl
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	llssa "github.com/goplus/llgo/ssa"
+)
+
+func TestFloatToUint32ConversionMode(t *testing.T) {
+	const src = `package floatconvert
+func Convert(x float32) uint32 { return uint32(x) }
+`
+	tests := []struct {
+		name       string
+		saturating bool
+		want       string
+		notWant    string
+	}{
+		{name: "legacy", want: "fptosi float", notWant: "fptoui float"},
+		{name: "saturating", saturating: true, want: "fptoui float", notWant: "fptosi float"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ssaPkg, _, files := buildGoSSAPkg(t, src)
+			prog := newLLSSAProgForTarget(t, &llssa.Target{
+				GOOS:                    runtime.GOOS,
+				GOARCH:                  runtime.GOARCH,
+				SaturatingFloatToUint32: tt.saturating,
+			})
+			pkg, err := NewPackage(prog, ssaPkg, files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ir := mustNamedFunction(t, pkg.Module(), "floatconvert.Convert").String()
+			if !strings.Contains(ir, tt.want) || strings.Contains(ir, tt.notWant) {
+				t.Fatalf("conversion IR does not use %s mode:\n%s", tt.name, ir)
+			}
+		})
+	}
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -188,6 +188,9 @@ type Config struct {
 	// DisableBoundsChecks disables index, slice, and slice-to-array conversion
 	// bounds checks while retaining required integer conversions and nil checks.
 	DisableBoundsChecks bool
+	// SaturatingFloatToUint32 enables Go's experimental converthash behavior
+	// for float-to-uint32 conversions.
+	SaturatingFloatToUint32 bool
 
 	// PthreadStackSize sets a custom stack size, in bytes, for pthread-backed
 	// goroutines. A zero value keeps the platform pthread default.
@@ -405,11 +408,12 @@ func Build(inv Invocation) ([]Package, error) {
 	verbose := conf.Verbose
 	patterns := slices.Clone(inv.Args)
 	target := &llssa.Target{
-		GOOS:       conf.Goos,
-		GOARCH:     conf.Goarch,
-		Target:     conf.Target,
-		LLVMTarget: export.LLVMTarget,
-		OptLevel:   conf.OptLevel,
+		GOOS:                    conf.Goos,
+		GOARCH:                  conf.Goarch,
+		Target:                  conf.Target,
+		LLVMTarget:              export.LLVMTarget,
+		OptLevel:                conf.OptLevel,
+		SaturatingFloatToUint32: conf.SaturatingFloatToUint32,
 	}
 	tags := defaultBuildTags(conf.Goarch, conf.Target) + "," + target.ClosureEnvBuildTag()
 	if conf.PCLNMode == PCLNExternal {

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -131,6 +131,7 @@ func (c *context) collectCommonInputs(m *manifestBuilder) {
 	m.common.EmitDWARF = shouldEmitDebugInfo(c.buildConf, &c.crossCompile)
 	m.common.PCLNMode = effectivePCLNMode(c.buildConf).String()
 	m.common.DisableBoundsChecks = c.buildConf.DisableBoundsChecks
+	m.common.SaturatingFloatToUint32 = c.buildConf.SaturatingFloatToUint32
 	m.common.LocalContext = c.prog != nil && c.prog.NeedsLocalContext()
 
 	// Compiler configuration

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -112,28 +112,29 @@ func (s *envSection) empty() bool {
 }
 
 type commonSection struct {
-	AbiMode             string       `yaml:"ABI_MODE,omitempty"`
-	BuildTags           []string     `yaml:"BUILD_TAGS,omitempty"`
-	Target              string       `yaml:"TARGET,omitempty"`
-	TargetABI           string       `yaml:"TARGET_ABI,omitempty"`
-	GoGlobalDCE         bool         `yaml:"GO_GLOBAL_DCE,omitempty"`
-	EnableLTOPlugin     bool         `yaml:"ENABLE_LTO_PLUGIN,omitempty"`
-	EmitDWARF           bool         `yaml:"EMIT_DWARF,omitempty"`
-	PCLNMode            string       `yaml:"PCLN_MODE,omitempty"`
-	DisableBoundsChecks bool         `yaml:"DISABLE_BOUNDS_CHECKS,omitempty"`
-	LocalContext        bool         `yaml:"LOCAL_CONTEXT,omitempty"`
-	CC                  string       `yaml:"CC,omitempty"`
-	CCFlags             []string     `yaml:"CCFLAGS,omitempty"`
-	CFlags              []string     `yaml:"CFLAGS,omitempty"`
-	LDFlags             []string     `yaml:"LDFLAGS,omitempty"`
-	Linker              string       `yaml:"LINKER,omitempty"`
-	ExtraFiles          []fileDigest `yaml:"EXTRA_FILES,omitempty"`
+	AbiMode                 string       `yaml:"ABI_MODE,omitempty"`
+	BuildTags               []string     `yaml:"BUILD_TAGS,omitempty"`
+	Target                  string       `yaml:"TARGET,omitempty"`
+	TargetABI               string       `yaml:"TARGET_ABI,omitempty"`
+	GoGlobalDCE             bool         `yaml:"GO_GLOBAL_DCE,omitempty"`
+	EnableLTOPlugin         bool         `yaml:"ENABLE_LTO_PLUGIN,omitempty"`
+	EmitDWARF               bool         `yaml:"EMIT_DWARF,omitempty"`
+	PCLNMode                string       `yaml:"PCLN_MODE,omitempty"`
+	DisableBoundsChecks     bool         `yaml:"DISABLE_BOUNDS_CHECKS,omitempty"`
+	SaturatingFloatToUint32 bool         `yaml:"SATURATING_FLOAT_TO_UINT32,omitempty"`
+	LocalContext            bool         `yaml:"LOCAL_CONTEXT,omitempty"`
+	CC                      string       `yaml:"CC,omitempty"`
+	CCFlags                 []string     `yaml:"CCFLAGS,omitempty"`
+	CFlags                  []string     `yaml:"CFLAGS,omitempty"`
+	LDFlags                 []string     `yaml:"LDFLAGS,omitempty"`
+	Linker                  string       `yaml:"LINKER,omitempty"`
+	ExtraFiles              []fileDigest `yaml:"EXTRA_FILES,omitempty"`
 }
 
 func (s *commonSection) empty() bool {
 	return s.AbiMode == "" && len(s.BuildTags) == 0 && s.Target == "" && s.TargetABI == "" &&
 		!s.GoGlobalDCE && !s.EnableLTOPlugin && !s.EmitDWARF && s.PCLNMode == "" &&
-		!s.DisableBoundsChecks && !s.LocalContext &&
+		!s.DisableBoundsChecks && !s.SaturatingFloatToUint32 && !s.LocalContext &&
 		s.CC == "" && len(s.CCFlags) == 0 && len(s.CFlags) == 0 && len(s.LDFlags) == 0 &&
 		s.Linker == "" && len(s.ExtraFiles) == 0
 }

--- a/internal/build/fingerprint_test.go
+++ b/internal/build/fingerprint_test.go
@@ -154,6 +154,26 @@ func TestManifestBuilder_DisableBoundsChecks(t *testing.T) {
 	}
 }
 
+func TestManifestBuilder_SaturatingFloatToUint32(t *testing.T) {
+	legacy := newManifestBuilder()
+	saturating := newManifestBuilder()
+	saturating.common.SaturatingFloatToUint32 = true
+
+	if saturating.common.empty() {
+		t.Fatal("saturating float-to-uint32 conversions did not make the common section non-empty")
+	}
+	if legacy.Fingerprint() == saturating.Fingerprint() {
+		t.Fatal("saturating float-to-uint32 conversions did not change the build fingerprint")
+	}
+	data, err := decodeManifest(saturating.Build())
+	if err != nil {
+		t.Fatalf("decodeManifest: %v", err)
+	}
+	if data.Common == nil || !data.Common.SaturatingFloatToUint32 {
+		t.Fatalf("decoded common section = %#v, want saturating float-to-uint32 conversions", data.Common)
+	}
+}
+
 func TestManifestBuilder_EmptySections(t *testing.T) {
 	m := newManifestBuilder()
 	content := m.Build()

--- a/internal/goflags/gcflags.go
+++ b/internal/goflags/gcflags.go
@@ -28,9 +28,10 @@ import (
 // frontend configuration. Raw flags remain in GoBuildFlags for go/packages.
 func applyFrontendGCFlags(conf *build.Config) {
 	type frontendFlags struct {
-		goVersion string
-		nNoOpt    bool
-		lNoOpt    bool
+		goVersion               string
+		nNoOpt                  bool
+		lNoOpt                  bool
+		saturatingFloatToUint32 bool
 	}
 	var applicable *frontendFlags
 	for _, buildFlag := range conf.GoBuildFlags {
@@ -57,6 +58,8 @@ func applyFrontendGCFlags(conf *build.Config) {
 				current.lNoOpt = true
 			case strings.HasPrefix(compilerFlag, "-l="):
 				current.lNoOpt = countFlagIsOne(strings.TrimPrefix(compilerFlag, "-l="))
+			case strings.HasPrefix(compilerFlag, "-d="):
+				current.saturatingFloatToUint32 = converthashAlwaysEnabled(strings.TrimPrefix(compilerFlag, "-d="))
 			}
 		}
 		applicable = current
@@ -70,6 +73,24 @@ func applyFrontendGCFlags(conf *build.Config) {
 	if applicable.nNoOpt || applicable.lNoOpt {
 		conf.OptLevel = optlevel.O0
 	}
+	conf.SaturatingFloatToUint32 = applicable.saturatingFloatToUint32
+}
+
+func converthashAlwaysEnabled(debugFlags string) bool {
+	enabled := false
+	for _, flag := range strings.Split(debugFlags, ",") {
+		value, ok := strings.CutPrefix(flag, "converthash=")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(value) {
+		case "y", "qy":
+			enabled = true
+		default:
+			enabled = false
+		}
+	}
+	return enabled
 }
 
 func countFlagEnabled(value string) bool {

--- a/internal/goflags/gcflags.go
+++ b/internal/goflags/gcflags.go
@@ -32,6 +32,7 @@ func applyFrontendGCFlags(conf *build.Config) {
 		nNoOpt                  bool
 		lNoOpt                  bool
 		saturatingFloatToUint32 bool
+		debug                   compilerDebugFlags
 	}
 	var applicable *frontendFlags
 	for _, buildFlag := range conf.GoBuildFlags {
@@ -45,7 +46,7 @@ func applyFrontendGCFlags(conf *build.Config) {
 			// cannot map them to one global frontend configuration safely.
 			continue
 		}
-		current := new(frontendFlags)
+		current := &frontendFlags{debug: make(compilerDebugFlags)}
 		for _, compilerFlag := range fields {
 			switch {
 			case strings.HasPrefix(compilerFlag, "-lang="):
@@ -59,9 +60,10 @@ func applyFrontendGCFlags(conf *build.Config) {
 			case strings.HasPrefix(compilerFlag, "-l="):
 				current.lNoOpt = countFlagIsOne(strings.TrimPrefix(compilerFlag, "-l="))
 			case strings.HasPrefix(compilerFlag, "-d="):
-				current.saturatingFloatToUint32 = converthashAlwaysEnabled(strings.TrimPrefix(compilerFlag, "-d="))
+				current.debug.apply(strings.TrimPrefix(compilerFlag, "-d="))
 			}
 		}
+		current.saturatingFloatToUint32 = bisectPatternAlwaysEnabled(current.debug["converthash"])
 		applicable = current
 	}
 	if applicable == nil {
@@ -76,21 +78,48 @@ func applyFrontendGCFlags(conf *build.Config) {
 	conf.SaturatingFloatToUint32 = applicable.saturatingFloatToUint32
 }
 
-func converthashAlwaysEnabled(debugFlags string) bool {
-	enabled := false
-	for _, flag := range strings.Split(debugFlags, ",") {
-		value, ok := strings.CutPrefix(flag, "converthash=")
+// compilerDebugFlags stores the last value of each comma-separated -d setting.
+// The syntax is shared by all cmd/compile debug settings; a setting without an
+// explicit value is equivalent to setting it to 1.
+type compilerDebugFlags map[string]string
+
+func (f compilerDebugFlags) apply(list string) {
+	for _, setting := range strings.Split(list, ",") {
+		name, value, ok := strings.Cut(setting, "=")
 		if !ok {
-			continue
+			value = "1"
 		}
-		switch strings.ToLower(value) {
-		case "y", "qy":
-			enabled = true
-		default:
-			enabled = false
+		if name != "" {
+			f[name] = value
 		}
 	}
-	return enabled
+}
+
+// bisectPatternAlwaysEnabled reports whether a Go internal/bisect pattern is
+// one of the global forms that enables every candidate. Hash-debug settings
+// such as converthash, fmahash, and loopvarhash all use this syntax. LLGo can
+// map these global forms to a build-wide option; selective hash patterns remain
+// forwarded to go/packages but cannot be represented by that option.
+func bisectPatternAlwaysEnabled(pattern string) bool {
+	// q suppresses match reports but does not change which candidates match.
+	if strings.HasPrefix(pattern, "q") {
+		pattern = pattern[1:]
+	}
+	// v requests visible reports and may be repeated by the bisect driver.
+	for strings.HasPrefix(pattern, "v") {
+		pattern = pattern[1:]
+	}
+
+	enable := true
+	for strings.HasPrefix(pattern, "!") {
+		enable = !enable
+		pattern = pattern[1:]
+	}
+	if pattern == "n" { // n is the bisect alias for !y.
+		enable = !enable
+		pattern = "y"
+	}
+	return enable && pattern == "y"
 }
 
 func countFlagEnabled(value string) bool {

--- a/internal/goflags/gobuild_test.go
+++ b/internal/goflags/gobuild_test.go
@@ -112,15 +112,22 @@ func TestApplyBuildFlagsInvalidParallelismIsAtomic(t *testing.T) {
 
 func TestApplyBuildFlagsFrontendGCFlagSemantics(t *testing.T) {
 	tests := []struct {
-		name      string
-		flags     []string
-		wantLevel optlevel.Level
-		wantGo    string
+		name           string
+		flags          []string
+		wantLevel      optlevel.Level
+		wantGo         string
+		wantSaturating bool
 	}{
 		{name: "unpatterned", flags: []string{"-gcflags=-lang=go1.25 -N"}, wantLevel: optlevel.O0, wantGo: "go1.25"},
 		{name: "all pattern", flags: []string{"-gcflags=all='-lang=go1.24' '-l'"}, wantLevel: optlevel.O0, wantGo: "go1.24"},
 		{name: "unrelated pattern", flags: []string{"-gcflags=example.com/other=-N"}},
 		{name: "last applicable list wins", flags: []string{"-gcflags=-N -lang=go1.23", "-gcflags="}},
+		{name: "converthash enabled", flags: []string{"-gcflags=-d=converthash=qy"}, wantSaturating: true},
+		{name: "converthash enabled in debug list", flags: []string{"-gcflags=-d=other=1,converthash=y"}, wantSaturating: true},
+		{name: "converthash disabled", flags: []string{"-gcflags=-d=converthash=qn"}},
+		{name: "last converthash debug value wins", flags: []string{"-gcflags=-d=converthash=qy,converthash=qn"}},
+		{name: "last converthash list wins", flags: []string{"-gcflags=-d=converthash=qy", "-gcflags=-d=converthash=qn"}},
+		{name: "package converthash ignored", flags: []string{"-gcflags=example.com/other=-d=converthash=qy"}},
 		{name: "N false", flags: []string{"-gcflags=-N=false"}},
 		{name: "N zero", flags: []string{"-gcflags=-N=0"}},
 		{name: "l false", flags: []string{"-gcflags=-l=false"}},
@@ -135,8 +142,8 @@ func TestApplyBuildFlagsFrontendGCFlagSemantics(t *testing.T) {
 			if err := ApplyBuildFlags(conf, tt.flags); err != nil {
 				t.Fatal(err)
 			}
-			if conf.OptLevel != tt.wantLevel || conf.GoVersion != tt.wantGo {
-				t.Fatalf("frontend config = (%v, %q), want (%v, %q)", conf.OptLevel, conf.GoVersion, tt.wantLevel, tt.wantGo)
+			if conf.OptLevel != tt.wantLevel || conf.GoVersion != tt.wantGo || conf.SaturatingFloatToUint32 != tt.wantSaturating {
+				t.Fatalf("frontend config = (%v, %q, saturating=%v), want (%v, %q, saturating=%v)", conf.OptLevel, conf.GoVersion, conf.SaturatingFloatToUint32, tt.wantLevel, tt.wantGo, tt.wantSaturating)
 			}
 		})
 	}

--- a/internal/goflags/gobuild_test.go
+++ b/internal/goflags/gobuild_test.go
@@ -124,7 +124,13 @@ func TestApplyBuildFlagsFrontendGCFlagSemantics(t *testing.T) {
 		{name: "last applicable list wins", flags: []string{"-gcflags=-N -lang=go1.23", "-gcflags="}},
 		{name: "converthash enabled", flags: []string{"-gcflags=-d=converthash=qy"}, wantSaturating: true},
 		{name: "converthash enabled in debug list", flags: []string{"-gcflags=-d=other=1,converthash=y"}, wantSaturating: true},
+		{name: "unrelated debug flag preserves converthash", flags: []string{"-gcflags=-d=converthash=qy -d=other=1"}, wantSaturating: true},
+		{name: "converthash verbose all", flags: []string{"-gcflags=-d=converthash=vy"}, wantSaturating: true},
+		{name: "converthash quiet verbose all", flags: []string{"-gcflags=-d=converthash=qvy"}, wantSaturating: true},
+		{name: "converthash double negation", flags: []string{"-gcflags=-d=converthash=!!y"}, wantSaturating: true},
+		{name: "converthash negated no", flags: []string{"-gcflags=-d=converthash=!n"}, wantSaturating: true},
 		{name: "converthash disabled", flags: []string{"-gcflags=-d=converthash=qn"}},
+		{name: "converthash uppercase is invalid", flags: []string{"-gcflags=-d=converthash=QY"}},
 		{name: "last converthash debug value wins", flags: []string{"-gcflags=-d=converthash=qy,converthash=qn"}},
 		{name: "last converthash list wins", flags: []string{"-gcflags=-d=converthash=qy", "-gcflags=-d=converthash=qn"}},
 		{name: "package converthash ignored", flags: []string{"-gcflags=example.com/other=-d=converthash=qy"}},
@@ -144,6 +150,47 @@ func TestApplyBuildFlagsFrontendGCFlagSemantics(t *testing.T) {
 			}
 			if conf.OptLevel != tt.wantLevel || conf.GoVersion != tt.wantGo || conf.SaturatingFloatToUint32 != tt.wantSaturating {
 				t.Fatalf("frontend config = (%v, %q, saturating=%v), want (%v, %q, saturating=%v)", conf.OptLevel, conf.GoVersion, conf.SaturatingFloatToUint32, tt.wantLevel, tt.wantGo, tt.wantSaturating)
+			}
+		})
+	}
+}
+
+func TestCompilerDebugFlagsLastValueWins(t *testing.T) {
+	got := make(compilerDebugFlags)
+	got.apply("fmahash=qy,loopvarhash=n,checkptr")
+	got.apply("fmahash=qn")
+	want := compilerDebugFlags{
+		"fmahash":     "qn",
+		"loopvarhash": "n",
+		"checkptr":    "1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("compiler debug flags = %#v, want %#v", got, want)
+	}
+}
+
+func TestBisectPatternAlwaysEnabled(t *testing.T) {
+	tests := []struct {
+		pattern string
+		want    bool
+	}{
+		{pattern: "y", want: true},
+		{pattern: "qy", want: true},
+		{pattern: "vy", want: true},
+		{pattern: "qvvy", want: true},
+		{pattern: "!!y", want: true},
+		{pattern: "!n", want: true},
+		{pattern: ""},
+		{pattern: "n"},
+		{pattern: "qn"},
+		{pattern: "!y"},
+		{pattern: "01"},
+		{pattern: "QY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			if got := bisectPatternAlwaysEnabled(tt.pattern); got != tt.want {
+				t.Fatalf("bisectPatternAlwaysEnabled(%q) = %v, want %v", tt.pattern, got, tt.want)
 			}
 		})
 	}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1084,10 +1084,12 @@ func castFloatToInt(b Builder, x llvm.Value, typ Type) llvm.Value {
 	dstSize := b.Prog.td.TypeAllocSize(typ.ll)
 	if typ.kind == vkUnsigned {
 		if dstSize < 4 {
+			// Go's converthash transition only changes float-to-uint32.
+			// Preserve the existing signed conversion and truncation for uint8/uint16.
 			tmp := castFloatToSignedInt(b, x, b.Prog.Int32(), 32)
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}
-		if dstSize == 4 {
+		if dstSize == 4 && !b.Prog.Target().SaturatingFloatToUint32 {
 			tmp := castFloatToSignedInt(b, x, b.Prog.Int64(), 64)
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -27,12 +27,13 @@ import (
 // -----------------------------------------------------------------------------
 
 type Target struct {
-	GOOS       string
-	GOARCH     string
-	GOARM      string // "5", "6", "7" (default)
-	Target     string // target name from -target flag (e.g., "esp32", "arm7tdmi", "wasi")
-	LLVMTarget string // physical LLVM target selected by a target configuration
-	OptLevel   optlevel.Level
+	GOOS                    string
+	GOARCH                  string
+	GOARM                   string // "5", "6", "7" (default)
+	Target                  string // target name from -target flag (e.g., "esp32", "arm7tdmi", "wasi")
+	LLVMTarget              string // physical LLVM target selected by a target configuration
+	OptLevel                optlevel.Level
+	SaturatingFloatToUint32 bool
 }
 
 func (p *Target) targetInfo() (llvm.TargetData, llvm.TargetMachine) {

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2046,11 +2046,6 @@ xfails:
     directive: run
     case: uintptrescapes3.go
     reason: uintptr escape round trip dereferences a nil pointer on darwin/arm64
-  - version: go1.26
-    platform: darwin/arm64
-    directive: run
-    case: convert5.go
-    reason: out-of-range float-to-uint32 conversions wrap instead of producing zero on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: noinit.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1371,16 +1371,6 @@ xfails:
     directive: run
     case: fixedbugs/issue31546.go
     reason: reflection exposes the initializer value of a blank struct field instead of zero on linux/amd64
-  - version: go1.26
-    platform: darwin/arm64
-    directive: run
-    case: convert5.go
-    reason: out-of-range float-to-uint32 conversions wrap instead of producing zero on darwin/arm64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: convert5.go
-    reason: out-of-range float-to-uint32 conversions wrap instead of producing zero on linux/amd64
   - platform: darwin/arm64
     directive: runoutput
     case: rangegen.go


### PR DESCRIPTION
Go 1.26 `convert5.go` selects the new saturating float-to-uint32 behavior with `-gcflags=-d=converthash=qy`. LLGo previously ignored that frontend flag and always used its legacy int64-then-truncate path.

Parse cmd/compile `-d` settings generically in `internal/goflags`, with Go-compatible last-value-wins behavior. Global hash-debug patterns share the `internal/bisect` syntax, so `q`, repeated `v`, `!`, and the `n`/`y` aliases are handled independently of `converthash`; the same parser can be reused by `fmahash`, `loopvarhash`, and other hash-debug settings. LLGo maps only patterns that enable every candidate to its build-wide option, while selective hash patterns remain forwarded to `go/packages`.

Carry the typed setting through the build configuration and SSA target, and include it in the build cache fingerprint. The default conversion path remains unchanged, so existing programs and demos keep their target-compatible legacy results; only explicitly flagged builds use the guarded unsigned conversion that clamps negative and out-of-range values.

This removes the Go 1.26 macOS/arm64 and Linux/amd64 xfails for `convert5.go`.

Validation:
- GOROOT `convert5.go` with Go 1.26.5 and an empty xfail file on macOS/arm64 and Linux/amd64
- review counterexamples `_demo/go/issue1538` and `_demo/go/issue1538-floatcvtuint-over` in default mode on both platforms
- `go test ./internal/goflags`
- focused build fingerprint and legacy/saturating IR checks
- full `go test ./ssa`
- Go 1.26 compiler acceptance checked for the supported global bisect-pattern spellings

The initial unconditional implementation failed the two `issue1538` demos. This version deliberately preserves their default behavior and enables saturation only for an applicable explicit compiler flag.
