### PR TITLE
build: schedule package initialization in Go order

### DIFF
--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -652,6 +652,12 @@ func TestPkgKindOf(t *testing.T) {
 	if v, _ := PkgKindOf(pkg); v != PkgNoInit {
 		t.Fatal("PkgKindOf foo:", v)
 	}
+	if PkgSkipsInit(PkgNormal) {
+		t.Fatal("normal package skips initialization")
+	}
+	if !PkgSkipsInit(PkgNoInit) || !PkgSkipsInit(PkgDeclOnly) {
+		t.Fatal("noinit/decl-only package does not skip initialization")
+	}
 }
 
 func TestIsAny(t *testing.T) {

--- a/cl/import.go
+++ b/cl/import.go
@@ -96,6 +96,12 @@ func PkgKindOf(pkg *types.Package) (int, string) {
 	return kind, param
 }
 
+// PkgSkipsInit reports whether packages of kind are excluded from Go package
+// initialization.
+func PkgSkipsInit(kind int) bool {
+	return kind >= PkgNoInit
+}
+
 // decl: a package that only contains declarations
 // noinit: a package that does not need to be initialized
 func pkgKind(v string) (int, string) {

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -708,7 +708,7 @@ func (p *context) funcKind(vfn ssa.Value) int {
 func (p *context) pkgNoInit(pkg *types.Package) bool {
 	p.ensureLoaded(pkg)
 	if i, ok := p.loaded[pkg]; ok {
-		return i.kind >= PkgNoInit
+		return PkgSkipsInit(i.kind)
 	}
 	return false
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1392,10 +1392,15 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 		funcInfo = prepareFuncInfoTableRecords(collectFuncInfo(linkedOrder), nil)
 		pcLineInfo = collectPCLineInfo(linkedOrder)
 	}
+	packageInits, err := linkedPackageInitNames(pkg, linkedOrder)
+	if err != nil {
+		return err
+	}
 	entryPkg := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
 		rtInit:        needRuntime,
 		pyInit:        needPyInit,
 		abiInit:       needAbiInit,
+		packageInits:  packageInits,
 		methodByIndex: methodByIndex,
 		methodByName:  methodByName,
 		abiSymbols:    linkedModuleGlobals(linkedOrder),

--- a/internal/build/init_order.go
+++ b/internal/build/init_order.go
@@ -1,0 +1,123 @@
+//go:build !llgo
+// +build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/goplus/llgo/cl"
+	"github.com/goplus/llgo/internal/packages"
+	llssa "github.com/goplus/llgo/ssa"
+)
+
+// packageInitOrder returns the packages reachable from root in the order in
+// which Go initializes them: among packages whose imports are initialized,
+// choose the one with the lexicographically first import path.
+func packageInitOrder(root *packages.Package) ([]*packages.Package, error) {
+	if root == nil {
+		return nil, nil
+	}
+
+	seen := make(map[*packages.Package]bool)
+	var all []*packages.Package
+	var collect func(*packages.Package)
+	collect = func(pkg *packages.Package) {
+		if pkg == nil || seen[pkg] {
+			return
+		}
+		seen[pkg] = true
+		all = append(all, pkg)
+		for _, imported := range pkg.Imports {
+			collect(imported)
+		}
+	}
+	collect(root)
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].PkgPath != all[j].PkgPath {
+			return all[i].PkgPath < all[j].PkgPath
+		}
+		return all[i].ID < all[j].ID
+	})
+
+	remaining := make(map[*packages.Package]int, len(all))
+	importers := make(map[*packages.Package][]*packages.Package, len(all))
+	for _, pkg := range all {
+		imports := make(map[*packages.Package]bool, len(pkg.Imports))
+		for _, imported := range pkg.Imports {
+			if imported == nil || !seen[imported] || imports[imported] {
+				continue
+			}
+			imports[imported] = true
+			remaining[pkg]++
+			importers[imported] = append(importers[imported], pkg)
+		}
+	}
+
+	order := make([]*packages.Package, 0, len(all))
+	initialized := make(map[*packages.Package]bool, len(all))
+	for len(order) != len(all) {
+		var next *packages.Package
+		for _, pkg := range all {
+			if !initialized[pkg] && remaining[pkg] == 0 {
+				next = pkg
+				break
+			}
+		}
+		if next == nil {
+			return nil, fmt.Errorf("package initialization graph rooted at %s contains a cycle", root.PkgPath)
+		}
+		initialized[next] = true
+		order = append(order, next)
+		for _, importer := range importers[next] {
+			remaining[importer]--
+		}
+	}
+	return order, nil
+}
+
+func linkedPackageInitNames(root *packages.Package, linked []Package) ([]string, error) {
+	order, err := packageInitOrder(root)
+	if err != nil {
+		return nil, err
+	}
+	builtByID := make(map[string]Package, len(linked))
+	for _, pkg := range linked {
+		if pkg != nil && pkg.Package != nil {
+			builtByID[pkg.ID] = pkg
+		}
+	}
+
+	names := make([]string, 0, len(order))
+	for _, pkg := range order {
+		if pkg == root {
+			continue
+		}
+		built := builtByID[pkg.ID]
+		if built == nil || built.SSA == nil || built.SSA.Func("init") == nil || pkg.Types == nil {
+			continue
+		}
+		if kind, _ := cl.PkgKindOf(pkg.Types); cl.PkgSkipsInit(kind) {
+			continue
+		}
+		names = append(names, llssa.FullName(pkg.Types, "init"))
+	}
+	return names, nil
+}

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -39,6 +39,7 @@ type genConfig struct {
 	rtInit        bool
 	pyInit        bool
 	abiInit       int
+	packageInits  []string
 	methodByIndex map[int]none
 	methodByName  map[string]none
 	abiSymbols    map[string]none
@@ -110,6 +111,11 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 
 	mainInit := declareNoArgFunc(mainPkg, pkgPath+".init")
 	mainMain := declareNoArgFunc(mainPkg, pkgPath+".main")
+	packageInits := make([]llssa.Function, len(cfg.packageInits))
+	for i, name := range cfg.packageInits {
+		packageInits[i] = declareNoArgFunc(mainPkg, name)
+	}
+	defineRootInitTask(mainPkg, pkgPath)
 
 	if ctx.buildConf.BuildMode != BuildModeExe {
 		initArraySection := ""
@@ -120,6 +126,7 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 		// The C test runner supplies argc/argv before calling the generated
 		// test main package's init and main functions.
 		if ctx.mode != ModeTest {
+			inits = append(inits, packageInits...)
 			inits = append(inits, mainInit)
 		}
 		defineLibraryRuntimeInit(mainPkg, initArraySection, inits...)
@@ -127,13 +134,14 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	}
 
 	entryFn := defineEntryFunction(ctx, mainPkg, argcVar, argvVar, argvValueType, entryFunctions{
-		runtimeStub: runtimeStub,
-		mainInit:    mainInit,
-		mainMain:    mainMain,
-		pyInit:      pyInit,
-		pyFinalize:  pyFinalize,
-		rtInit:      rtInit,
-		abiInit:     abiInit,
+		runtimeStub:  runtimeStub,
+		mainInit:     mainInit,
+		mainMain:     mainMain,
+		pyInit:       pyInit,
+		pyFinalize:   pyFinalize,
+		rtInit:       rtInit,
+		abiInit:      abiInit,
+		packageInits: packageInits,
 	})
 
 	if needStart(ctx) {
@@ -221,13 +229,14 @@ func filterAbiSymbol(abiInit int, sym *llssa.AbiSymbol) bool {
 }
 
 type entryFunctions struct {
-	runtimeStub llssa.Function
-	mainInit    llssa.Function
-	mainMain    llssa.Function
-	pyInit      llssa.Function
-	pyFinalize  llssa.Function
-	rtInit      llssa.Function
-	abiInit     llssa.Function
+	runtimeStub  llssa.Function
+	mainInit     llssa.Function
+	mainMain     llssa.Function
+	pyInit       llssa.Function
+	pyFinalize   llssa.Function
+	rtInit       llssa.Function
+	abiInit      llssa.Function
+	packageInits []llssa.Function
 }
 
 // defineEntryFunction creates the program's entry function. The name is
@@ -271,6 +280,9 @@ func defineEntryFunction(ctx *context, pkg llssa.Package, argcVar, argvVar llssa
 		b.Call(fns.abiInit.Expr)
 	}
 	b.Call(fns.runtimeStub.Expr)
+	for _, init := range fns.packageInits {
+		b.Call(init.Expr)
+	}
 	b.Call(fns.mainInit.Expr)
 	b.Call(fns.mainMain.Expr)
 	if fns.pyFinalize != nil {
@@ -294,6 +306,15 @@ func defineStart(pkg llssa.Package, entry llssa.Function, argvType llssa.Type) {
 
 func declareNoArgFunc(pkg llssa.Package, name string) llssa.Function {
 	return pkg.NewFunc(name, llssa.NoArgsNoRet, llssa.InC)
+}
+
+// defineRootInitTask exposes the header of the compiler-generated Go init task.
+// LLGo runs package initialization through guarded package init functions, so
+// there are no runtime-dispatched function entries in this compatibility task.
+func defineRootInitTask(pkg llssa.Package, pkgPath string) {
+	prog := pkg.Prog
+	taskType := prog.Struct(prog.Uint32(), prog.Uint32())
+	pkg.NewVarEx(pkgPath+"..inittask", prog.Pointer(taskType)).InitNil()
 }
 
 func defineWeakNoArgStub(pkg llssa.Package, name string) llssa.Function {

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -4,8 +4,10 @@
 package build
 
 import (
+	"go/constant"
 	"go/token"
 	"go/types"
+	"slices"
 	"strings"
 	"testing"
 
@@ -13,6 +15,7 @@ import (
 
 	"github.com/goplus/llgo/internal/packages"
 	llssa "github.com/goplus/llgo/ssa"
+	"golang.org/x/tools/go/ssa"
 )
 
 func init() {
@@ -32,7 +35,7 @@ func TestGenMainModuleExecutable(t *testing.T) {
 	}
 	pkg := &packages.Package{PkgPath: "example.com/foo", ExportFile: "foo.a"}
 	mod := genMainModule(ctx, llssa.PkgRuntime, pkg,
-		&genConfig{rtInit: true, pyInit: true})
+		&genConfig{rtInit: true, pyInit: true, packageInits: []string{"example.com/b.init", "example.com/z.init", "example.com/a.init"}})
 	if mod.ExportFile != "foo.a-main" {
 		t.Fatalf("unexpected export file: %s", mod.ExportFile)
 	}
@@ -42,6 +45,7 @@ func TestGenMainModuleExecutable(t *testing.T) {
 		"call void @Py_Initialize()",
 		"call void @Py_Finalize()",
 		"call void @\"example.com/foo.init\"()",
+		`@"example.com/foo..inittask" = global { i32, i32 } zeroinitializer`,
 		"define weak void @_start()",
 	}
 	for _, want := range checks {
@@ -51,10 +55,144 @@ func TestGenMainModuleExecutable(t *testing.T) {
 	}
 	assertInOrder(t, ir,
 		"call void @Py_Initialize()",
+		`call void @"example.com/b.init"()`,
+		`call void @"example.com/z.init"()`,
+		`call void @"example.com/a.init"()`,
 		"call void @\"example.com/foo.init\"()",
 		"call void @\"example.com/foo.main\"()",
 		"call void @Py_Finalize()",
 	)
+}
+
+func TestPackageInitOrderUsesLexicalReadyPackage(t *testing.T) {
+	newPackage := func(path string, imports ...*packages.Package) *packages.Package {
+		pkg := &packages.Package{ID: path, PkgPath: path, Imports: make(map[string]*packages.Package)}
+		for _, imported := range imports {
+			pkg.Imports[imported.PkgPath] = imported
+		}
+		return pkg
+	}
+	z := newPackage("example.com/z")
+	a := newPackage("example.com/a", z)
+	b := newPackage("example.com/b")
+	root := newPackage("example.com/main", a, b)
+
+	order, err := packageInitOrder(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, len(order))
+	for i, pkg := range order {
+		got[i] = pkg.PkgPath
+	}
+	want := []string{"example.com/b", "example.com/z", "example.com/a", "example.com/main"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("package init order = %v, want %v", got, want)
+	}
+}
+
+func TestPackageInitOrderEdgeCases(t *testing.T) {
+	if order, err := packageInitOrder(nil); err != nil || order != nil {
+		t.Fatalf("nil root order = %v, %v, want nil, nil", order, err)
+	}
+
+	first := &packages.Package{ID: "first", PkgPath: "example.com/same"}
+	second := &packages.Package{ID: "second", PkgPath: "example.com/same"}
+	root := &packages.Package{
+		ID:      "root",
+		PkgPath: "example.com/root",
+		Imports: map[string]*packages.Package{
+			"alias/first": first,
+			"first":       first,
+			"nil":         nil,
+			"second":      second,
+		},
+	}
+	order, err := packageInitOrder(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, len(order))
+	for i, pkg := range order {
+		got[i] = pkg.ID
+	}
+	if want := []string{"first", "second", "root"}; !slices.Equal(got, want) {
+		t.Fatalf("package init order = %v, want %v", got, want)
+	}
+
+	a := &packages.Package{ID: "a", PkgPath: "example.com/a", Imports: make(map[string]*packages.Package)}
+	b := &packages.Package{ID: "b", PkgPath: "example.com/b", Imports: map[string]*packages.Package{"a": a}}
+	a.Imports["b"] = b
+	if _, err := packageInitOrder(a); err == nil || !strings.Contains(err.Error(), "contains a cycle") {
+		t.Fatalf("cyclic package order error = %v, want cycle error", err)
+	}
+}
+
+func TestLinkedPackageInitNamesFiltersUnavailablePackages(t *testing.T) {
+	newPackage := func(id string) *packages.Package {
+		path := "example.com/" + id
+		return &packages.Package{ID: id, PkgPath: path, Types: types.NewPackage(path, id)}
+	}
+	root := newPackage("root")
+	normal := newPackage("normal")
+	noinit := newPackage("noinit")
+	noinit.Types.Scope().Insert(types.NewConst(token.NoPos, noinit.Types, "LLGoPackage", types.Typ[types.String], constant.MakeString("noinit")))
+	missingBuilt := newPackage("missing-built")
+	missingSSA := newPackage("missing-ssa")
+	missingInit := newPackage("missing-init")
+	missingTypes := &packages.Package{ID: "missing-types", PkgPath: "example.com/missing-types"}
+	root.Imports = map[string]*packages.Package{
+		"normal":        normal,
+		"noinit":        noinit,
+		"missing-built": missingBuilt,
+		"missing-ssa":   missingSSA,
+		"missing-init":  missingInit,
+		"missing-types": missingTypes,
+	}
+
+	ssaProg := ssa.NewProgram(token.NewFileSet(), 0)
+	normalSSA := ssaProg.CreatePackage(normal.Types, nil, nil, true)
+	noinitSSA := ssaProg.CreatePackage(noinit.Types, nil, nil, true)
+	if normalSSA.Func("init") == nil || noinitSSA.Func("init") == nil {
+		t.Fatal("test SSA packages are missing synthetic init functions")
+	}
+	missingInitSSA := &ssa.Package{Members: make(map[string]ssa.Member)}
+
+	linked := []Package{
+		nil,
+		&aPackage{},
+		{Package: normal, SSA: normalSSA},
+		{Package: noinit, SSA: noinitSSA},
+		{Package: missingSSA},
+		{Package: missingInit, SSA: missingInitSSA},
+		{Package: missingTypes, SSA: normalSSA},
+	}
+	names, err := linkedPackageInitNames(root, linked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"example.com/normal.init"}; !slices.Equal(names, want) {
+		t.Fatalf("linked init names = %v, want %v", names, want)
+	}
+
+	cycle := &packages.Package{ID: "cycle", PkgPath: "example.com/cycle", Imports: make(map[string]*packages.Package)}
+	cycle.Imports["self"] = cycle
+	if _, err := linkedPackageInitNames(cycle, nil); err == nil {
+		t.Fatal("linkedPackageInitNames accepted an import cycle")
+	}
+}
+
+func TestLinkMainPkgRejectsPackageInitCycle(t *testing.T) {
+	cycle := &packages.Package{ID: "cycle", PkgPath: "example.com/cycle", Imports: make(map[string]*packages.Package)}
+	cycle.Imports["self"] = cycle
+	ctx := &context{
+		buildConf: &Config{},
+		pkgs:      make(map[*packages.Package]Package),
+		pkgByID:   make(map[string]Package),
+	}
+	if err := linkMainPkg(ctx, cycle, nil, "", false); err == nil || !strings.Contains(err.Error(), "contains a cycle") {
+		t.Fatalf("linkMainPkg cycle error = %v, want cycle error", err)
+	}
 }
 
 func TestGenMainModuleLibrary(t *testing.T) {
@@ -96,11 +234,15 @@ func TestGenMainModuleLibraryInitializesRuntime(t *testing.T) {
 				},
 			}
 			pkg := &packages.Package{PkgPath: "example.com/foo", ExportFile: "foo.a"}
-			mod := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{rtInit: true})
+			mod := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
+				rtInit:       true,
+				packageInits: []string{"example.com/dep.init"},
+			})
 			ir := mod.LPkg.String()
 			checks := []string{
 				"define internal void @__llgo_runtime_ctor()",
 				"call void @\"github.com/goplus/llgo/runtime/internal/runtime.init\"()",
+				"call void @\"example.com/dep.init\"()",
 				"call void @\"example.com/foo.init\"()",
 			}
 			if mode == BuildModeCShared {
@@ -136,13 +278,19 @@ func TestGenMainModuleTestLibraryDefersMainInit(t *testing.T) {
 				},
 			}
 			pkg := &packages.Package{PkgPath: "example.com/foo", ExportFile: "foo.a"}
-			mod := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{rtInit: true})
+			mod := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
+				rtInit:       true,
+				packageInits: []string{"example.com/dep.init"},
+			})
 			ir := mod.LPkg.String()
 			if !strings.Contains(ir, "call void @\"github.com/goplus/llgo/runtime/internal/runtime.init\"()") {
 				t.Fatalf("test library constructor missing runtime init:\n%s", ir)
 			}
 			if strings.Contains(ir, "call void @\"example.com/foo.init\"()") {
 				t.Fatalf("test library constructor initialized test main before the C runner supplied argc/argv:\n%s", ir)
+			}
+			if strings.Contains(ir, "call void @\"example.com/dep.init\"()") {
+				t.Fatalf("test library constructor initialized a test dependency before the C runner supplied argc/argv:\n%s", ir)
 			}
 		})
 	}

--- a/test/go/package_init_order_test.go
+++ b/test/go/package_init_order_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+var (
+	packageInitLLGoOnce sync.Once
+	packageInitLLGoBin  string
+	packageInitLLGoErr  string
+)
+
+func packageInitLLGo(t *testing.T) string {
+	t.Helper()
+	repoRoot := findStringConversionRepoRoot(t)
+	t.Setenv("LLGO_ROOT", repoRoot)
+	packageInitLLGoOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "llgo-package-init-bin")
+		if err != nil {
+			packageInitLLGoErr = err.Error()
+			return
+		}
+		packageInitLLGoBin = filepath.Join(dir, "llgo")
+		cmd := exec.Command("go", "build", "-tags=dev", "-o", packageInitLLGoBin, "./cmd/llgo")
+		cmd.Dir = repoRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			packageInitLLGoErr = err.Error() + "\n" + string(out)
+		}
+	})
+	if packageInitLLGoErr != "" {
+		t.Fatalf("building llgo failed: %s", packageInitLLGoErr)
+	}
+	return packageInitLLGoBin
+}
+
+func TestPackageInitializationUsesLexicalReadyOrder(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"go.mod": "module initorder\n\ngo 1.21\n",
+		"tracker/tracker.go": `package tracker
+
+var Order []string
+
+func Add(name string) { Order = append(Order, name) }
+`,
+		"z/z.go": `package z
+
+import "initorder/tracker"
+
+func init() { tracker.Add("z") }
+`,
+		"a/a.go": `package a
+
+import (
+	_ "initorder/z"
+	"initorder/tracker"
+)
+
+func init() { tracker.Add("a") }
+`,
+		"b/b.go": `package b
+
+import "initorder/tracker"
+
+func init() { tracker.Add("b") }
+`,
+		"main.go": `package main
+
+import (
+	_ "initorder/a"
+	_ "initorder/b"
+	"initorder/tracker"
+	"strings"
+)
+
+func main() {
+	if got, want := strings.Join(tracker.Order, ","), "b,z,a"; got != want {
+		panic("package init order: got " + got + " want " + want)
+	}
+}
+`,
+	}
+	for name, contents := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	llgo := packageInitLLGo(t)
+	cmd := exec.Command(llgo, "run", ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("llgo package-init probe failed: %v\n%s", err, out)
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1929,16 +1929,6 @@ xfails:
   - version: go1.24
     platform: darwin/arm64
     directive: run
-    case: init1.go
-    reason: current main goroot run failure on darwin/arm64
-  - version: go1.25
-    platform: darwin/arm64
-    directive: run
-    case: init1.go
-    reason: current main goroot run failure on darwin/arm64
-  - version: go1.24
-    platform: darwin/arm64
-    directive: run
     case: finprofiled.go
     reason: LLGo finalizer profiling run hangs beyond the 1m timeout on darwin/arm64
   - version: go1.25
@@ -2007,10 +1997,6 @@ xfails:
     directive: run
     case: convert5.go
     reason: out-of-range float-to-uint32 conversions wrap instead of producing zero on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: noinit.go
-    reason: current main goroot run failure on darwin/arm64
   - version: go1.24
     platform: darwin/arm64
     directive: run
@@ -2092,11 +2078,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: noinit.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: recover2.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -2162,11 +2143,6 @@ xfails:
   - version: go1.25
     platform: linux/amd64
     directive: run
-    case: noinit.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
     case: recover2.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
@@ -2213,11 +2189,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: init1.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: noinit.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64
@@ -2954,10 +2925,6 @@ xfails:
     directive: rundir
     case: fixedbugs/issue29919.go
     reason: runtime CallersFrames reports llgo package names and initialization line metadata differently
-  - version: go1.26
-    directive: rundir
-    case: fixedbugs/issue31636.go
-    reason: llgo initializes independent imported packages in reverse source order
   - version: go1.26
     directive: rundir
     case: fixedbugs/issue24693.go


### PR DESCRIPTION
## Summary

- schedule reachable package initializers with the same dependency-constrained lexical ordering used by the Go linker
- expose the root `..inittask` header from the synthetic entry module for compiler-internal linkname compatibility
- centralize package-kind init filtering in `cl.PkgSkipsInit`
- remove the fixed `noinit.go` and `issue31636.go` xfails, plus stale Darwin `init1.go` xfails

The ordering is computed globally at final link time. This avoids the tempting but incorrect fix of sorting only direct imports: the added `a -> z`, independent `b`, shared tracker regression requires `b, z, a`, whereas sorted DFS would produce `z, a, b`. Existing guarded package init functions make the pre-scheduled calls idempotent when the root init later reaches its direct imports.

## Validation

- `go test ./internal/build -count=1`
- `go test ./internal/build ./test/goroot -count=1 -timeout=15m`
- `go test -vet=off ./test/go -run ^TestPackageInitializationUsesLexicalReadyOrder$ -count=1 -timeout=10m`
- focused coverage run: all PR-added `internal/build` lines covered, including `linkMainPkg` cycle-error propagation
- Go 1.24.11 and 1.25.0 GOROOT `init1.go` + `noinit.go` with the normal xfail file
- Go 1.26.5 GOROOT `init1.go`, `noinit.go`, and `fixedbugs/issue31636.go` with the normal xfail file

`go test ./test/go` without `-vet=off` still hits the pre-existing Go 1.26 vendored `printf` analyzer panic; the same command fails on unchanged main.