### PR TITLE
ssa: preserve package identity for unexported methods

### DIFF
--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -1183,7 +1183,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"main.*struct{m int; *bytes.Buffer}.empty"(ptr %0){{.*}} {
+// CHECK-LABEL: define i1 @"main.*struct{m int; *bytes.Buffer}.bytes.empty"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1191,7 +1191,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.bytes.grow"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1199,7 +1199,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.bytes.readSlice"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1211,7 +1211,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1533,7 +1533,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"main.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i1 @"main.struct{m int; *bytes.Buffer}.bytes.empty"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1544,7 +1544,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.bytes.grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1555,7 +1555,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.bytes.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1570,7 +1570,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"main.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"main.struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -1271,7 +1271,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"main.*struct{m int; *bytes.Buffer}.empty"(ptr %0){{.*}} {
+// CHECK-LABEL: define i1 @"main.*struct{m int; *bytes.Buffer}.bytes.empty"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1279,7 +1279,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.bytes.grow"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1287,7 +1287,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.bytes.readSlice"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1299,7 +1299,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1606,7 +1606,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"main.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i1 @"main.struct{m int; *bytes.Buffer}.bytes.empty"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1617,7 +1617,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.bytes.grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1628,7 +1628,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.bytes.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1643,7 +1643,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"main.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"main.struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1964,27 +1964,27 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i1 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.empty"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.bytes.empty"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i1 @"main.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i1 @"main.struct{m int; *bytes.Buffer}.bytes.empty"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i1 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.grow"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.bytes.grow"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"main.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.struct{m int; *bytes.Buffer}.bytes.grow"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.readSlice"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.bytes.readSlice"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.bytes.readSlice"({ i64, ptr } %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, i1 } @"main.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call { i64, i1 } @"main.struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret { i64, i1 } %3
 // CHECK-NEXT: }
 
@@ -2126,27 +2126,27 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i1 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.empty"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.bytes.empty"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i1 @"main.*struct{m int; *bytes.Buffer}.empty"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i1 @"main.*struct{m int; *bytes.Buffer}.bytes.empty"(ptr %1)
 // CHECK-NEXT:   ret i1 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.grow"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.bytes.grow"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"main.*struct{m int; *bytes.Buffer}.grow"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.*struct{m int; *bytes.Buffer}.bytes.grow"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, ptr %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.bytes.readSlice"(ptr %0, ptr %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.bytes.readSlice"(ptr %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.bytes.tryGrowByReslice"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret { i64, i1 } %3
 // CHECK-NEXT: }
 

--- a/cl/_testgo/embedunexport-1598/in.go
+++ b/cl/_testgo/embedunexport-1598/in.go
@@ -18,7 +18,7 @@ type Wrapped struct {
 // CHECK-NEXT:   %4 = call %"{{.*}}String" @"{{.*}}embedunexport.(*Base).Name"(ptr %3)
 // CHECK-NEXT:   ret %"{{.*}}String" %4
 
-// CHECK-LABEL: define void @main.Wrapped.setName(%main.Wrapped %0, %"{{.*}}String" %1){{.*}} {
+// CHECK-LABEL: define void @"main.Wrapped.github.com/goplus/llgo/cl/_testdata/embedunexport.setName"(%main.Wrapped %0, %"{{.*}}String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %main.Wrapped, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 8, i1 false)
@@ -35,7 +35,7 @@ type Wrapped struct {
 // CHECK-NEXT:   %3 = call %"{{.*}}String" @"{{.*}}embedunexport.(*Base).Name"(ptr %2)
 // CHECK-NEXT:   ret %"{{.*}}String" %3
 
-// CHECK-LABEL: define void @"main.(*Wrapped).setName"(ptr %0, %"{{.*}}String" %1){{.*}} {
+// CHECK-LABEL: define void @"main.(*Wrapped).github.com/goplus/llgo/cl/_testdata/embedunexport.setName"(ptr %0, %"{{.*}}String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds %main.Wrapped, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8

--- a/cl/import.go
+++ b/cl/import.go
@@ -529,6 +529,11 @@ func funcName(pkg *types.Package, fn *ssa.Function, org bool) string {
 	} else {
 		fnName = fn.Name()
 	}
+	if recv != nil {
+		if method, ok := fn.Object().(*types.Func); ok {
+			fnName = llssa.MethodSymbolName(pkg, method, fnName)
+		}
+	}
 	return llssa.FuncName(pkg, fnName, recv, org)
 }
 

--- a/cl/import.go
+++ b/cl/import.go
@@ -530,9 +530,16 @@ func funcName(pkg *types.Package, fn *ssa.Function, org bool) string {
 		fnName = fn.Name()
 	}
 	if recv != nil {
+		// funcName's pkg is the receiver named type's package for wrappers.
+		// Keep it identical to the receiver package passed by abiUncommonMethods
+		// when it declares the itab target, or definition and reference symbols
+		// will diverge for promoted unexported methods.
 		if method, ok := fn.Object().(*types.Func); ok {
 			fnName = llssa.MethodSymbolName(pkg, method, fnName)
 		}
+		// Synthesized $thunk/$bound functions have no Object. Their references
+		// are produced through this same funcName path, so the wrapper name is
+		// already internally consistent and needs no declaring-package suffix.
 	}
 	return llssa.FuncName(pkg, fnName, recv, org)
 }

--- a/cl/import.go
+++ b/cl/import.go
@@ -478,9 +478,16 @@ func funcName(pkg *types.Package, fn *ssa.Function, org bool) string {
 		fnName = fn.Name()
 	}
 	if recv != nil {
+		// funcName's pkg is the receiver named type's package for wrappers.
+		// Keep it identical to the receiver package passed by abiUncommonMethods
+		// when it declares the itab target, or definition and reference symbols
+		// will diverge for promoted unexported methods.
 		if method, ok := fn.Object().(*types.Func); ok {
 			fnName = llssa.MethodSymbolName(pkg, method, fnName)
 		}
+		// Synthesized $thunk/$bound functions have no Object. Their references
+		// are produced through this same funcName path, so the wrapper name is
+		// already internally consistent and needs no declaring-package suffix.
 	}
 	return llssa.FuncName(pkg, fnName, recv, org)
 }

--- a/cl/import.go
+++ b/cl/import.go
@@ -477,6 +477,11 @@ func funcName(pkg *types.Package, fn *ssa.Function, org bool) string {
 	} else {
 		fnName = fn.Name()
 	}
+	if recv != nil {
+		if method, ok := fn.Object().(*types.Func); ok {
+			fnName = llssa.MethodSymbolName(pkg, method, fnName)
+		}
+	}
 	return llssa.FuncName(pkg, fnName, recv, org)
 }
 

--- a/internal/build/interface_method_identity_test.go
+++ b/internal/build/interface_method_identity_test.go
@@ -1,0 +1,28 @@
+//go:build !llgo
+// +build !llgo
+
+package build
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildPreservesUnexportedMethodIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unexported-method-identity")
+	if runtime.GOOS == "windows" {
+		path += ".exe"
+	}
+	conf := NewDefaultConf(ModeBuild)
+	conf.OutFile = path
+	if _, err := Do([]string{"./testdata/unexportedmethodidentity"}, conf); err != nil {
+		t.Fatalf("build unexported method identity fixture: %v", err)
+	}
+	want := []string{"b", "b"}
+	if output := runBinary(t, path); !reflect.DeepEqual(strings.Fields(output), want) {
+		t.Fatalf("unexported method calls = %q, want %q", output, strings.Join(want, "\n")+"\n")
+	}
+}

--- a/internal/build/testdata/unexportedmethodidentity/a/a.go
+++ b/internal/build/testdata/unexportedmethodidentity/a/a.go
@@ -1,0 +1,7 @@
+package a
+
+type T struct{}
+
+func (T) m() string { return "a" }
+
+type I interface{ m() string }

--- a/internal/build/testdata/unexportedmethodidentity/b/b.go
+++ b/internal/build/testdata/unexportedmethodidentity/b/b.go
@@ -1,0 +1,17 @@
+package b
+
+import "github.com/goplus/llgo/internal/build/testdata/unexportedmethodidentity/a"
+
+type T struct{ a.T }
+
+func (T) m() string { return "b" }
+
+func F1(i interface{ m() string }) string { return i.m() }
+
+//go:noinline
+func F2(i interface {
+	m() string
+	a.I
+}) string {
+	return i.m()
+}

--- a/internal/build/testdata/unexportedmethodidentity/main.go
+++ b/internal/build/testdata/unexportedmethodidentity/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/goplus/llgo/internal/build/testdata/unexportedmethodidentity/b"
+)
+
+func main() {
+	fmt.Println(b.F1(b.T{}))
+	fmt.Println(b.F2(b.T{}))
+}

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -514,6 +514,8 @@ func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) ll
 		fullName := abiMethodName(obj)
 		name := b.Str(fullName).impl
 		mSig := m.Type().(*types.Signature)
+		// funcName uses this same receiver package for the emitted wrapper
+		// definition; MethodSymbolName must see identical inputs here.
 		mSymbolName := MethodSymbolName(pkg, obj, mName)
 		var tfn, ifn llvm.Value
 		tfnFn := b.abiMethodFunc(anonymous, pkg, mSymbolName, mSig)

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -509,13 +509,14 @@ func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) ll
 	}
 	for i := 0; i < n; i++ {
 		m := methods[i]
-		obj := m.Obj()
+		obj := m.Obj().(*types.Func)
 		mName := obj.Name()
 		fullName := abiMethodName(obj)
 		name := b.Str(fullName).impl
 		mSig := m.Type().(*types.Signature)
+		mSymbolName := MethodSymbolName(pkg, obj, mName)
 		var tfn, ifn llvm.Value
-		tfnFn := b.abiMethodFunc(anonymous, pkg, mName, mSig)
+		tfnFn := b.abiMethodFunc(anonymous, pkg, mSymbolName, mSig)
 		// Tfn is used as a method-expression funcval. Its explicit receiver is
 		// already part of that semantic signature, so it is a no-env entry.
 		tfn = tfnFn.impl
@@ -523,7 +524,7 @@ func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) ll
 		if _, ok := m.Recv().Underlying().(*types.Pointer); !ok {
 			pRecv := types.NewVar(token.NoPos, pkg, "", types.NewPointer(mSig.Recv().Type()))
 			pSig := types.NewSignature(pRecv, mSig.Params(), mSig.Results(), mSig.Variadic())
-			ifn = b.abiMethodFunc(anonymous, pkg, mName, pSig).impl
+			ifn = b.abiMethodFunc(anonymous, pkg, mSymbolName, pSig).impl
 		}
 		var values []llvm.Value
 		values = append(values, name)

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -496,20 +496,21 @@ func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) ll
 	}
 	for i := 0; i < n; i++ {
 		m := methods[i]
-		obj := m.Obj()
+		obj := m.Obj().(*types.Func)
 		mName := obj.Name()
 		fullName := abiMethodName(obj)
 		name := b.Str(fullName).impl
 		mSig := m.Type().(*types.Signature)
+		mSymbolName := MethodSymbolName(pkg, obj, mName)
 		var tfn, ifn llvm.Value
-		tfnFn := b.abiMethodFunc(anonymous, pkg, mName, mSig)
+		tfnFn := b.abiMethodFunc(anonymous, pkg, mSymbolName, mSig)
 		tfnSig := funcType(prog, methodExprSignature(mSig)).(*types.Signature)
 		tfn = b.Pkg.closureWrapDecl(tfnFn.Expr, tfnSig).impl
 		ifn = tfnFn.impl
 		if _, ok := m.Recv().Underlying().(*types.Pointer); !ok {
 			pRecv := types.NewVar(token.NoPos, pkg, "", types.NewPointer(mSig.Recv().Type()))
 			pSig := types.NewSignature(pRecv, mSig.Params(), mSig.Results(), mSig.Variadic())
-			ifn = b.abiMethodFunc(anonymous, pkg, mName, pSig).impl
+			ifn = b.abiMethodFunc(anonymous, pkg, mSymbolName, pSig).impl
 		}
 		var values []llvm.Value
 		values = append(values, name)

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -501,6 +501,8 @@ func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) ll
 		fullName := abiMethodName(obj)
 		name := b.Str(fullName).impl
 		mSig := m.Type().(*types.Signature)
+		// funcName uses this same receiver package for the emitted wrapper
+		// definition; MethodSymbolName must see identical inputs here.
 		mSymbolName := MethodSymbolName(pkg, obj, mName)
 		var tfn, ifn llvm.Value
 		tfnFn := b.abiMethodFunc(anonymous, pkg, mSymbolName, mSig)

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -50,12 +50,12 @@ func (b Builder) unsafeInterface(rawIntf *types.Interface, t Expr, data llvm.Val
 	return b.unsafeIface(itab.impl, data)
 }
 
-func iMethodOf(rawIntf *types.Interface, name string) int {
+func iMethodOf(rawIntf *types.Interface, method *types.Func) int {
+	id := types.Id(method.Pkg(), method.Name())
 	n := rawIntf.NumMethods()
 	for i := 0; i < n; i++ {
 		m := rawIntf.Method(i)
-		if m.Name() == name {
-			// TODO(xsw): check signature
+		if types.Id(m.Pkg(), m.Name()) == id {
 			return i
 		}
 	}
@@ -81,7 +81,7 @@ func (b Builder) Imethod(intf Expr, method *types.Func) Expr {
 		}
 	}
 	tclosure := prog.Type(sig, InGo)
-	i := iMethodOf(rawIntf, method.Name())
+	i := iMethodOf(rawIntf, method)
 	b.recordUseIfaceMethod(rawIntf, i)
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	var fn Expr

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -50,12 +50,12 @@ func (b Builder) unsafeInterface(rawIntf *types.Interface, t Expr, data llvm.Val
 	return b.unsafeIface(itab.impl, data)
 }
 
-func iMethodOf(rawIntf *types.Interface, name string) int {
+func iMethodOf(rawIntf *types.Interface, method *types.Func) int {
+	id := types.Id(method.Pkg(), method.Name())
 	n := rawIntf.NumMethods()
 	for i := 0; i < n; i++ {
 		m := rawIntf.Method(i)
-		if m.Name() == name {
-			// TODO(xsw): check signature
+		if types.Id(m.Pkg(), m.Name()) == id {
 			return i
 		}
 	}
@@ -91,7 +91,7 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 		}
 	}
 	tclosure := prog.Type(sig, InGo)
-	i := iMethodOf(rawIntf, method.Name())
+	i := iMethodOf(rawIntf, method)
 	b.recordUseIfaceMethod(rawIntf, i)
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	impl := intf.impl

--- a/ssa/method_identity_test.go
+++ b/ssa/method_identity_test.go
@@ -23,6 +23,8 @@ import (
 	"go/token"
 	"go/types"
 	"testing"
+
+	"github.com/goplus/llgo/ssa/abi"
 )
 
 func TestMethodSymbolNamePreservesUnexportedPackageIdentity(t *testing.T) {
@@ -46,6 +48,17 @@ func TestMethodSymbolNamePreservesUnexportedPackageIdentity(t *testing.T) {
 		if got := MethodSymbolName(pkgB, tt.method, tt.name); got != tt.want {
 			t.Errorf("MethodSymbolName(%v, %q) = %q, want %q", tt.method, tt.name, got, tt.want)
 		}
+	}
+}
+
+func TestMethodSymbolNameNormalizesPatchedPackageIdentity(t *testing.T) {
+	original := types.NewPackage("runtime", "runtime")
+	patched := types.NewPackage(abi.PatchPathPrefix+"runtime", "runtime")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	hidden := types.NewFunc(token.NoPos, original, "m", sig)
+
+	if got := MethodSymbolName(patched, hidden, hidden.Name()); got != "m" {
+		t.Fatalf("MethodSymbolName(patched runtime, runtime.m) = %q, want %q", got, "m")
 	}
 }
 

--- a/ssa/method_identity_test.go
+++ b/ssa/method_identity_test.go
@@ -1,0 +1,66 @@
+//go:build !llgo
+// +build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssa
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+func TestMethodSymbolNamePreservesUnexportedPackageIdentity(t *testing.T) {
+	pkgA := types.NewPackage("example.com/a", "a")
+	pkgB := types.NewPackage("example.com/b", "b")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	aHidden := types.NewFunc(token.NoPos, pkgA, "m", sig)
+	bHidden := types.NewFunc(token.NoPos, pkgB, "m", sig)
+	aExported := types.NewFunc(token.NoPos, pkgA, "M", sig)
+
+	for _, tt := range []struct {
+		method *types.Func
+		name   string
+		want   string
+	}{
+		{aHidden, "m", "example.com/a.m"},
+		{bHidden, "m", "m"},
+		{aExported, "M", "M"},
+		{nil, "m", "m"},
+	} {
+		if got := MethodSymbolName(pkgB, tt.method, tt.name); got != tt.want {
+			t.Errorf("MethodSymbolName(%v, %q) = %q, want %q", tt.method, tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestIMethodOfUsesUnexportedPackageIdentity(t *testing.T) {
+	pkgA := types.NewPackage("example.com/a", "a")
+	pkgB := types.NewPackage("example.com/b", "b")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	aMethod := types.NewFunc(token.NoPos, pkgA, "m", sig)
+	bMethod := types.NewFunc(token.NoPos, pkgB, "m", sig)
+	intf := types.NewInterfaceType([]*types.Func{bMethod, aMethod}, nil).Complete()
+
+	if got := iMethodOf(intf, aMethod); got < 0 || intf.Method(got) != aMethod {
+		t.Fatalf("iMethodOf(a.m) = %d, want a.m slot", got)
+	}
+	if got := iMethodOf(intf, bMethod); got < 0 || intf.Method(got) != bMethod {
+		t.Fatalf("iMethodOf(b.m) = %d, want b.m slot", got)
+	}
+}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1822,7 +1822,8 @@ func TestInterfaceHelpers(t *testing.T) {
 	rawIface := types.NewInterfaceType([]*types.Func{rawMeth}, nil)
 	rawIface.Complete()
 
-	if got := iMethodOf(rawIface, "missing"); got != -1 {
+	missingMethod := types.NewFunc(0, nil, "missing", rawSig)
+	if got := iMethodOf(rawIface, missingMethod); got != -1 {
 		t.Fatalf("iMethodOf missing: got %d", got)
 	}
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1901,7 +1901,8 @@ func TestInterfaceHelpers(t *testing.T) {
 	rawIface := types.NewInterfaceType([]*types.Func{rawMeth}, nil)
 	rawIface.Complete()
 
-	if got := iMethodOf(rawIface, "missing"); got != -1 {
+	missingMethod := types.NewFunc(0, nil, "missing", rawSig)
+	if got := iMethodOf(rawIface, missingMethod); got != -1 {
 		t.Fatalf("iMethodOf missing: got %d", got)
 	}
 

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -674,6 +674,8 @@ func FuncName(pkg *types.Package, name string, recv *types.Var, org bool) string
 // MethodSymbolName qualifies an unexported method name when its declaring
 // package differs from the receiver package. Promoted methods need this extra
 // identity component to avoid colliding with same-named receiver methods.
+// Package identity intentionally uses PathOf rather than Package.Path: patched
+// runtime packages and their original counterparts must name the same symbol.
 func MethodSymbolName(receiverPkg *types.Package, method *types.Func, name string) string {
 	if receiverPkg == nil || method == nil || method.Exported() || method.Pkg() == nil ||
 		PathOf(receiverPkg) == PathOf(method.Pkg()) {

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -671,6 +671,17 @@ func FuncName(pkg *types.Package, name string, recv *types.Var, org bool) string
 	return ret
 }
 
+// MethodSymbolName qualifies an unexported method name when its declaring
+// package differs from the receiver package. Promoted methods need this extra
+// identity component to avoid colliding with same-named receiver methods.
+func MethodSymbolName(receiverPkg *types.Package, method *types.Func, name string) string {
+	if receiverPkg == nil || method == nil || method.Exported() || method.Pkg() == nil ||
+		PathOf(receiverPkg) == PathOf(method.Pkg()) {
+		return name
+	}
+	return PathOf(method.Pkg()) + "." + name
+}
+
 func recvNamed(t types.Type) (typ *types.Named, ptr bool) {
 retry:
 	switch typ := t.(type) {

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -672,6 +672,8 @@ func FuncName(pkg *types.Package, name string, recv *types.Var, org bool) string
 // MethodSymbolName qualifies an unexported method name when its declaring
 // package differs from the receiver package. Promoted methods need this extra
 // identity component to avoid colliding with same-named receiver methods.
+// Package identity intentionally uses PathOf rather than Package.Path: patched
+// runtime packages and their original counterparts must name the same symbol.
 func MethodSymbolName(receiverPkg *types.Package, method *types.Func, name string) string {
 	if receiverPkg == nil || method == nil || method.Exported() || method.Pkg() == nil ||
 		PathOf(receiverPkg) == PathOf(method.Pkg()) {

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -669,6 +669,17 @@ func FuncName(pkg *types.Package, name string, recv *types.Var, org bool) string
 	return ret
 }
 
+// MethodSymbolName qualifies an unexported method name when its declaring
+// package differs from the receiver package. Promoted methods need this extra
+// identity component to avoid colliding with same-named receiver methods.
+func MethodSymbolName(receiverPkg *types.Package, method *types.Func, name string) string {
+	if receiverPkg == nil || method == nil || method.Exported() || method.Pkg() == nil ||
+		PathOf(receiverPkg) == PathOf(method.Pkg()) {
+		return name
+	}
+	return PathOf(method.Pkg()) + "." + name
+}
+
 func recvNamed(t types.Type) (typ *types.Named, ptr bool) {
 retry:
 	switch typ := t.(type) {

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3527,10 +3527,6 @@ xfails:
     reason: llgo does not preserve Go assembler return-jump ABI behavior
   - version: go1.26
     directive: rundir
-    case: fixedbugs/issue24693.go
-    reason: llgo constructs cross-package itabs incorrectly for unexported interface methods
-  - version: go1.26
-    directive: rundir
     case: fixedbugs/issue18911.go
     reason: llgo interface-conversion diagnostics omit the same-looking types from different packages detail
   - version: go1.26

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1604,7 +1604,3 @@ xfails:
     directive: rundir
     case: fixedbugs/issue29919.go
     reason: runtime CallersFrames reports llgo package names and initialization line metadata differently
-  - version: go1.26
-    directive: rundir
-    case: fixedbugs/issue24693.go
-    reason: llgo constructs cross-package itabs incorrectly for unexported interface methods


### PR DESCRIPTION
Fixes the shared method-identity root cause behind GOROOT `fixedbugs/issue24693.go`.

## Summary

- qualify promoted unexported method symbols when their declaring package differs from the receiver package, preventing wrapper and ABI method collisions
- select interface method slots with the Go-compatible package-qualified method identity instead of comparing the spelling alone
- add the review counterexample as a real multi-package build-and-run regression test
- document why symbol production and interface lookup must use the same normalized identity
- remove the Go 1.26 xfail

## Validation on current main

- focused SSA method-identity tests pass
- affected `abimethod`, `interface`, and `embedunexport-1598` IR tests pass
- the multi-package build-and-run regression passes
- Go 1.26.5 GOROOT `fixedbugs/issue24693.go` passes with an empty xfail configuration
- `MethodSymbolName` and `iMethodOf` are each covered at 100%
- `git diff --check upstream/main...HEAD` passes