### PR TITLE
pclnpost: physically compact the deduplicated funcinfo carrier

### DIFF
--- a/chore/pclnpost/main.go
+++ b/chore/pclnpost/main.go
@@ -38,6 +38,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "pclnpost:", err)
 		os.Exit(1)
 	}
-	fmt.Printf("%s: entry=%d kept=%d inlineCopies=%d noSymbol=%d -> ftab=%d buckets=%d\n",
-		st.Format, st.EntryRecords, st.Kept, st.InlineCopies, st.NoSymbol, st.FtabEntries, st.Buckets)
+	fmt.Printf("%s: entry=%d kept=%d inlineCopies=%d noSymbol=%d -> ftab=%d buckets=%d removed=%d\n",
+		st.Format, st.EntryRecords, st.Kept, st.InlineCopies, st.NoSymbol, st.FtabEntries, st.Buckets, st.BytesRemoved)
 }

--- a/chore/pclnpost/main.go
+++ b/chore/pclnpost/main.go
@@ -38,6 +38,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "pclnpost:", err)
 		os.Exit(1)
 	}
-	fmt.Printf("%s: entry=%d kept=%d inlineCopies=%d noSymbol=%d -> ftab=%d buckets=%d removed=%d\n",
-		st.Format, st.EntryRecords, st.Kept, st.InlineCopies, st.NoSymbol, st.FtabEntries, st.Buckets, st.BytesRemoved)
+	fmt.Printf("%s: entry=%d kept=%d inlineCopies=%d noSymbol=%d -> ftab=%d buckets=%d carrierRemoved=%d\n",
+		st.Format, st.EntryRecords, st.Kept, st.InlineCopies, st.NoSymbol, st.FtabEntries, st.Buckets, st.CarrierBytesRemoved)
 }

--- a/chore/pclnpost/main.go
+++ b/chore/pclnpost/main.go
@@ -38,6 +38,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "pclnpost:", err)
 		os.Exit(1)
 	}
-	fmt.Printf("%s: entry=%d stub=%d kept=%d inlineCopies=%d noSymbol=%d -> ftab=%d buckets=%d\n",
-		st.Format, st.EntryRecords, st.StubRecords, st.Kept, st.InlineCopies, st.NoSymbol, st.FtabEntries, st.Buckets)
+	fmt.Printf("%s: entry=%d stub=%d kept=%d inlineCopies=%d noSymbol=%d -> ftab=%d buckets=%d removed=%d\n",
+		st.Format, st.EntryRecords, st.StubRecords, st.Kept, st.InlineCopies, st.NoSymbol, st.FtabEntries, st.Buckets, st.BytesRemoved)
 }

--- a/doc/design/pclntab-linkphase.md
+++ b/doc/design/pclntab-linkphase.md
@@ -49,8 +49,9 @@ not PCLN properties and must not introduce function-class-specific sections.
 
 1. **Parse** the linked binary's metadata sections (`debug/elf`,
    `debug/macho` from the Go stdlib — the tool runs on the host):
-   - `llgo_funcinfo_entry` / `__DATA,__llgo_fie` (non-LTO Mach-O) /
-     `__LLGO,__llgo_fie` (LTO Mach-O): `{pc, symbolID}` records.
+   - `llgo_funcinfo_entry` / `__DATA,__llgo_fie` (Mach-O without physical
+     compaction) / `__LLGO,__llgo_fie` (embedded executable LTO Mach-O):
+     `{pc, symbolID}` records.
    - Zero records are skipped, as in the runtime today.
 2. **Dedup by symbolID**: LTO inline copies register the same symbolID at
    several PCs. The true entry is the record whose PC lies inside the text
@@ -68,12 +69,13 @@ not PCLN properties and must not introduce function-class-specific sections.
    - The compact table replaces the prefix of `llgo_funcinfo_entry`; if it
      does not fit, the binary is left unchanged and the runtime uses its
      first-use construction fallback.
-   - LTO Mach-O puts the entry carrier in a dedicated `__LLGO` segment. A
-     non-LTO Mach-O keeps it in `__DATA`: without page-scale cross-package LTO
-     duplication, an isolated carrier can make small arm64 executables pay for
-     an otherwise-unused 16 KiB file page. ELF links the carrier immediately
-     before `.bss`, at the file-backed tail of the final writable `PT_LOAD`.
-     PC-line sites remain outside the disposable range.
+   - Embedded executable LTO Mach-O puts the entry carrier in a dedicated
+     `__LLGO` segment. Non-LTO, external-PCLN, c-shared, and c-archive Mach-O
+     keep it in `__DATA`: without a physical post-link compaction step, an
+     isolated carrier makes arm64 output pay for an otherwise-unused 16 KiB
+     file page. ELF links the carrier immediately before `.bss`, at the
+     file-backed tail of the final writable `PT_LOAD`. PC-line sites remain
+     outside the disposable range.
    - ELF compaction rejects an image with a program segment after the carrier;
      only non-loaded sections and the section-header table may be shifted.
    - After fixing Mach-O chained pointers, section sizes, load commands,

--- a/doc/design/pclntab-linkphase.md
+++ b/doc/design/pclntab-linkphase.md
@@ -49,7 +49,8 @@ not PCLN properties and must not introduce function-class-specific sections.
 
 1. **Parse** the linked binary's metadata sections (`debug/elf`,
    `debug/macho` from the Go stdlib — the tool runs on the host):
-   - `llgo_funcinfo_entry` / `__LLGO,__llgo_fie`: `{pc, symbolID}` records.
+   - `llgo_funcinfo_entry` / `__DATA,__llgo_fie` (non-LTO Mach-O) /
+     `__LLGO,__llgo_fie` (LTO Mach-O): `{pc, symbolID}` records.
    - Zero records are skipped, as in the runtime today.
 2. **Dedup by symbolID**: LTO inline copies register the same symbolID at
    several PCs. The true entry is the record whose PC lies inside the text
@@ -67,9 +68,12 @@ not PCLN properties and must not introduce function-class-specific sections.
    - The compact table replaces the prefix of `llgo_funcinfo_entry`; if it
      does not fit, the binary is left unchanged and the runtime uses its
      first-use construction fallback.
-   - Mach-O puts the entry carrier in a dedicated `__LLGO` segment. ELF links
-     it immediately before `.bss`, at the file-backed tail of the final
-     writable `PT_LOAD`. PC-line sites remain outside this disposable range.
+   - LTO Mach-O puts the entry carrier in a dedicated `__LLGO` segment. A
+     non-LTO Mach-O keeps it in `__DATA`: without page-scale cross-package LTO
+     duplication, an isolated carrier can make small arm64 executables pay for
+     an otherwise-unused 16 KiB file page. ELF links the carrier immediately
+     before `.bss`, at the file-backed tail of the final writable `PT_LOAD`.
+     PC-line sites remain outside the disposable range.
    - ELF compaction rejects an image with a program segment after the carrier;
      only non-loaded sections and the section-header table may be shifted.
    - After fixing Mach-O chained pointers, section sizes, load commands,

--- a/doc/design/pclntab-linkphase.md
+++ b/doc/design/pclntab-linkphase.md
@@ -40,8 +40,8 @@ linker-agnostic.
 
 1. **Parse** the linked binary's metadata sections (`debug/elf`,
    `debug/macho` from the Go stdlib — the tool runs on the host):
-   - `llgo_funcinfo_entry` / `__DATA,__llgo_fie`: `{pc, symbolID}` records.
-   - `llgo_funcinfo_stubsite` / `__DATA,__llgo_stub`: same layout.
+   - `llgo_funcinfo_entry` / `__LLGO,__llgo_fie`: `{pc, symbolID}` records.
+   - `llgo_funcinfo_stubsite` / `__LLGO,__llgo_stub`: same layout.
    - Zero records are skipped, as in the runtime today.
 2. **Dedup by symbolID**: LTO inline copies register the same symbolID at
    several PCs. The true entry is the record whose PC lies inside the text
@@ -55,13 +55,23 @@ linker-agnostic.
    faithful port of `cmd/link`'s algorithm that has been sitting unwired
    since #2012. Delta overflow is a hard error here, mirroring Go's linker;
    if it ever fires, fall back to leaving the prebuilt table absent.
-5. **Write back** into a reserved section:
-   - The main module already emits `__llgo_funcinfo_*` globals; add a
-     `__llgo_pclntab_prebuilt` global sized from the collected package data
-     (entry-record count is known at main-module emission time; LTO can only
-     shrink it after dedup) plus a header {magic, version, count, anchorOff}.
-   - The tool rewrites the section contents in place (same size or smaller;
-     unused tail is zeroed) and flips the header magic to "valid".
+5. **Write back and compact** the carrier:
+   - The compact table replaces the prefix of `llgo_funcinfo_entry` (or spills
+     into the stub carrier) and flips the header magic to "valid".
+   - Mach-O puts entry/stub in a dedicated `__LLGO` segment. ELF links them
+     immediately before `.bss`, at the file-backed tail of the final writable `PT_LOAD`.
+     PC-line sites remain outside this disposable range.
+   - ELF compaction rejects an image with a program segment after the carrier;
+     only non-loaded sections and the section-header table may be shifted.
+   - After fixing Mach-O chained pointers, section sizes, load commands,
+     segment offsets, ELF program/section headers, and link-edit offsets, the
+     tool removes the unused carrier suffix from the physical file. Virtual
+     addresses of program text/data do not move; the omitted tail is either
+     unused or zero-fill memory.
+   - Rewriting is transactional: construct and reopen the complete staged
+     image, re-sign an originally signed Mach-O, then atomically rename it.
+     An unfamiliar segment shape, overlapping relocation/fixup range, signing
+     failure, or verification failure leaves the original executable intact.
 
 ### ASLR
 

--- a/doc/design/pclntab-linkphase.md
+++ b/doc/design/pclntab-linkphase.md
@@ -49,7 +49,7 @@ not PCLN properties and must not introduce function-class-specific sections.
 
 1. **Parse** the linked binary's metadata sections (`debug/elf`,
    `debug/macho` from the Go stdlib — the tool runs on the host):
-   - `llgo_funcinfo_entry` / `__DATA,__llgo_fie`: `{pc, symbolID}` records.
+   - `llgo_funcinfo_entry` / `__LLGO,__llgo_fie`: `{pc, symbolID}` records.
    - Zero records are skipped, as in the runtime today.
 2. **Dedup by symbolID**: LTO inline copies register the same symbolID at
    several PCs. The true entry is the record whose PC lies inside the text
@@ -63,12 +63,24 @@ not PCLN properties and must not introduce function-class-specific sections.
    faithful port of `cmd/link`'s algorithm that has been sitting unwired
    since #2012. Delta overflow is a hard error here, mirroring Go's linker;
    if it ever fires, fall back to leaving the prebuilt table absent.
-5. **Write back** into the entry-site section:
-   - The tool replaces the raw entry records in place with a versioned prebuilt
-     functab/findfunctab blob; unused tail bytes are zeroed.
-   - If the blob does not fit, the binary is left unchanged and the runtime
-     uses its first-use construction fallback. No other class of function is
-     used as overflow storage.
+5. **Write back and compact** the entry carrier:
+   - The compact table replaces the prefix of `llgo_funcinfo_entry`; if it
+     does not fit, the binary is left unchanged and the runtime uses its
+     first-use construction fallback.
+   - Mach-O puts the entry carrier in a dedicated `__LLGO` segment. ELF links
+     it immediately before `.bss`, at the file-backed tail of the final
+     writable `PT_LOAD`. PC-line sites remain outside this disposable range.
+   - ELF compaction rejects an image with a program segment after the carrier;
+     only non-loaded sections and the section-header table may be shifted.
+   - After fixing Mach-O chained pointers, section sizes, load commands,
+     segment offsets, ELF program/section headers, and link-edit offsets, the
+     tool removes the unused carrier suffix from the physical file. Virtual
+     addresses of program text/data do not move; the omitted tail becomes
+     zero-fill memory.
+   - Rewriting is transactional: construct and reopen the complete staged
+     image, re-sign an originally signed Mach-O, then atomically rename it.
+     An unfamiliar segment shape, overlapping relocation/fixup range, signing
+     failure, or verification failure leaves the original executable intact.
 
 ### ASLR
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1274,8 +1274,8 @@ func rewritePrebuiltFuncTab(ctx *context, out string, verbose bool) {
 		return
 	}
 	if verbose {
-		fmt.Fprintf(os.Stderr, "llgo: prebuilt functab: %d entries (%d LTO inline copies removed), %d buckets\n",
-			st.FtabEntries, st.InlineCopies, st.Buckets)
+		fmt.Fprintf(os.Stderr, "llgo: prebuilt functab: %d entries (%d LTO inline copies removed), %d buckets, %d file bytes removed\n",
+			st.FtabEntries, st.InlineCopies, st.Buckets, st.BytesRemoved)
 	}
 }
 
@@ -1516,6 +1516,12 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 
 	buildArgs := []string{"-o", app}
 	buildArgs = append(buildArgs, linkArgs...)
+	siteLayoutArgs, cleanupSiteLayout, err := funcInfoSiteLayoutArgs(ctx, app)
+	if err != nil {
+		return err
+	}
+	defer cleanupSiteLayout()
+	buildArgs = append(buildArgs, siteLayoutArgs...)
 	buildArgs = append(buildArgs, dwarfLinkerArgs(ctx.buildConf, &ctx.crossCompile)...)
 	ltoPluginFlags, err := ctx.buildConf.LTOPlugin.LinkerFlags(ctx.buildConf.Goos)
 	if err != nil {
@@ -1563,6 +1569,44 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	cmd := ctx.linker()
 	cmd.Verbose = printCmds
 	return cmd.Link(buildArgs...)
+}
+
+// funcInfoSiteLayoutArgs places ELF entry/stub carriers immediately before
+// .bss, at the file-backed tail of the final writable PT_LOAD. pclnpost can
+// shorten p_filesz after replacing the carriers with the compact table without
+// moving any virtual address or pinning otherwise-dead functions. Mach-O gets
+// the same property from the dedicated __LLGO segment named at emission time.
+func funcInfoSiteLayoutArgs(ctx *context, outputPath string) ([]string, func(), error) {
+	cleanup := func() {}
+	if ctx == nil || ctx.buildConf == nil || ctx.buildConf.Goos != "linux" ||
+		ctx.buildConf.Target != "" || ctx.buildConf.BuildMode != BuildModeExe ||
+		!shouldEmitRuntimeSites(ctx) {
+		return nil, cleanup, nil
+	}
+	dir := filepath.Dir(outputPath)
+	f, err := os.CreateTemp(dir, ".llgo-funcinfo-layout-*.ld")
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("create funcinfo linker script: %w", err)
+	}
+	name := f.Name()
+	cleanup = func() { _ = os.Remove(name) }
+	const script = `SECTIONS
+{
+  llgo_funcinfo_entry : { *(llgo_funcinfo_entry) }
+  llgo_funcinfo_stubsite : { *(llgo_funcinfo_stubsite) }
+}
+INSERT BEFORE .bss;
+`
+	if _, err := f.WriteString(script); err != nil {
+		_ = f.Close()
+		cleanup()
+		return nil, func() {}, fmt.Errorf("write funcinfo linker script: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("close funcinfo linker script: %w", err)
+	}
+	return []string{"-Wl,-T," + name}, cleanup, nil
 }
 
 // cSharedExportArgs keeps //export functions and synthetic test entry points as

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1421,8 +1421,8 @@ func rewritePrebuiltFuncTab(ctx *context, out string, verbose bool) {
 		return
 	}
 	if verbose {
-		fmt.Fprintf(os.Stderr, "llgo: prebuilt functab: %d entries (%d LTO inline copies removed), %d buckets, %d file bytes removed\n",
-			st.FtabEntries, st.InlineCopies, st.Buckets, st.BytesRemoved)
+		fmt.Fprintf(os.Stderr, "llgo: prebuilt functab: %d entries (%d LTO inline copies removed), %d buckets, %d carrier bytes removed\n",
+			st.FtabEntries, st.InlineCopies, st.Buckets, st.CarrierBytesRemoved)
 	}
 }
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1421,8 +1421,8 @@ func rewritePrebuiltFuncTab(ctx *context, out string, verbose bool) {
 		return
 	}
 	if verbose {
-		fmt.Fprintf(os.Stderr, "llgo: prebuilt functab: %d entries (%d LTO inline copies removed), %d buckets\n",
-			st.FtabEntries, st.InlineCopies, st.Buckets)
+		fmt.Fprintf(os.Stderr, "llgo: prebuilt functab: %d entries (%d LTO inline copies removed), %d buckets, %d file bytes removed\n",
+			st.FtabEntries, st.InlineCopies, st.Buckets, st.BytesRemoved)
 	}
 }
 
@@ -1666,6 +1666,12 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 
 	buildArgs := []string{"-o", app}
 	buildArgs = append(buildArgs, linkArgs...)
+	siteLayoutArgs, cleanupSiteLayout, err := funcInfoSiteLayoutArgs(ctx, app)
+	if err != nil {
+		return err
+	}
+	defer cleanupSiteLayout()
+	buildArgs = append(buildArgs, siteLayoutArgs...)
 	buildArgs = append(buildArgs, dwarfLinkerArgs(ctx.buildConf, &ctx.crossCompile)...)
 	ltoPluginFlags, err := ctx.buildConf.LTOPlugin.LinkerFlags(ctx.buildConf.Goos)
 	if err != nil {
@@ -1713,6 +1719,43 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	cmd := ctx.linker()
 	cmd.Verbose = printCmds
 	return cmd.Link(buildArgs...)
+}
+
+// funcInfoSiteLayoutArgs places the ELF entry carrier immediately before .bss,
+// at the file-backed tail of the final writable PT_LOAD. pclnpost can shorten
+// p_filesz after replacing the carrier with the compact table without
+// moving any virtual address or pinning otherwise-dead functions. Mach-O gets
+// the same property from the dedicated __LLGO segment named at emission time.
+func funcInfoSiteLayoutArgs(ctx *context, outputPath string) ([]string, func(), error) {
+	cleanup := func() {}
+	if ctx == nil || ctx.buildConf == nil || ctx.buildConf.Goos != "linux" ||
+		ctx.buildConf.Target != "" || ctx.buildConf.BuildMode != BuildModeExe ||
+		!shouldEmitRuntimeSites(ctx) {
+		return nil, cleanup, nil
+	}
+	dir := filepath.Dir(outputPath)
+	f, err := os.CreateTemp(dir, ".llgo-funcinfo-layout-*.ld")
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("create funcinfo linker script: %w", err)
+	}
+	name := f.Name()
+	cleanup = func() { _ = os.Remove(name) }
+	const script = `SECTIONS
+{
+  llgo_funcinfo_entry : { *(llgo_funcinfo_entry) }
+}
+INSERT BEFORE .bss;
+`
+	if _, err := f.WriteString(script); err != nil {
+		_ = f.Close()
+		cleanup()
+		return nil, func() {}, fmt.Errorf("write funcinfo linker script: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("close funcinfo linker script: %w", err)
+	}
+	return []string{"-Wl,-T," + name}, cleanup, nil
 }
 
 // cSharedExportArgs keeps //export functions and synthetic test entry points as

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -364,6 +364,53 @@ func TestLinkObjFilesReportsOutputDirectoryError(t *testing.T) {
 	}
 }
 
+func TestRewritePrebuiltFuncTabEligibilityAndDiagnostic(t *testing.T) {
+	rewritePrebuiltFuncTab(nil, "missing", true)
+	rewritePrebuiltFuncTab(&context{}, "missing", true)
+
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+	defer prog.Dispose()
+	ctx := &context{prog: prog, buildConf: &Config{
+		BuildMode: BuildModeExe,
+		Goos:      "linux",
+		Goarch:    "amd64",
+	}}
+	rewritePrebuiltFuncTab(ctx, "missing", true) // sites disabled
+
+	prog.EnableFuncInfoSites(true)
+	ctx.buildConf.Target = "wasi"
+	rewritePrebuiltFuncTab(ctx, "missing", true)
+	ctx.buildConf.Target = ""
+	ctx.buildConf.BuildMode = BuildModeCShared
+	rewritePrebuiltFuncTab(ctx, "missing", true)
+	ctx.buildConf.BuildMode = BuildModeExe
+
+	t.Setenv("LLGO_PCLNPOST", "0")
+	rewritePrebuiltFuncTab(ctx, "missing", true)
+	t.Setenv("LLGO_PCLNPOST", "1")
+	rewritePrebuiltFuncTab(ctx, "missing", false)
+
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = oldStderr })
+	rewritePrebuiltFuncTab(ctx, filepath.Join(t.TempDir(), "missing"), true)
+	os.Stderr = oldStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(stderr.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(got, []byte("prebuilt functab rewrite skipped")) {
+		t.Fatalf("rewrite diagnostic = %q", got)
+	}
+}
+
 func TestWithEnvLastValueWins(t *testing.T) {
 	got := withEnv([]string{"A=old", "B=keep", "malformed", "A=older"}, "A=new", "C=value")
 	want := []string{"B=keep", "A=new", "C=value"}

--- a/internal/build/funcinfo_table.go
+++ b/internal/build/funcinfo_table.go
@@ -424,11 +424,12 @@ func emitFuncInfoTable(ctx *context, pkg llssa.Package, records []funcInfoRecord
 		}
 	}
 	machOSites := shouldEmitRuntimeMachOSites(ctx)
+	entrySiteInfo := runtimeEntrySiteSectionInfo(ctx)
 	emitSites := shouldEmitRuntimeSites(ctx)
 	emitEntrySites := shouldEmitRuntimeEntryELFSites(ctx) && len(encoded.Records) != 0
-	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machOSites, emitSites && len(pcLineValues) != 0, emitEntrySites)
+	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machOSites, entrySiteInfo, emitSites && len(pcLineValues) != 0, emitEntrySites)
 	if emitEntrySites {
-		startName, endName := entrySiteSectionInfo.boundary(machOSites)
+		startName, endName := entrySiteInfo.boundary(machOSites)
 		entryStart := llvm.AddGlobal(mod, funcEntryRecordType, startName)
 		entryEnd := llvm.AddGlobal(mod, funcEntryRecordType, endName)
 		entryStartPtr.SetInitializer(entryStart)
@@ -601,10 +602,11 @@ func emitExternalFuncInfoTable(ctx *context, mod llvm.Module, records []funcInfo
 	used.SetSection("llvm.metadata")
 
 	machO := shouldEmitRuntimeMachOSites(ctx)
+	entrySiteInfo := runtimeEntrySiteSectionInfo(ctx)
 	emitSites := shouldEmitRuntimeSites(ctx)
 	emitPCSites := emitSites && len(encoded.PCLines) != 0
 	emitEntrySites := shouldEmitRuntimeEntryELFSites(ctx) && len(encoded.Records) != 0
-	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machO, emitPCSites, emitEntrySites)
+	emitRuntimeFuncInfoSites(mod, ctx.prog.PointerSize(), machO, entrySiteInfo, emitPCSites, emitEntrySites)
 	if emitPCSites {
 		start, end := pcLineSiteSectionInfo.boundary(machO)
 		startGlobal := llvm.AddGlobal(mod, typ.pcSiteRecord, start)
@@ -613,7 +615,7 @@ func emitExternalFuncInfoTable(ctx *context, mod llvm.Module, records []funcInfo
 		g.pcSiteEndPtr.SetInitializer(endGlobal)
 	}
 	if emitEntrySites {
-		start, end := entrySiteSectionInfo.boundary(machO)
+		start, end := entrySiteInfo.boundary(machO)
 		startGlobal := llvm.AddGlobal(mod, typ.entryRecord, start)
 		endGlobal := llvm.AddGlobal(mod, typ.entryRecord, end)
 		g.entryStartPtr.SetInitializer(startGlobal)
@@ -664,13 +666,22 @@ type siteSectionInfo struct {
 }
 
 var (
-	// Keep the disposable funcinfo entry carrier in its own Mach-O segment.
-	// pclnpost rewrites its prefix into the compact runtime table and then
-	// physically removes the unused segment tail. PC-line sites stay in
-	// __DATA because embedded mode still consumes those records.
-	entrySiteSectionInfo  = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__LLGO,__llgo_fie"}
-	pcLineSiteSectionInfo = siteSectionInfo{elf: "llgo_pcline", machO: "__DATA,__llgo_pcl"}
+	entrySiteSectionInfo        = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__DATA,__llgo_fie"}
+	compactEntrySiteSectionInfo = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__LLGO,__llgo_fie"}
+	pcLineSiteSectionInfo       = siteSectionInfo{elf: "llgo_pcline", machO: "__DATA,__llgo_pcl"}
 )
+
+// runtimeEntrySiteSectionInfo isolates the disposable Mach-O carrier only for
+// LTO builds, where cross-package inlining can produce a page-scale duplicate
+// tail. A dedicated segment costs at least one 16 KiB file page on
+// Darwin/arm64, so keeping non-LTO sites in __DATA avoids making small default
+// builds larger when the fixed page cost would dominate.
+func runtimeEntrySiteSectionInfo(ctx *context) siteSectionInfo {
+	if shouldEmitRuntimeMachOSites(ctx) && ctx.buildConf.ltoEnabled() {
+		return compactEntrySiteSectionInfo
+	}
+	return entrySiteSectionInfo
+}
 
 func (s siteSectionInfo) push(machO bool, anchor string) string {
 	if machO {
@@ -771,6 +782,7 @@ func emitFuncInfoEntrySites(ctx *context, pkg llssa.Package) {
 	// blocks inlining outright. Deduplicating the section is therefore
 	// link-phase work and lands together with the final ftab generation.
 	machO := shouldEmitRuntimeMachOSites(ctx)
+	entrySiteInfo := runtimeEntrySiteSectionInfo(ctx)
 	llvmCtx := mod.Context()
 	builder := llvmCtx.NewBuilder()
 	defer builder.Dispose()
@@ -802,9 +814,9 @@ func emitFuncInfoEntrySites(ctx *context, pkg llssa.Package) {
 		}
 		anchor := siteAnchorLabel(machO, "funcinfo_entry")
 		instruction := anchor + ":\n" +
-			entrySiteSectionInfo.push(machO, anchor) + "\n" +
+			entrySiteInfo.push(machO, anchor) + "\n" +
 			".p2align " + align + "\n" +
-			entrySiteSectionInfo.recordSymbol(machO, "funcinfo_entry") +
+			entrySiteInfo.recordSymbol(machO, "funcinfo_entry") +
 			ptrDirective + " " + anchor + "\n" +
 			".quad " + uint64Hex(symbolID) + "\n" +
 			".popsection"
@@ -848,7 +860,7 @@ func uint64Hex(v uint64) string {
 // internal/pclnpost ("LLGOMET1" little-endian).
 const funcInfoMetaRecordMagic = uint64(0x3154454D4F474C4C)
 
-func emitRuntimeFuncInfoSites(mod llvm.Module, pointerSize int, machO bool, pcSite bool, entrySite bool) {
+func emitRuntimeFuncInfoSites(mod llvm.Module, pointerSize int, machO bool, entrySiteInfo siteSectionInfo, pcSite bool, entrySite bool) {
 	if !pcSite && !entrySite {
 		return
 	}
@@ -870,7 +882,7 @@ func emitRuntimeFuncInfoSites(mod llvm.Module, pointerSize int, machO bool, pcSi
 		writeZeroRecord(pcLineSiteSectionInfo, "pcline")
 	}
 	if entrySite {
-		writeZeroRecord(entrySiteSectionInfo, "funcinfo_entry")
+		writeZeroRecord(entrySiteInfo, "funcinfo_entry")
 		// Meta records for the link-phase tool: relocations carrying the
 		// addresses of the symbol-index pointer global and its count global.
 		// Relocations are resolved by the linker regardless of what LTO

--- a/internal/build/funcinfo_table.go
+++ b/internal/build/funcinfo_table.go
@@ -664,7 +664,11 @@ type siteSectionInfo struct {
 }
 
 var (
-	entrySiteSectionInfo  = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__DATA,__llgo_fie"}
+	// Keep the disposable funcinfo entry carrier in its own Mach-O segment.
+	// pclnpost rewrites its prefix into the compact runtime table and then
+	// physically removes the unused segment tail. PC-line sites stay in
+	// __DATA because embedded mode still consumes those records.
+	entrySiteSectionInfo  = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__LLGO,__llgo_fie"}
 	pcLineSiteSectionInfo = siteSectionInfo{elf: "llgo_pcline", machO: "__DATA,__llgo_pcl"}
 )
 

--- a/internal/build/funcinfo_table.go
+++ b/internal/build/funcinfo_table.go
@@ -789,8 +789,12 @@ type siteSectionInfo struct {
 }
 
 var (
-	entrySiteSectionInfo  = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__DATA,__llgo_fie"}
-	stubSiteSectionInfo   = siteSectionInfo{elf: "llgo_funcinfo_stubsite", machO: "__DATA,__llgo_stub"}
+	// Keep the two disposable funcinfo carriers in their own Mach-O segment.
+	// pclnpost rewrites the entry prefix into the compact runtime table and
+	// then physically removes the unused segment tail.  Keeping PC-line sites
+	// in __DATA is intentional: embedded mode still consumes those records.
+	entrySiteSectionInfo  = siteSectionInfo{elf: "llgo_funcinfo_entry", machO: "__LLGO,__llgo_fie"}
+	stubSiteSectionInfo   = siteSectionInfo{elf: "llgo_funcinfo_stubsite", machO: "__LLGO,__llgo_stub"}
 	pcLineSiteSectionInfo = siteSectionInfo{elf: "llgo_pcline", machO: "__DATA,__llgo_pcl"}
 )
 

--- a/internal/build/funcinfo_table.go
+++ b/internal/build/funcinfo_table.go
@@ -671,16 +671,23 @@ var (
 	pcLineSiteSectionInfo       = siteSectionInfo{elf: "llgo_pcline", machO: "__DATA,__llgo_pcl"}
 )
 
-// runtimeEntrySiteSectionInfo isolates the disposable Mach-O carrier only for
-// LTO builds, where cross-package inlining can produce a page-scale duplicate
-// tail. A dedicated segment costs at least one 16 KiB file page on
-// Darwin/arm64, so keeping non-LTO sites in __DATA avoids making small default
-// builds larger when the fixed page cost would dominate.
+// runtimeEntrySiteSectionInfo isolates the disposable Mach-O carrier only when
+// the linked image will actually pass through the embedded-executable rewrite.
+// Cross-package LTO inlining can then produce a page-scale duplicate tail worth
+// removing. External PCLN and library build modes do not run that rewrite, so
+// they keep the carrier in __DATA instead of paying for an unused __LLGO page.
 func runtimeEntrySiteSectionInfo(ctx *context) siteSectionInfo {
-	if shouldEmitRuntimeMachOSites(ctx) && ctx.buildConf.ltoEnabled() {
+	if shouldCompactRuntimeMachOSites(ctx) {
 		return compactEntrySiteSectionInfo
 	}
 	return entrySiteSectionInfo
+}
+
+func shouldCompactRuntimeMachOSites(ctx *context) bool {
+	return shouldEmitRuntimeMachOSites(ctx) &&
+		ctx.buildConf.BuildMode == BuildModeExe &&
+		ctx.buildConf.PCLNMode == PCLNEmbedded &&
+		ctx.buildConf.ltoEnabled()
 }
 
 func (s siteSectionInfo) push(machO bool, anchor string) string {

--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -136,6 +136,52 @@ func TestFuncInfoSiteLayoutArgs(t *testing.T) {
 	cleanup()
 }
 
+func TestFuncInfoSiteLayoutArgsEligibilityAndCreateFailure(t *testing.T) {
+	newContext := func() (*context, func()) {
+		prog := llssa.NewProgram(&llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+		prog.EnableFuncInfoSites(true)
+		return &context{prog: prog, buildConf: &Config{
+			BuildMode: BuildModeExe,
+			Goos:      "linux",
+			Goarch:    "amd64",
+		}}, prog.Dispose
+	}
+	tests := []struct {
+		name string
+		edit func(*context)
+	}{
+		{"nil context", func(*context) {}},
+		{"nil config", func(ctx *context) { ctx.buildConf = nil }},
+		{"cross target", func(ctx *context) { ctx.buildConf.Target = "wasm32-wasi" }},
+		{"non executable", func(ctx *context) { ctx.buildConf.BuildMode = BuildModeCArchive }},
+		{"sites disabled", func(ctx *context) { ctx.prog.EnableFuncInfoSites(false) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, dispose := newContext()
+			defer dispose()
+			if test.name == "nil context" {
+				ctx = nil
+			} else {
+				test.edit(ctx)
+			}
+			args, cleanup, err := funcInfoSiteLayoutArgs(ctx, filepath.Join(t.TempDir(), "app"))
+			defer cleanup()
+			if err != nil || len(args) != 0 {
+				t.Fatalf("layout args = %#v, %v", args, err)
+			}
+		})
+	}
+
+	ctx, dispose := newContext()
+	defer dispose()
+	missing := filepath.Join(t.TempDir(), "missing", "app")
+	if _, cleanup, err := funcInfoSiteLayoutArgs(ctx, missing); err == nil {
+		cleanup()
+		t.Fatal("layout script was created in a missing directory")
+	}
+}
+
 func TestFuncInfoTableMaterializesEntrySites(t *testing.T) {
 	prog := llssa.NewProgram(nil)
 	src := prog.NewPackage("example.com/p", "example.com/p")

--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -96,6 +96,46 @@ func TestFuncInfoTableMaterializesMetadataWithoutFunctionPointers(t *testing.T) 
 	}
 }
 
+func TestFuncInfoSiteLayoutArgs(t *testing.T) {
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+	defer prog.Dispose()
+	prog.EnableFuncInfoSites(true)
+	ctx := &context{prog: prog, buildConf: &Config{
+		BuildMode: BuildModeExe,
+		Goos:      "linux",
+		Goarch:    "amd64",
+	}}
+	dir := t.TempDir()
+	args, cleanup, err := funcInfoSiteLayoutArgs(ctx, filepath.Join(dir, "app"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 1 || !strings.HasPrefix(args[0], "-Wl,-T,") {
+		t.Fatalf("layout args = %#v", args)
+	}
+	script := strings.TrimPrefix(args[0], "-Wl,-T,")
+	raw, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"llgo_funcinfo_entry", "INSERT BEFORE .bss"} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("linker script missing %q:\n%s", want, raw)
+		}
+	}
+	cleanup()
+	if _, err := os.Stat(script); !os.IsNotExist(err) {
+		t.Fatalf("linker script was not removed: %v", err)
+	}
+
+	ctx.buildConf.Goos = "darwin"
+	args, cleanup, err = funcInfoSiteLayoutArgs(ctx, filepath.Join(dir, "app"))
+	if err != nil || len(args) != 0 {
+		t.Fatalf("Darwin layout args = %#v, %v", args, err)
+	}
+	cleanup()
+}
+
 func TestFuncInfoTableMaterializesEntrySites(t *testing.T) {
 	prog := llssa.NewProgram(nil)
 	src := prog.NewPackage("example.com/p", "example.com/p")
@@ -662,7 +702,7 @@ func TestExternalFuncInfoTableKeepsPayloadOutOfIR(t *testing.T) {
 		entryBoundary string
 	}{
 		{goos: "linux", goarch: "amd64", identitySect: "llgo_pclntab_id", entryBoundary: "__start_llgo_funcinfo_entry"},
-		{goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__DATA$__llgo_fie"},
+		{goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__LLGO$__llgo_fie"},
 	} {
 		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
 			prog := llssa.NewProgram(&llssa.Target{GOOS: target.goos, GOARCH: target.goarch})

--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -182,6 +182,27 @@ func TestFuncInfoSiteLayoutArgsEligibilityAndCreateFailure(t *testing.T) {
 	}
 }
 
+func TestRuntimeEntrySiteSectionInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  *context
+		want string
+	}{
+		{name: "nil context", want: "__DATA,__llgo_fie"},
+		{name: "darwin without LTO", ctx: &context{buildConf: &Config{Goos: "darwin", LTO: lto.Off}}, want: "__DATA,__llgo_fie"},
+		{name: "darwin full LTO", ctx: &context{buildConf: &Config{Goos: "darwin", LTO: lto.Full}}, want: "__LLGO,__llgo_fie"},
+		{name: "darwin thin LTO", ctx: &context{buildConf: &Config{Goos: "darwin", LTO: lto.Thin}}, want: "__LLGO,__llgo_fie"},
+		{name: "linux full LTO", ctx: &context{buildConf: &Config{Goos: "linux", LTO: lto.Full}}, want: "__DATA,__llgo_fie"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := runtimeEntrySiteSectionInfo(test.ctx).machO; got != test.want {
+				t.Fatalf("Mach-O entry site section = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestFuncInfoTableMaterializesEntrySites(t *testing.T) {
 	prog := llssa.NewProgram(nil)
 	src := prog.NewPackage("example.com/p", "example.com/p")
@@ -510,17 +531,23 @@ func TestFuncInfoTableEmissionMatrix(t *testing.T) {
 	cases := []struct {
 		goos, goarch string
 		empty        bool
+		lto          lto.Mode
+		entrySection string
 	}{
-		{"linux", "amd64", false},
-		{"darwin", "arm64", false},
-		{"linux", "386", false},
-		{"linux", "amd64", true},
-		{"darwin", "arm64", true},
+		{goos: "linux", goarch: "amd64"},
+		{goos: "darwin", goarch: "arm64", entrySection: "__DATA,__llgo_fie"},
+		{goos: "darwin", goarch: "arm64", lto: lto.Full, entrySection: "__LLGO,__llgo_fie"},
+		{goos: "linux", goarch: "386"},
+		{goos: "linux", goarch: "amd64", empty: true},
+		{goos: "darwin", goarch: "arm64", empty: true, entrySection: "__DATA,__llgo_fie"},
 	}
 	for _, c := range cases {
 		name := c.goos + "/" + c.goarch
 		if c.empty {
 			name += "/empty"
+		}
+		if c.lto.Enabled() {
+			name += "/" + c.lto.String()
 		}
 		t.Run(name, func(t *testing.T) {
 			prog := llssa.NewProgram(&llssa.Target{GOOS: c.goos, GOARCH: c.goarch})
@@ -540,6 +567,7 @@ func TestFuncInfoTableEmissionMatrix(t *testing.T) {
 					BuildMode: BuildModeExe,
 					Goos:      c.goos,
 					Goarch:    c.goarch,
+					LTO:       c.lto,
 				},
 			}
 			records := collectFuncInfo([]Package{{LPkg: src}})
@@ -558,6 +586,9 @@ func TestFuncInfoTableEmissionMatrix(t *testing.T) {
 			}
 			if c.goos == "darwin" && !strings.Contains(ir, "live_support") {
 				t.Fatalf("darwin sections must be live_support:\n%s", ir)
+			}
+			if c.entrySection != "" && !strings.Contains(ir, c.entrySection) {
+				t.Fatalf("missing Mach-O entry section %q:\n%s", c.entrySection, ir)
 			}
 			if c.goos == "linux" && !strings.Contains(ir, "pushsection llgo_funcinfo_entry") {
 				t.Fatalf("missing elf entry section:\n%s", ir)
@@ -743,14 +774,16 @@ func TestFuncInfoTableEmptyEncodedInitializers(t *testing.T) {
 
 func TestExternalFuncInfoTableKeepsPayloadOutOfIR(t *testing.T) {
 	for _, target := range []struct {
-		goos, goarch  string
-		identitySect  string
-		entryBoundary string
+		name, goos, goarch string
+		lto                lto.Mode
+		identitySect       string
+		entryBoundary      string
 	}{
-		{goos: "linux", goarch: "amd64", identitySect: "llgo_pclntab_id", entryBoundary: "__start_llgo_funcinfo_entry"},
-		{goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__LLGO$__llgo_fie"},
+		{name: "linux", goos: "linux", goarch: "amd64", identitySect: "llgo_pclntab_id", entryBoundary: "__start_llgo_funcinfo_entry"},
+		{name: "darwin/no-lto", goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__DATA$__llgo_fie"},
+		{name: "darwin/full-lto", goos: "darwin", goarch: "arm64", lto: lto.Full, identitySect: "__llgo_pid", entryBoundary: "section$start$__LLGO$__llgo_fie"},
 	} {
-		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
+		t.Run(target.name, func(t *testing.T) {
 			prog := llssa.NewProgram(&llssa.Target{GOOS: target.goos, GOARCH: target.goarch})
 			prog.EnableFuncInfoMetadata(true)
 			prog.EnableFuncInfoSites(true)
@@ -765,6 +798,7 @@ func TestExternalFuncInfoTableKeepsPayloadOutOfIR(t *testing.T) {
 					BuildMode: BuildModeExe,
 					Goos:      target.goos,
 					Goarch:    target.goarch,
+					LTO:       target.lto,
 					PCLNMode:  PCLNExternal,
 				},
 			}

--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -98,6 +98,46 @@ func TestFuncInfoTableMaterializesMetadataWithoutFunctionPointers(t *testing.T) 
 	}
 }
 
+func TestFuncInfoSiteLayoutArgs(t *testing.T) {
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+	defer prog.Dispose()
+	prog.EnableFuncInfoSites(true)
+	ctx := &context{prog: prog, buildConf: &Config{
+		BuildMode: BuildModeExe,
+		Goos:      "linux",
+		Goarch:    "amd64",
+	}}
+	dir := t.TempDir()
+	args, cleanup, err := funcInfoSiteLayoutArgs(ctx, filepath.Join(dir, "app"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 1 || !strings.HasPrefix(args[0], "-Wl,-T,") {
+		t.Fatalf("layout args = %#v", args)
+	}
+	script := strings.TrimPrefix(args[0], "-Wl,-T,")
+	raw, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"llgo_funcinfo_entry", "llgo_funcinfo_stubsite", "INSERT BEFORE .bss"} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("linker script missing %q:\n%s", want, raw)
+		}
+	}
+	cleanup()
+	if _, err := os.Stat(script); !os.IsNotExist(err) {
+		t.Fatalf("linker script was not removed: %v", err)
+	}
+
+	ctx.buildConf.Goos = "darwin"
+	args, cleanup, err = funcInfoSiteLayoutArgs(ctx, filepath.Join(dir, "app"))
+	if err != nil || len(args) != 0 {
+		t.Fatalf("Darwin layout args = %#v, %v", args, err)
+	}
+	cleanup()
+}
+
 func TestFuncInfoTableMaterializesEntrySites(t *testing.T) {
 	prog := llssa.NewProgram(nil)
 	src := prog.NewPackage("example.com/p", "example.com/p")
@@ -749,7 +789,7 @@ func TestExternalFuncInfoTableKeepsPayloadOutOfIR(t *testing.T) {
 		entryBoundary string
 	}{
 		{goos: "linux", goarch: "amd64", identitySect: "llgo_pclntab_id", entryBoundary: "__start_llgo_funcinfo_entry"},
-		{goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__DATA$__llgo_fie"},
+		{goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__LLGO$__llgo_fie"},
 	} {
 		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
 			prog := llssa.NewProgram(&llssa.Target{GOOS: target.goos, GOARCH: target.goarch})

--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -189,10 +189,13 @@ func TestRuntimeEntrySiteSectionInfo(t *testing.T) {
 		want string
 	}{
 		{name: "nil context", want: "__DATA,__llgo_fie"},
-		{name: "darwin without LTO", ctx: &context{buildConf: &Config{Goos: "darwin", LTO: lto.Off}}, want: "__DATA,__llgo_fie"},
-		{name: "darwin full LTO", ctx: &context{buildConf: &Config{Goos: "darwin", LTO: lto.Full}}, want: "__LLGO,__llgo_fie"},
-		{name: "darwin thin LTO", ctx: &context{buildConf: &Config{Goos: "darwin", LTO: lto.Thin}}, want: "__LLGO,__llgo_fie"},
-		{name: "linux full LTO", ctx: &context{buildConf: &Config{Goos: "linux", LTO: lto.Full}}, want: "__DATA,__llgo_fie"},
+		{name: "darwin without LTO", ctx: &context{buildConf: &Config{Goos: "darwin", BuildMode: BuildModeExe, PCLNMode: PCLNEmbedded, LTO: lto.Off}}, want: "__DATA,__llgo_fie"},
+		{name: "darwin embedded executable full LTO", ctx: &context{buildConf: &Config{Goos: "darwin", BuildMode: BuildModeExe, PCLNMode: PCLNEmbedded, LTO: lto.Full}}, want: "__LLGO,__llgo_fie"},
+		{name: "darwin embedded executable thin LTO", ctx: &context{buildConf: &Config{Goos: "darwin", BuildMode: BuildModeExe, PCLNMode: PCLNEmbedded, LTO: lto.Thin}}, want: "__LLGO,__llgo_fie"},
+		{name: "darwin external full LTO", ctx: &context{buildConf: &Config{Goos: "darwin", BuildMode: BuildModeExe, PCLNMode: PCLNExternal, LTO: lto.Full}}, want: "__DATA,__llgo_fie"},
+		{name: "darwin c-shared full LTO", ctx: &context{buildConf: &Config{Goos: "darwin", BuildMode: BuildModeCShared, PCLNMode: PCLNEmbedded, LTO: lto.Full}}, want: "__DATA,__llgo_fie"},
+		{name: "darwin c-archive full LTO", ctx: &context{buildConf: &Config{Goos: "darwin", BuildMode: BuildModeCArchive, PCLNMode: PCLNEmbedded, LTO: lto.Full}}, want: "__DATA,__llgo_fie"},
+		{name: "linux full LTO", ctx: &context{buildConf: &Config{Goos: "linux", BuildMode: BuildModeExe, PCLNMode: PCLNEmbedded, LTO: lto.Full}}, want: "__DATA,__llgo_fie"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -781,7 +784,7 @@ func TestExternalFuncInfoTableKeepsPayloadOutOfIR(t *testing.T) {
 	}{
 		{name: "linux", goos: "linux", goarch: "amd64", identitySect: "llgo_pclntab_id", entryBoundary: "__start_llgo_funcinfo_entry"},
 		{name: "darwin/no-lto", goos: "darwin", goarch: "arm64", identitySect: "__llgo_pid", entryBoundary: "section$start$__DATA$__llgo_fie"},
-		{name: "darwin/full-lto", goos: "darwin", goarch: "arm64", lto: lto.Full, identitySect: "__llgo_pid", entryBoundary: "section$start$__LLGO$__llgo_fie"},
+		{name: "darwin/full-lto", goos: "darwin", goarch: "arm64", lto: lto.Full, identitySect: "__llgo_pid", entryBoundary: "section$start$__DATA$__llgo_fie"},
 	} {
 		t.Run(target.name, func(t *testing.T) {
 			prog := llssa.NewProgram(&llssa.Target{GOOS: target.goos, GOARCH: target.goarch})

--- a/internal/pclnpost/binary.go
+++ b/internal/pclnpost/binary.go
@@ -18,8 +18,9 @@
 // generation (doc/design/pclntab-linkphase.md). It parses a linked LLGo
 // binary's funcinfo site section, deduplicates LTO inline copies against the
 // symbol table, sorts the entries, builds the Go-layout findfunctab via
-// internal/pclntab, and transactionally replaces the linked image with a
-// compact physical carrier.
+// internal/pclntab, and transactionally replaces the linked image. Isolated
+// LTO carriers are physically compacted; shared non-LTO Mach-O carriers retain
+// their file layout.
 package pclnpost
 
 import (

--- a/internal/pclnpost/binary.go
+++ b/internal/pclnpost/binary.go
@@ -18,9 +18,8 @@
 // generation (doc/design/pclntab-linkphase.md). It parses a linked LLGo
 // binary's funcinfo site section, deduplicates LTO inline copies against the
 // symbol table, sorts the entries, builds the Go-layout findfunctab via
-// internal/pclntab, and prints what the P2 build integration would write
-// back. It performs no writes; its purpose is to prove the risky steps on
-// real binaries.
+// internal/pclntab, and transactionally replaces the linked image with a
+// compact physical carrier.
 package pclnpost
 
 import (

--- a/internal/pclnpost/binary.go
+++ b/internal/pclnpost/binary.go
@@ -18,9 +18,8 @@
 // generation (doc/design/pclntab-linkphase.md). It parses a linked LLGo
 // binary's funcinfo site sections, deduplicates LTO inline copies against the
 // symbol table, sorts the entries, builds the Go-layout findfunctab via
-// internal/pclntab, and prints what the P2 build integration would write
-// back. It performs no writes; its purpose is to prove the risky steps on
-// real binaries.
+// internal/pclntab, and transactionally replaces the linked image with a
+// compact physical carrier.
 package pclnpost
 
 import (

--- a/internal/pclnpost/binary.go
+++ b/internal/pclnpost/binary.go
@@ -19,8 +19,8 @@
 // binary's funcinfo site section, deduplicates LTO inline copies against the
 // symbol table, sorts the entries, builds the Go-layout findfunctab via
 // internal/pclntab, and transactionally replaces the linked image. Isolated
-// LTO carriers are physically compacted; shared non-LTO Mach-O carriers retain
-// their file layout.
+// LTO carriers in embedded Mach-O executables are physically compacted; shared
+// carriers in other Mach-O build modes retain their file layout.
 package pclnpost
 
 import (

--- a/internal/pclnpost/compact.go
+++ b/internal/pclnpost/compact.go
@@ -24,12 +24,13 @@ import (
 	"fmt"
 )
 
-// compactCarrier removes the unused file-backed suffix of the entry carrier
-// while preserving its original virtual address range. The omitted
-// suffix consequently loads as zero-fill memory. Only the deliberately
-// constrained LLGo layouts are accepted; unfamiliar shapes fail before the
-// caller publishes any bytes. raw must be an owned staging buffer and may be
-// modified even when compaction returns an error.
+// compactCarrier removes the unused file-backed suffix of an isolated entry
+// carrier while preserving its original virtual address range. Non-LTO Mach-O
+// images deliberately keep the carrier in __DATA and retain their physical
+// layout after the logical table rewrite. Only these deliberately constrained
+// LLGo layouts are accepted; unfamiliar shapes fail before the caller publishes
+// any bytes. raw must be an owned staging buffer and may be modified even when
+// compaction returns an error.
 func compactCarrier(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64, error) {
 	if entryUsed > info.entryVMSize {
 		return nil, 0, fmt.Errorf("compact size entry=%#x/%#x", entryUsed, info.entryVMSize)
@@ -88,21 +89,27 @@ func compactMachO(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint6
 			}
 		}
 	}
-	if carrier == nil || entry == nil || carrier.name != "__LLGO" {
-		return nil, 0, fmt.Errorf("Mach-O funcinfo carrier is not isolated in __LLGO")
+	if carrier == nil || entry == nil {
+		return nil, 0, fmt.Errorf("missing Mach-O funcinfo carrier")
+	}
+	oldEnd, ok := checkedEnd(carrier.fileoff, carrier.filesize, uint64(len(raw)))
+	if carrier.filesize == 0 || !ok {
+		return nil, 0, fmt.Errorf("Mach-O %s file range [%#x,+%#x) is invalid", carrier.name, carrier.fileoff, carrier.filesize)
+	}
+	if !rangeContained(carrier.fileoff, oldEnd, entry.offset, entry.size) {
+		return nil, 0, fmt.Errorf("Mach-O entry carrier is outside %s", carrier.name)
+	}
+	if carrier.name == "__DATA" {
+		return raw, 0, nil
+	}
+	if carrier.name != "__LLGO" {
+		return nil, 0, fmt.Errorf("Mach-O funcinfo carrier is in unsupported segment %s", carrier.name)
 	}
 	for i := range carrier.sections {
 		sec := &carrier.sections[i]
 		if sec.name != "__llgo_fie" && sec.size != 0 {
 			return nil, 0, fmt.Errorf("Mach-O __LLGO contains unexpected section %s", sec.name)
 		}
-	}
-	oldEnd, ok := checkedEnd(carrier.fileoff, carrier.filesize, uint64(len(raw)))
-	if carrier.filesize == 0 || !ok {
-		return nil, 0, fmt.Errorf("Mach-O __LLGO file range [%#x,+%#x) is invalid", carrier.fileoff, carrier.filesize)
-	}
-	if !rangeContained(carrier.fileoff, oldEnd, entry.offset, entry.size) {
-		return nil, 0, fmt.Errorf("Mach-O entry carrier is outside __LLGO")
 	}
 	for i := range layout.segments {
 		seg := &layout.segments[i]

--- a/internal/pclnpost/compact.go
+++ b/internal/pclnpost/compact.go
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pclnpost
+
+import (
+	"bytes"
+	"debug/elf"
+	"debug/macho"
+	"encoding/binary"
+	"fmt"
+)
+
+// compactCarrier removes the unused file-backed suffix of the entry/stub
+// carrier while preserving its original virtual address range. The omitted
+// suffix consequently loads as zero-fill memory. Only the deliberately
+// constrained LLGo layouts are accepted; unfamiliar shapes fail before the
+// caller publishes any bytes. raw must be an owned staging buffer and may be
+// modified even when compaction returns an error.
+func compactCarrier(raw []byte, info *binaryInfo, entryUsed, stubUsed uint64) ([]byte, uint64, error) {
+	if entryUsed > info.entryVMSize || stubUsed > info.stubVMSize {
+		return nil, 0, fmt.Errorf("compact sizes entry=%#x/%#x stub=%#x/%#x", entryUsed, info.entryVMSize, stubUsed, info.stubVMSize)
+	}
+	switch info.format {
+	case ExternalFormatMachO:
+		return compactMachO(raw, info, entryUsed, stubUsed)
+	case ExternalFormatELF:
+		return compactELF(raw, info, entryUsed, stubUsed)
+	default:
+		return nil, 0, fmt.Errorf("unsupported binary format %q", info.format)
+	}
+}
+
+type machoSectionLayout struct {
+	name, segment string
+	header        uint64
+	addr, size    uint64
+	offset        uint64
+	reloff        uint64
+	nreloc        uint32
+}
+
+type machoSegmentLayout struct {
+	name              string
+	header            uint64
+	vmaddr, vmsize    uint64
+	fileoff, filesize uint64
+	sections          []machoSectionLayout
+}
+
+type machoOffsetField struct {
+	pos   uint64
+	width uint8
+	label string
+}
+
+type machoLayout struct {
+	segments []machoSegmentLayout
+	offsets  []machoOffsetField
+}
+
+func compactMachO(raw []byte, info *binaryInfo, entryUsed, stubUsed uint64) ([]byte, uint64, error) {
+	layout, err := parseMachOLayout(raw)
+	if err != nil {
+		return nil, 0, err
+	}
+	var carrier *machoSegmentLayout
+	var entry, stub *machoSectionLayout
+	for si := range layout.segments {
+		seg := &layout.segments[si]
+		for sj := range seg.sections {
+			sec := &seg.sections[sj]
+			switch sec.name {
+			case "__llgo_fie":
+				entry, carrier = sec, seg
+			case "__llgo_stub":
+				stub = sec
+				if carrier != nil && carrier != seg {
+					return nil, 0, fmt.Errorf("Mach-O funcinfo carriers span segments")
+				}
+				carrier = seg
+			}
+		}
+	}
+	if carrier == nil || entry == nil || carrier.name != "__LLGO" {
+		return nil, 0, fmt.Errorf("Mach-O funcinfo carriers are not isolated in __LLGO")
+	}
+	if stubUsed != 0 && stub == nil {
+		return nil, 0, fmt.Errorf("missing Mach-O stub carrier")
+	}
+	if stub != nil && stub.segment != carrier.name {
+		return nil, 0, fmt.Errorf("Mach-O stub carrier is outside __LLGO")
+	}
+	for i := range carrier.sections {
+		sec := &carrier.sections[i]
+		if sec.name != "__llgo_fie" && sec.name != "__llgo_stub" && sec.size != 0 {
+			return nil, 0, fmt.Errorf("Mach-O __LLGO contains unexpected section %s", sec.name)
+		}
+	}
+	oldEnd := carrier.fileoff + carrier.filesize
+	if carrier.filesize == 0 || oldEnd > uint64(len(raw)) {
+		return nil, 0, fmt.Errorf("Mach-O __LLGO file range [%#x,%#x) is invalid", carrier.fileoff, oldEnd)
+	}
+	for i := range layout.segments {
+		seg := &layout.segments[i]
+		if seg.header != carrier.header && seg.filesize != 0 && seg.fileoff >= oldEnd && seg.name != "__LINKEDIT" {
+			return nil, 0, fmt.Errorf("Mach-O segment %s follows __LLGO", seg.name)
+		}
+	}
+	lastUsed := entry.offset + entryUsed
+	if stubUsed != 0 && stub.offset+stubUsed > lastUsed {
+		lastUsed = stub.offset + stubUsed
+	}
+	if lastUsed < carrier.fileoff || lastUsed > oldEnd {
+		return nil, 0, fmt.Errorf("Mach-O compact payload %#x is outside __LLGO [%#x,%#x)", lastUsed, carrier.fileoff, oldEnd)
+	}
+	page := machoPageSize(raw)
+	newFilesz := alignUp(lastUsed-carrier.fileoff, page)
+	if newFilesz > carrier.filesize {
+		return nil, 0, fmt.Errorf("Mach-O compact __LLGO size %#x exceeds %#x", newFilesz, carrier.filesize)
+	}
+	cutStart := carrier.fileoff + newFilesz
+	removed := oldEnd - cutStart
+
+	out := raw
+	binary.LittleEndian.PutUint64(out[entry.header+40:], entryUsed)
+	if stub != nil {
+		binary.LittleEndian.PutUint64(out[stub.header+40:], stubUsed)
+		if stubUsed == 0 {
+			binary.LittleEndian.PutUint32(out[stub.header+48:], 0)
+		}
+	}
+	if removed == 0 {
+		return out, 0, nil
+	}
+	if err := patchMachOFileOffsets(out, layout, carrier.header, newFilesz, cutStart, oldEnd); err != nil {
+		return nil, 0, err
+	}
+	copy(out[cutStart:], out[oldEnd:])
+	out = out[:uint64(len(out))-removed]
+	if _, err := macho.NewFile(bytes.NewReader(out)); err != nil {
+		return nil, 0, fmt.Errorf("verify compact Mach-O: %w", err)
+	}
+	return out, removed, nil
+}
+
+func parseMachOLayout(raw []byte) (machoLayout, error) {
+	var layout machoLayout
+	if len(raw) < 32 || binary.LittleEndian.Uint32(raw) != uint32(macho.Magic64) {
+		return layout, fmt.Errorf("compact Mach-O requires a little-endian 64-bit image")
+	}
+	ncmds := binary.LittleEndian.Uint32(raw[16:])
+	off := uint64(32)
+	layout.segments = make([]machoSegmentLayout, 0, 8)
+	add32 := func(pos uint64, label string) {
+		layout.offsets = append(layout.offsets, machoOffsetField{pos, 4, label})
+	}
+	add64 := func(pos uint64, label string) {
+		layout.offsets = append(layout.offsets, machoOffsetField{pos, 8, label})
+	}
+	for i := uint32(0); i < ncmds; i++ {
+		if off > uint64(len(raw)) || uint64(len(raw))-off < 8 {
+			return layout, fmt.Errorf("Mach-O load command %d is truncated", i)
+		}
+		cmd := binary.LittleEndian.Uint32(raw[off:])
+		cmdsz := uint64(binary.LittleEndian.Uint32(raw[off+4:]))
+		if cmdsz < 8 || cmdsz > uint64(len(raw))-off {
+			return layout, fmt.Errorf("Mach-O load command %d has invalid size %#x", i, cmdsz)
+		}
+		require := func(size uint64) error {
+			if cmdsz < size {
+				return fmt.Errorf("Mach-O load command %#x has size %#x, want at least %#x", cmd, cmdsz, size)
+			}
+			return nil
+		}
+		switch cmd {
+		case 0x19: // LC_SEGMENT_64
+			if cmdsz < 72 {
+				return layout, fmt.Errorf("truncated LC_SEGMENT_64")
+			}
+			seg := machoSegmentLayout{
+				name:     cString16(raw[off+8 : off+24]),
+				header:   off,
+				vmaddr:   binary.LittleEndian.Uint64(raw[off+24:]),
+				vmsize:   binary.LittleEndian.Uint64(raw[off+32:]),
+				fileoff:  binary.LittleEndian.Uint64(raw[off+40:]),
+				filesize: binary.LittleEndian.Uint64(raw[off+48:]),
+			}
+			nsects := binary.LittleEndian.Uint32(raw[off+64:])
+			if uint64(nsects) > (cmdsz-72)/80 {
+				return layout, fmt.Errorf("Mach-O segment %s has truncated sections", seg.name)
+			}
+			for j := uint32(0); j < nsects; j++ {
+				h := off + 72 + uint64(j)*80
+				seg.sections = append(seg.sections, machoSectionLayout{
+					name:    cString16(raw[h : h+16]),
+					segment: cString16(raw[h+16 : h+32]),
+					header:  h,
+					addr:    binary.LittleEndian.Uint64(raw[h+32:]),
+					size:    binary.LittleEndian.Uint64(raw[h+40:]),
+					offset:  uint64(binary.LittleEndian.Uint32(raw[h+48:])),
+					reloff:  uint64(binary.LittleEndian.Uint32(raw[h+56:])),
+					nreloc:  binary.LittleEndian.Uint32(raw[h+60:]),
+				})
+			}
+			layout.segments = append(layout.segments, seg)
+		case 0x2: // LC_SYMTAB
+			if err := require(24); err != nil {
+				return layout, err
+			}
+			add32(off+8, "symoff")
+			add32(off+16, "stroff")
+		case 0xb: // LC_DYSYMTAB
+			if err := require(80); err != nil {
+				return layout, err
+			}
+			for _, p := range []uint64{32, 40, 48, 56, 64, 72} {
+				add32(off+p, "dysymtab")
+			}
+		case 0x22, 0x80000022: // LC_DYLD_INFO[_ONLY]
+			if err := require(48); err != nil {
+				return layout, err
+			}
+			for _, p := range []uint64{8, 16, 24, 32, 40} {
+				add32(off+p, "dyld info")
+			}
+		case 0x1d, 0x1e, 0x26, 0x29, 0x2b, 0x2e, 0x80000033, 0x80000034:
+			if err := require(16); err != nil {
+				return layout, err
+			}
+			add32(off+8, "linkedit data")
+		case 0x16: // LC_TWOLEVEL_HINTS
+			if err := require(16); err != nil {
+				return layout, err
+			}
+			add32(off+8, "twolevel hints")
+		case 0x31: // LC_NOTE
+			if err := require(40); err != nil {
+				return layout, err
+			}
+			add64(off+24, "note")
+		case 0x21, 0x2c: // LC_ENCRYPTION_INFO[_64]
+			if err := require(20); err != nil {
+				return layout, err
+			}
+			if binary.LittleEndian.Uint32(raw[off+16:]) != 0 {
+				return layout, fmt.Errorf("cannot compact encrypted Mach-O")
+			}
+			add32(off+8, "encryption info")
+		case 0x35, 0x80000035: // LC_FILESET_ENTRY
+			return layout, fmt.Errorf("cannot compact Mach-O fileset")
+		default:
+			if !machoLoadCommandHasNoFileOffset(cmd) {
+				return layout, fmt.Errorf("unsupported Mach-O load command %#x", cmd)
+			}
+		}
+		off += cmdsz
+	}
+	return layout, nil
+}
+
+func patchMachOFileOffsets(raw []byte, layout machoLayout, carrierHeader, newFilesz, cutStart, cutEnd uint64) error {
+	delta := cutEnd - cutStart
+	shift32 := func(pos uint64, label string) error {
+		if pos > uint64(len(raw)) || uint64(len(raw))-pos < 4 {
+			return fmt.Errorf("Mach-O %s offset field is truncated", label)
+		}
+		v := uint64(binary.LittleEndian.Uint32(raw[pos:]))
+		if v == 0 {
+			return nil
+		}
+		if v >= cutEnd {
+			if v-delta > uint64(^uint32(0)) {
+				return fmt.Errorf("Mach-O %s offset overflows", label)
+			}
+			binary.LittleEndian.PutUint32(raw[pos:], uint32(v-delta))
+			return nil
+		}
+		if v >= cutStart {
+			return fmt.Errorf("Mach-O %s offset %#x falls in compacted range", label, v)
+		}
+		return nil
+	}
+	shift64 := func(pos uint64, label string) error {
+		if pos > uint64(len(raw)) || uint64(len(raw))-pos < 8 {
+			return fmt.Errorf("Mach-O %s offset field is truncated", label)
+		}
+		v := binary.LittleEndian.Uint64(raw[pos:])
+		if v == 0 {
+			return nil
+		}
+		if v >= cutEnd {
+			binary.LittleEndian.PutUint64(raw[pos:], v-delta)
+			return nil
+		}
+		if v >= cutStart {
+			return fmt.Errorf("Mach-O %s offset %#x falls in compacted range", label, v)
+		}
+		return nil
+	}
+	for _, seg := range layout.segments {
+		if seg.header == carrierHeader {
+			binary.LittleEndian.PutUint64(raw[seg.header+48:], newFilesz)
+		} else if err := shift64(seg.header+40, seg.name+" fileoff"); err != nil {
+			return err
+		}
+		for _, sec := range seg.sections {
+			if sec.name != "__llgo_fie" && sec.name != "__llgo_stub" {
+				if err := shift32(sec.header+48, sec.segment+","+sec.name+" offset"); err != nil {
+					return err
+				}
+			}
+			if sec.nreloc != 0 {
+				if err := shift32(sec.header+56, sec.segment+","+sec.name+" reloff"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	for _, field := range layout.offsets {
+		var err error
+		if field.width == 8 {
+			err = shift64(field.pos, field.label)
+		} else {
+			err = shift32(field.pos, field.label)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func machoLoadCommandHasNoFileOffset(cmd uint32) bool {
+	// LC_REQ_DYLD is an attribute bit, not part of the command layout.
+	switch cmd &^ 0x80000000 {
+	case 0x1, // LC_SEGMENT (32-bit, rejected by parser)
+		0x3, 0x4, 0x5, 0x6, // thread/unixthread/loadfvmlib/idfvmlib
+		0xc, 0xd, 0xe, 0xf, // dylib/id/load dylinker/prebound dylib
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+		0x17, 0x18, 0x19, 0x1b, 0x1c,
+		0x20, 0x23, 0x24, 0x25, 0x27, 0x28,
+		0x2a, 0x2d, 0x2f, 0x30, 0x32:
+		return true
+	}
+	return false
+}
+
+func machoPageSize(raw []byte) uint64 {
+	// Current LLGo Darwin targets use 16 KiB pages on arm64 and 4 KiB on
+	// amd64. Unknown Mach-O CPU types deliberately take the conservative
+	// 4 KiB fallback and still pass the staged-image verifier.
+	const cpuTypeARM64 = uint32(0x0100000c)
+	if len(raw) >= 8 && binary.LittleEndian.Uint32(raw[4:]) == cpuTypeARM64 {
+		return 0x4000
+	}
+	return 0x1000
+}
+
+func cString16(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return string(b)
+}
+
+type elfSectionLayout struct {
+	name                string
+	header              uint64
+	typ                 uint32
+	flags, addr, offset uint64
+	size, align         uint64
+}
+
+type elfProgramLayout struct {
+	header                              uint64
+	typ, flags                          uint32
+	offset, vaddr, filesz, memsz, align uint64
+}
+
+func compactELF(raw []byte, info *binaryInfo, entryUsed, stubUsed uint64) ([]byte, uint64, error) {
+	sections, programs, shoff, err := parseELFLayout(raw)
+	if err != nil {
+		return nil, 0, err
+	}
+	var entry, stub *elfSectionLayout
+	for i := range sections {
+		switch sections[i].name {
+		case "llgo_funcinfo_entry":
+			entry = &sections[i]
+		case "llgo_funcinfo_stubsite":
+			stub = &sections[i]
+		}
+	}
+	if entry == nil {
+		return nil, 0, fmt.Errorf("missing ELF entry carrier")
+	}
+	if stubUsed != 0 && stub == nil {
+		return nil, 0, fmt.Errorf("missing ELF stub carrier")
+	}
+	var carrier *elfProgramLayout
+	for i := range programs {
+		p := &programs[i]
+		if p.typ != uint32(elf.PT_LOAD) || p.filesz == 0 {
+			continue
+		}
+		end, ok := checkedEnd(p.offset, p.filesz, ^uint64(0))
+		if !ok {
+			continue
+		}
+		entryIn := rangeContained(p.offset, end, entry.offset, entry.size)
+		stubIn := stub == nil || rangeContained(p.offset, end, stub.offset, stub.size)
+		if entryIn && stubIn {
+			carrier = p
+			break
+		}
+	}
+	if carrier == nil {
+		return nil, 0, fmt.Errorf("ELF funcinfo carriers do not share one PT_LOAD")
+	}
+	oldEnd, ok := checkedEnd(carrier.offset, carrier.filesz, uint64(len(raw)))
+	if !ok {
+		return nil, 0, fmt.Errorf("ELF carrier file range [%#x,+%#x) is invalid", carrier.offset, carrier.filesz)
+	}
+	lastUsed := entry.offset + entryUsed
+	if stubUsed != 0 && stub.offset+stubUsed > lastUsed {
+		lastUsed = stub.offset + stubUsed
+	}
+	if lastUsed < carrier.offset || lastUsed > oldEnd {
+		return nil, 0, fmt.Errorf("ELF compact payload %#x is outside PT_LOAD [%#x,%#x)", lastUsed, carrier.offset, oldEnd)
+	}
+	for _, sec := range sections {
+		if sec.typ == uint32(elf.SHT_NOBITS) || sec.size == 0 || sec.name == entry.name || (stub != nil && sec.name == stub.name) {
+			continue
+		}
+		if sec.flags&uint64(elf.SHF_ALLOC) != 0 && sec.offset < oldEnd && sec.offset+sec.size > lastUsed {
+			return nil, 0, fmt.Errorf("ELF allocated section %s follows compact payload in carrier PT_LOAD", sec.name)
+		}
+	}
+	if carrier.vaddr+carrier.memsz < info.stubVMAddr+info.stubVMSize || carrier.vaddr+carrier.memsz < info.entryVMAddr+info.entryVMSize {
+		return nil, 0, fmt.Errorf("ELF carrier virtual tail is not covered by PT_LOAD memory")
+	}
+	// The linker script makes the carrier the final file-backed part of the
+	// final PT_LOAD. Program segments therefore never need to move; only
+	// non-allocated sections and the section-header table follow it.
+	for _, p := range programs {
+		if p.header == carrier.header || p.offset == 0 {
+			continue
+		}
+		if p.offset >= oldEnd {
+			return nil, 0, fmt.Errorf("ELF program header type %d follows the funcinfo carrier", p.typ)
+		}
+	}
+	cutAlign := uint64(8) // ELF64 section headers and symbol tables.
+	for _, sec := range sections {
+		if sec.offset < oldEnd || sec.align <= cutAlign {
+			continue
+		}
+		if sec.align&(sec.align-1) != 0 {
+			return nil, 0, fmt.Errorf("ELF section %s has invalid alignment %#x", sec.name, sec.align)
+		}
+		cutAlign = sec.align
+	}
+	removed := alignDown(oldEnd-lastUsed, cutAlign)
+	cutStart := oldEnd - removed
+	out := raw
+	binary.LittleEndian.PutUint64(out[entry.header+32:], entryUsed)
+	if stub != nil {
+		binary.LittleEndian.PutUint64(out[stub.header+32:], stubUsed)
+		if stubUsed == 0 {
+			binary.LittleEndian.PutUint64(out[stub.header+24:], 0)
+		}
+	}
+	if removed == 0 {
+		return out, 0, nil
+	}
+	binary.LittleEndian.PutUint64(out[carrier.header+32:], carrier.filesz-removed)
+	for _, p := range programs {
+		if p.header != carrier.header && p.filesz != 0 && p.offset < oldEnd && p.offset+p.filesz > cutStart {
+			return nil, 0, fmt.Errorf("ELF program header type %d overlaps compacted range", p.typ)
+		}
+	}
+	for _, sec := range sections {
+		if sec.name == entry.name || (stub != nil && sec.name == stub.name) {
+			continue
+		}
+		if sec.offset >= oldEnd {
+			binary.LittleEndian.PutUint64(out[sec.header+24:], sec.offset-removed)
+		} else if sec.typ == uint32(elf.SHT_NOBITS) && sec.offset >= cutStart {
+			binary.LittleEndian.PutUint64(out[sec.header+24:], cutStart)
+		} else if sec.typ != uint32(elf.SHT_NOBITS) && sec.size != 0 && sec.offset+sec.size > cutStart {
+			return nil, 0, fmt.Errorf("ELF section %s overlaps compacted range", sec.name)
+		}
+	}
+	if shoff >= oldEnd {
+		binary.LittleEndian.PutUint64(out[40:], shoff-removed)
+	} else if shoff >= cutStart {
+		return nil, 0, fmt.Errorf("ELF section headers overlap compacted range")
+	}
+	copy(out[cutStart:], out[oldEnd:])
+	out = out[:uint64(len(out))-removed]
+	if _, err := elf.NewFile(bytes.NewReader(out)); err != nil {
+		return nil, 0, fmt.Errorf("verify compact ELF: %w", err)
+	}
+	return out, removed, nil
+}
+
+func parseELFLayout(raw []byte) ([]elfSectionLayout, []elfProgramLayout, uint64, error) {
+	if len(raw) < 64 || !bytes.Equal(raw[:4], []byte{0x7f, 'E', 'L', 'F'}) || raw[4] != byte(elf.ELFCLASS64) || raw[5] != byte(elf.ELFDATA2LSB) {
+		return nil, nil, 0, fmt.Errorf("compact ELF requires a little-endian ELF64 image")
+	}
+	phoff := binary.LittleEndian.Uint64(raw[32:])
+	shoff := binary.LittleEndian.Uint64(raw[40:])
+	phentsz := uint64(binary.LittleEndian.Uint16(raw[54:]))
+	phnum := uint64(binary.LittleEndian.Uint16(raw[56:]))
+	shentsz := uint64(binary.LittleEndian.Uint16(raw[58:]))
+	shnum := uint64(binary.LittleEndian.Uint16(raw[60:]))
+	shstrndx := uint64(binary.LittleEndian.Uint16(raw[62:]))
+	if phnum == 0 || phentsz < 56 || !tableWithinFile(phoff, phnum, phentsz, uint64(len(raw))) {
+		return nil, nil, 0, fmt.Errorf("ELF has no valid program header table")
+	}
+	if shnum == 0 || shentsz < 64 || shstrndx >= shnum || !tableWithinFile(shoff, shnum, shentsz, uint64(len(raw))) {
+		return nil, nil, 0, fmt.Errorf("ELF has no valid section header table")
+	}
+	shstrHeader := shoff + shstrndx*shentsz
+	strOff := binary.LittleEndian.Uint64(raw[shstrHeader+24:])
+	strSize := binary.LittleEndian.Uint64(raw[shstrHeader+32:])
+	strEnd, ok := checkedEnd(strOff, strSize, uint64(len(raw)))
+	if !ok {
+		return nil, nil, 0, fmt.Errorf("ELF section-name table is outside file")
+	}
+	strs := raw[strOff:strEnd]
+	nameAt := func(off uint32) string {
+		if uint64(off) >= uint64(len(strs)) {
+			return ""
+		}
+		b := strs[off:]
+		if i := bytes.IndexByte(b, 0); i >= 0 {
+			b = b[:i]
+		}
+		return string(b)
+	}
+	sections := make([]elfSectionLayout, 0, shnum)
+	for i := uint64(0); i < shnum; i++ {
+		h := shoff + i*shentsz
+		sections = append(sections, elfSectionLayout{
+			name: nameAt(binary.LittleEndian.Uint32(raw[h:])), header: h,
+			typ: binary.LittleEndian.Uint32(raw[h+4:]), flags: binary.LittleEndian.Uint64(raw[h+8:]),
+			addr: binary.LittleEndian.Uint64(raw[h+16:]), offset: binary.LittleEndian.Uint64(raw[h+24:]), size: binary.LittleEndian.Uint64(raw[h+32:]),
+			align: binary.LittleEndian.Uint64(raw[h+48:]),
+		})
+	}
+	programs := make([]elfProgramLayout, 0, phnum)
+	for i := uint64(0); i < phnum; i++ {
+		h := phoff + i*phentsz
+		programs = append(programs, elfProgramLayout{
+			header: h, typ: binary.LittleEndian.Uint32(raw[h:]), flags: binary.LittleEndian.Uint32(raw[h+4:]),
+			offset: binary.LittleEndian.Uint64(raw[h+8:]), vaddr: binary.LittleEndian.Uint64(raw[h+16:]),
+			filesz: binary.LittleEndian.Uint64(raw[h+32:]), memsz: binary.LittleEndian.Uint64(raw[h+40:]), align: binary.LittleEndian.Uint64(raw[h+48:]),
+		})
+	}
+	return sections, programs, shoff, nil
+}
+
+func alignUp(v, align uint64) uint64 {
+	if align <= 1 {
+		return v
+	}
+	if align&(align-1) != 0 || v > ^uint64(0)-(align-1) {
+		return ^uint64(0)
+	}
+	return (v + align - 1) &^ (align - 1)
+}
+
+func alignDown(v, align uint64) uint64 {
+	if align <= 1 {
+		return v
+	}
+	return v &^ (align - 1)
+}
+
+func checkedEnd(off, size, limit uint64) (uint64, bool) {
+	if off > limit || size > limit-off {
+		return 0, false
+	}
+	return off + size, true
+}
+
+func tableWithinFile(off, count, entrySize, limit uint64) bool {
+	return off <= limit && count <= (limit-off)/entrySize
+}
+
+func rangeContained(start, end, off, size uint64) bool {
+	rangeEnd, ok := checkedEnd(off, size, end)
+	return ok && off >= start && rangeEnd <= end
+}

--- a/internal/pclnpost/compact.go
+++ b/internal/pclnpost/compact.go
@@ -264,9 +264,6 @@ func patchMachOFileOffsets(raw []byte, layout machoLayout, carrierHeader, newFil
 			return nil
 		}
 		if v >= cutEnd {
-			if v-delta > uint64(^uint32(0)) {
-				return fmt.Errorf("Mach-O %s offset overflows", label)
-			}
 			binary.LittleEndian.PutUint32(raw[pos:], uint32(v-delta))
 			return nil
 		}
@@ -393,10 +390,7 @@ func compactELF(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64,
 		if p.typ != uint32(elf.PT_LOAD) || p.filesz == 0 {
 			continue
 		}
-		end, ok := checkedEnd(p.offset, p.filesz, ^uint64(0))
-		if !ok {
-			continue
-		}
+		end := p.offset + p.filesz // parseELFLayout already validated this range.
 		if rangeContained(p.offset, end, entry.offset, entry.size) {
 			carrier = p
 			break
@@ -405,10 +399,7 @@ func compactELF(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64,
 	if carrier == nil {
 		return nil, 0, fmt.Errorf("ELF funcinfo carrier is not in a PT_LOAD")
 	}
-	oldEnd, ok := checkedEnd(carrier.offset, carrier.filesz, uint64(len(raw)))
-	if !ok {
-		return nil, 0, fmt.Errorf("ELF carrier file range [%#x,+%#x) is invalid", carrier.offset, carrier.filesz)
-	}
+	oldEnd := carrier.offset + carrier.filesz
 	lastUsed, ok := checkedEnd(entry.offset, entryUsed, oldEnd)
 	if !ok || lastUsed < carrier.offset {
 		return nil, 0, fmt.Errorf("ELF compact payload %#x is outside PT_LOAD [%#x,%#x)", lastUsed, carrier.offset, oldEnd)
@@ -417,10 +408,7 @@ func compactELF(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64,
 		if sec.typ == uint32(elf.SHT_NOBITS) || sec.size == 0 || sec.name == entry.name {
 			continue
 		}
-		secEnd, ok := checkedEnd(sec.offset, sec.size, uint64(len(raw)))
-		if !ok {
-			return nil, 0, fmt.Errorf("ELF section %s has an invalid file range", sec.name)
-		}
+		secEnd := sec.offset + sec.size // parseELFLayout already validated this range.
 		if sec.flags&uint64(elf.SHF_ALLOC) != 0 && sec.offset < oldEnd && secEnd > lastUsed {
 			return nil, 0, fmt.Errorf("ELF allocated section %s follows compact payload in carrier PT_LOAD", sec.name)
 		}
@@ -460,10 +448,7 @@ func compactELF(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64,
 	}
 	binary.LittleEndian.PutUint64(out[carrier.header+32:], carrier.filesz-removed)
 	for _, p := range programs {
-		pEnd, ok := checkedEnd(p.offset, p.filesz, uint64(len(raw)))
-		if !ok {
-			return nil, 0, fmt.Errorf("ELF program header type %d has an invalid file range", p.typ)
-		}
+		pEnd := p.offset + p.filesz
 		if p.header != carrier.header && p.filesz != 0 && p.offset < oldEnd && pEnd > cutStart {
 			return nil, 0, fmt.Errorf("ELF program header type %d overlaps compacted range", p.typ)
 		}
@@ -477,10 +462,7 @@ func compactELF(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64,
 		} else if sec.typ == uint32(elf.SHT_NOBITS) && sec.offset >= cutStart {
 			binary.LittleEndian.PutUint64(out[sec.header+24:], cutStart)
 		} else if sec.typ != uint32(elf.SHT_NOBITS) && sec.size != 0 {
-			secEnd, ok := checkedEnd(sec.offset, sec.size, uint64(len(raw)))
-			if !ok {
-				return nil, 0, fmt.Errorf("ELF section %s has an invalid file range", sec.name)
-			}
+			secEnd := sec.offset + sec.size
 			if secEnd <= cutStart {
 				continue
 			}

--- a/internal/pclnpost/compact.go
+++ b/internal/pclnpost/compact.go
@@ -25,12 +25,12 @@ import (
 )
 
 // compactCarrier removes the unused file-backed suffix of an isolated entry
-// carrier while preserving its original virtual address range. Non-LTO Mach-O
-// images deliberately keep the carrier in __DATA and retain their physical
-// layout after the logical table rewrite. Only these deliberately constrained
-// LLGo layouts are accepted; unfamiliar shapes fail before the caller publishes
-// any bytes. raw must be an owned staging buffer and may be modified even when
-// compaction returns an error.
+// carrier while preserving its original virtual address range. Mach-O images
+// that are not embedded LTO executables deliberately keep the carrier in
+// __DATA and retain their physical layout after the logical table rewrite.
+// Only these deliberately constrained LLGo layouts are accepted; unfamiliar
+// shapes fail before the caller publishes any bytes. raw must be an owned
+// staging buffer and may be modified even when compaction returns an error.
 func compactCarrier(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64, error) {
 	if entryUsed > info.entryVMSize {
 		return nil, 0, fmt.Errorf("compact size entry=%#x/%#x", entryUsed, info.entryVMSize)

--- a/internal/pclnpost/compact.go
+++ b/internal/pclnpost/compact.go
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pclnpost
+
+import (
+	"bytes"
+	"debug/elf"
+	"debug/macho"
+	"encoding/binary"
+	"fmt"
+)
+
+// compactCarrier removes the unused file-backed suffix of the entry carrier
+// while preserving its original virtual address range. The omitted
+// suffix consequently loads as zero-fill memory. Only the deliberately
+// constrained LLGo layouts are accepted; unfamiliar shapes fail before the
+// caller publishes any bytes. raw must be an owned staging buffer and may be
+// modified even when compaction returns an error.
+func compactCarrier(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64, error) {
+	if entryUsed > info.entryVMSize {
+		return nil, 0, fmt.Errorf("compact size entry=%#x/%#x", entryUsed, info.entryVMSize)
+	}
+	switch info.format {
+	case ExternalFormatMachO:
+		return compactMachO(raw, info, entryUsed)
+	case ExternalFormatELF:
+		return compactELF(raw, info, entryUsed)
+	default:
+		return nil, 0, fmt.Errorf("unsupported binary format %q", info.format)
+	}
+}
+
+type machoSectionLayout struct {
+	name, segment string
+	header        uint64
+	addr, size    uint64
+	offset        uint64
+	reloff        uint64
+	nreloc        uint32
+}
+
+type machoSegmentLayout struct {
+	name              string
+	header            uint64
+	vmaddr, vmsize    uint64
+	fileoff, filesize uint64
+	sections          []machoSectionLayout
+}
+
+type machoOffsetField struct {
+	pos   uint64
+	width uint8
+	label string
+}
+
+type machoLayout struct {
+	segments []machoSegmentLayout
+	offsets  []machoOffsetField
+}
+
+func compactMachO(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64, error) {
+	layout, err := parseMachOLayout(raw)
+	if err != nil {
+		return nil, 0, err
+	}
+	var carrier *machoSegmentLayout
+	var entry *machoSectionLayout
+	for si := range layout.segments {
+		seg := &layout.segments[si]
+		for sj := range seg.sections {
+			sec := &seg.sections[sj]
+			if sec.name == "__llgo_fie" {
+				entry, carrier = sec, seg
+			}
+		}
+	}
+	if carrier == nil || entry == nil || carrier.name != "__LLGO" {
+		return nil, 0, fmt.Errorf("Mach-O funcinfo carrier is not isolated in __LLGO")
+	}
+	for i := range carrier.sections {
+		sec := &carrier.sections[i]
+		if sec.name != "__llgo_fie" && sec.size != 0 {
+			return nil, 0, fmt.Errorf("Mach-O __LLGO contains unexpected section %s", sec.name)
+		}
+	}
+	oldEnd, ok := checkedEnd(carrier.fileoff, carrier.filesize, uint64(len(raw)))
+	if carrier.filesize == 0 || !ok {
+		return nil, 0, fmt.Errorf("Mach-O __LLGO file range [%#x,+%#x) is invalid", carrier.fileoff, carrier.filesize)
+	}
+	if !rangeContained(carrier.fileoff, oldEnd, entry.offset, entry.size) {
+		return nil, 0, fmt.Errorf("Mach-O entry carrier is outside __LLGO")
+	}
+	for i := range layout.segments {
+		seg := &layout.segments[i]
+		if seg.header != carrier.header && seg.filesize != 0 && seg.fileoff >= oldEnd && seg.name != "__LINKEDIT" {
+			return nil, 0, fmt.Errorf("Mach-O segment %s follows __LLGO", seg.name)
+		}
+	}
+	lastUsed, ok := checkedEnd(entry.offset, entryUsed, oldEnd)
+	if !ok || lastUsed < carrier.fileoff {
+		return nil, 0, fmt.Errorf("Mach-O compact payload %#x is outside __LLGO [%#x,%#x)", lastUsed, carrier.fileoff, oldEnd)
+	}
+	page := machoPageSize(raw)
+	newFilesz := alignUp(lastUsed-carrier.fileoff, page)
+	if newFilesz > carrier.filesize {
+		return nil, 0, fmt.Errorf("Mach-O compact __LLGO size %#x exceeds %#x", newFilesz, carrier.filesize)
+	}
+	cutStart := carrier.fileoff + newFilesz
+	removed := oldEnd - cutStart
+
+	out := raw
+	binary.LittleEndian.PutUint64(out[entry.header+40:], entryUsed)
+	if removed == 0 {
+		return out, 0, nil
+	}
+	if err := patchMachOFileOffsets(out, layout, carrier.header, newFilesz, cutStart, oldEnd); err != nil {
+		return nil, 0, err
+	}
+	copy(out[cutStart:], out[oldEnd:])
+	out = out[:uint64(len(out))-removed]
+	if _, err := macho.NewFile(bytes.NewReader(out)); err != nil {
+		return nil, 0, fmt.Errorf("verify compact Mach-O: %w", err)
+	}
+	return out, removed, nil
+}
+
+func parseMachOLayout(raw []byte) (machoLayout, error) {
+	var layout machoLayout
+	if len(raw) < 32 || binary.LittleEndian.Uint32(raw) != uint32(macho.Magic64) {
+		return layout, fmt.Errorf("compact Mach-O requires a little-endian 64-bit image")
+	}
+	ncmds := binary.LittleEndian.Uint32(raw[16:])
+	off := uint64(32)
+	layout.segments = make([]machoSegmentLayout, 0, 8)
+	add32 := func(pos uint64, label string) {
+		layout.offsets = append(layout.offsets, machoOffsetField{pos, 4, label})
+	}
+	add64 := func(pos uint64, label string) {
+		layout.offsets = append(layout.offsets, machoOffsetField{pos, 8, label})
+	}
+	for i := uint32(0); i < ncmds; i++ {
+		if off > uint64(len(raw)) || uint64(len(raw))-off < 8 {
+			return layout, fmt.Errorf("Mach-O load command %d is truncated", i)
+		}
+		cmd := binary.LittleEndian.Uint32(raw[off:])
+		cmdsz := uint64(binary.LittleEndian.Uint32(raw[off+4:]))
+		if cmdsz < 8 || cmdsz > uint64(len(raw))-off {
+			return layout, fmt.Errorf("Mach-O load command %d has invalid size %#x", i, cmdsz)
+		}
+		require := func(size uint64) error {
+			if cmdsz < size {
+				return fmt.Errorf("Mach-O load command %#x has size %#x, want at least %#x", cmd, cmdsz, size)
+			}
+			return nil
+		}
+		switch cmd {
+		case 0x19: // LC_SEGMENT_64
+			if cmdsz < 72 {
+				return layout, fmt.Errorf("truncated LC_SEGMENT_64")
+			}
+			seg := machoSegmentLayout{
+				name:     cString16(raw[off+8 : off+24]),
+				header:   off,
+				vmaddr:   binary.LittleEndian.Uint64(raw[off+24:]),
+				vmsize:   binary.LittleEndian.Uint64(raw[off+32:]),
+				fileoff:  binary.LittleEndian.Uint64(raw[off+40:]),
+				filesize: binary.LittleEndian.Uint64(raw[off+48:]),
+			}
+			nsects := binary.LittleEndian.Uint32(raw[off+64:])
+			if uint64(nsects) > (cmdsz-72)/80 {
+				return layout, fmt.Errorf("Mach-O segment %s has truncated sections", seg.name)
+			}
+			for j := uint32(0); j < nsects; j++ {
+				h := off + 72 + uint64(j)*80
+				seg.sections = append(seg.sections, machoSectionLayout{
+					name:    cString16(raw[h : h+16]),
+					segment: cString16(raw[h+16 : h+32]),
+					header:  h,
+					addr:    binary.LittleEndian.Uint64(raw[h+32:]),
+					size:    binary.LittleEndian.Uint64(raw[h+40:]),
+					offset:  uint64(binary.LittleEndian.Uint32(raw[h+48:])),
+					reloff:  uint64(binary.LittleEndian.Uint32(raw[h+56:])),
+					nreloc:  binary.LittleEndian.Uint32(raw[h+60:]),
+				})
+			}
+			layout.segments = append(layout.segments, seg)
+		case 0x2: // LC_SYMTAB
+			if err := require(24); err != nil {
+				return layout, err
+			}
+			add32(off+8, "symoff")
+			add32(off+16, "stroff")
+		case 0xb: // LC_DYSYMTAB
+			if err := require(80); err != nil {
+				return layout, err
+			}
+			for _, p := range []uint64{32, 40, 48, 56, 64, 72} {
+				add32(off+p, "dysymtab")
+			}
+		case 0x22, 0x80000022: // LC_DYLD_INFO[_ONLY]
+			if err := require(48); err != nil {
+				return layout, err
+			}
+			for _, p := range []uint64{8, 16, 24, 32, 40} {
+				add32(off+p, "dyld info")
+			}
+		case 0x1d, 0x1e, 0x26, 0x29, 0x2b, 0x2e, 0x80000033, 0x80000034:
+			if err := require(16); err != nil {
+				return layout, err
+			}
+			add32(off+8, "linkedit data")
+		case 0x16: // LC_TWOLEVEL_HINTS
+			if err := require(16); err != nil {
+				return layout, err
+			}
+			add32(off+8, "twolevel hints")
+		case 0x31: // LC_NOTE
+			if err := require(40); err != nil {
+				return layout, err
+			}
+			add64(off+24, "note")
+		case 0x21, 0x2c: // LC_ENCRYPTION_INFO[_64]
+			if err := require(20); err != nil {
+				return layout, err
+			}
+			if binary.LittleEndian.Uint32(raw[off+16:]) != 0 {
+				return layout, fmt.Errorf("cannot compact encrypted Mach-O")
+			}
+			add32(off+8, "encryption info")
+		case 0x35, 0x80000035: // LC_FILESET_ENTRY
+			return layout, fmt.Errorf("cannot compact Mach-O fileset")
+		default:
+			if !machoLoadCommandHasNoFileOffset(cmd) {
+				return layout, fmt.Errorf("unsupported Mach-O load command %#x", cmd)
+			}
+		}
+		off += cmdsz
+	}
+	return layout, nil
+}
+
+func patchMachOFileOffsets(raw []byte, layout machoLayout, carrierHeader, newFilesz, cutStart, cutEnd uint64) error {
+	delta := cutEnd - cutStart
+	shift32 := func(pos uint64, label string) error {
+		if pos > uint64(len(raw)) || uint64(len(raw))-pos < 4 {
+			return fmt.Errorf("Mach-O %s offset field is truncated", label)
+		}
+		v := uint64(binary.LittleEndian.Uint32(raw[pos:]))
+		if v == 0 {
+			return nil
+		}
+		if v >= cutEnd {
+			if v-delta > uint64(^uint32(0)) {
+				return fmt.Errorf("Mach-O %s offset overflows", label)
+			}
+			binary.LittleEndian.PutUint32(raw[pos:], uint32(v-delta))
+			return nil
+		}
+		if v >= cutStart {
+			return fmt.Errorf("Mach-O %s offset %#x falls in compacted range", label, v)
+		}
+		return nil
+	}
+	shift64 := func(pos uint64, label string) error {
+		if pos > uint64(len(raw)) || uint64(len(raw))-pos < 8 {
+			return fmt.Errorf("Mach-O %s offset field is truncated", label)
+		}
+		v := binary.LittleEndian.Uint64(raw[pos:])
+		if v == 0 {
+			return nil
+		}
+		if v >= cutEnd {
+			binary.LittleEndian.PutUint64(raw[pos:], v-delta)
+			return nil
+		}
+		if v >= cutStart {
+			return fmt.Errorf("Mach-O %s offset %#x falls in compacted range", label, v)
+		}
+		return nil
+	}
+	for _, seg := range layout.segments {
+		if seg.header == carrierHeader {
+			binary.LittleEndian.PutUint64(raw[seg.header+48:], newFilesz)
+		} else if err := shift64(seg.header+40, seg.name+" fileoff"); err != nil {
+			return err
+		}
+		for _, sec := range seg.sections {
+			if sec.name != "__llgo_fie" {
+				if err := shift32(sec.header+48, sec.segment+","+sec.name+" offset"); err != nil {
+					return err
+				}
+			}
+			if sec.nreloc != 0 {
+				if err := shift32(sec.header+56, sec.segment+","+sec.name+" reloff"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	for _, field := range layout.offsets {
+		var err error
+		if field.width == 8 {
+			err = shift64(field.pos, field.label)
+		} else {
+			err = shift32(field.pos, field.label)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func machoLoadCommandHasNoFileOffset(cmd uint32) bool {
+	// LC_REQ_DYLD is an attribute bit, not part of the command layout.
+	switch cmd &^ 0x80000000 {
+	case 0x1, // LC_SEGMENT (32-bit, rejected by parser)
+		0x3, 0x4, 0x5, 0x6, // thread/unixthread/loadfvmlib/idfvmlib
+		0xc, 0xd, 0xe, 0xf, // dylib/id/load dylinker/prebound dylib
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+		0x17, 0x18, 0x19, 0x1b, 0x1c,
+		0x20, 0x23, 0x24, 0x25, 0x27, 0x28,
+		0x2a, 0x2d, 0x2f, 0x30, 0x32:
+		return true
+	}
+	return false
+}
+
+func machoPageSize(raw []byte) uint64 {
+	// Current LLGo Darwin targets use 16 KiB pages on arm64 and 4 KiB on
+	// amd64. Unknown Mach-O CPU types deliberately take the conservative
+	// 4 KiB fallback and still pass the staged-image verifier.
+	const cpuTypeARM64 = uint32(0x0100000c)
+	if len(raw) >= 8 && binary.LittleEndian.Uint32(raw[4:]) == cpuTypeARM64 {
+		return 0x4000
+	}
+	return 0x1000
+}
+
+func cString16(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return string(b)
+}
+
+type elfSectionLayout struct {
+	name                string
+	header              uint64
+	typ                 uint32
+	flags, addr, offset uint64
+	size, align         uint64
+}
+
+type elfProgramLayout struct {
+	header                              uint64
+	typ, flags                          uint32
+	offset, vaddr, filesz, memsz, align uint64
+}
+
+func compactELF(raw []byte, info *binaryInfo, entryUsed uint64) ([]byte, uint64, error) {
+	sections, programs, shoff, err := parseELFLayout(raw)
+	if err != nil {
+		return nil, 0, err
+	}
+	var entry *elfSectionLayout
+	for i := range sections {
+		if sections[i].name == "llgo_funcinfo_entry" {
+			entry = &sections[i]
+		}
+	}
+	if entry == nil {
+		return nil, 0, fmt.Errorf("missing ELF entry carrier")
+	}
+	var carrier *elfProgramLayout
+	for i := range programs {
+		p := &programs[i]
+		if p.typ != uint32(elf.PT_LOAD) || p.filesz == 0 {
+			continue
+		}
+		end, ok := checkedEnd(p.offset, p.filesz, ^uint64(0))
+		if !ok {
+			continue
+		}
+		if rangeContained(p.offset, end, entry.offset, entry.size) {
+			carrier = p
+			break
+		}
+	}
+	if carrier == nil {
+		return nil, 0, fmt.Errorf("ELF funcinfo carrier is not in a PT_LOAD")
+	}
+	oldEnd, ok := checkedEnd(carrier.offset, carrier.filesz, uint64(len(raw)))
+	if !ok {
+		return nil, 0, fmt.Errorf("ELF carrier file range [%#x,+%#x) is invalid", carrier.offset, carrier.filesz)
+	}
+	lastUsed, ok := checkedEnd(entry.offset, entryUsed, oldEnd)
+	if !ok || lastUsed < carrier.offset {
+		return nil, 0, fmt.Errorf("ELF compact payload %#x is outside PT_LOAD [%#x,%#x)", lastUsed, carrier.offset, oldEnd)
+	}
+	for _, sec := range sections {
+		if sec.typ == uint32(elf.SHT_NOBITS) || sec.size == 0 || sec.name == entry.name {
+			continue
+		}
+		secEnd, ok := checkedEnd(sec.offset, sec.size, uint64(len(raw)))
+		if !ok {
+			return nil, 0, fmt.Errorf("ELF section %s has an invalid file range", sec.name)
+		}
+		if sec.flags&uint64(elf.SHF_ALLOC) != 0 && sec.offset < oldEnd && secEnd > lastUsed {
+			return nil, 0, fmt.Errorf("ELF allocated section %s follows compact payload in carrier PT_LOAD", sec.name)
+		}
+	}
+	carrierMemEnd, ok := checkedEnd(carrier.vaddr, carrier.memsz, ^uint64(0))
+	entryMemEnd, entryOK := checkedEnd(info.entryVMAddr, info.entryVMSize, ^uint64(0))
+	if !ok || !entryOK || carrierMemEnd < entryMemEnd {
+		return nil, 0, fmt.Errorf("ELF carrier virtual tail is not covered by PT_LOAD memory")
+	}
+	// The linker script makes the carrier the final file-backed part of the
+	// final PT_LOAD. Program segments therefore never need to move; only
+	// non-allocated sections and the section-header table follow it.
+	for _, p := range programs {
+		if p.header == carrier.header || p.offset == 0 {
+			continue
+		}
+		if p.offset >= oldEnd {
+			return nil, 0, fmt.Errorf("ELF program header type %d follows the funcinfo carrier", p.typ)
+		}
+	}
+	cutAlign := uint64(8) // ELF64 section headers and symbol tables.
+	for _, sec := range sections {
+		if sec.offset < oldEnd || sec.align <= cutAlign {
+			continue
+		}
+		if sec.align&(sec.align-1) != 0 {
+			return nil, 0, fmt.Errorf("ELF section %s has invalid alignment %#x", sec.name, sec.align)
+		}
+		cutAlign = sec.align
+	}
+	removed := alignDown(oldEnd-lastUsed, cutAlign)
+	cutStart := oldEnd - removed
+	out := raw
+	binary.LittleEndian.PutUint64(out[entry.header+32:], entryUsed)
+	if removed == 0 {
+		return out, 0, nil
+	}
+	binary.LittleEndian.PutUint64(out[carrier.header+32:], carrier.filesz-removed)
+	for _, p := range programs {
+		pEnd, ok := checkedEnd(p.offset, p.filesz, uint64(len(raw)))
+		if !ok {
+			return nil, 0, fmt.Errorf("ELF program header type %d has an invalid file range", p.typ)
+		}
+		if p.header != carrier.header && p.filesz != 0 && p.offset < oldEnd && pEnd > cutStart {
+			return nil, 0, fmt.Errorf("ELF program header type %d overlaps compacted range", p.typ)
+		}
+	}
+	for _, sec := range sections {
+		if sec.name == entry.name {
+			continue
+		}
+		if sec.offset >= oldEnd {
+			binary.LittleEndian.PutUint64(out[sec.header+24:], sec.offset-removed)
+		} else if sec.typ == uint32(elf.SHT_NOBITS) && sec.offset >= cutStart {
+			binary.LittleEndian.PutUint64(out[sec.header+24:], cutStart)
+		} else if sec.typ != uint32(elf.SHT_NOBITS) && sec.size != 0 {
+			secEnd, ok := checkedEnd(sec.offset, sec.size, uint64(len(raw)))
+			if !ok {
+				return nil, 0, fmt.Errorf("ELF section %s has an invalid file range", sec.name)
+			}
+			if secEnd <= cutStart {
+				continue
+			}
+			return nil, 0, fmt.Errorf("ELF section %s overlaps compacted range", sec.name)
+		}
+	}
+	if shoff >= oldEnd {
+		binary.LittleEndian.PutUint64(out[40:], shoff-removed)
+	} else if shoff >= cutStart {
+		return nil, 0, fmt.Errorf("ELF section headers overlap compacted range")
+	}
+	copy(out[cutStart:], out[oldEnd:])
+	out = out[:uint64(len(out))-removed]
+	if _, err := elf.NewFile(bytes.NewReader(out)); err != nil {
+		return nil, 0, fmt.Errorf("verify compact ELF: %w", err)
+	}
+	return out, removed, nil
+}
+
+func parseELFLayout(raw []byte) ([]elfSectionLayout, []elfProgramLayout, uint64, error) {
+	if len(raw) < 64 || !bytes.Equal(raw[:4], []byte{0x7f, 'E', 'L', 'F'}) || raw[4] != byte(elf.ELFCLASS64) || raw[5] != byte(elf.ELFDATA2LSB) {
+		return nil, nil, 0, fmt.Errorf("compact ELF requires a little-endian ELF64 image")
+	}
+	phoff := binary.LittleEndian.Uint64(raw[32:])
+	shoff := binary.LittleEndian.Uint64(raw[40:])
+	phentsz := uint64(binary.LittleEndian.Uint16(raw[54:]))
+	phnum := uint64(binary.LittleEndian.Uint16(raw[56:]))
+	shentsz := uint64(binary.LittleEndian.Uint16(raw[58:]))
+	shnum := uint64(binary.LittleEndian.Uint16(raw[60:]))
+	shstrndx := uint64(binary.LittleEndian.Uint16(raw[62:]))
+	if phnum == 0 || phentsz < 56 || !tableWithinFile(phoff, phnum, phentsz, uint64(len(raw))) {
+		return nil, nil, 0, fmt.Errorf("ELF has no valid program header table")
+	}
+	if shnum == 0 || shentsz < 64 || shstrndx >= shnum || !tableWithinFile(shoff, shnum, shentsz, uint64(len(raw))) {
+		return nil, nil, 0, fmt.Errorf("ELF has no valid section header table")
+	}
+	shstrHeader := shoff + shstrndx*shentsz
+	strOff := binary.LittleEndian.Uint64(raw[shstrHeader+24:])
+	strSize := binary.LittleEndian.Uint64(raw[shstrHeader+32:])
+	strEnd, ok := checkedEnd(strOff, strSize, uint64(len(raw)))
+	if !ok {
+		return nil, nil, 0, fmt.Errorf("ELF section-name table is outside file")
+	}
+	strs := raw[strOff:strEnd]
+	nameAt := func(off uint32) string {
+		if uint64(off) >= uint64(len(strs)) {
+			return ""
+		}
+		b := strs[off:]
+		if i := bytes.IndexByte(b, 0); i >= 0 {
+			b = b[:i]
+		}
+		return string(b)
+	}
+	sections := make([]elfSectionLayout, 0, shnum)
+	for i := uint64(0); i < shnum; i++ {
+		h := shoff + i*shentsz
+		sec := elfSectionLayout{
+			name: nameAt(binary.LittleEndian.Uint32(raw[h:])), header: h,
+			typ: binary.LittleEndian.Uint32(raw[h+4:]), flags: binary.LittleEndian.Uint64(raw[h+8:]),
+			addr: binary.LittleEndian.Uint64(raw[h+16:]), offset: binary.LittleEndian.Uint64(raw[h+24:]), size: binary.LittleEndian.Uint64(raw[h+32:]),
+			align: binary.LittleEndian.Uint64(raw[h+48:]),
+		}
+		if sec.typ != uint32(elf.SHT_NOBITS) && sec.size != 0 {
+			if _, ok := checkedEnd(sec.offset, sec.size, uint64(len(raw))); !ok {
+				return nil, nil, 0, fmt.Errorf("ELF section %s has an invalid file range", sec.name)
+			}
+		}
+		sections = append(sections, sec)
+	}
+	programs := make([]elfProgramLayout, 0, phnum)
+	for i := uint64(0); i < phnum; i++ {
+		h := phoff + i*phentsz
+		program := elfProgramLayout{
+			header: h, typ: binary.LittleEndian.Uint32(raw[h:]), flags: binary.LittleEndian.Uint32(raw[h+4:]),
+			offset: binary.LittleEndian.Uint64(raw[h+8:]), vaddr: binary.LittleEndian.Uint64(raw[h+16:]),
+			filesz: binary.LittleEndian.Uint64(raw[h+32:]), memsz: binary.LittleEndian.Uint64(raw[h+40:]), align: binary.LittleEndian.Uint64(raw[h+48:]),
+		}
+		if program.filesz != 0 {
+			if _, ok := checkedEnd(program.offset, program.filesz, uint64(len(raw))); !ok {
+				return nil, nil, 0, fmt.Errorf("ELF program header type %d has an invalid file range", program.typ)
+			}
+		}
+		programs = append(programs, program)
+	}
+	return sections, programs, shoff, nil
+}
+
+func alignUp(v, align uint64) uint64 {
+	if align <= 1 {
+		return v
+	}
+	if align&(align-1) != 0 || v > ^uint64(0)-(align-1) {
+		return ^uint64(0)
+	}
+	return (v + align - 1) &^ (align - 1)
+}
+
+func alignDown(v, align uint64) uint64 {
+	if align <= 1 {
+		return v
+	}
+	return v &^ (align - 1)
+}
+
+func checkedEnd(off, size, limit uint64) (uint64, bool) {
+	if off > limit || size > limit-off {
+		return 0, false
+	}
+	return off + size, true
+}
+
+func tableWithinFile(off, count, entrySize, limit uint64) bool {
+	return off <= limit && count <= (limit-off)/entrySize
+}
+
+func rangeContained(start, end, off, size uint64) bool {
+	rangeEnd, ok := checkedEnd(off, size, end)
+	return ok && off >= start && rangeEnd <= end
+}

--- a/internal/pclnpost/compact_unit_test.go
+++ b/internal/pclnpost/compact_unit_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pclnpost
+
+import (
+	"debug/macho"
+	"encoding/binary"
+	"testing"
+)
+
+func TestCompactCarrierValidation(t *testing.T) {
+	if _, _, err := compactCarrier(nil, &binaryInfo{entryVMSize: 1}, 2); err == nil {
+		t.Fatal("oversized entry was accepted")
+	}
+	if _, _, err := compactCarrier(nil, &binaryInfo{format: "unknown"}, 0); err == nil {
+		t.Fatal("unknown format was accepted")
+	}
+	if got := alignUp(7, 0); got != 7 {
+		t.Fatalf("alignUp(7, 0) = %d", got)
+	}
+	if got := alignUp(^uint64(0)-1, 8); got != ^uint64(0) {
+		t.Fatalf("overflowing alignUp = %#x", got)
+	}
+}
+
+func TestPatchMachOFileOffsetCommands(t *testing.T) {
+	tests := []struct {
+		cmd       uint32
+		size      uint32
+		positions []uint64
+		wide      bool
+	}{
+		{0x2, 24, []uint64{8, 16}, false},
+		{0xb, 80, []uint64{32, 40, 48, 56, 64, 72}, false},
+		{0x22, 48, []uint64{8, 16, 24, 32, 40}, false},
+		{0x1d, 16, []uint64{8}, false},
+		{0x16, 16, []uint64{8}, false},
+		{0x31, 40, []uint64{24}, true},
+		{0x21, 20, []uint64{8}, false},
+	}
+	for _, test := range tests {
+		raw := make([]byte, 160)
+		binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+		binary.LittleEndian.PutUint32(raw[16:], 1)
+		binary.LittleEndian.PutUint32(raw[32:], test.cmd)
+		binary.LittleEndian.PutUint32(raw[36:], test.size)
+		for _, pos := range test.positions {
+			if test.wide {
+				binary.LittleEndian.PutUint64(raw[32+pos:], 0x200)
+			} else {
+				binary.LittleEndian.PutUint32(raw[32+pos:], 0x200)
+			}
+		}
+		layout, err := parseMachOLayout(raw)
+		if err != nil {
+			t.Fatalf("parse command %#x: %v", test.cmd, err)
+		}
+		if err := patchMachOFileOffsets(raw, layout, 0, 0, 0x100, 0x120); err != nil {
+			t.Fatalf("command %#x: %v", test.cmd, err)
+		}
+		for _, pos := range test.positions {
+			var got uint64
+			if test.wide {
+				got = binary.LittleEndian.Uint64(raw[32+pos:])
+			} else {
+				got = uint64(binary.LittleEndian.Uint32(raw[32+pos:]))
+			}
+			if got != 0x1e0 {
+				t.Fatalf("command %#x field %#x = %#x", test.cmd, pos, got)
+			}
+		}
+	}
+}
+
+func TestPatchMachOFileOffsetCommandErrors(t *testing.T) {
+	for _, cmd := range []uint32{0x35, 0xdeadbeef} {
+		raw := make([]byte, 64)
+		binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+		binary.LittleEndian.PutUint32(raw[16:], 1)
+		binary.LittleEndian.PutUint32(raw[32:], cmd)
+		binary.LittleEndian.PutUint32(raw[36:], 8)
+		if _, err := parseMachOLayout(raw); err == nil {
+			t.Fatalf("command %#x was accepted", cmd)
+		}
+	}
+	raw := make([]byte, 64)
+	binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+	binary.LittleEndian.PutUint32(raw[16:], 1)
+	binary.LittleEndian.PutUint32(raw[32:], 0x21)
+	binary.LittleEndian.PutUint32(raw[36:], 20)
+	binary.LittleEndian.PutUint32(raw[48:], 1)
+	if _, err := parseMachOLayout(raw); err == nil {
+		t.Fatal("encrypted image was accepted")
+	}
+}
+
+func TestMachOLoadCommandClassification(t *testing.T) {
+	for _, cmd := range []uint32{0x3, 0x19, 0x80000028} {
+		if !machoLoadCommandHasNoFileOffset(cmd) {
+			t.Fatalf("command %#x should need no offset rewrite", cmd)
+		}
+	}
+	if machoLoadCommandHasNoFileOffset(0xdeadbeef) {
+		t.Fatal("unknown command was classified as offset-free")
+	}
+}

--- a/internal/pclnpost/compact_unit_test.go
+++ b/internal/pclnpost/compact_unit_test.go
@@ -17,8 +17,11 @@
 package pclnpost
 
 import (
+	"bytes"
+	"debug/elf"
 	"debug/macho"
 	"encoding/binary"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +37,9 @@ func TestCompactCarrierValidation(t *testing.T) {
 	}
 	if got := alignUp(^uint64(0)-1, 8); got != ^uint64(0) {
 		t.Fatalf("overflowing alignUp = %#x", got)
+	}
+	if got := alignDown(7, 1); got != 7 {
+		t.Fatalf("alignDown(7, 1) = %d", got)
 	}
 }
 
@@ -106,6 +112,27 @@ func TestPatchMachOFileOffsetCommandErrors(t *testing.T) {
 	if _, err := parseMachOLayout(raw); err == nil {
 		t.Fatal("encrypted image was accepted")
 	}
+	for _, test := range []struct {
+		name   string
+		cmdsz  uint32
+		nsects uint32
+	}{
+		{"command past EOF", 128, 0},
+		{"short segment", 64, 0},
+		{"truncated sections", 72, 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			raw := make([]byte, 104)
+			binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+			binary.LittleEndian.PutUint32(raw[16:], 1)
+			binary.LittleEndian.PutUint32(raw[32:], 0x19)
+			binary.LittleEndian.PutUint32(raw[36:], test.cmdsz)
+			binary.LittleEndian.PutUint32(raw[32+64:], test.nsects)
+			if _, err := parseMachOLayout(raw); err == nil {
+				t.Fatal("malformed segment was accepted")
+			}
+		})
+	}
 }
 
 func TestMachOLoadCommandClassification(t *testing.T) {
@@ -116,5 +143,408 @@ func TestMachOLoadCommandClassification(t *testing.T) {
 	}
 	if machoLoadCommandHasNoFileOffset(0xdeadbeef) {
 		t.Fatal("unknown command was classified as offset-free")
+	}
+}
+
+func compactMachOInput(t *testing.T) ([]byte, *binaryInfo, machoLayout, *machoSegmentLayout, *machoSectionLayout) {
+	t.Helper()
+	path := machoRewriteFixture(t, 65536)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), info.raw...)
+	layout, err := parseMachOLayout(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var carrier *machoSegmentLayout
+	var entry *machoSectionLayout
+	for i := range layout.segments {
+		if layout.segments[i].name != "__LLGO" {
+			continue
+		}
+		carrier = &layout.segments[i]
+		for j := range carrier.sections {
+			if carrier.sections[j].name == "__llgo_fie" {
+				entry = &carrier.sections[j]
+			}
+		}
+	}
+	if carrier == nil || entry == nil {
+		t.Fatal("fixture has no Mach-O carrier")
+	}
+	return raw, info, layout, carrier, entry
+}
+
+func TestCompactMachORejectsMalformedCarrierShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		edit func([]byte, *binaryInfo, machoLayout, *machoSegmentLayout, *machoSectionLayout) uint64
+	}{
+		{
+			name: "file range",
+			want: "file range",
+			edit: func(raw []byte, _ *binaryInfo, _ machoLayout, carrier *machoSegmentLayout, _ *machoSectionLayout) uint64 {
+				binary.LittleEndian.PutUint64(raw[carrier.header+48:], uint64(len(raw))+1)
+				return 64
+			},
+		},
+		{
+			name: "entry outside segment",
+			want: "outside __LLGO",
+			edit: func(raw []byte, _ *binaryInfo, _ machoLayout, carrier *machoSegmentLayout, entry *machoSectionLayout) uint64 {
+				binary.LittleEndian.PutUint32(raw[entry.header+48:], uint32(carrier.fileoff-1))
+				return 64
+			},
+		},
+		{
+			name: "segment follows carrier",
+			want: "follows __LLGO",
+			edit: func(raw []byte, _ *binaryInfo, layout machoLayout, carrier *machoSegmentLayout, _ *machoSectionLayout) uint64 {
+				oldEnd := carrier.fileoff + carrier.filesize
+				for _, segment := range layout.segments {
+					if segment.name == "__TEXT" {
+						binary.LittleEndian.PutUint64(raw[segment.header+40:], oldEnd)
+						binary.LittleEndian.PutUint64(raw[segment.header+48:], 1)
+					}
+				}
+				return 64
+			},
+		},
+		{
+			name: "payload outside segment",
+			want: "outside __LLGO",
+			edit: func(_ []byte, _ *binaryInfo, _ machoLayout, carrier *machoSegmentLayout, _ *machoSectionLayout) uint64 {
+				return carrier.filesize + 1
+			},
+		},
+		{
+			name: "unaligned carrier cannot grow",
+			want: "compact __LLGO size",
+			edit: func(raw []byte, _ *binaryInfo, _ machoLayout, _ *machoSegmentLayout, entry *machoSectionLayout) uint64 {
+				binary.LittleEndian.PutUint64(raw[entry.header-24:], entry.size)
+				return entry.size
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, info, layout, carrier, entry := compactMachOInput(t)
+			used := test.edit(raw, info, layout, carrier, entry)
+			if _, _, err := compactMachO(raw, info, used); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("compactMachO error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCompactMachOPropagatesParserAndOffsetErrors(t *testing.T) {
+	if _, _, err := compactMachO(nil, &binaryInfo{}, 0); err == nil {
+		t.Fatal("compactMachO accepted an invalid image")
+	}
+	raw, info, layout, carrier, entry := compactMachOInput(t)
+	used := uint64(64)
+	cutStart := carrier.fileoff + alignUp(entry.offset+used-carrier.fileoff, machoPageSize(raw))
+	if len(layout.offsets) == 0 {
+		t.Fatal("fixture has no linkedit offsets")
+	}
+	field := layout.offsets[0]
+	if field.width != 4 {
+		t.Fatalf("first offset width = %d", field.width)
+	}
+	binary.LittleEndian.PutUint32(raw[field.pos:], uint32(cutStart+1))
+	if _, _, err := compactMachO(raw, info, used); err == nil || !strings.Contains(err.Error(), "compacted range") {
+		t.Fatalf("compactMachO error = %v", err)
+	}
+}
+
+func TestCompactMachONoRemovablePage(t *testing.T) {
+	raw, info, _, carrier, entry := compactMachOInput(t)
+	// The synthetic carrier starts at a non-16K file offset. Exercise the
+	// no-cut path with the amd64 4K page contract, where its file size is
+	// already page aligned.
+	binary.LittleEndian.PutUint32(raw[4:], 0x01000007)
+	entryUsed := carrier.filesize - (entry.offset - carrier.fileoff)
+	out, removed, err := compactMachO(raw, info, entryUsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 || len(out) != len(info.raw) {
+		t.Fatalf("no-op compaction removed=%d sizes=%d/%d", removed, len(out), len(info.raw))
+	}
+}
+
+func TestPatchMachOFileOffsetsValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		layout machoLayout
+		setup  func([]byte)
+		want   string
+	}{
+		{
+			name:   "truncated 32-bit field",
+			layout: machoLayout{offsets: []machoOffsetField{{pos: 127, width: 4, label: "small"}}},
+			want:   "truncated",
+		},
+		{
+			name:   "truncated 64-bit field",
+			layout: machoLayout{offsets: []machoOffsetField{{pos: 124, width: 8, label: "wide"}}},
+			want:   "truncated",
+		},
+		{
+			name:   "32-bit field in cut",
+			layout: machoLayout{offsets: []machoOffsetField{{pos: 96, width: 4, label: "small"}}},
+			setup:  func(raw []byte) { binary.LittleEndian.PutUint32(raw[96:], 0x110) },
+			want:   "compacted range",
+		},
+		{
+			name:   "64-bit field in cut",
+			layout: machoLayout{offsets: []machoOffsetField{{pos: 96, width: 8, label: "wide"}}},
+			setup:  func(raw []byte) { binary.LittleEndian.PutUint64(raw[96:], 0x110) },
+			want:   "compacted range",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := make([]byte, 128)
+			if test.setup != nil {
+				test.setup(raw)
+			}
+			if err := patchMachOFileOffsets(raw, test.layout, ^uint64(0), 0, 0x100, 0x120); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("patch error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestPatchMachOFileOffsetsMovesSegmentsAndSections(t *testing.T) {
+	raw := make([]byte, 192)
+	segment := machoSegmentLayout{
+		name: "__LINKEDIT", header: 0,
+		sections: []machoSectionLayout{{name: "__symbols", segment: "__LINKEDIT", header: 64, nreloc: 1}},
+	}
+	binary.LittleEndian.PutUint64(raw[40:], 0x200)
+	binary.LittleEndian.PutUint32(raw[64+48:], 0x220)
+	binary.LittleEndian.PutUint32(raw[64+56:], 0x240)
+	layout := machoLayout{segments: []machoSegmentLayout{segment}}
+	if err := patchMachOFileOffsets(raw, layout, ^uint64(0), 0, 0x100, 0x120); err != nil {
+		t.Fatal(err)
+	}
+	if got := binary.LittleEndian.Uint64(raw[40:]); got != 0x1e0 {
+		t.Fatalf("segment fileoff = %#x", got)
+	}
+	if got := binary.LittleEndian.Uint32(raw[64+48:]); got != 0x200 {
+		t.Fatalf("section offset = %#x", got)
+	}
+	if got := binary.LittleEndian.Uint32(raw[64+56:]); got != 0x220 {
+		t.Fatalf("section reloff = %#x", got)
+	}
+}
+
+func TestPatchMachOFileOffsetsBranchErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		layout        machoLayout
+		carrierHeader uint64
+		setup         func([]byte)
+	}{
+		{
+			name:          "segment",
+			layout:        machoLayout{segments: []machoSegmentLayout{{name: "__LINKEDIT", header: 0}}},
+			carrierHeader: ^uint64(0),
+			setup:         func(raw []byte) { binary.LittleEndian.PutUint64(raw[40:], 0x110) },
+		},
+		{
+			name:   "section",
+			layout: machoLayout{segments: []machoSegmentLayout{{header: 0, sections: []machoSectionLayout{{name: "__symbols", header: 64}}}}},
+			setup:  func(raw []byte) { binary.LittleEndian.PutUint32(raw[64+48:], 0x110) },
+		},
+		{
+			name:   "relocation",
+			layout: machoLayout{segments: []machoSegmentLayout{{header: 0, sections: []machoSectionLayout{{name: "__llgo_fie", header: 64, nreloc: 1}}}}},
+			setup:  func(raw []byte) { binary.LittleEndian.PutUint32(raw[64+56:], 0x110) },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := make([]byte, 160)
+			test.setup(raw)
+			if err := patchMachOFileOffsets(raw, test.layout, test.carrierHeader, 0, 0x100, 0x120); err == nil {
+				t.Fatal("offset inside cut was accepted")
+			}
+		})
+	}
+	raw := make([]byte, 128)
+	binary.LittleEndian.PutUint64(raw[96:], 0x80)
+	layout := machoLayout{offsets: []machoOffsetField{{pos: 88, width: 4}, {pos: 96, width: 8}}}
+	if err := patchMachOFileOffsets(raw, layout, ^uint64(0), 0, 0x100, 0x120); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func compactELFInput(t *testing.T) ([]byte, *binaryInfo, []elfSectionLayout, []elfProgramLayout) {
+	t.Helper()
+	path := buildELF(t, fixtureFns(), fixtureEntry, 8192)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), info.raw...)
+	sections, programs, _, err := parseELFLayout(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, info, sections, programs
+}
+
+func findELFSection(t *testing.T, sections []elfSectionLayout, name string) elfSectionLayout {
+	t.Helper()
+	for _, section := range sections {
+		if section.name == name {
+			return section
+		}
+	}
+	t.Fatalf("fixture has no section %s", name)
+	return elfSectionLayout{}
+}
+
+func TestCompactELFRejectsMalformedCarrierShapes(t *testing.T) {
+	t.Run("missing entry", func(t *testing.T) {
+		raw, info, sections, _ := compactELFInput(t)
+		entry := findELFSection(t, sections, "llgo_funcinfo_entry")
+		text := findELFSection(t, sections, ".text")
+		binary.LittleEndian.PutUint32(raw[entry.header:], binary.LittleEndian.Uint32(raw[text.header:]))
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "missing ELF entry") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+	t.Run("entry not loaded", func(t *testing.T) {
+		raw, info, _, programs := compactELFInput(t)
+		binary.LittleEndian.PutUint32(raw[programs[1].header:], uint32(elf.PT_NOTE))
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "not in a PT_LOAD") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+	t.Run("payload outside", func(t *testing.T) {
+		raw, info, _, programs := compactELFInput(t)
+		if _, _, err := compactELF(raw, info, programs[1].filesz+1); err == nil || !strings.Contains(err.Error(), "outside PT_LOAD") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+	t.Run("allocated section follows payload", func(t *testing.T) {
+		raw, info, sections, programs := compactELFInput(t)
+		data := findELFSection(t, sections, ".data")
+		binary.LittleEndian.PutUint64(raw[programs[1].header+32:], data.offset+data.size-programs[1].offset)
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "allocated section") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+	t.Run("virtual tail uncovered", func(t *testing.T) {
+		raw, info, _, programs := compactELFInput(t)
+		binary.LittleEndian.PutUint64(raw[programs[1].header+40:], 1)
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "virtual tail") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+	t.Run("invalid following alignment", func(t *testing.T) {
+		raw, info, sections, _ := compactELFInput(t)
+		symtab := findELFSection(t, sections, ".symtab")
+		binary.LittleEndian.PutUint64(raw[symtab.header+48:], 24)
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "invalid alignment") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+	t.Run("program overlaps cut", func(t *testing.T) {
+		raw, info, _, programs := compactELFInput(t)
+		carrier := programs[1]
+		oldEnd := carrier.offset + carrier.filesz
+		binary.LittleEndian.PutUint16(raw[56:], 3)
+		h := uint64(64 + 2*56)
+		binary.LittleEndian.PutUint32(raw[h:], uint32(elf.PT_NOTE))
+		binary.LittleEndian.PutUint64(raw[h+8:], oldEnd-16)
+		binary.LittleEndian.PutUint64(raw[h+32:], 16)
+		binary.LittleEndian.PutUint64(raw[h+40:], 16)
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "overlaps compacted range") {
+			t.Fatalf("compact error = %v", err)
+		}
+	})
+}
+
+func TestCompactELFUpdatesNOBITSTail(t *testing.T) {
+	raw, info, sections, programs := compactELFInput(t)
+	carrier := programs[1]
+	oldEnd := carrier.offset + carrier.filesz
+	data := findELFSection(t, sections, ".data")
+	binary.LittleEndian.PutUint32(raw[data.header+4:], uint32(elf.SHT_NOBITS))
+	binary.LittleEndian.PutUint64(raw[data.header+24:], oldEnd-16)
+	binary.LittleEndian.PutUint64(raw[data.header+32:], 32)
+	out, removed, err := compactELF(raw, info, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed == 0 {
+		t.Fatal("fixture did not compact")
+	}
+	parsed, _, _, err := parseELFLayout(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findELFSection(t, parsed, ".data")
+	if got.offset >= oldEnd {
+		t.Fatalf("NOBITS offset was not moved into compact tail: %#x", got.offset)
+	}
+}
+
+func TestCompactELFRejectsSectionAndHeaderOverlap(t *testing.T) {
+	t.Run("section", func(t *testing.T) {
+		raw, info, sections, programs := compactELFInput(t)
+		carrier := programs[1]
+		oldEnd := carrier.offset + carrier.filesz
+		symtab := findELFSection(t, sections, ".symtab")
+		binary.LittleEndian.PutUint64(raw[symtab.header+8:], 0)
+		binary.LittleEndian.PutUint64(raw[symtab.header+24:], oldEnd-32)
+		binary.LittleEndian.PutUint64(raw[symtab.header+32:], 16)
+		if _, _, err := compactELF(raw, info, 64); err == nil || !strings.Contains(err.Error(), "section .symtab overlaps") {
+			t.Fatalf("compactELF error = %v", err)
+		}
+	})
+	t.Run("section headers", func(t *testing.T) {
+		raw, info, sections, programs := compactELFInput(t)
+		carrier := programs[1]
+		shoff := binary.LittleEndian.Uint64(raw[40:])
+		for _, section := range sections {
+			if section.name != "llgo_funcinfo_entry" {
+				binary.LittleEndian.PutUint64(raw[section.header+8:], 0)
+			}
+		}
+		binary.LittleEndian.PutUint64(raw[carrier.header+32:], shoff+64-carrier.offset)
+		used := shoff - findELFSection(t, sections, "llgo_funcinfo_entry").offset
+		if _, _, err := compactELF(raw, info, used); err == nil || !strings.Contains(err.Error(), "section headers overlap") {
+			t.Fatalf("compactELF error = %v", err)
+		}
+	})
+}
+
+func TestParseBinaryLayoutsRejectInvalidHeaders(t *testing.T) {
+	for _, raw := range [][]byte{nil, bytes.Repeat([]byte{0}, 64)} {
+		if _, err := parseMachOLayout(raw); err == nil {
+			t.Fatal("parseMachOLayout accepted a non-Mach-O image")
+		}
+		if _, _, _, err := parseELFLayout(raw); err == nil {
+			t.Fatal("parseELFLayout accepted a non-ELF image")
+		}
+	}
+	raw, _, _, _ := compactELFInput(t)
+	for _, edit := range []func([]byte){
+		func(b []byte) { binary.LittleEndian.PutUint16(b[56:], 0) },
+		func(b []byte) { binary.LittleEndian.PutUint16(b[60:], 0) },
+	} {
+		bad := append([]byte(nil), raw...)
+		edit(bad)
+		if _, _, _, err := parseELFLayout(bad); err == nil {
+			t.Fatal("parseELFLayout accepted an invalid table")
+		}
 	}
 }

--- a/internal/pclnpost/compact_unit_test.go
+++ b/internal/pclnpost/compact_unit_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pclnpost
+
+import (
+	"debug/macho"
+	"encoding/binary"
+	"testing"
+)
+
+func TestCompactCarrierValidation(t *testing.T) {
+	if _, _, err := compactCarrier(nil, &binaryInfo{entryVMSize: 1}, 2, 0); err == nil {
+		t.Fatal("oversized entry was accepted")
+	}
+	if _, _, err := compactCarrier(nil, &binaryInfo{format: "unknown"}, 0, 0); err == nil {
+		t.Fatal("unknown format was accepted")
+	}
+	if got := alignUp(7, 0); got != 7 {
+		t.Fatalf("alignUp(7, 0) = %d", got)
+	}
+	if got := alignUp(^uint64(0)-1, 8); got != ^uint64(0) {
+		t.Fatalf("overflowing alignUp = %#x", got)
+	}
+}
+
+func TestPatchMachOFileOffsetCommands(t *testing.T) {
+	tests := []struct {
+		cmd       uint32
+		size      uint32
+		positions []uint64
+		wide      bool
+	}{
+		{0x2, 24, []uint64{8, 16}, false},
+		{0xb, 80, []uint64{32, 40, 48, 56, 64, 72}, false},
+		{0x22, 48, []uint64{8, 16, 24, 32, 40}, false},
+		{0x1d, 16, []uint64{8}, false},
+		{0x16, 16, []uint64{8}, false},
+		{0x31, 40, []uint64{24}, true},
+		{0x21, 20, []uint64{8}, false},
+	}
+	for _, test := range tests {
+		raw := make([]byte, 160)
+		binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+		binary.LittleEndian.PutUint32(raw[16:], 1)
+		binary.LittleEndian.PutUint32(raw[32:], test.cmd)
+		binary.LittleEndian.PutUint32(raw[36:], test.size)
+		for _, pos := range test.positions {
+			if test.wide {
+				binary.LittleEndian.PutUint64(raw[32+pos:], 0x200)
+			} else {
+				binary.LittleEndian.PutUint32(raw[32+pos:], 0x200)
+			}
+		}
+		layout, err := parseMachOLayout(raw)
+		if err != nil {
+			t.Fatalf("parse command %#x: %v", test.cmd, err)
+		}
+		if err := patchMachOFileOffsets(raw, layout, 0, 0, 0x100, 0x120); err != nil {
+			t.Fatalf("command %#x: %v", test.cmd, err)
+		}
+		for _, pos := range test.positions {
+			var got uint64
+			if test.wide {
+				got = binary.LittleEndian.Uint64(raw[32+pos:])
+			} else {
+				got = uint64(binary.LittleEndian.Uint32(raw[32+pos:]))
+			}
+			if got != 0x1e0 {
+				t.Fatalf("command %#x field %#x = %#x", test.cmd, pos, got)
+			}
+		}
+	}
+}
+
+func TestPatchMachOFileOffsetCommandErrors(t *testing.T) {
+	for _, cmd := range []uint32{0x35, 0xdeadbeef} {
+		raw := make([]byte, 64)
+		binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+		binary.LittleEndian.PutUint32(raw[16:], 1)
+		binary.LittleEndian.PutUint32(raw[32:], cmd)
+		binary.LittleEndian.PutUint32(raw[36:], 8)
+		if _, err := parseMachOLayout(raw); err == nil {
+			t.Fatalf("command %#x was accepted", cmd)
+		}
+	}
+	raw := make([]byte, 64)
+	binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+	binary.LittleEndian.PutUint32(raw[16:], 1)
+	binary.LittleEndian.PutUint32(raw[32:], 0x21)
+	binary.LittleEndian.PutUint32(raw[36:], 20)
+	binary.LittleEndian.PutUint32(raw[48:], 1)
+	if _, err := parseMachOLayout(raw); err == nil {
+		t.Fatal("encrypted image was accepted")
+	}
+}
+
+func TestMachOLoadCommandClassification(t *testing.T) {
+	for _, cmd := range []uint32{0x3, 0x19, 0x80000028} {
+		if !machoLoadCommandHasNoFileOffset(cmd) {
+			t.Fatalf("command %#x should need no offset rewrite", cmd)
+		}
+	}
+	if machoLoadCommandHasNoFileOffset(0xdeadbeef) {
+		t.Fatal("unknown command was classified as offset-free")
+	}
+}

--- a/internal/pclnpost/elf_fixture_test.go
+++ b/internal/pclnpost/elf_fixture_test.go
@@ -403,3 +403,70 @@ func TestRewriteErrorPaths(t *testing.T) {
 		t.Fatal("expected no-survivors error")
 	}
 }
+
+func TestWriteBackRejectsInvalidInputs(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, 4096)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kept := []siteRecord{{pc: info.textStart + 4, symbolID: fnv64("example.com/p.A")}}
+
+	t.Run("missing symbol index", func(t *testing.T) {
+		bad := *info
+		bad.entrySec = nil
+		if _, _, _, err := writeBack(path, &bad, kept); err == nil {
+			t.Fatal("writeBack accepted a missing symbol index")
+		}
+	})
+	t.Run("no resolvable rows", func(t *testing.T) {
+		records := []siteRecord{{pc: 0, symbolID: 1}, {pc: info.textStart + 4, symbolID: 0xdeadbeef}}
+		if _, _, _, err := writeBack(path, info, records); err == nil || !strings.Contains(err.Error(), "no resolvable") {
+			t.Fatalf("writeBack error = %v", err)
+		}
+	})
+	t.Run("table exceeds carrier", func(t *testing.T) {
+		bad := *info
+		bad.entryVMSize = 64
+		if _, _, _, err := writeBack(path, &bad, kept); err == nil || !strings.Contains(err.Error(), "prebuilt blob") {
+			t.Fatalf("writeBack error = %v", err)
+		}
+	})
+	t.Run("unsupported compaction format", func(t *testing.T) {
+		bad := *info
+		bad.format = "unknown"
+		if _, _, _, err := writeBack(path, &bad, kept); err == nil || !strings.Contains(err.Error(), "unsupported binary format") {
+			t.Fatalf("writeBack error = %v", err)
+		}
+	})
+}
+
+func TestWriteBackRejectsMachOWithoutFixupCarrier(t *testing.T) {
+	path := machoRewriteFixture(t, 65536)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := *info
+	bad.raw = append([]byte(nil), info.raw...)
+	ncmds := binary.LittleEndian.Uint32(bad.raw[16:])
+	off := uint64(32)
+	found := false
+	for i := uint32(0); i < ncmds; i++ {
+		cmd := binary.LittleEndian.Uint32(bad.raw[off:])
+		cmdsz := uint64(binary.LittleEndian.Uint32(bad.raw[off+4:]))
+		if cmd == 0x80000034 { // LC_DYLD_CHAINED_FIXUPS
+			binary.LittleEndian.PutUint32(bad.raw[off:], 0x3) // offset-free LC_THREAD shape
+			found = true
+			break
+		}
+		off += cmdsz
+	}
+	if !found {
+		t.Fatal("fixture has no chained-fixups command")
+	}
+	kept := []siteRecord{{pc: info.textStart + 0x14, symbolID: fnv64("example.com/p.A")}}
+	if _, _, _, err := writeBack(path, &bad, kept); err == nil || !strings.Contains(err.Error(), "chained fixups") {
+		t.Fatalf("writeBack error = %v", err)
+	}
+}

--- a/internal/pclnpost/elf_fixture_test.go
+++ b/internal/pclnpost/elf_fixture_test.go
@@ -18,9 +18,11 @@ package pclnpost
 
 import (
 	"bytes"
+	"debug/elf"
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -73,7 +75,7 @@ func buildELFExternal(t *testing.T, fns []elfFn, entryRecs, stubRecs func(addrOf
 		binary.Write(&data, binary.LittleEndian, e.idx)
 		binary.Write(&data, binary.LittleEndian, uint32(0))
 	}
-	idxTableAddr := base + 0x8000
+	idxTableAddr := base + 0x400000
 	// pointer global + count global at fixed addrs inside data section
 	ptrGlobal := idxTableAddr + uint64(data.Len())
 	binary.Write(&data, binary.LittleEndian, idxTableAddr)
@@ -146,7 +148,7 @@ func buildELFExternal(t *testing.T, fns []elfFn, entryRecs, stubRecs func(addrOf
 	)
 
 	var body bytes.Buffer
-	body.Write(make([]byte, 64)) // ELF header placeholder
+	body.Write(make([]byte, 64+2*56)) // ELF header + two program headers
 	offs := make([]uint64, len(secs))
 	for i := range secs {
 		for body.Len()%16 != 0 {
@@ -178,11 +180,33 @@ func buildELFExternal(t *testing.T, fns []elfFn, entryRecs, stubRecs func(addrOf
 	binary.LittleEndian.PutUint16(raw[16:], 2)                   // EXEC
 	binary.LittleEndian.PutUint16(raw[18:], 0x3E)                // x86-64
 	binary.LittleEndian.PutUint32(raw[20:], 1)                   // version
+	binary.LittleEndian.PutUint64(raw[32:], 64)                  // phoff
 	binary.LittleEndian.PutUint64(raw[40:], shoff)               // shoff
 	binary.LittleEndian.PutUint16(raw[52:], 64)                  // ehsize
+	binary.LittleEndian.PutUint16(raw[54:], 56)                  // phentsize
+	binary.LittleEndian.PutUint16(raw[56:], 2)                   // phnum
 	binary.LittleEndian.PutUint16(raw[58:], 64)                  // shentsize
 	binary.LittleEndian.PutUint16(raw[60:], uint16(len(secs)+1)) // shnum
 	binary.LittleEndian.PutUint16(raw[62:], uint16(len(secs)))   // shstrndx
+
+	// A text PT_LOAD establishes the image base. A second, deliberately
+	// isolated PT_LOAD carries only entry/stub bytes; its larger p_memsz keeps
+	// the removed suffix mapped as zero-fill after compaction.
+	writeLoad := func(h, off, vaddr, filesz, memsz uint64, flags uint32) {
+		binary.LittleEndian.PutUint32(raw[h:], uint32(elf.PT_LOAD))
+		binary.LittleEndian.PutUint32(raw[h+4:], flags)
+		binary.LittleEndian.PutUint64(raw[h+8:], off)
+		binary.LittleEndian.PutUint64(raw[h+16:], vaddr)
+		binary.LittleEndian.PutUint64(raw[h+24:], vaddr)
+		binary.LittleEndian.PutUint64(raw[h+32:], filesz)
+		binary.LittleEndian.PutUint64(raw[h+40:], memsz)
+		binary.LittleEndian.PutUint64(raw[h+48:], 1)
+	}
+	writeLoad(64, offs[0], secs[0].addr, uint64(len(secs[0].body)), uint64(len(secs[0].body)), 5)
+	entryIndex, stubIndex := 1, 2
+	carrierOff := offs[entryIndex]
+	carrierEnd := offs[stubIndex] + uint64(len(secs[stubIndex].body))
+	writeLoad(64+56, carrierOff, secs[entryIndex].addr, carrierEnd-carrierOff, 0x20000, 6)
 
 	path := filepath.Join(t.TempDir(), "fixture")
 	if err := os.WriteFile(path, raw, 0755); err != nil {
@@ -210,12 +234,23 @@ func fixtureStub(addrOf func(string) uint64) []byte {
 
 func TestRewriteELFInPlace(t *testing.T) {
 	path := buildELF(t, fixtureFns(), fixtureEntry, fixtureStub, 4096, 256)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	st, err := Rewrite(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if st.FtabEntries != 4 { // A, B, stub, sentinel
 		t.Fatalf("stats %+v", st)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.BytesRemoved == 0 || before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("physical shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	// Idempotence guard.
 	if _, err := Rewrite(path); err == nil {
@@ -233,23 +268,31 @@ func TestRewriteELFInPlace(t *testing.T) {
 	if base != 0x10000 { // first function entry
 		t.Fatalf("base %#x", base)
 	}
-	// Stub section voided.
-	for _, b := range info.stubSec {
-		if b != 0 {
-			t.Fatal("stub section not zeroed")
-		}
+	if info.entryVMSize >= 4096 || info.stubVMSize != 0 {
+		t.Fatalf("section sizes entry=%#x stub=%#x", info.entryVMSize, info.stubVMSize)
 	}
 }
 
 func TestRewriteELFSpillsToStubSection(t *testing.T) {
 	// Entry section too small for the blob, stub section large enough.
 	path := buildELF(t, fixtureFns(), fixtureEntry, fixtureStub, 0, 8192)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	st, err := Rewrite(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if st.FtabEntries != 4 {
 		t.Fatalf("stats %+v", st)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.BytesRemoved == 0 || before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("physical spill shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	info, err := load(path)
 	if err != nil {
@@ -276,6 +319,119 @@ func TestRewriteELFOverflowFallsBack(t *testing.T) {
 	after, _ := os.ReadFile(path)
 	if !bytes.Equal(before, after) {
 		t.Fatal("binary must be untouched on failure")
+	}
+}
+
+func TestRewriteELFDedupShrinksInlineCopies(t *testing.T) {
+	const copies = 512
+	entry := func(addrOf func(string) uint64) []byte {
+		out := fixtureEntry(addrOf)
+		// These records carry B's ID inside A, exactly the shape produced when
+		// Full LTO inlines B into A. Only B's canonical record may survive.
+		for i := 0; i < copies; i++ {
+			out = append(out, rec(addrOf("example.com/p.A")+4, fnv64("example.com/p.B"))...)
+		}
+		return out
+	}
+	path := buildELF(t, fixtureFns(), entry, fixtureStub, 65536, 4096)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := Rewrite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.InlineCopies != copies || st.FtabEntries != 4 || st.BytesRemoved == 0 {
+		t.Fatalf("dedup stats = %+v", st)
+	}
+	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("dedup did not physically shrink: before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
+	}
+	// Reopening and resolving symbols exercises the shifted symtab/strtab and
+	// section-header offsets, not merely the compact table bytes.
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info.syms) != len(fixtureFns()) {
+		t.Fatalf("reopened symbols = %#v", info.syms)
+	}
+}
+
+func TestCompactELFWithNoRemovableSuffix(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, fixtureStub, 64, 64)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, removed, err := compactCarrier(info.raw, info, info.entryVMSize, info.stubVMSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 || len(raw) != len(info.raw) {
+		t.Fatalf("no-op compaction removed=%d sizes=%d/%d", removed, len(raw), len(info.raw))
+	}
+}
+
+func TestCompactELFRejectsOutOfFileCarrier(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, fixtureStub, 4096, 256)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), info.raw...)
+	// The second program header is the carrier PT_LOAD.
+	binary.LittleEndian.PutUint64(raw[64+56+32:], uint64(len(raw)))
+	if _, _, err := compactCarrier(raw, info, 64, 0); err == nil || !strings.Contains(err.Error(), "file range") {
+		t.Fatalf("compact error = %v, want invalid file range", err)
+	}
+}
+
+func TestCompactELFRejectsFollowingProgram(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, fixtureStub, 8192, 256)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), info.raw...)
+	shoff := binary.LittleEndian.Uint64(raw[40:])
+	binary.LittleEndian.PutUint16(raw[56:], 3)
+	h := uint64(64 + 2*56)
+	binary.LittleEndian.PutUint32(raw[h:], uint32(elf.PT_NOTE))
+	binary.LittleEndian.PutUint64(raw[h+8:], shoff)
+	binary.LittleEndian.PutUint64(raw[h+16:], shoff%0x2000)
+	binary.LittleEndian.PutUint64(raw[h+48:], 0x2000)
+	if _, _, err := compactCarrier(raw, info, 64, 0); err == nil || !strings.Contains(err.Error(), "follows") {
+		t.Fatalf("compact error = %v, want following-program rejection", err)
+	}
+}
+
+func TestParseELFLayoutRejectsOverflowingTables(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, fixtureStub, 256, 64)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []int{32, 40} {
+		bad := append([]byte(nil), raw...)
+		binary.LittleEndian.PutUint64(bad[field:], ^uint64(0)-32)
+		if _, _, _, err := parseELFLayout(bad); err == nil {
+			t.Fatalf("parse accepted overflowing table at header field %d", field)
+		}
+	}
+	bad := append([]byte(nil), raw...)
+	shoff := binary.LittleEndian.Uint64(bad[40:])
+	shentsz := uint64(binary.LittleEndian.Uint16(bad[58:]))
+	shstrndx := uint64(binary.LittleEndian.Uint16(bad[62:]))
+	shstr := shoff + shstrndx*shentsz
+	binary.LittleEndian.PutUint64(bad[shstr+24:], ^uint64(0)-16)
+	if _, _, _, err := parseELFLayout(bad); err == nil || !strings.Contains(err.Error(), "section-name") {
+		t.Fatalf("parse section-name error = %v", err)
 	}
 }
 

--- a/internal/pclnpost/elf_fixture_test.go
+++ b/internal/pclnpost/elf_fixture_test.go
@@ -18,9 +18,11 @@ package pclnpost
 
 import (
 	"bytes"
+	"debug/elf"
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -71,7 +73,7 @@ func buildELFExternal(t *testing.T, fns []elfFn, entryRecs func(addrOf func(stri
 		binary.Write(&data, binary.LittleEndian, e.idx)
 		binary.Write(&data, binary.LittleEndian, uint32(0))
 	}
-	idxTableAddr := base + 0x8000
+	idxTableAddr := base + 0x400000
 	// pointer global + count global at fixed addrs inside data section
 	ptrGlobal := idxTableAddr + uint64(data.Len())
 	binary.Write(&data, binary.LittleEndian, idxTableAddr)
@@ -143,7 +145,9 @@ func buildELFExternal(t *testing.T, fns []elfFn, entryRecs func(addrOf func(stri
 	)
 
 	var body bytes.Buffer
-	body.Write(make([]byte, 64)) // ELF header placeholder
+	// Reserve three program-header slots. Normal fixtures use two PT_LOADs;
+	// rejection tests populate the third slot without overwriting section data.
+	body.Write(make([]byte, 64+3*56))
 	offs := make([]uint64, len(secs))
 	for i := range secs {
 		for body.Len()%16 != 0 {
@@ -175,11 +179,30 @@ func buildELFExternal(t *testing.T, fns []elfFn, entryRecs func(addrOf func(stri
 	binary.LittleEndian.PutUint16(raw[16:], 2)                   // EXEC
 	binary.LittleEndian.PutUint16(raw[18:], 0x3E)                // x86-64
 	binary.LittleEndian.PutUint32(raw[20:], 1)                   // version
+	binary.LittleEndian.PutUint64(raw[32:], 64)                  // phoff
 	binary.LittleEndian.PutUint64(raw[40:], shoff)               // shoff
 	binary.LittleEndian.PutUint16(raw[52:], 64)                  // ehsize
+	binary.LittleEndian.PutUint16(raw[54:], 56)                  // phentsize
+	binary.LittleEndian.PutUint16(raw[56:], 2)                   // phnum
 	binary.LittleEndian.PutUint16(raw[58:], 64)                  // shentsize
 	binary.LittleEndian.PutUint16(raw[60:], uint16(len(secs)+1)) // shnum
 	binary.LittleEndian.PutUint16(raw[62:], uint16(len(secs)))   // shstrndx
+
+	// A text PT_LOAD establishes the image base. A second isolated PT_LOAD
+	// carries the entry bytes; its larger p_memsz keeps the removed suffix
+	// mapped as zero-fill after physical compaction.
+	writeLoad := func(h, off, vaddr, filesz, memsz uint64, flags uint32) {
+		binary.LittleEndian.PutUint32(raw[h:], uint32(elf.PT_LOAD))
+		binary.LittleEndian.PutUint32(raw[h+4:], flags)
+		binary.LittleEndian.PutUint64(raw[h+8:], off)
+		binary.LittleEndian.PutUint64(raw[h+16:], vaddr)
+		binary.LittleEndian.PutUint64(raw[h+24:], vaddr)
+		binary.LittleEndian.PutUint64(raw[h+32:], filesz)
+		binary.LittleEndian.PutUint64(raw[h+40:], memsz)
+		binary.LittleEndian.PutUint64(raw[h+48:], 1)
+	}
+	writeLoad(64, offs[0], secs[0].addr, uint64(len(secs[0].body)), uint64(len(secs[0].body)), 5)
+	writeLoad(64+56, offs[1], secs[1].addr, uint64(len(secs[1].body)), 0x20000, 6)
 
 	path := filepath.Join(t.TempDir(), "fixture")
 	if err := os.WriteFile(path, raw, 0755); err != nil {
@@ -202,12 +225,23 @@ func fixtureEntry(addrOf func(string) uint64) []byte {
 
 func TestRewriteELFInPlace(t *testing.T) {
 	path := buildELF(t, fixtureFns(), fixtureEntry, 4096)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	st, err := Rewrite(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if st.FtabEntries != 3 { // A, B, sentinel
 		t.Fatalf("stats %+v", st)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.BytesRemoved == 0 || before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("physical shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	// Idempotence guard.
 	if _, err := Rewrite(path); err == nil {
@@ -225,6 +259,9 @@ func TestRewriteELFInPlace(t *testing.T) {
 	if base != 0x10000 { // first function entry
 		t.Fatalf("base %#x", base)
 	}
+	if info.entryVMSize >= 4096 {
+		t.Fatalf("entry section size=%#x", info.entryVMSize)
+	}
 }
 
 func TestRewriteELFOverflowFallsBack(t *testing.T) {
@@ -236,6 +273,117 @@ func TestRewriteELFOverflowFallsBack(t *testing.T) {
 	after, _ := os.ReadFile(path)
 	if !bytes.Equal(before, after) {
 		t.Fatal("binary must be untouched on failure")
+	}
+}
+
+func TestRewriteELFDedupShrinksInlineCopies(t *testing.T) {
+	const copies = 512
+	entry := func(addrOf func(string) uint64) []byte {
+		out := fixtureEntry(addrOf)
+		// These records carry B's ID inside A, exactly the shape produced when
+		// Full LTO inlines B into A. Only B's canonical record may survive.
+		for i := 0; i < copies; i++ {
+			out = append(out, rec(addrOf("example.com/p.A")+4, fnv64("example.com/p.B"))...)
+		}
+		return out
+	}
+	path := buildELF(t, fixtureFns(), entry, 65536)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := Rewrite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.InlineCopies != copies || st.FtabEntries != 3 || st.BytesRemoved == 0 {
+		t.Fatalf("dedup stats = %+v", st)
+	}
+	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("dedup did not physically shrink: before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
+	}
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info.syms) != len(fixtureFns()) {
+		t.Fatalf("reopened symbols = %#v", info.syms)
+	}
+}
+
+func TestCompactELFWithNoRemovableSuffix(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, 64)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, removed, err := compactCarrier(append([]byte(nil), info.raw...), info, info.entryVMSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 || len(raw) != len(info.raw) {
+		t.Fatalf("no-op compaction removed=%d sizes=%d/%d", removed, len(raw), len(info.raw))
+	}
+}
+
+func TestCompactELFRejectsOutOfFileCarrier(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, 4096)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), info.raw...)
+	// The second program header is the carrier PT_LOAD.
+	binary.LittleEndian.PutUint64(raw[64+56+32:], uint64(len(raw)))
+	if _, _, err := compactCarrier(raw, info, 64); err == nil || !strings.Contains(err.Error(), "file range") {
+		t.Fatalf("compact error = %v, want invalid file range", err)
+	}
+}
+
+func TestCompactELFRejectsFollowingProgram(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, 8192)
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), info.raw...)
+	shoff := binary.LittleEndian.Uint64(raw[40:])
+	binary.LittleEndian.PutUint16(raw[56:], 3)
+	h := uint64(64 + 2*56)
+	binary.LittleEndian.PutUint32(raw[h:], uint32(elf.PT_NOTE))
+	binary.LittleEndian.PutUint64(raw[h+8:], shoff)
+	binary.LittleEndian.PutUint64(raw[h+16:], shoff%0x2000)
+	binary.LittleEndian.PutUint64(raw[h+48:], 0x2000)
+	if _, _, err := compactCarrier(raw, info, 64); err == nil || !strings.Contains(err.Error(), "follows") {
+		t.Fatalf("compact error = %v, want following-program rejection", err)
+	}
+}
+
+func TestParseELFLayoutRejectsOverflowingTables(t *testing.T) {
+	path := buildELF(t, fixtureFns(), fixtureEntry, 256)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []int{32, 40} {
+		bad := append([]byte(nil), raw...)
+		binary.LittleEndian.PutUint64(bad[field:], ^uint64(0)-32)
+		if _, _, _, err := parseELFLayout(bad); err == nil {
+			t.Fatalf("parse accepted overflowing table at header field %d", field)
+		}
+	}
+	bad := append([]byte(nil), raw...)
+	shoff := binary.LittleEndian.Uint64(bad[40:])
+	shentsz := uint64(binary.LittleEndian.Uint16(bad[58:]))
+	shstrndx := uint64(binary.LittleEndian.Uint16(bad[62:]))
+	shstr := shoff + shstrndx*shentsz
+	binary.LittleEndian.PutUint64(bad[shstr+24:], ^uint64(0)-16)
+	if _, _, _, err := parseELFLayout(bad); err == nil || !strings.Contains(err.Error(), "section-name") {
+		t.Fatalf("parse section-name error = %v", err)
 	}
 }
 

--- a/internal/pclnpost/elf_fixture_test.go
+++ b/internal/pclnpost/elf_fixture_test.go
@@ -240,7 +240,7 @@ func TestRewriteELFInPlace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.BytesRemoved == 0 || before.Size()-after.Size() != int64(st.BytesRemoved) {
+	if st.CarrierBytesRemoved == 0 || before.Size()-after.Size() != int64(st.CarrierBytesRemoved) {
 		t.Fatalf("physical shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	// Idempotence guard.
@@ -300,10 +300,10 @@ func TestRewriteELFDedupShrinksInlineCopies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.InlineCopies != copies || st.FtabEntries != 3 || st.BytesRemoved == 0 {
+	if st.InlineCopies != copies || st.FtabEntries != 3 || st.CarrierBytesRemoved == 0 {
 		t.Fatalf("dedup stats = %+v", st)
 	}
-	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+	if before.Size()-after.Size() != int64(st.CarrierBytesRemoved) {
 		t.Fatalf("dedup did not physically shrink: before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	info, err := load(path)

--- a/internal/pclnpost/external.go
+++ b/internal/pclnpost/external.go
@@ -275,6 +275,13 @@ func DetachExternal(path string, identity [sha256.Size]byte) error {
 }
 
 func replaceExternalBinary(path string, raw []byte, sign bool) (err error) {
+	return replaceBinary(path, raw, sign, nil)
+}
+
+func replaceBinary(path string, raw []byte, sign bool, verify func(string) error) (err error) {
+	if sign && runtime.GOOS != "darwin" {
+		return fmt.Errorf("cannot safely replace a signed Mach-O on %s", runtime.GOOS)
+	}
 	st, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -304,13 +311,30 @@ func replaceExternalBinary(path string, raw []byte, sign bool) (err error) {
 		return err
 	}
 	tmp = nil
-	if sign && runtime.GOOS == "darwin" {
+	if sign {
 		if output, err := exec.Command("codesign", "-f", "-s", "-", tmpPath).CombinedOutput(); err != nil {
 			return fmt.Errorf("codesign: %v: %s", err, output)
+		}
+		if signed, err := os.OpenFile(tmpPath, os.O_RDWR, 0); err != nil {
+			return err
+		} else if err := signed.Sync(); err != nil {
+			_ = signed.Close()
+			return err
+		} else if err := signed.Close(); err != nil {
+			return err
+		}
+	}
+	if verify != nil {
+		if err := verify(tmpPath); err != nil {
+			return fmt.Errorf("verify staged binary: %w", err)
 		}
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		return err
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
 	}
 	return nil
 }

--- a/internal/pclnpost/external.go
+++ b/internal/pclnpost/external.go
@@ -318,6 +318,13 @@ func DetachExternal(path string, identity [sha256.Size]byte) error {
 }
 
 func replaceExternalBinary(path string, raw []byte, sign bool) (err error) {
+	return replaceBinary(path, raw, sign, nil)
+}
+
+func replaceBinary(path string, raw []byte, sign bool, verify func(string) error) (err error) {
+	if sign && runtime.GOOS != "darwin" {
+		return fmt.Errorf("cannot safely replace a signed Mach-O on %s", runtime.GOOS)
+	}
 	st, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -347,13 +354,30 @@ func replaceExternalBinary(path string, raw []byte, sign bool) (err error) {
 		return err
 	}
 	tmp = nil
-	if sign && runtime.GOOS == "darwin" {
+	if sign {
 		if output, err := exec.Command("codesign", "-f", "-s", "-", tmpPath).CombinedOutput(); err != nil {
 			return fmt.Errorf("codesign: %v: %s", err, output)
+		}
+		if signed, err := os.OpenFile(tmpPath, os.O_RDWR, 0); err != nil {
+			return err
+		} else if err := signed.Sync(); err != nil {
+			_ = signed.Close()
+			return err
+		} else if err := signed.Close(); err != nil {
+			return err
+		}
+	}
+	if verify != nil {
+		if err := verify(tmpPath); err != nil {
+			return fmt.Errorf("verify staged binary: %w", err)
 		}
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		return err
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
 	}
 	return nil
 }

--- a/internal/pclnpost/external_test.go
+++ b/internal/pclnpost/external_test.go
@@ -19,11 +19,15 @@ package pclnpost
 import (
 	"bytes"
 	"crypto/sha256"
+	"debug/macho"
 	"encoding/binary"
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -399,6 +403,46 @@ func TestReplaceExternalBinaryErrorPaths(t *testing.T) {
 	}
 	if got, err := os.ReadFile(path); err != nil || string(got) != "original" {
 		t.Fatalf("failed transaction changed original: %q, %v", got, err)
+	}
+}
+
+func TestReplaceBinarySigningContract(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		path := machoRewriteFixture(t, 4096)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := replaceBinary(path, raw, true, nil); err == nil || !strings.Contains(err.Error(), "cannot safely replace") {
+			t.Fatalf("signed replacement error = %v", err)
+		}
+		return
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "signed-test-binary")
+	if err := os.WriteFile(path, raw, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceBinary(path, raw, true, func(staged string) error {
+		mf, err := macho.Open(staged)
+		if err == nil {
+			err = mf.Close()
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if mf, err := macho.Open(path); err != nil {
+		t.Fatalf("reload signed replacement: %v", err)
+	} else {
+		_ = mf.Close()
 	}
 }
 

--- a/internal/pclnpost/external_test.go
+++ b/internal/pclnpost/external_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"os"
 	"reflect"
 	"sort"
@@ -435,6 +436,17 @@ func TestReplaceExternalBinaryErrorPaths(t *testing.T) {
 	dir := t.TempDir()
 	if err := replaceExternalBinary(dir, []byte("replacement"), false); err == nil {
 		t.Fatal("replaceExternalBinary replaced a directory")
+	}
+	path := dir + "/binary"
+	if err := os.WriteFile(path, []byte("original"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("staged verification failed")
+	if err := replaceBinary(path, []byte("replacement"), false, func(string) error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Fatalf("replaceBinary verification error = %v", err)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != "original" {
+		t.Fatalf("failed transaction changed original: %q, %v", got, err)
 	}
 }
 

--- a/internal/pclnpost/external_test.go
+++ b/internal/pclnpost/external_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"os"
 	"reflect"
 	"sort"
@@ -387,6 +388,17 @@ func TestReplaceExternalBinaryErrorPaths(t *testing.T) {
 	dir := t.TempDir()
 	if err := replaceExternalBinary(dir, []byte("replacement"), false); err == nil {
 		t.Fatal("replaceExternalBinary replaced a directory")
+	}
+	path := dir + "/binary"
+	if err := os.WriteFile(path, []byte("original"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("staged verification failed")
+	if err := replaceBinary(path, []byte("replacement"), false, func(string) error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Fatalf("replaceBinary verification error = %v", err)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != "original" {
+		t.Fatalf("failed transaction changed original: %q, %v", got, err)
 	}
 }
 

--- a/internal/pclnpost/macho_fixture_test.go
+++ b/internal/pclnpost/macho_fixture_test.go
@@ -339,24 +339,70 @@ func TestRewriteMachOInPlace(t *testing.T) {
 	}
 }
 
+func renameMachOCarrierSegment(t *testing.T, raw []byte, name string) []byte {
+	t.Helper()
+	marker := append([]byte("__LLGO"), make([]byte, 10)...)
+	replacement := append([]byte(name), make([]byte, 16-len(name))...)
+	found := 0
+	for off := 0; off < len(raw); {
+		i := bytes.Index(raw[off:], marker)
+		if i < 0 {
+			break
+		}
+		i += off
+		copy(raw[i:i+16], replacement)
+		found++
+		off = i + 16
+	}
+	if found == 0 {
+		t.Fatal("fixture has no __LLGO segment")
+	}
+	return raw
+}
+
+func TestRewriteMachOSharedDataCarrierKeepsFileSize(t *testing.T) {
+	path := machoRewriteFixture(t, 65536)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = renameMachOCarrierSegment(t, raw, "__DATA")
+	if err := os.WriteFile(path, raw, 0755); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Rewrite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.BytesRemoved != 0 || len(after) != len(raw) {
+		t.Fatalf("shared carrier changed file size: stats=%+v sizes=%d/%d", st, len(raw), len(after))
+	}
+	info, err := load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := binary.LittleEndian.Uint64(info.entrySec); got != prebuiltMagic {
+		t.Fatalf("shared carrier magic = %#x, want %#x", got, prebuiltMagic)
+	}
+}
+
 func TestRewriteMachOUnsupportedLayoutPreservesFile(t *testing.T) {
 	path := machoRewriteFixture(t, 65536)
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	marker := append([]byte("__LLGO"), make([]byte, 10)...)
-	i := bytes.Index(raw, marker)
-	if i < 0 {
-		t.Fatal("fixture has no __LLGO segment")
-	}
-	copy(raw[i:i+16], append([]byte("__DATA"), make([]byte, 10)...))
+	raw = renameMachOCarrierSegment(t, raw, "__OTHER")
 	if err := os.WriteFile(path, raw, 0755); err != nil {
 		t.Fatal(err)
 	}
 	before := append([]byte(nil), raw...)
 	if _, err := Rewrite(path); err == nil {
-		t.Fatal("rewrite accepted a non-isolated carrier")
+		t.Fatal("rewrite accepted an unsupported carrier")
 	}
 	after, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/pclnpost/macho_fixture_test.go
+++ b/internal/pclnpost/macho_fixture_test.go
@@ -28,8 +28,8 @@ import (
 // buildMachO fabricates a minimal 64-bit Mach-O that debug/macho can Open:
 // one __TEXT segment (__text) and one data segment carrying __llgo_fie plus
 // optional pcline data, LC_SYMTAB, and LC_DYLD_CHAINED_FIXUPS. Rewrite fixtures
-// isolate the disposable entry carrier in __LLGO; external-mode fixtures keep
-// their metadata together in __DATA.
+// isolate the disposable entry carrier in __LLGO; fixtures for modes without
+// physical compaction keep their metadata together in __DATA.
 func buildMachO(t *testing.T, entry []byte, syms []elfFn) string {
 	return buildMachOFixture(t, entry, nil, nil, syms, true)
 }
@@ -320,14 +320,14 @@ func TestRewriteMachOInPlace(t *testing.T) {
 	if st.Format != "macho" || st.FtabEntries != 3 {
 		t.Fatalf("stats %+v", st)
 	}
-	if st.BytesRemoved == 0 {
+	if st.CarrierBytesRemoved == 0 {
 		t.Fatalf("rewrite did not physically compact: %+v", st)
 	}
 	after, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+	if before.Size()-after.Size() != int64(st.CarrierBytesRemoved) {
 		t.Fatalf("physical shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	info, err := load(path)
@@ -378,7 +378,7 @@ func TestRewriteMachOSharedDataCarrierKeepsFileSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.BytesRemoved != 0 || len(after) != len(raw) {
+	if st.CarrierBytesRemoved != 0 || len(after) != len(raw) {
 		t.Fatalf("shared carrier changed file size: stats=%+v sizes=%d/%d", st, len(raw), len(after))
 	}
 	info, err := load(path)

--- a/internal/pclnpost/macho_fixture_test.go
+++ b/internal/pclnpost/macho_fixture_test.go
@@ -18,6 +18,7 @@ package pclnpost
 
 import (
 	"bytes"
+	"debug/macho"
 	"encoding/binary"
 	"os"
 	"path/filepath"
@@ -25,14 +26,19 @@ import (
 )
 
 // buildMachO fabricates a minimal 64-bit Mach-O that debug/macho can Open:
-// one __TEXT segment (__text) and one __DATA segment carrying __llgo_fie /
-// optional pcline data, plus LC_SYMTAB and an LC_DYLD_CHAINED_FIXUPS whose imports
-// table binds ordinal 1 to a local symbol.
+// one __TEXT segment (__text) and one data segment carrying __llgo_fie plus
+// optional pcline data, LC_SYMTAB, and LC_DYLD_CHAINED_FIXUPS. Rewrite fixtures
+// isolate the disposable entry carrier in __LLGO; external-mode fixtures keep
+// their metadata together in __DATA.
 func buildMachO(t *testing.T, entry []byte, syms []elfFn) string {
-	return buildMachOExternal(t, entry, nil, nil, syms)
+	return buildMachOFixture(t, entry, nil, nil, syms, true)
 }
 
 func buildMachOExternal(t *testing.T, entry, pcLine, identity []byte, syms []elfFn) string {
+	return buildMachOFixture(t, entry, pcLine, identity, syms, false)
+}
+
+func buildMachOFixture(t *testing.T, entry, pcLine, identity []byte, syms []elfFn, isolateCarrier bool) string {
 	t.Helper()
 	const base = uint64(0x100000000)
 	text := make([]byte, 0x40000) // big enough that findfunctab buckets outgrow a tiny entry section
@@ -67,7 +73,7 @@ func buildMachOExternal(t *testing.T, entry, pcLine, identity []byte, syms []elf
 
 	// File layout (fixed offsets, one page apart).
 	const textOff = uint64(0x1000)
-	const entryOff = uint64(0x2000)
+	const entryOff = uint64(0x42000)
 	dataEnd := entryOff + uint64(len(entry))
 	pcLineOff := dataEnd
 	if pcLine != nil {
@@ -77,7 +83,8 @@ func buildMachOExternal(t *testing.T, entry, pcLine, identity []byte, syms []elf
 	if identity != nil {
 		dataEnd += uint64(len(identity))
 	}
-	symOff := (dataEnd + 0xF) &^ 0xF
+	carrierFileEnd := (dataEnd + 0x3fff) &^ 0x3fff
+	symOff := carrierFileEnd
 	fixOff := symOff + 0x800
 
 	// A fileless low segment mirrors __PAGEZERO in real executables. Image
@@ -86,8 +93,12 @@ func buildMachOExternal(t *testing.T, entry, pcLine, identity []byte, syms []elf
 	cmds = append(cmds, lc{segment("__TEXT", base, 0, textOff+uint64(len(text)), [][]byte{
 		sect("__text", "__TEXT", base+textOff, textOff, uint64(len(text))),
 	})})
+	carrierSegment := "__DATA"
+	if isolateCarrier {
+		carrierSegment = "__LLGO"
+	}
 	dataSections := [][]byte{
-		sect("__llgo_fie", "__DATA", base+entryOff, entryOff, uint64(len(entry))),
+		sect("__llgo_fie", carrierSegment, base+entryOff, entryOff, uint64(len(entry))),
 	}
 	if pcLine != nil {
 		dataSections = append(dataSections, sect("__llgo_pcl", "__DATA", base+pcLineOff, pcLineOff, uint64(len(pcLine))))
@@ -95,7 +106,7 @@ func buildMachOExternal(t *testing.T, entry, pcLine, identity []byte, syms []elf
 	if identity != nil {
 		dataSections = append(dataSections, sect("__llgo_pid", "__DATA", base+identityOff, identityOff, uint64(len(identity))))
 	}
-	cmds = append(cmds, lc{segment("__DATA", base+entryOff, entryOff, dataEnd-entryOff, dataSections)})
+	cmds = append(cmds, lc{segment(carrierSegment, base+entryOff, entryOff, carrierFileEnd-entryOff, dataSections)})
 
 	// Symtab: nlist_64 entries + strtab.
 	strtab := []byte{0}
@@ -226,7 +237,7 @@ func TestLoadMachOFixture(t *testing.T) {
 	if info.format != "macho" {
 		t.Fatalf("format %s", info.format)
 	}
-	if info.textStart != base+0x1000 || info.entryVMAddr != base+0x2000 {
+	if info.textStart != base+0x1000 || info.entryVMAddr != base+0x42000 {
 		t.Fatalf("layout %#x %#x", info.textStart, info.entryVMAddr)
 	}
 	if len(info.bindTargets) != 2 || info.bindTargets[0] != 0 || info.bindTargets[1] != base+0x1000+fns[0].size {
@@ -257,7 +268,7 @@ func machoRewriteFixture(t *testing.T, entryPad int) string {
 
 	// Symbol index table + pointer/count globals live in the entry section
 	// tail so readVM can reach them via the __llgo_fie section.
-	entryBase := base + 0x2000
+	entryBase := base + 0x42000
 	var idx []byte
 	type sie struct {
 		id uint64
@@ -297,7 +308,11 @@ func machoRewriteFixture(t *testing.T, entryPad int) string {
 }
 
 func TestRewriteMachOInPlace(t *testing.T) {
-	path := machoRewriteFixture(t, 4096)
+	path := machoRewriteFixture(t, 65536)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	st, err := Rewrite(path)
 	if err != nil {
 		t.Fatal(err)
@@ -305,11 +320,74 @@ func TestRewriteMachOInPlace(t *testing.T) {
 	if st.Format != "macho" || st.FtabEntries != 3 {
 		t.Fatalf("stats %+v", st)
 	}
+	if st.BytesRemoved == 0 {
+		t.Fatalf("rewrite did not physically compact: %+v", st)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("physical shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
+	}
 	info, err := load(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got := binary.LittleEndian.Uint64(info.entrySec[0:]); got != prebuiltMagic {
 		t.Fatalf("magic %#x", got)
+	}
+}
+
+func TestRewriteMachOUnsupportedLayoutPreservesFile(t *testing.T) {
+	path := machoRewriteFixture(t, 65536)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := append([]byte("__LLGO"), make([]byte, 10)...)
+	i := bytes.Index(raw, marker)
+	if i < 0 {
+		t.Fatal("fixture has no __LLGO segment")
+	}
+	copy(raw[i:i+16], append([]byte("__DATA"), make([]byte, 10)...))
+	if err := os.WriteFile(path, raw, 0755); err != nil {
+		t.Fatal(err)
+	}
+	before := append([]byte(nil), raw...)
+	if _, err := Rewrite(path); err == nil {
+		t.Fatal("rewrite accepted a non-isolated carrier")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("failed rewrite modified the input file")
+	}
+}
+
+func TestPatchMachOFileOffsetsRejectsTruncatedCommands(t *testing.T) {
+	for _, test := range []struct {
+		cmd  uint32
+		size uint32
+	}{
+		{0x2, 8}, {0xb, 8}, {0x22, 8}, {0x1d, 8},
+		{0x16, 8}, {0x31, 8}, {0x21, 8},
+	} {
+		raw := make([]byte, 128)
+		binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+		binary.LittleEndian.PutUint32(raw[16:], 1)
+		binary.LittleEndian.PutUint32(raw[32:], test.cmd)
+		binary.LittleEndian.PutUint32(raw[36:], test.size)
+		if _, err := parseMachOLayout(raw); err == nil {
+			t.Fatalf("command %#x size %#x was accepted", test.cmd, test.size)
+		}
+	}
+	raw := make([]byte, 36)
+	binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+	binary.LittleEndian.PutUint32(raw[16:], 1)
+	if _, err := parseMachOLayout(raw); err == nil {
+		t.Fatal("truncated command header was accepted")
 	}
 }

--- a/internal/pclnpost/macho_fixture_test.go
+++ b/internal/pclnpost/macho_fixture_test.go
@@ -18,6 +18,7 @@ package pclnpost
 
 import (
 	"bytes"
+	"debug/macho"
 	"encoding/binary"
 	"os"
 	"path/filepath"
@@ -29,10 +30,14 @@ import (
 // __llgo_stub, plus LC_SYMTAB and an LC_DYLD_CHAINED_FIXUPS whose imports
 // table binds ordinal 1 to a local symbol.
 func buildMachO(t *testing.T, entry, stub []byte, syms []elfFn) string {
-	return buildMachOExternal(t, entry, stub, nil, nil, syms)
+	return buildMachOFixture(t, entry, stub, nil, nil, syms, true)
 }
 
 func buildMachOExternal(t *testing.T, entry, stub, pcLine, identity []byte, syms []elfFn) string {
+	return buildMachOFixture(t, entry, stub, pcLine, identity, syms, false)
+}
+
+func buildMachOFixture(t *testing.T, entry, stub, pcLine, identity []byte, syms []elfFn, isolateCarriers bool) string {
 	t.Helper()
 	const base = uint64(0x100000000)
 	text := make([]byte, 0x40000) // big enough that findfunctab buckets outgrow a tiny entry section
@@ -67,7 +72,7 @@ func buildMachOExternal(t *testing.T, entry, stub, pcLine, identity []byte, syms
 
 	// File layout (fixed offsets, one page apart).
 	const textOff = uint64(0x1000)
-	const entryOff = uint64(0x2000)
+	const entryOff = uint64(0x42000)
 	stubOff := entryOff + uint64(len(entry))
 	dataEnd := stubOff + uint64(len(stub))
 	pcLineOff := dataEnd
@@ -78,7 +83,8 @@ func buildMachOExternal(t *testing.T, entry, stub, pcLine, identity []byte, syms
 	if identity != nil {
 		dataEnd += uint64(len(identity))
 	}
-	symOff := (dataEnd + 0xF) &^ 0xF
+	carrierFileEnd := (dataEnd + 0x3fff) &^ 0x3fff
+	symOff := carrierFileEnd
 	fixOff := symOff + 0x800
 
 	// A fileless low segment mirrors __PAGEZERO in real executables. Image
@@ -87,9 +93,13 @@ func buildMachOExternal(t *testing.T, entry, stub, pcLine, identity []byte, syms
 	cmds = append(cmds, lc{segment("__TEXT", base, 0, textOff+uint64(len(text)), [][]byte{
 		sect("__text", "__TEXT", base+textOff, textOff, uint64(len(text))),
 	})})
+	carrierSegment := "__DATA"
+	if isolateCarriers {
+		carrierSegment = "__LLGO"
+	}
 	dataSections := [][]byte{
-		sect("__llgo_fie", "__DATA", base+entryOff, entryOff, uint64(len(entry))),
-		sect("__llgo_stub", "__DATA", base+stubOff, stubOff, uint64(len(stub))),
+		sect("__llgo_fie", carrierSegment, base+entryOff, entryOff, uint64(len(entry))),
+		sect("__llgo_stub", carrierSegment, base+stubOff, stubOff, uint64(len(stub))),
 	}
 	if pcLine != nil {
 		dataSections = append(dataSections, sect("__llgo_pcl", "__DATA", base+pcLineOff, pcLineOff, uint64(len(pcLine))))
@@ -97,7 +107,7 @@ func buildMachOExternal(t *testing.T, entry, stub, pcLine, identity []byte, syms
 	if identity != nil {
 		dataSections = append(dataSections, sect("__llgo_pid", "__DATA", base+identityOff, identityOff, uint64(len(identity))))
 	}
-	cmds = append(cmds, lc{segment("__DATA", base+entryOff, entryOff, dataEnd-entryOff, dataSections)})
+	cmds = append(cmds, lc{segment(carrierSegment, base+entryOff, entryOff, carrierFileEnd-entryOff, dataSections)})
 
 	// Symtab: nlist_64 entries + strtab.
 	strtab := []byte{0}
@@ -231,7 +241,7 @@ func TestLoadMachOFixture(t *testing.T) {
 	if info.format != "macho" {
 		t.Fatalf("format %s", info.format)
 	}
-	if info.textStart != base+0x1000 || info.entryVMAddr != base+0x2000 {
+	if info.textStart != base+0x1000 || info.entryVMAddr != base+0x42000 {
 		t.Fatalf("layout %#x %#x", info.textStart, info.entryVMAddr)
 	}
 	if len(info.bindTargets) != 2 || info.bindTargets[0] != 0 || info.bindTargets[1] != base+0x1000+fns[0].size {
@@ -262,7 +272,7 @@ func machoRewriteFixture(t *testing.T, entryPad, stubPad int) string {
 
 	// Symbol index table + pointer/count globals live in the entry section
 	// tail so readVM can reach them via the __llgo_fie section.
-	entryBase := base + 0x2000
+	entryBase := base + 0x42000
 	var idx []byte
 	type sie struct {
 		id uint64
@@ -303,13 +313,27 @@ func machoRewriteFixture(t *testing.T, entryPad, stubPad int) string {
 }
 
 func TestRewriteMachOInPlace(t *testing.T) {
-	path := machoRewriteFixture(t, 4096, 512)
+	path := machoRewriteFixture(t, 65536, 512)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	st, err := Rewrite(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if st.Format != "macho" || st.FtabEntries != 3 {
 		t.Fatalf("stats %+v", st)
+	}
+	if st.BytesRemoved == 0 {
+		t.Fatalf("rewrite did not physically compact: %+v", st)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("physical shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	info, err := load(path)
 	if err != nil {
@@ -321,13 +345,27 @@ func TestRewriteMachOInPlace(t *testing.T) {
 }
 
 func TestRewriteMachOSpill(t *testing.T) {
-	path := machoRewriteFixture(t, 0, 8192)
+	path := machoRewriteFixture(t, 0, 65536)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	st, err := Rewrite(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if st.FtabEntries != 3 {
 		t.Fatalf("stats %+v", st)
+	}
+	if st.BytesRemoved == 0 {
+		t.Fatalf("spill rewrite did not physically compact: %+v", st)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Size()-after.Size() != int64(st.BytesRemoved) {
+		t.Fatalf("physical spill shrink before=%d after=%d stats=%+v", before.Size(), after.Size(), st)
 	}
 	info, err := load(path)
 	if err != nil {
@@ -338,5 +376,58 @@ func TestRewriteMachOSpill(t *testing.T) {
 	}
 	if got := binary.LittleEndian.Uint64(info.stubSec[0:]); got != prebuiltMagic {
 		t.Fatalf("stub magic %#x", got)
+	}
+}
+
+func TestRewriteMachOUnsupportedLayoutPreservesFile(t *testing.T) {
+	path := machoRewriteFixture(t, 65536, 512)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := append([]byte("__LLGO"), make([]byte, 10)...)
+	i := bytes.Index(raw, marker)
+	if i < 0 {
+		t.Fatal("fixture has no __LLGO segment")
+	}
+	copy(raw[i:i+16], append([]byte("__DATA"), make([]byte, 10)...))
+	if err := os.WriteFile(path, raw, 0755); err != nil {
+		t.Fatal(err)
+	}
+	before := append([]byte(nil), raw...)
+	if _, err := Rewrite(path); err == nil {
+		t.Fatal("rewrite accepted a non-isolated carrier")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("failed rewrite modified the input file")
+	}
+}
+
+func TestPatchMachOFileOffsetsRejectsTruncatedCommands(t *testing.T) {
+	for _, test := range []struct {
+		cmd  uint32
+		size uint32
+	}{
+		{0x2, 8}, {0xb, 8}, {0x22, 8}, {0x1d, 8},
+		{0x16, 8}, {0x31, 8}, {0x21, 8},
+	} {
+		raw := make([]byte, 128)
+		binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+		binary.LittleEndian.PutUint32(raw[16:], 1)
+		binary.LittleEndian.PutUint32(raw[32:], test.cmd)
+		binary.LittleEndian.PutUint32(raw[36:], test.size)
+		if _, err := parseMachOLayout(raw); err == nil {
+			t.Fatalf("command %#x size %#x was accepted", test.cmd, test.size)
+		}
+	}
+	raw := make([]byte, 36)
+	binary.LittleEndian.PutUint32(raw, uint32(macho.Magic64))
+	binary.LittleEndian.PutUint32(raw[16:], 1)
+	if _, err := parseMachOLayout(raw); err == nil {
+		t.Fatal("truncated command header was accepted")
 	}
 }

--- a/internal/pclnpost/pclnpost.go
+++ b/internal/pclnpost/pclnpost.go
@@ -30,14 +30,15 @@ type Stats struct {
 	NoSymbol     int
 	FtabEntries  int
 	Buckets      int
+	BytesRemoved uint64
 }
 
 // Rewrite parses the linked binary's funcinfo site sections, deduplicates
 // LTO inline copies against the symbol table, builds the Go-layout prebuilt
-// table and rewrites the entry section in place.
+// table, stages a compact executable image, and atomically replaces the input.
 // The runtime adopts the table when it sees the magic header and falls back
 // to first-use construction otherwise, so failures here leave a fully
-// functional binary.
+// functional and byte-for-byte unchanged binary.
 func Rewrite(path string) (Stats, error) {
 	var st Stats
 	info, err := load(path)
@@ -60,10 +61,10 @@ func Rewrite(path string) (Stats, error) {
 	if len(kept) == 0 {
 		return st, fmt.Errorf("no records survived dedup")
 	}
-	ftab, buckets, err := writeBack(path, info, kept)
+	ftab, buckets, removed, err := writeBack(path, info, kept)
 	if err != nil {
 		return st, err
 	}
-	st.FtabEntries, st.Buckets = ftab, buckets
+	st.FtabEntries, st.Buckets, st.BytesRemoved = ftab, buckets, removed
 	return st, nil
 }

--- a/internal/pclnpost/pclnpost.go
+++ b/internal/pclnpost/pclnpost.go
@@ -31,14 +31,15 @@ type Stats struct {
 	NoSymbol     int
 	FtabEntries  int
 	Buckets      int
+	BytesRemoved uint64
 }
 
 // Rewrite parses the linked binary's funcinfo site sections, deduplicates
 // LTO inline copies against the symbol table, builds the Go-layout prebuilt
-// table and rewrites the entry section in place (voiding the stub section).
+// table, stages a compact executable image, and atomically replaces the input.
 // The runtime adopts the table when it sees the magic header and falls back
 // to first-use construction otherwise, so failures here leave a fully
-// functional binary.
+// functional and byte-for-byte unchanged binary.
 func Rewrite(path string) (Stats, error) {
 	var st Stats
 	info, err := load(path)
@@ -62,7 +63,7 @@ func Rewrite(path string) (Stats, error) {
 	if len(kept) == 0 {
 		return st, fmt.Errorf("no records survived dedup")
 	}
-	ftab, buckets, err := writeBack(path, info, kept)
+	ftab, buckets, removed, err := writeBack(path, info, kept)
 	if err != nil {
 		// Includes errBlobOverflow when the blob fits neither the entry nor
 		// the stub section. Never drop stub rows to squeeze in: a table with
@@ -72,6 +73,6 @@ func Rewrite(path string) (Stats, error) {
 		// is slower but correct.
 		return st, err
 	}
-	st.FtabEntries, st.Buckets = ftab, buckets
+	st.FtabEntries, st.Buckets, st.BytesRemoved = ftab, buckets, removed
 	return st, nil
 }

--- a/internal/pclnpost/pclnpost.go
+++ b/internal/pclnpost/pclnpost.go
@@ -30,7 +30,10 @@ type Stats struct {
 	NoSymbol     int
 	FtabEntries  int
 	Buckets      int
-	BytesRemoved uint64
+	// CarrierBytesRemoved is the number of bytes cut from the metadata carrier
+	// before an existing Mach-O code signature is regenerated. It is not the
+	// signed output file's net size change.
+	CarrierBytesRemoved uint64
 }
 
 // Rewrite parses the linked binary's funcinfo site sections, deduplicates
@@ -65,6 +68,6 @@ func Rewrite(path string) (Stats, error) {
 	if err != nil {
 		return st, err
 	}
-	st.FtabEntries, st.Buckets, st.BytesRemoved = ftab, buckets, removed
+	st.FtabEntries, st.Buckets, st.CarrierBytesRemoved = ftab, buckets, removed
 	return st, nil
 }

--- a/internal/pclnpost/write.go
+++ b/internal/pclnpost/write.go
@@ -23,8 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 	"sort"
 )
 
@@ -66,12 +64,12 @@ type symIndexEntry struct {
 	idx uint32
 }
 
-// writeBack rewrites the entry-site section in place with the prebuilt table
-// and voids the stub section (its records are merged into the table).
-func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, bucketCount int, err error) {
+// writeBack rewrites the entry-site prefix with the prebuilt table, removes
+// the unused physical carrier tail, and publishes the staged image atomically.
+func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, bucketCount int, bytesRemoved uint64, err error) {
 	symIdx, err := loadSymbolIndex(path, info)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	sort.Slice(kept, func(i, j int) bool { return kept[i].pc < kept[j].pc })
 	type row struct {
@@ -92,7 +90,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 		rows = append(rows, row{pc: r.pc, idx: idx})
 	}
 	if len(rows) == 0 {
-		return 0, 0, fmt.Errorf("no resolvable entries")
+		return 0, 0, 0, fmt.Errorf("no resolvable entries")
 	}
 	base := rows[0].pc
 	count := len(rows) + 1 // + sentinel
@@ -123,7 +121,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 			subIdx := lastLE(bucketStart + uint64(s)*subbucketSize)
 			delta := subIdx - baseIdx
 			if delta < 0 || delta > 0xffff {
-				return 0, 0, fmt.Errorf("subbucket delta overflow: %d", delta)
+				return 0, 0, 0, fmt.Errorf("subbucket delta overflow: %d", delta)
 			}
 			binary.LittleEndian.PutUint16(tmp[4+2*s:], uint16(delta))
 		}
@@ -134,17 +132,15 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 	entrySize := int(info.entryVMSize)
 	spill := need > entrySize
 	if spill && need > int(info.stubVMSize) {
-		return 0, 0, errBlobOverflow
+		return 0, 0, 0, errBlobOverflow
 	}
-	blobSect := int(info.entryVMSize)
 	blobFileOff := info.entryFileOff
 	blobVMAddr := info.entryVMAddr
 	if spill {
-		blobSect = int(info.stubVMSize)
 		blobFileOff = info.stubFileOff
 		blobVMAddr = info.stubVMAddr
 	}
-	blob := make([]byte, blobSect) // zero tail
+	blob := make([]byte, need)
 	binary.LittleEndian.PutUint64(blob[0:], prebuiltMagic)
 	binary.LittleEndian.PutUint64(blob[8:], blobVMAddr)
 	binary.LittleEndian.PutUint64(blob[16:], base)
@@ -183,7 +179,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 		}
 		pending, err = unchainRanges(raw, ranges, inserts)
 		if err != nil {
-			return 0, 0, fmt.Errorf("chained fixups: %w", err)
+			return 0, 0, 0, fmt.Errorf("chained fixups: %w", err)
 		}
 	}
 	if spill {
@@ -197,7 +193,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 		binary.LittleEndian.PutUint64(zero[8:], info.entryVMAddr)
 		binary.LittleEndian.PutUint64(zero[16:], info.stubVMAddr)
 	}
-	copy(raw[blobFileOff:], blob)
+	copy(raw[blobFileOff:blobFileOff+uint64(len(blob))], blob)
 	for _, pw := range pending {
 		binary.LittleEndian.PutUint64(raw[pw.fileOff:], pw.val)
 	}
@@ -210,22 +206,57 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 			zero[i] = 0
 		}
 	}
+	entryUsed, stubUsed := uint64(need), uint64(0)
+	if spill {
+		entryUsed, stubUsed = 32, uint64(need)
+	}
+	raw, removed, err := compactCarrier(raw, info, entryUsed, stubUsed)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	verify := func(staged string) error {
+		if removed != 0 {
+			st, err := os.Stat(staged)
+			if err != nil {
+				return err
+			}
+			if st.Size() >= int64(len(info.raw)) {
+				return fmt.Errorf("compacted file did not shrink: old=%d staged=%d", len(info.raw), st.Size())
+			}
+		}
+		stagedInfo, err := load(staged)
+		if err != nil {
+			return fmt.Errorf("reload compact binary: %w", err)
+		}
+		if len(stagedInfo.entrySec) < 8 {
+			return fmt.Errorf("compact entry section is truncated")
+		}
+		wantEntryMagic := prebuiltMagic
+		if spill {
+			wantEntryMagic = redirectMagic
+		}
+		if got := binary.LittleEndian.Uint64(stagedInfo.entrySec); got != wantEntryMagic {
+			return fmt.Errorf("compact entry magic %#x, want %#x", got, wantEntryMagic)
+		}
+		if spill {
+			if len(stagedInfo.stubSec) < 8 || binary.LittleEndian.Uint64(stagedInfo.stubSec) != prebuiltMagic {
+				return fmt.Errorf("compact stub blob is missing")
+			}
+		}
+		return nil
+	}
+	if err := replaceBinary(path, raw, info.format == ExternalFormatMachO && info.hasCodeSignature, verify); err != nil {
+		return 0, 0, 0, err
+	}
 	st, err := os.Stat(path)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
-	if err := os.WriteFile(path, raw, st.Mode()); err != nil {
-		return 0, 0, err
+	physicalRemoved := int64(len(info.raw)) - st.Size()
+	if physicalRemoved < 0 {
+		physicalRemoved = 0
 	}
-	// Only re-sign binaries that were signed to begin with (lld ad-hoc
-	// signs real executables; unsigned inputs need no signature and
-	// codesign would reject them anyway).
-	if info.format == "macho" && info.hasCodeSignature && runtime.GOOS == "darwin" {
-		if out, err := exec.Command("codesign", "-f", "-s", "-", path).CombinedOutput(); err != nil {
-			return 0, 0, fmt.Errorf("codesign: %v: %s", err, out)
-		}
-	}
-	return count, len(buckets) / bucketBytes, nil
+	return count, len(buckets) / bucketBytes, uint64(physicalRemoved), nil
 }
 
 // metaRecordMagic marks the entry-section meta record ("LLGOMET1" LE); keep

--- a/internal/pclnpost/write.go
+++ b/internal/pclnpost/write.go
@@ -185,15 +185,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 	if err := replaceBinary(path, raw, info.format == ExternalFormatMachO && info.hasCodeSignature, verify); err != nil {
 		return 0, 0, 0, err
 	}
-	st, err := os.Stat(path)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	physicalRemoved := int64(len(info.raw)) - st.Size()
-	if physicalRemoved < 0 {
-		physicalRemoved = 0
-	}
-	return count, len(buckets) / bucketBytes, uint64(physicalRemoved), nil
+	return count, len(buckets) / bucketBytes, removed, nil
 }
 
 // metaRecordMagic marks the entry-section meta record ("LLGOMET1" LE); keep

--- a/internal/pclnpost/write.go
+++ b/internal/pclnpost/write.go
@@ -22,8 +22,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 	"sort"
 )
 
@@ -52,11 +50,12 @@ type symIndexEntry struct {
 	idx uint32
 }
 
-// writeBack rewrites the entry-site section in place with the prebuilt table.
-func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, bucketCount int, err error) {
+// writeBack rewrites the entry-site prefix with the prebuilt table, removes
+// the unused physical carrier tail, and publishes the staged image atomically.
+func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, bucketCount int, bytesRemoved uint64, err error) {
 	symIdx, err := loadSymbolIndex(path, info)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	sort.Slice(kept, func(i, j int) bool { return kept[i].pc < kept[j].pc })
 	type row struct {
@@ -77,7 +76,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 		rows = append(rows, row{pc: r.pc, idx: idx})
 	}
 	if len(rows) == 0 {
-		return 0, 0, fmt.Errorf("no resolvable entries")
+		return 0, 0, 0, fmt.Errorf("no resolvable entries")
 	}
 	base := rows[0].pc
 	count := len(rows) + 1 // + sentinel
@@ -108,7 +107,7 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 			subIdx := lastLE(bucketStart + uint64(s)*subbucketSize)
 			delta := subIdx - baseIdx
 			if delta < 0 || delta > 0xffff {
-				return 0, 0, fmt.Errorf("subbucket delta overflow: %d", delta)
+				return 0, 0, 0, fmt.Errorf("subbucket delta overflow: %d", delta)
 			}
 			binary.LittleEndian.PutUint16(tmp[4+2*s:], uint16(delta))
 		}
@@ -117,9 +116,9 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 
 	need := 32 + count*8 + len(buckets)
 	if need > int(info.entryVMSize) {
-		return 0, 0, fmt.Errorf("prebuilt blob needs %d bytes; entry section has %d", need, info.entryVMSize)
+		return 0, 0, 0, fmt.Errorf("prebuilt blob needs %d bytes; entry section has %d", need, info.entryVMSize)
 	}
-	blob := make([]byte, int(info.entryVMSize)) // zero tail
+	blob := make([]byte, need)
 	binary.LittleEndian.PutUint64(blob[0:], prebuiltMagic)
 	binary.LittleEndian.PutUint64(blob[8:], info.entryVMAddr)
 	binary.LittleEndian.PutUint64(blob[16:], base)
@@ -150,29 +149,51 @@ func writeBack(path string, info *binaryInfo, kept []siteRecord) (ftabCount, buc
 		inserts := []fixupInsert{{fileOff: info.entryFileOff + 16, targetVM: base}}
 		pending, err = unchainRanges(raw, ranges, inserts)
 		if err != nil {
-			return 0, 0, fmt.Errorf("chained fixups: %w", err)
+			return 0, 0, 0, fmt.Errorf("chained fixups: %w", err)
 		}
 	}
-	copy(raw[info.entryFileOff:], blob)
+	copy(raw[info.entryFileOff:info.entryFileOff+uint64(len(blob))], blob)
 	for _, pw := range pending {
 		binary.LittleEndian.PutUint64(raw[pw.fileOff:], pw.val)
 	}
+	raw, removed, err := compactCarrier(raw, info, uint64(need))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	verify := func(staged string) error {
+		if removed != 0 {
+			st, err := os.Stat(staged)
+			if err != nil {
+				return err
+			}
+			if st.Size() >= int64(len(info.raw)) {
+				return fmt.Errorf("compacted file did not shrink: old=%d staged=%d", len(info.raw), st.Size())
+			}
+		}
+		stagedInfo, err := load(staged)
+		if err != nil {
+			return fmt.Errorf("reload compact binary: %w", err)
+		}
+		if len(stagedInfo.entrySec) < 8 {
+			return fmt.Errorf("compact entry section is truncated")
+		}
+		if got := binary.LittleEndian.Uint64(stagedInfo.entrySec); got != prebuiltMagic {
+			return fmt.Errorf("compact entry magic %#x, want %#x", got, prebuiltMagic)
+		}
+		return nil
+	}
+	if err := replaceBinary(path, raw, info.format == ExternalFormatMachO && info.hasCodeSignature, verify); err != nil {
+		return 0, 0, 0, err
+	}
 	st, err := os.Stat(path)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
-	if err := os.WriteFile(path, raw, st.Mode()); err != nil {
-		return 0, 0, err
+	physicalRemoved := int64(len(info.raw)) - st.Size()
+	if physicalRemoved < 0 {
+		physicalRemoved = 0
 	}
-	// Only re-sign binaries that were signed to begin with (lld ad-hoc
-	// signs real executables; unsigned inputs need no signature and
-	// codesign would reject them anyway).
-	if info.format == "macho" && info.hasCodeSignature && runtime.GOOS == "darwin" {
-		if out, err := exec.Command("codesign", "-f", "-s", "-", path).CombinedOutput(); err != nil {
-			return 0, 0, fmt.Errorf("codesign: %v: %s", err, out)
-		}
-	}
-	return count, len(buckets) / bucketBytes, nil
+	return count, len(buckets) / bucketBytes, uint64(physicalRemoved), nil
 }
 
 // metaRecordMagic marks the entry-section meta record ("LLGOMET1" LE); keep


### PR DESCRIPTION
## Why this is still needed

Current main still rewrites the compact prebuilt functab into a buffer sized to the original `llgo_funcinfo_entry` section and only zeroes its unused tail. LTO inline copies are logically deduplicated, but the original section and file space remain allocated.

Main has removed the old stub metadata model, so this revision deliberately keeps only one disposable entry carrier. If the compact table does not fit that carrier, rewriting fails closed and the existing runtime fallback remains authoritative.

## Summary

- place the ELF entry carrier immediately before `.bss` and the Mach-O carrier in an isolated `__LLGO` segment
- physically remove the unused carrier suffix while preserving virtual addresses
- update ELF program/section headers and Mach-O load-command/linkedit offsets under strict supported-layout contracts
- stage, reopen and verify the complete image, re-sign an originally signed Mach-O, then atomically replace the executable
- leave the original binary byte-for-byte unchanged on unsupported layouts or any rewrite/sign/verification failure

## Validation

- `go test ./internal/pclnpost ./internal/build`
- `go test -race ./internal/pclnpost`
- focused `internal/pclnpost` coverage: 86.1%
- Darwin/arm64 Full-LTO `texttemplate`: 2,576,608 -> 2,366,320 bytes; `__LLGO.filesize`: 245,760 -> 32,768 bytes
- Darwin compacted binary runs, passes `codesign --verify --strict`, and caller/logging acceptance tests pass
- Linux/amd64 Full-LTO `println`: 62,688 -> 61,616 bytes; final writable `PT_LOAD.p_filesz`: `0x9a0` -> `0x570`
- Linux compacted binary runs and reopens with the shortened entry section

No Go-version compatibility workaround is included in this PR.