### PR TITLE
runtime: drain BDWGC finalizers during explicit GC

### DIFF
--- a/runtime/internal/clite/bdwgc/bdwgc.go
+++ b/runtime/internal/clite/bdwgc/bdwgc.go
@@ -88,6 +88,12 @@ func RegisterFinalizerUnreachable(
 	fn FinalizerFunc, cd c.Pointer,
 	oldFn *FinalizerFunc, oldCd *c.Pointer)
 
+// InvokeFinalizers runs all finalizers that BDWGC has queued as ready.
+// It returns the number of finalizers that were run.
+//
+//go:linkname InvokeFinalizers C.GC_invoke_finalizers
+func InvokeFinalizers() c.Int
+
 // -----------------------------------------------------------------------------
 
 //go:linkname Enable C.GC_enable

--- a/runtime/internal/lib/runtime/runtime_gc.go
+++ b/runtime/internal/lib/runtime/runtime_gc.go
@@ -36,17 +36,23 @@ func ReadMemStats(m *runtime.MemStats) {
 }
 
 func GC() {
-	bdwgc.Gcollect()
-	runFinalizers()
-	// BDW finalizers are observed on a subsequent collection cycle.
+	collectAndRunFinalizers()
 	// Run one extra cycle so weak-pointer cleanup hooks (unique/weak) see
 	// finalized state before we trigger map cleanup callbacks.
-	bdwgc.Gcollect()
-	runFinalizers()
+	collectAndRunFinalizers()
 	unique_runtime_notifyMapCleanup()
 	if poolCleanup != nil {
 		poolCleanup()
 	}
+}
+
+func collectAndRunFinalizers() {
+	bdwgc.Gcollect()
+	// GC_gcollect only discovers unreachable finalizable objects. Explicitly
+	// drain BDWGC's ready queue so runtime.GC does not depend on a later
+	// allocation to invoke the callbacks that feed runFinalizers.
+	bdwgc.InvokeFinalizers()
+	runFinalizers()
 }
 
 func saturatingSub(x, y uintptr) uintptr {

--- a/test/go/finalizer_llgo_test.go
+++ b/test/go/finalizer_llgo_test.go
@@ -1,0 +1,50 @@
+//go:build llgo && !baremetal && !nogc
+
+package gotest
+
+import (
+	"runtime"
+	"testing"
+	_ "unsafe"
+)
+
+//go:linkname getBDWGCFinalizeOnDemand C.GC_get_finalize_on_demand
+func getBDWGCFinalizeOnDemand() int32
+
+//go:linkname setBDWGCFinalizeOnDemand C.GC_set_finalize_on_demand
+func setBDWGCFinalizeOnDemand(enabled int32)
+
+func TestRuntimeGCDrainsBDWGCFinalizersOnDemand(t *testing.T) {
+	// BDWGC normally may invoke ready finalizers during a later allocation.
+	// On-demand mode makes runtime.GC's explicit drain observable without
+	// relying on allocation timing. This setting is process-global, so this
+	// test and the neighboring finalizer tests must remain sequential.
+	old := getBDWGCFinalizeOnDemand()
+	setBDWGCFinalizeOnDemand(1)
+	t.Cleanup(func() {
+		setBDWGCFinalizeOnDemand(old)
+	})
+
+	const n = 32
+	finalized := make(chan int32, n)
+	created := make(chan struct{})
+	go func() {
+		makeFinalizerTinyObjects(n, finalized)
+		close(created)
+	}()
+	<-created
+
+	// InvokeFinalizers runs synchronously once BDWGC has queued an object.
+	// The retries only let the producer goroutine exit so that conservative
+	// stack and register roots no longer keep the objects reachable.
+	for range 8 {
+		runtime.Gosched()
+		runGCWithTimeout(t)
+		if len(finalized) > n/2 {
+			return
+		}
+	}
+	if got := len(finalized); got <= n/2 {
+		t.Fatalf("runtime.GC ran only %d/%d on-demand finalizers", got, n)
+	}
+}


### PR DESCRIPTION
## Summary

- bind BDWGC `GC_invoke_finalizers`
- explicitly drain ready BDWGC callbacks after each `GC_gcollect` in `runtime.GC`
- add an LLGo-only regression that forces `finalize_on_demand`, removing later-allocation timing from the assertion

## Root cause

`GC_gcollect` discovers unreachable finalizable objects, while BDWGC documents that `GC_invoke_finalizers` is normally called implicitly only during some later allocations. LLGo called `runFinalizers` immediately after collection without first moving BDWGC ready callbacks into the Go finalizer queue. The test therefore depended on unrelated allocation and scheduling timing, producing both 12/32 and 0/32 CI failures before an unchanged rerun passed.

The regression enables BDWGC on-demand finalization temporarily. Before this fix, eight explicit `runtime.GC` calls deterministically execute 0/32 finalizers. With the fix, the test passes without extending a wall-clock deadline.

This is separate from conservative dead stack/register roots tracked by #2036; it does not broaden that compiler/runtime liveness scope.

Fixes #2275

## Validation

- deterministic on-demand regression fails before the runtime change with 0/32 and passes after it
- finalizer, cancellation, and on-demand tests pass for 200 repetitions
- complete LLGo `test/go` passes
- `test/std/weak` GC test passes for 100 repetitions
- LLGo memprofile tests pass
- runtime `internal/clite/bdwgc` and `internal/lib/runtime` packages build with host Go
- host `test/go` finalizer selection passes; LLGo-only regression is correctly excluded
- `git diff --check` passes