### PR TITLE
test: use shared repository root helper

### DIFF
--- a/test/go/package_init_order_test.go
+++ b/test/go/package_init_order_test.go
@@ -32,7 +32,7 @@ var (
 
 func packageInitLLGo(t *testing.T) string {
 	t.Helper()
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	packageInitLLGoOnce.Do(func() {
 		dir, err := os.MkdirTemp("", "llgo-package-init-bin")


### PR DESCRIPTION
## Summary

- fix the `test/go` compile failure introduced when #2254 retained the old helper name
- reuse the existing `findRepoRoot` helper without changing package-initialization coverage

This fixes the current `main` failures in the [Go workflow](https://github.com/xgo-dev/llgo/actions/runs/31295007966) and [LLGo workflow](https://github.com/xgo-dev/llgo/actions/runs/31295008002).

## Testing

- `go test -vet=off ./test/go -run "^TestPackageInitializationUsesLexicalReadyOrder$" -count=1`
- `go test -vet=off ./test/go -run "^$" -count=1`