### PR TITLE
chore/litgen: preserve declaration directives

### DIFF
--- a/chore/litgen/rewrite.go
+++ b/chore/litgen/rewrite.go
@@ -218,10 +218,16 @@ func collectAnchors(src string, fset *token.FileSet, file *ast.File) (map[string
 
 func topInsertPos(src string, fset *token.FileSet, file *ast.File) int {
 	for _, decl := range file.Decls {
-		if gen, ok := decl.(*ast.GenDecl); ok && gen.Tok == token.IMPORT {
-			continue
+		// Insert before declaration docs so compiler directives stay attached.
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			return declInsertPos(src, fset, d.Pos(), d.Doc)
+		case *ast.GenDecl:
+			if d.Tok == token.IMPORT {
+				continue
+			}
+			return declInsertPos(src, fset, d.Pos(), d.Doc)
 		}
-		return lineStart(src, offsetOf(fset, decl.Pos()))
 	}
 	return len(src)
 }

--- a/chore/litgen/rewrite.go
+++ b/chore/litgen/rewrite.go
@@ -205,12 +205,12 @@ func collectAnchors(src string, fset *token.FileSet, file *ast.File) (map[string
 		case *ast.FuncDecl:
 			name := inPkgFuncName(d)
 			anchors[name] = declInsertPos(src, fset, d.Pos(), d.Doc)
-			collectFuncLitAnchors(src, fset, d.Body, name, anchors, counts)
+			collectFuncLitAnchors(src, fset, d.Body, name, anchors, counts, declDocAnchors(src, fset, d))
 		case *ast.GenDecl:
 			if d.Tok == token.IMPORT {
 				continue
 			}
-			collectFuncLitAnchors(src, fset, d, "init", anchors, counts)
+			collectFuncLitAnchors(src, fset, d, "init", anchors, counts, declDocAnchors(src, fset, d))
 		}
 	}
 	return anchors, topPos
@@ -255,7 +255,32 @@ func declInsertPos(src string, fset *token.FileSet, pos token.Pos, doc *ast.Comm
 	return lineStart(src, offsetOf(fset, pos))
 }
 
-func collectFuncLitAnchors(src string, fset *token.FileSet, node ast.Node, parent string, anchors map[string]int, counts map[string]int) {
+func declDocAnchors(src string, fset *token.FileSet, decl ast.Decl) map[int]int {
+	var anchors map[int]int
+	add := func(pos token.Pos, doc *ast.CommentGroup) {
+		if doc == nil {
+			return
+		}
+		if anchors == nil {
+			anchors = make(map[int]int)
+		}
+		anchors[lineStart(src, offsetOf(fset, pos))] = declInsertPos(src, fset, pos, doc)
+	}
+	switch d := decl.(type) {
+	case *ast.FuncDecl:
+		add(d.Pos(), d.Doc)
+	case *ast.GenDecl:
+		add(d.Pos(), d.Doc)
+		for _, spec := range d.Specs {
+			if s, ok := spec.(*ast.ValueSpec); ok {
+				add(s.Pos(), s.Doc)
+			}
+		}
+	}
+	return anchors
+}
+
+func collectFuncLitAnchors(src string, fset *token.FileSet, node ast.Node, parent string, anchors map[string]int, counts map[string]int, docAnchors map[int]int) {
 	if isNilNode(node) {
 		return
 	}
@@ -271,7 +296,12 @@ func collectFuncLitAnchors(src string, fset *token.FileSet, node ast.Node, paren
 			}
 			counts[current]++
 			name := fmt.Sprintf("%s$%d", current, counts[current])
-			anchors[name] = lineStart(src, offsetOf(fset, lit.Pos()))
+			pos := lineStart(src, offsetOf(fset, lit.Pos()))
+			// Keep declaration docs attached when a closure shares the declaration line.
+			if docPos, ok := docAnchors[pos]; ok {
+				pos = docPos
+			}
+			anchors[name] = pos
 			walk(lit.Body, name)
 			return false
 		})

--- a/chore/litgen/rewrite_test.go
+++ b/chore/litgen/rewrite_test.go
@@ -229,6 +229,88 @@ func callSqrt(x float64) float64 {
 	}
 }
 
+func TestRewriteSource_PreservesDirectiveBeforeInlineClosure(t *testing.T) {
+	const funcIR = `define ptr @"example.com/p.makeFn"() {
+_llgo_0:
+  ret ptr @"example.com/p.makeFn$1"
+}
+
+define void @"example.com/p.makeFn$1"() {
+_llgo_0:
+  ret void
+}
+`
+	const initIR = `@0 = private unnamed_addr constant [3 x i8] c"fn"
+
+define void @"example.com/p.init"() {
+_llgo_0:
+  store ptr @"example.com/p.init$1", ptr null
+  ret void
+}
+
+define void @"example.com/p.init$1"() {
+_llgo_0:
+  ret void
+}
+`
+	tests := []struct {
+		name      string
+		src       string
+		ir        string
+		adjacency string
+	}{
+		{
+			name: "function declaration",
+			src: `// LITTEST
+package main
+
+//go:noinline
+func makeFn() func() { return func() {} }
+`,
+			ir:        funcIR,
+			adjacency: "//go:noinline\nfunc makeFn",
+		},
+		{
+			name: "variable declaration",
+			src: `// LITTEST
+package main
+
+//llgo:tls
+var fn = func() {}
+`,
+			ir:        initIR,
+			adjacency: "//llgo:tls\nvar fn",
+		},
+		{
+			name: "variable specification",
+			src: `// LITTEST
+package main
+
+var (
+	//llgo:tls
+	fn = func() {}
+)
+`,
+			ir:        initIR,
+			adjacency: "\t//llgo:tls\n\tfn =",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := rewriteSource(test.src, "in.go", "example.com/p", "example.com", test.ir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, test.adjacency) {
+				t.Fatalf("declaration directive separated from declaration:\n%s", got)
+			}
+			if !strings.Contains(got, "$1") {
+				t.Fatalf("closure checks not inserted:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestRewriteSource_SharesInitClosureCountsAcrossDecls(t *testing.T) {
 	const src = `// LITTEST
 package main

--- a/chore/litgen/rewrite_test.go
+++ b/chore/litgen/rewrite_test.go
@@ -173,6 +173,62 @@ _llgo_0:
 	}
 }
 
+func TestRewriteSource_PreservesDeclarationDirectiveAdjacency(t *testing.T) {
+	const src = `// LITTEST
+package main
+
+import _ "unsafe"
+
+//go:linkname cSqrt C.sqrt
+func cSqrt(float64) float64
+
+func callSqrt(x float64) float64 {
+	println("sqrt")
+	return cSqrt(x)
+}
+`
+	const ir = `@0 = private unnamed_addr constant [4 x i8] c"sqrt"
+
+declare double @sqrt(double)
+
+define double @"example.com/p.callSqrt"(double %0) {
+_llgo_0:
+  call void @"example.com/runtime/internal/runtime.PrintString"(ptr @0)
+  %1 = call double @sqrt(double %0)
+  ret double %1
+}
+`
+	got, err := rewriteSource(src, "in.go", "example.com/p", "example.com", ir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `// LITTEST
+package main
+
+import _ "unsafe"
+
+// CHECK: {{^}}@0 = private unnamed_addr constant [4 x i8] c"sqrt"{{$}}
+
+//go:linkname cSqrt C.sqrt
+func cSqrt(float64) float64
+
+// CHECK-LABEL: define double @"{{.*}}/p.callSqrt"(double %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(ptr @0)
+// CHECK-NEXT:   %1 = call double @sqrt(double %0)
+// CHECK-NEXT:   ret double %1
+// CHECK-NEXT: }
+
+func callSqrt(x float64) float64 {
+	println("sqrt")
+	return cSqrt(x)
+}
+`
+	if got != want {
+		t.Fatalf("rewriteSource mismatch:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
 func TestRewriteSource_SharesInitClosureCountsAcrossDecls(t *testing.T) {
 	const src = `// LITTEST
 package main


### PR DESCRIPTION
## Problem

litgen could insert generated CHECK lines between declaration directives and their declarations:

- module-global checks used the declaration token instead of the beginning of its doc group;
- an inline function literal used its declaration line as the closure anchor, which could split `FuncDecl.Doc`, `GenDecl.Doc`, or grouped `ValueSpec.Doc`.

This changed generated program semantics. In closureall, `//go:linkname` was detached and the program linked `main.cSqrt` instead of `C.sqrt`.

## Change

- anchor module-global checks before the first non-import declaration doc group;
- when a closure shares a declaration or variable-specification line, anchor its checks before the attached doc group;
- keep imports and other closure placement unchanged;
- cover function directives, standalone variable directives, and grouped variable-spec directives.

The positioning is directive-agnostic, so it also preserves `//go:noinline`, `//export`, `//go:embed`, `//llgo:type`, and `//llgo:tls`/`//llgo:gls` according to their declaration kind.

## Validation

- `go test ./chore/litgen -count=1`
- package coverage: 76.6%