### PR TITLE
test/goroot: keep xfail successes non-fatal

### DIFF
--- a/test/goroot/README.md
+++ b/test/goroot/README.md
@@ -25,6 +25,12 @@ explicitly host-unsafe cases are skipped. Each not-applicable entry documents
 both the toolchain-specific mechanism under test and why the corresponding
 behavior is not an LLGo compatibility goal.
 
+An xfail that unexpectedly succeeds is reported in the verbose test log but
+does not fail the runner. This keeps stale expectations visible in verbose CI
+and audit runs without making a newly passing compatibility case fail CI. An
+unexpectedly successful not-applicable case still fails because it indicates a
+misclassification.
+
 Basic usage:
 
 ```bash

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -359,7 +359,7 @@ func TestGoRootRunCases(t *testing.T) {
 			case err == nil && notApply:
 				t.Fatalf("unexpected success for not-applicable case: %s", notApplyReason)
 			case err == nil && match:
-				t.Fatalf("unexpected success for xfail case: %s", reason)
+				t.Logf("unexpected success for xfail case: %s", reason)
 			case err == nil && flaky:
 				t.Logf("flaky case passed: %s", flakyReason)
 			case err != nil && match:


### PR DESCRIPTION
## Summary

- report an xfail that unexpectedly passes in the verbose runner log
- keep the case and the GOROOT job successful
- retain strict handling for unexpected not-applicable successes and unclassified failures

## Validation

- `go test ./test/goroot -run '^Test' -skip '^TestGoRootRunCases$' -count=1`\n- controlled Go 1.26.5 `compile` XPASS: the runner logged the unexpected success while the case and overall test both passed\n- `git diff --check`