### PR TITLE
build: prototype package-level deadcode planning for ThinLTO

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -350,6 +350,18 @@ func (c *Config) thinLTODeadcodeEnabled() bool {
 	return c != nil && c.deadcodeDropEnabled() && c.ltoMode() == lto.Thin
 }
 
+const thinLTODeadcodeImportLimitFlag = "-Wl,-mllvm,-import-instr-limit=5"
+
+func thinLTODeadcodeLinkerArgs(c *Config) []string {
+	if !c.thinLTODeadcodeEnabled() {
+		return nil
+	}
+	// LLVM's default import budget is performance-biased. Imported bodies also
+	// duplicate LLGo funcinfo sites, so use the established size-oriented
+	// budget while retaining imports of very small cross-package callees.
+	return []string{thinLTODeadcodeImportLimitFlag}
+}
+
 func (c *Config) packageMetaEnabled() bool {
 	return c.CollectPackageMeta || c.deadcodeDropEnabled()
 }
@@ -1678,6 +1690,7 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 		return err
 	}
 	buildArgs = append(buildArgs, ltoPluginFlags...)
+	buildArgs = append(buildArgs, thinLTODeadcodeLinkerArgs(ctx.buildConf)...)
 
 	// Add build mode specific linker arguments
 	switch ctx.buildConf.BuildMode {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -343,6 +343,13 @@ func (c *Config) deadcodeDropEnabled() bool {
 	return buildenv.Dev && c.DeadcodeDrop && !c.goGlobalDCEEnabled()
 }
 
+// thinLTODeadcodeEnabled selects the experimental planner/rewrite path. The
+// package archives are materialized only after the link-specific plan has been
+// computed so their ThinLTO summaries describe the rewritten method tables.
+func (c *Config) thinLTODeadcodeEnabled() bool {
+	return c != nil && c.deadcodeDropEnabled() && c.ltoMode() == lto.Thin
+}
+
 func (c *Config) packageMetaEnabled() bool {
 	return c.CollectPackageMeta || c.deadcodeDropEnabled()
 }
@@ -1108,7 +1115,12 @@ func prePackageBuild(ctx *context, task *packageBuildTask, verbose bool) error {
 	if err := ctx.collectFingerprint(aPkg); err != nil {
 		return err
 	}
-	ctx.tryLoadFromCache(aPkg)
+	// The first ThinLTO planner prototype needs the package LLVM modules alive
+	// until linkMainPkg computes the link-specific rewrite. Avoid consuming a
+	// prebuilt archive here; cache-aware bitcode overlays are a follow-up.
+	if !ctx.buildConf.thinLTODeadcodeEnabled() {
+		ctx.tryLoadFromCache(aPkg)
+	}
 	if verbose {
 		status := "MISS"
 		if aPkg.CacheHit {
@@ -1136,6 +1148,12 @@ func executePackageBuild(ctx *context, task *packageBuildTask, verbose bool) err
 func finalizePackageBuild(ctx *context, task *packageBuildTask, verbose bool) (packageBuildResult, error) {
 	aPkg := task.pkg
 	if aPkg.CacheHit {
+		return packageBuildResultFor(task), nil
+	}
+	if ctx.buildConf.thinLTODeadcodeEnabled() {
+		if task.kind == cl.PkgLinkExtern {
+			appendExternalLinkArgs(ctx, aPkg, task.kindParam)
+		}
 		return packageBuildResultFor(task), nil
 	}
 	if err := normalizeToArchive(ctx, aPkg, verbose); err != nil {
@@ -1435,6 +1453,27 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 		linkArgs = append(linkArgs, rtLinkArgs...)
 		archiveInputs = append(archiveInputs, rtLinkInputs...)
 	}
+	if ctx.buildConf.thinLTODeadcodeEnabled() {
+		if err := materializeThinLTODeadcode(ctx, linkedOrder, needRuntime, verbose); err != nil {
+			return err
+		}
+		// The package archives are intentionally delayed in this mode so the
+		// rewritten module, rather than the original module, supplies the
+		// ThinLTO summary. Rebuild the package input list after materialization.
+		archiveInputs = archiveInputs[:0]
+		for _, aPkg := range linkedOrder {
+			if aPkg == nil || aPkg.ArchiveFile == "" {
+				continue
+			}
+			if isRuntimePkg(aPkg.PkgPath) {
+				if needRuntime || needPyInit || ctx.buildConf.Target == "" {
+					archiveInputs = append(archiveInputs, aPkg.ArchiveFile)
+				}
+				continue
+			}
+			archiveInputs = append(archiveInputs, aPkg.ArchiveFile)
+		}
+	}
 
 	// Generate main module file (needed for global variables even in library modes)
 	// This is compiled directly to .o and added to linkInputs (not cached)
@@ -1460,7 +1499,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 		funcInfo:      funcInfo,
 		pcLineInfo:    pcLineInfo,
 	})
-	if ctx.buildConf.deadcodeDropEnabled() {
+	if ctx.buildConf.deadcodeDropEnabled() && !ctx.buildConf.thinLTODeadcodeEnabled() {
 		if err := applyDeadcodeDropOverrides(linkedOrder, entryPkg, needRuntime, verbose); err != nil {
 			return err
 		}
@@ -1513,16 +1552,58 @@ func linkedPackageMetas(pkgs []Package) []*meta.PackageMeta {
 	return metas
 }
 
-func applyDeadcodeDropOverrides(pkgs []Package, entryPkg Package, needRuntime bool, verbose bool) error {
+func buildDeadcodePlan(pkgs []Package, needRuntime bool) (deadcode.Plan, error) {
 	metas := linkedPackageMetas(pkgs)
 	summary, err := meta.NewGlobalSummary(metas)
 	if err != nil {
+		return deadcode.Plan{}, err
+	}
+	return deadcode.BuildPlan(summary, dceEntryRootCandidates(pkgs, needRuntime)), nil
+}
+
+func applyDeadcodeDropOverrides(pkgs []Package, entryPkg Package, needRuntime bool, verbose bool) error {
+	plan, err := buildDeadcodePlan(pkgs, needRuntime)
+	if err != nil {
 		return err
 	}
+	dcepass.EmitStrongTypeOverrides(entryPkg.LPkg.Module(), dceSourceModules(pkgs), plan.LiveSlots, verbose)
+	return nil
+}
 
-	roots := dceEntryRootCandidates(pkgs, needRuntime)
-	liveSlots := deadcode.Analyze(summary, roots)
-	dcepass.EmitStrongTypeOverrides(entryPkg.LPkg.Module(), dceSourceModules(pkgs), liveSlots, verbose)
+// materializeThinLTODeadcode applies the link-specific Go plan to each package
+// module before its ThinLTO bitcode is emitted. Package cache overlays are
+// deliberately out of scope for this first prototype; cache loading is
+// disabled for thinLTODeadcodeEnabled above, so every package still owns its
+// full LLVM module here.
+func materializeThinLTODeadcode(ctx *context, pkgs []Package, needRuntime, verbose bool) error {
+	plan, err := buildDeadcodePlan(pkgs, needRuntime)
+	if err != nil {
+		return err
+	}
+	for _, aPkg := range pkgs {
+		if aPkg == nil || aPkg.LPkg == nil || aPkg.Package == nil {
+			continue
+		}
+		if aPkg.CacheHit {
+			return fmt.Errorf("thin LTO deadcode planner cannot rewrite cached package %s yet", aPkg.PkgPath)
+		}
+		dcepass.RewriteTypeMethodTables(aPkg.LPkg.Module(), plan.LiveSlots, verbose)
+		if aPkg.Package.ExportFile == "" {
+			continue
+		}
+		exportFile, exportBuffer, err := exportPackageObject(ctx, aPkg.PkgPath, aPkg.Package.ExportFile, aPkg.LPkg)
+		if err != nil {
+			return fmt.Errorf("export rewritten ThinLTO object of %s failed: %w", aPkg.PkgPath, err)
+		}
+		if exportFile != "" {
+			aPkg.ObjFiles = append(aPkg.ObjFiles, exportFile)
+		} else {
+			aPkg.ObjBuffers = append(aPkg.ObjBuffers, exportBuffer)
+		}
+		if err := normalizeToArchive(ctx, aPkg, verbose); err != nil {
+			return fmt.Errorf("archive rewritten ThinLTO object of %s failed: %w", aPkg.PkgPath, err)
+		}
+	}
 	return nil
 }
 
@@ -1992,6 +2073,12 @@ func compilePackageModule(ctx *context, aPkg *aPackage, externs []string, verbos
 		aPkg.LinkArgs = append(aPkg.LinkArgs, goCgoLinkArgs(ctx.buildConf.Goos, aPkg.AltPkg.Syntax)...)
 	}
 	if pkg.ExportFile != "" {
+		if ctx.buildConf.thinLTODeadcodeEnabled() {
+			if debugBuild || verbose {
+				fmt.Fprintf(os.Stderr, "==> Defer ThinLTO export %s: %s\n", aPkg.PkgPath, pkg.ExportFile)
+			}
+			return nil
+		}
 		exportFile, exportBuffer, err := exportPackageObject(ctx, pkg.PkgPath, pkg.ExportFile, ret)
 		if err != nil {
 			return fmt.Errorf("export object of %v failed: %v", pkgPath, err)

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1394,6 +1394,31 @@ func TestThinLTODeadcodeEnabled(t *testing.T) {
 	}
 }
 
+func TestThinLTODeadcodeLinkerArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *Config
+		want []string
+	}{
+		{name: "not requested", conf: &Config{LTO: lto.Thin}},
+		{name: "lto off", conf: &Config{DeadcodeDrop: true, LTO: lto.Off}},
+		{name: "full lto", conf: &Config{DeadcodeDrop: true, LTO: lto.Full, DisableGoGlobalDCE: true}},
+		{name: "thin lto deadcode", conf: &Config{DeadcodeDrop: true, LTO: lto.Thin}, want: []string{thinLTODeadcodeImportLimitFlag}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := tt.want
+			if !buildenv.Dev {
+				want = nil
+			}
+			if got := thinLTODeadcodeLinkerArgs(tt.conf); !reflect.DeepEqual(got, want) {
+				t.Fatalf("thinLTODeadcodeLinkerArgs() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestPackageMetaEnabled(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1373,6 +1373,27 @@ func TestDeadcodeDropEnabled(t *testing.T) {
 	}
 }
 
+func TestThinLTODeadcodeEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *Config
+		want bool
+	}{
+		{name: "not requested", conf: &Config{LTO: lto.Thin}, want: false},
+		{name: "thin lto", conf: &Config{DeadcodeDrop: true, LTO: lto.Thin}, want: buildenv.Dev},
+		{name: "lto off", conf: &Config{DeadcodeDrop: true, LTO: lto.Off}, want: false},
+		{name: "full lto", conf: &Config{DeadcodeDrop: true, LTO: lto.Full, DisableGoGlobalDCE: true}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.conf.thinLTODeadcodeEnabled(); got != tt.want {
+				t.Fatalf("thinLTODeadcodeEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPackageMetaEnabled(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -252,7 +252,10 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 			"-Wl,--icf=none",
 		}
 		if ltoMode.Enabled() {
-			export.LDFLAGS = append(export.LDFLAGS, ltoMode.ClangFlag(), "-Wl,--lto"+level.Flag())
+			export.LDFLAGS = append(export.LDFLAGS, ltoMode.ClangFlag())
+			if flag := ltoLinkerOptFlag(level); flag != "" {
+				export.LDFLAGS = append(export.LDFLAGS, flag)
+			}
 		}
 		if clangRoot != "" {
 			clangLib := filepath.Join(clangRoot, "lib")
@@ -463,6 +466,17 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 		return
 	}
 	return
+}
+
+func ltoLinkerOptFlag(level optlevel.Level) string {
+	switch level {
+	case optlevel.O0, optlevel.O1, optlevel.O2, optlevel.O3:
+		return "-Wl,--lto" + level.Flag()
+	default:
+		// LLD's --lto-O option accepts only numeric levels. Clang likewise
+		// omits it for -Os/-Oz and lets the size-optimized IR drive LTO.
+		return ""
+	}
 }
 
 // UseTarget loads configuration from a target name (e.g., "rp2040", "wasi")

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -429,6 +429,17 @@ func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 	if !slices.Contains(thin.LDFLAGS, "-Wl,--lto-O2") {
 		t.Fatalf("missing thin LTO linker opt flag: %v", thin.LDFLAGS)
 	}
+	for _, level := range []optlevel.Level{optlevel.Os, optlevel.Oz} {
+		thinSize, err := use(runtime.GOOS, runtime.GOARCH, false, false, level, lto.Thin, false)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		for _, flag := range thinSize.LDFLAGS {
+			if strings.HasPrefix(flag, "-Wl,--lto-O") {
+				t.Fatalf("unexpected numeric-only LTO linker opt flag for %s: %v", level, thinSize.LDFLAGS)
+			}
+		}
+	}
 
 	full, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Full, false)
 	if err != nil {

--- a/internal/dcepass/dcepass.go
+++ b/internal/dcepass/dcepass.go
@@ -38,6 +38,85 @@ func EmitStrongTypeOverrides(dst llvm.Module, srcMods []llvm.Module, liveSlots m
 	}
 }
 
+// RewriteTypeMethodTables rewrites ABI method table initializers in mod in
+// place. It preserves each type descriptor's existing linkage and COMDAT, so
+// ThinLTO sees one ordinary definition per package instead of an entry-module
+// strong override competing with weak_odr definitions.
+//
+// A missing type entry in liveSlots means that no method slot is demanded.
+// The method name and type are retained while IFn/TFn point at the runtime
+// unreachable stub, preserving ABI table shape and method matching metadata.
+func RewriteTypeMethodTables(mod llvm.Module, liveSlots map[string][]int, verbose bool) int {
+	if mod.IsNil() {
+		return 0
+	}
+	rewriter := &moduleRewriter{mod: mod}
+	rewritten := 0
+	for g := mod.FirstGlobal(); !g.IsNil(); g = llvm.NextGlobal(g) {
+		if g.IsDeclaration() || !g.IsGlobalConstant() {
+			continue
+		}
+		methodsVal, elemTy, ok := methodArray(g.Initializer())
+		if !ok {
+			continue
+		}
+		if rewriter.rewriteGlobal(g, methodsVal, elemTy, liveSlotSet(liveSlots[g.Name()]), verbose) {
+			rewritten++
+		}
+	}
+	return rewritten
+}
+
+type moduleRewriter struct {
+	mod         llvm.Module
+	unreachable llvm.Value
+}
+
+func (r *moduleRewriter) unreachableMethod() llvm.Value {
+	if r.unreachable.IsNil() {
+		r.unreachable = r.mod.NamedFunction(unreachableMethodName)
+	}
+	if r.unreachable.IsNil() {
+		r.unreachable = llvm.AddFunction(r.mod, unreachableMethodName,
+			llvm.FunctionType(r.mod.Context().VoidType(), nil, false))
+	}
+	return r.unreachable
+}
+
+func (r *moduleRewriter) rewriteGlobal(g, methodsVal llvm.Value, elemTy llvm.Type, keepIdx map[int]bool, verbose bool) bool {
+	init := g.Initializer()
+	fields := make([]llvm.Value, init.OperandsCount())
+	for i := range fields {
+		fields[i] = init.Operand(i)
+	}
+	methods := make([]llvm.Value, methodsVal.OperandsCount())
+	dropped := false
+	for i := range methods {
+		orig := methodsVal.Operand(i)
+		if keepIdx[i] {
+			methods[i] = orig
+			continue
+		}
+		dropped = true
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[dce] drop method %s[%d] ifn=%s tfn=%s\n", g.Name(), i, orig.Operand(2).Name(), orig.Operand(3).Name())
+		}
+		unreachable := r.unreachableMethod()
+		methods[i] = llvm.ConstNamedStruct(elemTy, []llvm.Value{
+			orig.Operand(0),
+			orig.Operand(1),
+			unreachable,
+			unreachable,
+		})
+	}
+	if !dropped {
+		return false
+	}
+	fields[len(fields)-1] = llvm.ConstArray(elemTy, methods)
+	g.SetInitializer(constStructOfType(init.Type(), fields))
+	return true
+}
+
 type overrideEmitter struct {
 	dst    llvm.Module
 	values map[llvm.Value]llvm.Value

--- a/internal/dcepass/dcepass_test.go
+++ b/internal/dcepass/dcepass_test.go
@@ -3,6 +3,7 @@ package dcepass
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qtest "github.com/qiniu/x/test"
@@ -44,6 +45,30 @@ func TestEmitStrongTypeOverrides(t *testing.T) {
 			}
 			qtest.Diff(t, filepath.Join(dir, "expect.ll.new"), []byte(dst.String()), want)
 		})
+	}
+}
+
+func TestRewriteTypeMethodTablesPreservesLinkage(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := parseModule(t, &ctx, filepath.Join("testdata", "method_slots", "in.ll"))
+	defer mod.Dispose()
+
+	if got := RewriteTypeMethodTables(mod, map[string][]int{
+		taskTypeName:    {1},
+		ptrTaskTypeName: {1},
+	}, false); got != 2 {
+		t.Fatalf("RewriteTypeMethodTables rewrote %d globals, want 2", got)
+	}
+	out := mod.String()
+	if !strings.Contains(out, `@_llgo_main.Task = weak_odr constant`) {
+		t.Fatalf("rewrite changed the source type linkage:\n%s", out)
+	}
+	if strings.Contains(out, `@_llgo_main.Task = constant`) {
+		t.Fatalf("rewrite introduced a strong duplicate:\n%s", out)
+	}
+	if !strings.Contains(out, `ptr @"github.com/goplus/llgo/runtime/internal/runtime.unreachableMethod"`) {
+		t.Fatalf("rewrite did not replace the dead method slot:\n%s", out)
 	}
 }
 

--- a/internal/deadcode/analyze.go
+++ b/internal/deadcode/analyze.go
@@ -42,8 +42,25 @@ type pass struct {
 	liveSlots       map[meta.Symbol][]int
 }
 
+// Plan is the link-specific semantic result consumed by a backend rewrite.
+// The package metadata remains analyzer-independent; this structure is the
+// boundary between whole-program planning and LLVM module transformation.
+type Plan struct {
+	LiveSlots map[string][]int
+}
+
+// BuildPlan computes the conservative Go method liveness plan for one link.
+// rootNames are final linker-visible roots, not package-local source names.
+func BuildPlan(info *meta.GlobalSummary, rootNames []string) Plan {
+	return Plan{LiveSlots: analyze(info, rootNames)}
+}
+
 // Analyze returns live ABI method slot indexes by concrete type symbol name.
 func Analyze(info *meta.GlobalSummary, rootNames []string) map[string][]int {
+	return BuildPlan(info, rootNames).LiveSlots
+}
+
+func analyze(info *meta.GlobalSummary, rootNames []string) map[string][]int {
 	roots := make([]meta.Symbol, 0, len(rootNames))
 	for _, name := range rootNames {
 		if sym, ok := info.LookupSymbol(name); ok {


### PR DESCRIPTION
## Summary

This PR prototypes a ThinLTO-compatible deadcode pipeline for LLGo's Go method-table pruning.

The main architectural change is to separate the work into three stages:

1. each package produces its normal LLVM module plus LLGo Meta information;
2. a global Meta planner computes which method-table slots must remain live;
3. each package module is rewritten in place before its ThinLTO bitcode summary is emitted, and LLVM ThinLTO performs the remaining cross-module optimization.

This keeps LLGo's language-specific reachability knowledge in the planner while handing the rewritten program to the standard ThinLTO pipeline. It also establishes a boundary where the current planner can be replaced or extended later without changing the package rewrite/link flow.

This is intentionally a prototype. It validates the architecture and size behavior first; it does not yet implement `MethodByName` string propagation, archive/cache integration, or ThinLTO backend caching.

## Motivation

The existing `-deadcodedrop` path materializes strong method-table overrides in the entry module. That approach works for the normal link pipeline, but it does not compose correctly with ThinLTO.

With:

```text
-lto=thin -deadcodedrop
```

LLVM 19.1.7 previously crashed in:

```text
FunctionImportGlobalProcessing::processGlobalForThinLTO
```

The strong override is also an awkward long-term integration point: the replacement global is detached from the package module that owns the original `weak_odr` global, its COMDAT, and its ThinLTO summary identity.

The goal of this experiment is therefore not to teach the existing override mechanism about ThinLTO. Instead, it makes LLGo's planner produce a global liveness plan, applies that plan to the owning package modules, and then lets ThinLTO analyze the resulting modules normally.

## Previous strong-override design

The old non-ThinLTO path remains available and unchanged.

It computes dead method slots and emits same-name strong globals in the entry module to override the package-owned weak method tables at link time. ThinLTO sees both the original package definition and the late replacement through its module-summary/global-resolution machinery. That mismatch is the source of the LLVM crash seen in this experiment.

The new ThinLTO path deliberately does not emit those entry-module overrides.

## Proposed pipeline

When both `-lto=thin` and `-deadcodedrop` are enabled, the build now performs:

```text
package compilation
    -> collect package LLVM modules and Meta
    -> merge Meta into a global summary
    -> build one global deadcode.Plan
    -> rewrite each owning package module in place
    -> emit rewritten ThinLTO bitcode and module summaries
    -> build temporary linker archives
    -> run the normal ThinLTO link
```

The plan currently contains the live method slots for each type:

```go
type Plan struct {
    LiveSlots map[string][]int
}
```

`deadcode.BuildPlan` uses the existing reachability analysis. `deadcode.Analyze` is retained as a compatibility wrapper.

The important boundary is that the package contributes Meta and owns its LLVM globals, while the planner makes one whole-program decision. The planner implementation can evolve independently; for example, later work could add reflection/string-flow facts or consume additional LLVM analysis without restoring the strong-override design.

## Implementation

### Global planning

`internal/deadcode` now exposes `BuildPlan`, which converts the merged global Meta summary and root set into an explicit reusable plan.

### Package-local rewrite

`internal/dcepass.RewriteTypeMethodTables` applies the global plan to each package module in place.

For dead method slots, it replaces `IFn`/`TFn` targets with `runtime.unreachableMethod`. The original method-table global remains in its owning module, including its:

- `weak_odr` linkage;
- COMDAT membership;
- module identity used by ThinLTO;
- ABI-compatible initializer layout.

No same-name strong duplicate is added to the entry module.

### Build integration

The experimental path is enabled only for the combination:

```text
-lto=thin -deadcodedrop
```

For this mode, package bitcode/archive emission is delayed until all package Meta has been merged and the global plan is available. Each package module is rewritten first, then its ThinLTO bitcode and summary are generated from the rewritten IR.

Other build configurations continue to use their existing paths.

### Size-level linker compatibility

`ld64.lld` accepts numeric values for `--lto-O0..3` and rejects `--lto-Oz`. `ltoLinkerOptFlag` now emits the numeric linker flag only for `O0` through `O3`; `Os` and `Oz` omit it, matching Clang driver behavior while retaining the size-oriented LLGo pre-link pipeline.

## Why rewrite before emitting ThinLTO summaries?

ThinLTO decisions are driven by per-module summaries. Rewriting after summary emission would leave LLVM analyzing stale references: the summary could claim a method target is live even though the IR was later changed to `runtime.unreachableMethod`.

Emitting the summary from the already-rewritten package module ensures that symbol resolution, importing, internalization, and backend DCE all see the same graph.

## Correctness validation

The ThinLTO + deadcode combination now completes and runs correctly for the interface/reflection cases used to exercise method-table reachability:

```text
globaldce_interface_matrix
globaldce_interface_slots
globaldce_reflect_method
globaldce_reflect_type_method
globaldce_typeid_dce
globaldce_unexported_method_identity
```

A small interface experiment also confirms that pruning reaches the final binary while preserving behavior:

| Metric | ThinLTO baseline | ThinLTO + planner DCE |
|---|---:|---:|
| File size | 122,112 B | 121,328 B |
| `__text` | `0x51a4` | `0x506c` |
| `Drop` symbols | 3 | 0 |

Program output is identical.

## Four-demo size experiment

Environment:

```text
macOS arm64
LLVM 19.1.7
LLGO_BUILD_CACHE=off
-a (force package rebuild)
```

All 12 final binaries exited with status 0, and every output matched the previous DCE reference byte for byte.

### Binary size

The no-DCE baseline is the normal non-ThinLTO build. Previous DCE is the existing non-ThinLTO strong-override path. The two new columns use the package-level planner and ThinLTO rewrite.

| Demo | No-DCE baseline | Previous DCE | ThinLTO O2 + DCE | O2 vs previous | ThinLTO Oz + DCE | Oz vs previous | Oz vs O2 |
|---|---:|---:|---:|---:|---:|---:|---:|
| goimporter-1389 | 5342.0 KiB | 3881.6 KiB | 4150.3 KiB | +268.7 KiB / +6.92% | 4238.9 KiB | +357.3 KiB / +9.21% | +88.7 KiB / +2.14% |
| embedunexport-1598 | 3904.5 KiB | 2514.5 KiB | 2653.9 KiB | +139.5 KiB / +5.55% | 2689.3 KiB | +174.9 KiB / +6.95% | +35.4 KiB / +1.33% |
| mimeheader | 2201.0 KiB | 1613.3 KiB | 1504.2 KiB | -109.1 KiB / -6.76% | 1527.9 KiB | -85.5 KiB / -5.30% | +23.6 KiB / +1.57% |
| gotypes | 3938.2 KiB | 3269.1 KiB | 3594.7 KiB | +325.6 KiB / +9.96% | 3696.3 KiB | +427.2 KiB / +13.07% | +101.6 KiB / +2.83% |

A positive value means the first column in the comparison is larger. `mimeheader` is smaller than the previous DCE in both ThinLTO modes, but `Oz` is larger than ThinLTO `O2` in all four demos.

### Build time

Each value is the median wall time (`real`) of three sequential forced rebuilds for one demo. The compiler binary build is excluded. The rounds were ordered differently to reduce warm-cache and thermal-order effects.

| Demo | Previous DCE | ThinLTO O2 + DCE | ThinLTO Oz + DCE | O2 vs previous | Oz vs previous |
|---|---:|---:|---:|---:|---:|
| goimporter-1389 | 37.59 s | 47.52 s | 45.84 s | +9.93 s / +26.4% | +8.25 s / +21.9% |
| embedunexport-1598 | 27.66 s | 39.94 s | 40.41 s | +12.28 s / +44.4% | +12.75 s / +46.1% |
| mimeheader | 28.66 s | 38.84 s | 37.32 s | +10.18 s / +35.5% | +8.66 s / +30.2% |
| gotypes | 28.35 s | 41.05 s | 40.80 s | +12.70 s / +44.8% | +12.45 s / +43.9% |
| **All four, per-round sum median** | **122.26 s** | **168.41 s** | **161.91 s** | **+46.15 s / +37.7%** | **+39.65 s / +32.4%** |

ThinLTO is currently slower because this prototype disables package cache in the ThinLTO + deadcode mode, delays package emission, rewrites every package module, regenerates its bitcode summary, and then performs the ThinLTO link.

### Section attribution

The incremental `Oz` size is not explained by `__text` alone:

| Demo | O2 `__text` | Oz `__text` | Oz minus O2 | O2 `__llgo_fie` | Oz `__llgo_fie` | FIE delta |
|---|---:|---:|---:|---:|---:|---:|
| goimporter-1389 | 1120.3 KiB | 1111.2 KiB | -9.1 KiB | 282.9 KiB | 365.4 KiB | +82.6 KiB |
| embedunexport-1598 | 581.8 KiB | 582.8 KiB | +1.0 KiB | 133.2 KiB | 176.0 KiB | +42.9 KiB |
| mimeheader | 389.6 KiB | 390.8 KiB | +1.3 KiB | 81.5 KiB | 107.7 KiB | +26.2 KiB |
| gotypes | 1029.0 KiB | 1040.6 KiB | +11.6 KiB | 254.0 KiB | 332.3 KiB | +78.4 KiB |

`__llgo_fie` contains the funcinfo entry-site records emitted inside function bodies. ThinLTO can duplicate those records through inline copies. The link-phase `pclnpost` rewrite deduplicates the logical table in place, but it does not shrink the already allocated Mach-O section, so its zero-filled tail still contributes to the file size. The Oz pipeline produced more such records than O2, which dominates the Oz size increase in these binaries.

The final text-symbol counts also show that Oz is not simply retaining all code:

| Demo | ThinLTO O2 text symbols | ThinLTO Oz text symbols |
|---|---:|---:|
| goimporter-1389 | 2028 | 2091 |
| embedunexport-1598 | 1064 | 1097 |
| mimeheader | 508 | 535 |
| gotypes | 1868 | 1918 |

### Interpretation

The planner itself still prunes method targets correctly. The size comparison is affected by three independent factors:

1. ThinLTO O2 changes the baseline through cross-package import and inlining, so it is not directly comparable to the old non-ThinLTO DCE pipeline.
2. The current LLGo funcinfo site representation makes inline copies consume `__llgo_fie` section capacity, and the in-place post-link rewrite cannot return that capacity to the Mach-O file.
3. `ld64.lld` accepts only numeric `--lto-O0..3`; there is no `--lto-Oz` backend flag. The Oz experiment therefore applies `thinlto-pre-link<Oz>` and size-oriented front-end IR optimization, while the ThinLTO backend keeps its numeric default optimization level.

This means the current Oz result is a useful diagnostic experiment, not yet an end-to-end size-optimized ThinLTO mode. The next size experiments should tune ThinLTO import/inlining and funcinfo-section emission directly.

## Known limitations

- Package cache use is temporarily disabled for ThinLTO + deadcode.
- The prototype still creates temporary archives to match the linker's existing input contract, but it does not read or write cached package archives in this mode.
- Reusing one in-memory package module for multiple entry points/plans is not supported; a second link cannot reconstruct the original method table after the first rewrite.
- ThinLTO backend caching is not wired up yet.
- `Oz` currently controls the LLGo pre-link pipeline; an end-to-end size-oriented ThinLTO backend mode is not wired up.
- The planner still uses the current Meta reachability algorithm.
- `MethodByName` string/control-flow propagation is out of scope for this experiment.
- Archive and cache design needs to be revisited before enabling this path as the default.

## Follow-ups

- Evaluate `-Oz` and size-oriented ThinLTO import/inlining thresholds.
- Make package bitcode immutable or reloadable so multiple entry-point plans can be applied independently.
- Define a cache key for the global plan and rewritten package bitcode.
- Wire ThinLTO backend cache directories into the build.
- Extend planner inputs when reflection/string-flow analysis is ready.
- Revisit temporary archive construction once the architecture is validated.

## Tests

Passed:

```text
go test ./internal/crosscompile
go test ./internal/deadcode ./internal/dcepass
go test ./internal/build -run "Test(ThinLTODeadcodeEnabled|DeadcodeDropEnabled|ApplyDeadcode)" -v
```

The four-demo runtime/build experiment also passed with identical output for all 12 binaries.

A full `go test ./internal/build` run was started but entered an existing long-running build test path and was interrupted after the targeted tests passed. The earlier full-suite attempt in this checkout also has the known `test/go` analyzer panic, `cl` matrix segfault, and `cl` timeout described above.
