### PR TITLE
build(deps): bump setup-benchmark-go-action from 1.0.3 to 1.0.4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,7 +78,7 @@ jobs:
             "$GITHUB_WORKSPACE/.benchmark/results"
 
       - name: Record benchmark result
-        uses: xgo-dev/setup-benchmark-go-action@v1.0.3
+        uses: xgo-dev/setup-benchmark-go-action@v1.0.4
         with:
           config: .github/llgo-benchmark.yml
           benchmark-file: .benchmark/results/benchmark.txt


### PR DESCRIPTION
## Summary

- update the benchmark recorder from v1.0.3 to v1.0.4
- restore support for the existing same-runner baseline-benchmark-file input
- make pull request benchmark comments compare against the measured base commit again

v1.0.3 predates paired baseline artifacts and silently ignored the input with an unexpected-input warning. v1.0.4 contains the tested paired baseline implementation and commit-indexed history storage.

## Validation

- release action CI passed before v1.0.4 was published
- this PR changes only the action version pin
- the pull request benchmark workflow should produce a vs base comment