### PR TITLE
runtime: replace superseded panics across nested defer frames

### DIFF
--- a/cl/_testgo/nesteddeferpanic/expect.txt
+++ b/cl/_testgo/nesteddeferpanic/expect.txt
@@ -1,0 +1,5 @@
+replacement 5
+resume inner 2
+resume outer 1
+recover-then-panic old 2
+recover-then-panic outer 3

--- a/cl/_testgo/nesteddeferpanic/in.go
+++ b/cl/_testgo/nesteddeferpanic/in.go
@@ -1,0 +1,56 @@
+// LITTEST
+package main
+
+// CHECK-LABEL: define void @main.replacement(){{.*}} {
+func replacement() {
+	defer func() {
+		println("replacement", recover().(int))
+	}()
+
+	func() {
+		for {
+			defer func() {
+				defer panic(5)
+			}()
+			break
+		}
+		panic(4)
+	}()
+}
+
+func resumeOuterPanic() {
+	defer func() {
+		println("resume outer", recover().(int))
+	}()
+
+	func() {
+		defer func() {
+			defer func() {
+				println("resume inner", recover().(int))
+			}()
+			panic(2)
+		}()
+		panic(1)
+	}()
+}
+
+func recoverThenPanic() {
+	defer func() {
+		println("recover-then-panic outer", recover().(int))
+	}()
+
+	func() {
+		defer func() {
+			old := recover().(int)
+			defer panic(3)
+			println("recover-then-panic old", old)
+		}()
+		panic(2)
+	}()
+}
+
+func main() {
+	replacement()
+	resumeOuterPanic()
+	recoverThenPanic()
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -92,6 +92,8 @@ var embedTargetConfigs = []embedTargetConfig{
 				"./_testgo/selects",     // timeout: emulator did not auto-exit
 				"./_testgo/sigsegv",     // unexpected output: got "0/main", expected recover nil-pointer message
 				"./_testgo/syncmap",     // llgo panic: unsatisfied import internal/runtime/sys
+				// Baremetal terminates after an outermost panic is recovered.
+				"./_testgo/nesteddeferpanic",
 			},
 			"./_testlibc": {
 				"./_testlibc/argv",     // timeout: emulator panic (Load access fault), no auto-exit
@@ -138,6 +140,8 @@ var embedTargetConfigs = []embedTargetConfig{
 				"./_testgo/select",    // timeout: emulator did not auto-exit
 				"./_testgo/sigsegv",   // unexpected output
 				"./_testgo/struczero", // timeout: emulator did not auto-exit
+				// Baremetal terminates after an outermost panic is recovered.
+				"./_testgo/nesteddeferpanic",
 			},
 			"./_testlibc": {
 				"./_testlibc/atomic",   // unexpected output

--- a/runtime/internal/runtime/z_baremetal.go
+++ b/runtime/internal/runtime/z_baremetal.go
@@ -20,6 +20,11 @@ func Rethrow(link *Defer) {
 	if ptr := gp.panic_; gp.panicIsSuspended(ptr) {
 		return
 	}
+	if ptr := gp.panic_; ptr != nil {
+		gp.movePanicToDefer((*panicNode)(ptr), link)
+	} else {
+		gp.defer_ = link
+	}
 	if link == nil {
 		// Bare-metal has one execution context and no goroutine-exit
 		// transition. Goexit still drains every defer through the longjmp
@@ -27,10 +32,6 @@ func Rethrow(link *Defer) {
 		c.Printf(c.Str("fatal error\n"))
 		c.Exit(2)
 	} else {
-		if ptr := gp.panic_; ptr != nil && link == GetThreadDefer() {
-			node := (*panicNode)(ptr)
-			node.moveToDefer(link)
-		}
 		setjmp.Longjmp((*setjmp.JmpBuf)(link.Addr), 1)
 	}
 }

--- a/runtime/internal/runtime/z_default.go
+++ b/runtime/internal/runtime/z_default.go
@@ -22,8 +22,9 @@ func Rethrow(link *Defer) {
 		if gp.panicIsSuspended(ptr) {
 			return
 		}
+		node := (*panicNode)(ptr)
+		gp.movePanicToDefer(node, link)
 		if link == nil {
-			node := (*panicNode)(ptr)
 			TracePanic(node.arg)
 			if PanicTraceback == nil || !PanicTraceback(2) {
 				debug.PrintStack(2)
@@ -31,10 +32,6 @@ func Rethrow(link *Defer) {
 			c.Free(unsafe.Pointer(node))
 			c.Exit(2)
 		} else {
-			node := (*panicNode)(ptr)
-			if link == gp.defer_ {
-				node.moveToDefer(link)
-			}
 			c.Siglongjmp(link.Addr, 1)
 		}
 	} else if gp.goexit {
@@ -43,6 +40,7 @@ func Rethrow(link *Defer) {
 		// 1) If we have a defer frame, longjmp to it so it can execute defers.
 		// 2) Once we've unwound past the last frame (link==nil), terminate the
 		//    current pthread.
+		gp.defer_ = link
 		if link != nil {
 			c.Siglongjmp(link.Addr, 1)
 		}

--- a/runtime/internal/runtime/z_rt.go
+++ b/runtime/internal/runtime/z_rt.go
@@ -49,11 +49,13 @@ type recoverState struct {
 	panic_ unsafe.Pointer
 }
 
-// moveToDefer advances a panic to the next defer frame. A panic already
-// unwinding that frame has been replaced by this newer panic and must not
-// resume if the newer panic is recovered farther down the defer chain.
-func (node *panicNode) moveToDefer(link *Defer) {
-	gp := getg()
+// movePanicToDefer advances a panic and the goroutine's unwind cursor to the
+// next defer frame. A longjmp can reach a parent's rethrow block before the
+// child's normal defer cleanup restores gp.defer_, so both cursors are updated
+// here. A panic already unwinding that frame has been replaced by this newer
+// panic and must not resume if the newer panic is recovered farther down the
+// defer chain.
+func (gp *g) movePanicToDefer(node *panicNode, link *Defer) {
 	for node.prev != nil {
 		prev := (*panicNode)(node.prev)
 		if prev.defer_ != link {
@@ -66,6 +68,7 @@ func (node *panicNode) moveToDefer(link *Defer) {
 		c.Free(unsafe.Pointer(prev))
 	}
 	node.defer_ = link
+	gp.defer_ = link
 }
 
 // Recover recovers a panic.

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1150,11 +1150,6 @@ flakes:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue43942.go
-    reason: go1.24 goroot run can either pass or fail on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue48898.go
     reason: go1.24 goroot run can either pass or fail on linux/amd64
   - version: go1.26
@@ -1177,11 +1172,6 @@ flakes:
     directive: run
     case: stack.go
     reason: go1.24 goroot run can either pass or fail on darwin/arm64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue43942.go
-    reason: go1.26 goroot run can either pass or fail on linux/amd64
   - version: go1.26
     platform: linux/amd64
     directive: run
@@ -1214,10 +1204,6 @@ flakes:
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue48898.go
-    reason: darwin/arm64 goroot run can either pass or fail
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue43942.go
     reason: darwin/arm64 goroot run can either pass or fail
   - platform: darwin/arm64
     directive: run


### PR DESCRIPTION
## Summary

- advance the active panic and goroutine defer cursors together when a longjmp rethrows into the parent defer frame
- discard an older panic once a newer panic reaches the same defer frame, matching Go panic replacement semantics
- add a three-scenario LLGo black-box regression and retire the three platform/version flake records for `fixedbugs/issue43942.go`

## Root cause

The generated normal defer cleanup restores the goroutine defer head, but a panic raised by a nested deferred call can longjmp directly to the parent rethrow block and bypass that cleanup. The panic node then reaches the parent frame while the goroutine cursor still points at the child frame. The old `link == gp.defer_` guard consequently skipped panic replacement, allowing the older panic to resume after the newer panic was recovered.

Keep this transition in the runtime rethrow abstraction: moving to the parent frame now updates both cursors and removes older panic nodes already unwinding that frame. The same invariant is maintained for Goexit and the bare-metal rethrow implementation.

## Coverage

The new LLGo-executed fixture covers:

1. a nested deferred panic replacing the panic already unwinding the parent frame (the `issue43942` shape)
2. recovery of an inner panic followed by resumption and recovery of the outer panic
3. recovery of one panic followed by a new deferred panic escaping to an outer recovery point

## Validation

Runtime sources were exercised only through LLGo-built programs; host `go test` commands below are compiler/test drivers.

- macOS/arm64, Go 1.26.5: 13 related LLGo black-box cases passed
- macOS/arm64, Go 1.26.5: official `fixedbugs/issue43942.go` and adjacent `issue48898.go` passed when run with LLGo
- Linux/amd64, Go 1.26.5: the new fixture plus related defer/recover cases passed, and official `fixedbugs/issue43942.go` passed with LLGo
- macOS/arm64 and Linux/amd64: LLGo-built `issue43942` binaries passed 20/20 runs on Go 1.26.5; the Go 1.24.2 source also passed 20/20 on both platforms
- 15 additional related GOROOT defer/recover cases passed on macOS/arm64
- `go test ./ssa -count=1 -timeout=20m`

This fixes one unique GOROOT case and removes three records that represented that case on different Go versions/platforms.

## Embedded scope

The new regression fixture is excluded from the existing ESP32 and ESP32-C3 emulator suites. Their bare-metal runtime still terminates after an outermost panic is recovered (the same limitation already documented for other panic fixtures); changing that runtime and its constrained panic-node allocator is outside this native GOROOT fix. Native macOS and Linux execution remains mandatory.
