### PR TITLE
runtime: support assignable finalizer arguments

### DIFF
--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -30,18 +30,17 @@ type finalizerInterfaceArg struct {
 }
 
 type finalizerEntry struct {
-	fn                  any
-	sig                 *ffi.Signature // retains the conservatively allocated return-type graph
-	argTypes            []*ffi.Type    // owns the backing storage referenced by sig.ArgTypes
-	retSize             uintptr
-	interfaceTypeOrItab unsafe.Pointer
-	obj                 unsafe.Pointer
-	key                 uintptr
-	next                *finalizerEntry
-	prevFn              bdwgc.FinalizerFunc
-	prevCb              unsafe.Pointer
-	stop                int32
-	explicitEnv         bool
+	fn          any
+	sig         *ffi.Signature // retains the conservatively allocated return-type graph
+	argTypes    []*ffi.Type    // owns the backing storage referenced by sig.ArgTypes
+	retSize     uintptr
+	arg         unsafe.Pointer // object pointer or preallocated interface header
+	key         uintptr
+	next        *finalizerEntry
+	prevFn      bdwgc.FinalizerFunc
+	prevCb      unsafe.Pointer
+	stop        int32
+	explicitEnv bool
 }
 
 var finalizerState struct {
@@ -92,32 +91,22 @@ func SetFinalizer(obj any, finalizer any) {
 	if ft.Variadic() {
 		throw("runtime.SetFinalizer: cannot pass " + objFace._type.String() + " to finalizer " + finalizerFace._type.String() + " because dotdotdot")
 	}
-	if len(ft.In) != 1 || !finalizerArgAssignable(objFace._type, ft.In[0]) {
+	if len(ft.In) != 1 {
 		throw("runtime.SetFinalizer: cannot pass " + objFace._type.String() + " to finalizer " + finalizerFace._type.String())
 	}
-	argType := ft.In[0]
-	argFFIType := ffi.TypePointer
-	var interfaceTypeOrItab unsafe.Pointer
-	if argType.Kind() == abi.Interface {
-		argFFIType = ffi.TypeInterface
-		interfaceType := argType.InterfaceType()
-		if len(interfaceType.Methods) == 0 {
-			interfaceTypeOrItab = unsafe.Pointer(objFace._type)
-		} else {
-			interfaceTypeOrItab = unsafe.Pointer(llruntime.NewItab(interfaceType, objFace._type))
-		}
+	argFFIType, interfaceTypeOrItab, ok := prepareFinalizerArgument(objFace._type, ft.In[0])
+	if !ok {
+		throw("runtime.SetFinalizer: cannot pass " + objFace._type.String() + " to finalizer " + finalizerFace._type.String())
 	}
 	c := (*finalizerClosure)(finalizerFace.data)
 	explicitEnv := c.env != nil && ffi.ClosureEnvExplicit
 	sig, argTypes, retSize := newFinalizerFFISignature(ft, explicitEnv, argFFIType)
 	entry := &finalizerEntry{
-		fn:                  finalizer,
-		sig:                 sig,
-		argTypes:            argTypes,
-		explicitEnv:         explicitEnv,
-		retSize:             retSize,
-		interfaceTypeOrItab: interfaceTypeOrItab,
-		key:                 key,
+		fn: finalizer, sig: sig, argTypes: argTypes, explicitEnv: explicitEnv,
+		retSize: retSize, key: key,
+	}
+	if interfaceTypeOrItab != nil {
+		entry.arg = unsafe.Pointer(&finalizerInterfaceArg{typeOrItab: interfaceTypeOrItab})
 	}
 	var oldFn bdwgc.FinalizerFunc
 	var oldCb unsafe.Pointer
@@ -130,17 +119,26 @@ func SetFinalizer(obj any, finalizer any) {
 	finalizerState.mu.Unlock()
 }
 
-func finalizerArgAssignable(objType, argType *abi.Type) bool {
+func prepareFinalizerArgument(objType, argType *abi.Type) (*ffi.Type, unsafe.Pointer, bool) {
 	if argType == objType {
-		return true
+		return ffi.TypePointer, nil, true
 	}
 	switch argType.Kind() {
 	case abi.Pointer:
-		return (argType.Uncommon() == nil || objType.Uncommon() == nil) && argType.Elem() == objType.Elem()
+		if (argType.Uncommon() == nil || objType.Uncommon() == nil) && argType.Elem() == objType.Elem() {
+			return ffi.TypePointer, nil, true
+		}
 	case abi.Interface:
-		return llruntime.Implements(argType, objType)
+		if llruntime.Implements(argType, objType) {
+			interfaceType := argType.InterfaceType()
+			typeOrItab := unsafe.Pointer(objType)
+			if len(interfaceType.Methods) != 0 {
+				typeOrItab = unsafe.Pointer(llruntime.NewItab(interfaceType, objType))
+			}
+			return ffi.TypeInterface, typeOrItab, true
+		}
 	}
-	return false
+	return nil, nil, false
 }
 
 func ifacePointerData(e *eface) unsafe.Pointer {
@@ -148,6 +146,10 @@ func ifacePointerData(e *eface) unsafe.Pointer {
 		return e.data
 	}
 	return *(*unsafe.Pointer)(e.data)
+}
+
+func (entry *finalizerEntry) hasInterfaceArg() bool {
+	return entry.argTypes[len(entry.argTypes)-1] == ffi.TypeInterface
 }
 
 func finalizerFuncType(t *abi.Type) *abi.FuncType {
@@ -168,13 +170,10 @@ func callFinalizer(entry *finalizerEntry) {
 	if entry.retSize != 0 {
 		ret = llruntime.AllocU(entry.retSize)
 	}
-	ptr := entry.obj
-	arg := unsafe.Pointer(&ptr)
-	var interfaceArg finalizerInterfaceArg
-	if entry.interfaceTypeOrItab != nil {
-		interfaceArg.typeOrItab = entry.interfaceTypeOrItab
-		interfaceArg.data = ptr
-		arg = unsafe.Pointer(&interfaceArg)
+	arg := entry.arg
+	if !entry.hasInterfaceArg() {
+		ptr := entry.arg
+		arg = unsafe.Pointer(&ptr)
 	}
 	if entry.explicitEnv {
 		ffi.CallWithEnv(entry.sig, c.fn, c.env, ret, unsafe.Pointer(&c.env), arg)
@@ -197,7 +196,11 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 
 	// Keep the object alive until runFinalizers invokes the Go finalizer.
 	// Do not allocate or lock here; BDWGC calls this while collecting.
-	entry.obj = ptr
+	if entry.hasInterfaceArg() {
+		(*finalizerInterfaceArg)(entry.arg).data = ptr
+	} else {
+		entry.arg = ptr
+	}
 	entry.next = nil
 	if finalizerState.tail == nil {
 		finalizerState.head = entry
@@ -239,7 +242,7 @@ func runFinalizers() {
 		if atomic.Load(&entry.stop) != 1 {
 			callFinalizer(entry)
 		}
-		entry.obj = nil
+		entry.arg = nil
 	}
 }
 

--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -24,18 +24,24 @@ type finalizerClosure struct {
 	env unsafe.Pointer
 }
 
+type finalizerInterfaceArg struct {
+	typeOrItab unsafe.Pointer
+	data       unsafe.Pointer
+}
+
 type finalizerEntry struct {
-	fn          any
-	sig         *ffi.Signature // retains the conservatively allocated return-type graph
-	argTypes    []*ffi.Type    // owns the backing storage referenced by sig.ArgTypes
-	retSize     uintptr
-	obj         unsafe.Pointer
-	key         uintptr
-	next        *finalizerEntry
-	prevFn      bdwgc.FinalizerFunc
-	prevCb      unsafe.Pointer
-	stop        int32
-	explicitEnv bool
+	fn                  any
+	sig                 *ffi.Signature // retains the conservatively allocated return-type graph
+	argTypes            []*ffi.Type    // owns the backing storage referenced by sig.ArgTypes
+	retSize             uintptr
+	interfaceTypeOrItab unsafe.Pointer
+	obj                 unsafe.Pointer
+	key                 uintptr
+	next                *finalizerEntry
+	prevFn              bdwgc.FinalizerFunc
+	prevCb              unsafe.Pointer
+	stop                int32
+	explicitEnv         bool
 }
 
 var finalizerState struct {
@@ -83,19 +89,35 @@ func SetFinalizer(obj any, finalizer any) {
 	if ft == nil {
 		throw("runtime.SetFinalizer: second argument is " + finalizerFace._type.String() + ", not a function")
 	}
-	if len(ft.In) != 1 || ft.In[0] != objFace._type {
+	if ft.Variadic() {
+		throw("runtime.SetFinalizer: cannot pass " + objFace._type.String() + " to finalizer " + finalizerFace._type.String() + " because dotdotdot")
+	}
+	if len(ft.In) != 1 || !finalizerArgAssignable(objFace._type, ft.In[0]) {
 		throw("runtime.SetFinalizer: cannot pass " + objFace._type.String() + " to finalizer " + finalizerFace._type.String())
+	}
+	argType := ft.In[0]
+	argFFIType := ffi.TypePointer
+	var interfaceTypeOrItab unsafe.Pointer
+	if argType.Kind() == abi.Interface {
+		argFFIType = ffi.TypeInterface
+		interfaceType := argType.InterfaceType()
+		if len(interfaceType.Methods) == 0 {
+			interfaceTypeOrItab = unsafe.Pointer(objFace._type)
+		} else {
+			interfaceTypeOrItab = unsafe.Pointer(llruntime.NewItab(interfaceType, objFace._type))
+		}
 	}
 	c := (*finalizerClosure)(finalizerFace.data)
 	explicitEnv := c.env != nil && ffi.ClosureEnvExplicit
-	sig, argTypes, retSize := newFinalizerFFISignature(ft, explicitEnv)
+	sig, argTypes, retSize := newFinalizerFFISignature(ft, explicitEnv, argFFIType)
 	entry := &finalizerEntry{
-		fn:          finalizer,
-		sig:         sig,
-		argTypes:    argTypes,
-		explicitEnv: explicitEnv,
-		retSize:     retSize,
-		key:         key,
+		fn:                  finalizer,
+		sig:                 sig,
+		argTypes:            argTypes,
+		explicitEnv:         explicitEnv,
+		retSize:             retSize,
+		interfaceTypeOrItab: interfaceTypeOrItab,
+		key:                 key,
 	}
 	var oldFn bdwgc.FinalizerFunc
 	var oldCb unsafe.Pointer
@@ -106,6 +128,19 @@ func SetFinalizer(obj any, finalizer any) {
 	finalizerState.mu.Lock()
 	finalizerState.m[key] = entry
 	finalizerState.mu.Unlock()
+}
+
+func finalizerArgAssignable(objType, argType *abi.Type) bool {
+	if argType == objType {
+		return true
+	}
+	switch argType.Kind() {
+	case abi.Pointer:
+		return (argType.Uncommon() == nil || objType.Uncommon() == nil) && argType.Elem() == objType.Elem()
+	case abi.Interface:
+		return llruntime.Implements(argType, objType)
+	}
+	return false
 }
 
 func ifacePointerData(e *eface) unsafe.Pointer {
@@ -134,10 +169,17 @@ func callFinalizer(entry *finalizerEntry) {
 		ret = llruntime.AllocU(entry.retSize)
 	}
 	ptr := entry.obj
+	arg := unsafe.Pointer(&ptr)
+	var interfaceArg finalizerInterfaceArg
+	if entry.interfaceTypeOrItab != nil {
+		interfaceArg.typeOrItab = entry.interfaceTypeOrItab
+		interfaceArg.data = ptr
+		arg = unsafe.Pointer(&interfaceArg)
+	}
 	if entry.explicitEnv {
-		ffi.CallWithEnv(entry.sig, c.fn, c.env, ret, unsafe.Pointer(&c.env), unsafe.Pointer(&ptr))
+		ffi.CallWithEnv(entry.sig, c.fn, c.env, ret, unsafe.Pointer(&c.env), arg)
 	} else {
-		ffi.CallWithEnv(entry.sig, c.fn, c.env, ret, unsafe.Pointer(&ptr))
+		ffi.CallWithEnv(entry.sig, c.fn, c.env, ret, arg)
 	}
 	KeepAlive(entry.fn)
 	KeepAlive(entry.sig)

--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -29,6 +29,11 @@ type finalizerInterfaceArg struct {
 	data       unsafe.Pointer
 }
 
+const (
+	finalizerStopped        int32 = 1
+	finalizerInterfaceState       = 2
+)
+
 type finalizerEntry struct {
 	fn          any
 	sig         *ffi.Signature // retains the conservatively allocated return-type graph
@@ -39,7 +44,7 @@ type finalizerEntry struct {
 	next        *finalizerEntry
 	prevFn      bdwgc.FinalizerFunc
 	prevCb      unsafe.Pointer
-	stop        int32
+	state       int32
 	explicitEnv bool
 }
 
@@ -74,7 +79,7 @@ func SetFinalizer(obj any, finalizer any) {
 
 	finalizerState.mu.Lock()
 	if old := finalizerState.m[key]; old != nil {
-		atomic.Store(&old.stop, 1)
+		atomic.Store(&old.state, finalizerStopped)
 		delete(finalizerState.m, key)
 		restoreFinalizer(objPtr, old)
 	}
@@ -106,6 +111,7 @@ func SetFinalizer(obj any, finalizer any) {
 		retSize: retSize, key: key,
 	}
 	if interfaceTypeOrItab != nil {
+		entry.state = finalizerInterfaceState
 		entry.arg = unsafe.Pointer(&finalizerInterfaceArg{typeOrItab: interfaceTypeOrItab})
 	}
 	var oldFn bdwgc.FinalizerFunc
@@ -148,10 +154,6 @@ func ifacePointerData(e *eface) unsafe.Pointer {
 	return *(*unsafe.Pointer)(e.data)
 }
 
-func (entry *finalizerEntry) hasInterfaceArg() bool {
-	return entry.argTypes[len(entry.argTypes)-1] == ffi.TypeInterface
-}
-
 func finalizerFuncType(t *abi.Type) *abi.FuncType {
 	if !t.IsClosure() {
 		return nil
@@ -163,7 +165,7 @@ func finalizerFuncType(t *abi.Type) *abi.FuncType {
 	return st.Fields[0].Typ.FuncType()
 }
 
-func callFinalizer(entry *finalizerEntry) {
+func callFinalizer(entry *finalizerEntry, hasInterfaceArg bool) {
 	face := (*eface)(unsafe.Pointer(&entry.fn))
 	c := (*finalizerClosure)(face.data)
 	var ret unsafe.Pointer
@@ -171,7 +173,7 @@ func callFinalizer(entry *finalizerEntry) {
 		ret = llruntime.AllocU(entry.retSize)
 	}
 	arg := entry.arg
-	if !entry.hasInterfaceArg() {
+	if !hasInterfaceArg {
 		ptr := entry.arg
 		arg = unsafe.Pointer(&ptr)
 	}
@@ -190,13 +192,14 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 	if entry.prevFn != nil {
 		entry.prevFn(ptr, entry.prevCb)
 	}
-	if atomic.Load(&entry.stop) == 1 {
+	state := atomic.Load(&entry.state)
+	if state == finalizerStopped {
 		return
 	}
 
 	// Keep the object alive until runFinalizers invokes the Go finalizer.
 	// Do not allocate or lock here; BDWGC calls this while collecting.
-	if entry.hasInterfaceArg() {
+	if state == finalizerInterfaceState {
 		(*finalizerInterfaceArg)(entry.arg).data = ptr
 	} else {
 		entry.arg = ptr
@@ -239,8 +242,9 @@ func runFinalizers() {
 		}
 		finalizerState.mu.Unlock()
 
-		if atomic.Load(&entry.stop) != 1 {
-			callFinalizer(entry)
+		state := atomic.Load(&entry.state)
+		if state != finalizerStopped {
+			callFinalizer(entry, state == finalizerInterfaceState)
 		}
 		entry.arg = nil
 	}

--- a/runtime/internal/lib/runtime/mfinal_ffi.go
+++ b/runtime/internal/lib/runtime/mfinal_ffi.go
@@ -99,14 +99,12 @@ func finalizerFFIReturnType(results []*abi.Type) *ffi.Type {
 	}
 }
 
-func newFinalizerFFISignature(ft *abi.FuncType, explicitEnv bool) (*ffi.Signature, []*ffi.Type, uintptr) {
+func newFinalizerFFISignature(ft *abi.FuncType, explicitEnv bool, argType *ffi.Type) (*ffi.Signature, []*ffi.Type, uintptr) {
 	paramTypes := make([]*ffi.Type, 0, 2)
 	if explicitEnv {
 		paramTypes = append(paramTypes, ffi.TypePointer)
 	}
-	// SetFinalizer currently requires the finalizer argument to have the
-	// object's pointer type exactly.
-	paramTypes = append(paramTypes, ffi.TypePointer)
+	paramTypes = append(paramTypes, argType)
 	sig, err := ffi.NewSignature(finalizerFFIReturnType(ft.Out), paramTypes...)
 	if err != nil {
 		panic(err)

--- a/runtime/internal/lib/runtime/mfinal_ffi.go
+++ b/runtime/internal/lib/runtime/mfinal_ffi.go
@@ -14,11 +14,39 @@ var finalizerFFITypeClosure = ffi.StructOf(ffi.TypePointer, ffi.TypePointer)
 // Keep the Go ABI conversion local to finalizers. The low-level ffi package
 // should not depend on runtime/abi.
 func finalizerFFIType(typ *abi.Type) *ffi.Type {
-	switch kind := typ.Kind(); kind {
-	case abi.Bool, abi.Int, abi.Int8, abi.Int16, abi.Int32, abi.Int64,
-		abi.Uint, abi.Uint8, abi.Uint16, abi.Uint32, abi.Uint64, abi.Uintptr,
-		abi.Float32, abi.Float64, abi.Complex64, abi.Complex128:
-		return ffi.Typ[kind]
+	switch typ.Kind() {
+	case abi.Bool:
+		return ffi.TypeBool
+	case abi.Int:
+		return ffi.TypeInt
+	case abi.Int8:
+		return ffi.TypeInt8
+	case abi.Int16:
+		return ffi.TypeInt16
+	case abi.Int32:
+		return ffi.TypeInt32
+	case abi.Int64:
+		return ffi.TypeInt64
+	case abi.Uint:
+		return ffi.TypeUint
+	case abi.Uint8:
+		return ffi.TypeUint8
+	case abi.Uint16:
+		return ffi.TypeUint16
+	case abi.Uint32:
+		return ffi.TypeUint32
+	case abi.Uint64:
+		return ffi.TypeUint64
+	case abi.Uintptr:
+		return ffi.TypeUintptr
+	case abi.Float32:
+		return ffi.TypeFloat32
+	case abi.Float64:
+		return ffi.TypeFloat64
+	case abi.Complex64:
+		return ffi.TypeComplex64
+	case abi.Complex128:
+		return ffi.TypeComplex128
 	case abi.Array:
 		at := typ.ArrayType()
 		return ffi.ArrayOf(finalizerFFIType(at.Elem), int(at.Len))
@@ -55,8 +83,10 @@ func finalizerFFIStructType(typ *abi.Type) *ffi.Type {
 		fields = append(fields, finalizerFFIType(field.Typ))
 		off = field.Offset + field.Typ.Size_
 	}
-	// Do not pad to typ.Size_: trailing zero-sized fields can enlarge the
-	// Go-visible size without consuming registers in llgo's callable ABI.
+	// Zero-sized fields do not consume registers in llgo's callable ABI.
+	// Interior padding is already reconstructed from the following field's
+	// offset, so do not pad solely to typ.Size_: a trailing zero-sized field
+	// can enlarge the Go-visible size without adding an ABI slot.
 	return ffi.StructOf(fields...)
 }
 

--- a/test/go/finalizer_assignability_test.go
+++ b/test/go/finalizer_assignability_test.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type finalizerAssignableValue struct {
+	value int
+	keep  *int
+}
+
+type finalizerAssignablePointer *finalizerAssignableValue
+
+type finalizerInterfaceValue struct {
+	value int
+	keep  *int
+}
+
+type finalizerAssignableInterface interface {
+	finalizerValue() int
+}
+
+func (p *finalizerInterfaceValue) finalizerValue() int {
+	return p.value
+}
+
+func TestRuntimeSetFinalizerAssignableArgumentTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		register func(chan<- int, int)
+	}{
+		{
+			name: "identical pointer",
+			register: func(done chan<- int, value int) {
+				p := &finalizerAssignableValue{value: value, keep: new(int)}
+				runtime.SetFinalizer(p, func(p *finalizerAssignableValue) { done <- p.value })
+			},
+		},
+		{
+			name: "identical named pointer",
+			register: func(done chan<- int, value int) {
+				p := finalizerAssignablePointer(&finalizerAssignableValue{value: value, keep: new(int)})
+				runtime.SetFinalizer(p, func(p finalizerAssignablePointer) { done <- p.value })
+			},
+		},
+		{
+			name: "named to unnamed pointer",
+			register: func(done chan<- int, value int) {
+				p := finalizerAssignablePointer(&finalizerAssignableValue{value: value, keep: new(int)})
+				runtime.SetFinalizer(p, func(p *finalizerAssignableValue) { done <- p.value })
+			},
+		},
+		{
+			name: "empty interface with aggregate result",
+			register: func(done chan<- int, value int) {
+				p := &finalizerAssignableValue{value: value, keep: new(int)}
+				runtime.SetFinalizer(p, func(v any) (unused [4]int64) {
+					done <- v.(*finalizerAssignableValue).value
+					return
+				})
+			},
+		},
+		{
+			name: "implemented interface",
+			register: func(done chan<- int, value int) {
+				p := &finalizerInterfaceValue{value: value, keep: new(int)}
+				runtime.SetFinalizer(p, func(v finalizerAssignableInterface) { done <- v.finalizerValue() })
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const wantBase = 97531
+			want := wantBase + i
+			done := make(chan int, 1)
+			created := make(chan struct{})
+			go func() {
+				tt.register(done, want)
+				close(created)
+			}()
+			<-created
+
+			deadline := time.After(3 * time.Second)
+			for {
+				runGCWithTimeout(t)
+				select {
+				case got := <-done:
+					if got != want {
+						t.Fatalf("finalizer got %d, want %d", got, want)
+					}
+					return
+				case <-deadline:
+					t.Fatal("finalizer did not run")
+				default:
+				}
+			}
+		})
+	}
+}
+
+const finalizerInvalidCaseEnv = "LLGO_TEST_FINALIZER_INVALID_CASE"
+
+func TestRuntimeSetFinalizerRejectsInvalidArgumentTypes(t *testing.T) {
+	if name := os.Getenv(finalizerInvalidCaseEnv); name != "" {
+		p := &finalizerAssignableValue{keep: new(int)}
+		switch name {
+		case "non-function":
+			runtime.SetFinalizer(p, 1)
+		case "no parameters":
+			runtime.SetFinalizer(p, func() {})
+		case "two parameters":
+			runtime.SetFinalizer(p, func(*finalizerAssignableValue, int) {})
+		case "variadic":
+			runtime.SetFinalizer(p, func(...*finalizerAssignableValue) {})
+		case "wrong type":
+			runtime.SetFinalizer(p, func(*int) {})
+		default:
+			panic("unknown invalid finalizer case: " + name)
+		}
+		os.Exit(0)
+	}
+
+	tests := []string{
+		"non-function",
+		"no parameters",
+		"two parameters",
+		"variadic",
+		"wrong type",
+	}
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRuntimeSetFinalizerRejectsInvalidArgumentTypes$")
+			cmd.Env = append(os.Environ(), finalizerInvalidCaseEnv+"="+name)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("SetFinalizer accepted invalid %s", name)
+			}
+			if !strings.Contains(string(out), "runtime.SetFinalizer:") {
+				t.Fatalf("SetFinalizer error for %s:\n%s", name, out)
+			}
+		})
+	}
+}

--- a/test/go/finalizer_assignability_test.go
+++ b/test/go/finalizer_assignability_test.go
@@ -22,7 +22,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 )
 
 type finalizerAssignableValue struct {
@@ -92,30 +91,19 @@ func TestRuntimeSetFinalizerAssignableArgumentTypes(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// BDWGC conservatively scans stacks and registers, so a stale
+			// pointer can keep any one object reachable. Register several
+			// objects and require one real finalizer call to verify the ABI.
+			const registrations = 8
 			const wantBase = 97531
 			want := wantBase + i
-			done := make(chan int, 1)
-			created := make(chan struct{})
-			go func() {
-				tt.register(done, want)
-				close(created)
-			}()
-			<-created
-
-			deadline := time.After(3 * time.Second)
-			for {
-				runGCWithTimeout(t)
-				select {
-				case got := <-done:
-					if got != want {
-						t.Fatalf("finalizer got %d, want %d", got, want)
-					}
-					return
-				case <-deadline:
-					t.Fatal("finalizer did not run")
-				default:
+			done := make(chan int, registrations)
+			registerFinalizerForTest(func() {
+				for range registrations {
+					tt.register(done, want)
 				}
-			}
+			})
+			waitForFinalizerValue(t, done, want)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- match Go's `runtime.SetFinalizer` argument validation for identical and assignable pointer types
- support empty and implemented non-empty interface finalizer parameters with the correct interface ABI
- reject variadic finalizers explicitly and add Go-compatible positive and negative regression coverage
- keep the FFI signature and interface metadata on the registration path so finalizer invocation does not rebuild them

Closes #2298.

## Dependency

Depends on #2296, which provides the dynamic finalizer call/result ABI used here. Until #2296 merges, this PR intentionally includes that stack in the comparison against `main`.

The commits specific to this PR are:

1. `99421fc1e` — regression tests
2. `9154c0105` — assignability and interface ABI support
3. `7cc067ab3` — keep ordinary pointer finalizer entries compact
4. `aebe2afc9` — use explicit Go-to-FFI scalar mappings and clarify zero-sized-field handling
5. `37d4e38f9` — avoid repeated argument-kind checks on the finalizer path

They are based directly on the fully passing #2296 head `46a64176d`.

## Compatibility details

The validation follows the Go runtime rules:

- exact dynamic type
- pointer types with the same element type when at least one side is unnamed
- empty interfaces
- non-empty interfaces implemented by the object pointer type

Interface calls use the expected two-word value (`type + data` or `itab + data`). The header and non-empty-interface itab are prepared at registration, while the BDWGC callback only fills the object data word and queues the entry; it does not allocate or lock.

The latest #2296 implementation is retained, including cached FFI signatures, uncollectable result buffers, cached explicit-environment dispatch, and signature lifetime protection. This PR also replaces the fragile `abi.Kind`/`ffi.BasicKind` ordinal coupling with an explicit mapping.

## Tests

- standard Go 1.26.5: new positive/negative compatibility matrix (`-vet=off`, matching CI)
- LLGo on macOS arm64 with Go 1.24.11 and Go 1.26.5: all `TestRuntimeSetFinalizer*` tests
- post-rebase stress verification: all finalizer tests passed 20 consecutive rounds on each LLGo toolchain
- LLGo on macOS arm64 with Go 1.24.11 and Go 1.26.5: GOROOT `test/mallocfin.go`
- CI covers Linux and the broader test matrix
