### PR TITLE
test: refresh runtime FileCheck fixtures

### DIFF
--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -7,201 +7,14 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
+// Converting the two named values to interface{} must select their distinct
+// runtime type descriptors; the test body then exercises pointer-to-this and
+// element links from those descriptors.
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   store %main.T zeroinitializer, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T, ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call ptr @main.toEface(%"{{.*}}/runtime/internal/runtime.eface" %1)
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 72)
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.Type" zeroinitializer, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/runtime/abi.Type", ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %5 = call ptr @main.toEface(%"{{.*}}/runtime/internal/runtime.eface" %4)
-// CHECK-NEXT:   %6 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %9 = load ptr, ptr %8, align 8
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %9, i32 0, i32 10
-// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %11)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %14 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %15 = load ptr, ptr %14, align 8
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %15, i32 0, i32 10
-// CHECK-NEXT:   %17 = load ptr, ptr %16, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %17)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %18 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %19 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %20 = load ptr, ptr %19, align 8
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %20)
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %21, i32 0, i32 2
-// CHECK-NEXT:   %23 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %22, align 8
-// CHECK-NEXT:   %24 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %23, 0
-// CHECK-NEXT:   %25 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %23, 1
-// CHECK-NEXT:   %26 = icmp uge i64 0, %25
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %26, {{.*}})
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %24, i64 0
-// CHECK-NEXT:   %28 = load %"{{.*}}/runtime/abi.StructField", ptr %27, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %28, ptr %18, align 8
-// CHECK-NEXT:   %29 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %18, i32 0, i32 1
-// CHECK-NEXT:   %30 = load ptr, ptr %29, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %32 = load ptr, ptr %31, align 8
-// CHECK-NEXT:   %33 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %32, i32 0, i32 10
-// CHECK-NEXT:   %34 = load ptr, ptr %33, align 8
-// CHECK-NEXT:   %35 = icmp ne ptr %30, %34
-// CHECK-NEXT:   br i1 %35, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %36, align 8
-// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %36, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %37)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %38 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %18, i32 0, i32 1
-// CHECK-NEXT:   %39 = load ptr, ptr %38, align 8
-// CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %39)
-// CHECK-NEXT:   %41 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %42 = load ptr, ptr %41, align 8
-// CHECK-NEXT:   %43 = icmp ne ptr %40, %42
-// CHECK-NEXT:   br i1 %43, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 18 }, ptr %44, align 8
-// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %46 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %46, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %47 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %48 = load ptr, ptr %47, align 8
-// CHECK-NEXT:   %49 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %48)
-// CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %49, i32 0, i32 2
-// CHECK-NEXT:   %51 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %50, align 8
-// CHECK-NEXT:   %52 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 0
-// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 1
-// CHECK-NEXT:   %54 = icmp uge i64 1, %53
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %54, {{.*}})
-// CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %52, i64 1
-// CHECK-NEXT:   %56 = load %"{{.*}}/runtime/abi.StructField", ptr %55, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %56, ptr %46, align 8
-// CHECK-NEXT:   %57 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %46, i32 0, i32 1
-// CHECK-NEXT:   %58 = load ptr, ptr %57, align 8
-// CHECK-NEXT:   %59 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %60 = load ptr, ptr %59, align 8
-// CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %60, i32 0, i32 10
-// CHECK-NEXT:   %62 = load ptr, ptr %61, align 8
-// CHECK-NEXT:   %63 = icmp ne ptr %58, %62
-// CHECK-NEXT:   br i1 %63, label %_llgo_5, label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %64 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %64, align 8
-// CHECK-NEXT:   %65 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %64, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %65)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %66 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %46, i32 0, i32 1
-// CHECK-NEXT:   %67 = load ptr, ptr %66, align 8
-// CHECK-NEXT:   %68 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %67)
-// CHECK-NEXT:   %69 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %70 = load ptr, ptr %69, align 8
-// CHECK-NEXT:   %71 = icmp ne ptr %68, %70
-// CHECK-NEXT:   br i1 %71, label %_llgo_7, label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %72 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 18 }, ptr %72, align 8
-// CHECK-NEXT:   %73 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %72, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %73)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %74 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %74, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %75 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %76 = load ptr, ptr %75, align 8
-// CHECK-NEXT:   %77 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %76)
-// CHECK-NEXT:   %78 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %77, i32 0, i32 2
-// CHECK-NEXT:   %79 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %78, align 8
-// CHECK-NEXT:   %80 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %79, 0
-// CHECK-NEXT:   %81 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %79, 1
-// CHECK-NEXT:   %82 = icmp uge i64 2, %81
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %82, {{.*}})
-// CHECK-NEXT:   %83 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %80, i64 2
-// CHECK-NEXT:   %84 = load %"{{.*}}/runtime/abi.StructField", ptr %83, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %84, ptr %74, align 8
-// CHECK-NEXT:   %85 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %74, i32 0, i32 1
-// CHECK-NEXT:   %86 = load ptr, ptr %85, align 8
-// CHECK-NEXT:   %87 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %88 = load ptr, ptr %87, align 8
-// CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %88)
-// CHECK-NEXT:   %90 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %89, i32 0, i32 2
-// CHECK-NEXT:   %91 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %90, align 8
-// CHECK-NEXT:   %92 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, 0
-// CHECK-NEXT:   %93 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, 1
-// CHECK-NEXT:   %94 = icmp uge i64 0, %93
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %94, {{.*}})
-// CHECK-NEXT:   %95 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %92, i64 0
-// CHECK-NEXT:   %96 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %95, i32 0, i32 1
-// CHECK-NEXT:   %97 = load ptr, ptr %96, align 8
-// CHECK-NEXT:   %98 = icmp ne ptr %86, %97
-// CHECK-NEXT:   br i1 %98, label %_llgo_9, label %_llgo_10
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_8
-// CHECK-NEXT:   %99 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %99, align 8
-// CHECK-NEXT:   %100 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %99, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %100)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
-// CHECK-NEXT:   %101 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %101, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %102 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %103 = load ptr, ptr %102, align 8
-// CHECK-NEXT:   %104 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %103)
-// CHECK-NEXT:   %105 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %104, i32 0, i32 2
-// CHECK-NEXT:   %106 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %105, align 8
-// CHECK-NEXT:   %107 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %106, 0
-// CHECK-NEXT:   %108 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %106, 1
-// CHECK-NEXT:   %109 = icmp uge i64 3, %108
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %109, {{.*}})
-// CHECK-NEXT:   %110 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %107, i64 3
-// CHECK-NEXT:   %111 = load %"{{.*}}/runtime/abi.StructField", ptr %110, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %111, ptr %101, align 8
-// CHECK-NEXT:   %112 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %101, i32 0, i32 1
-// CHECK-NEXT:   %113 = load ptr, ptr %112, align 8
-// CHECK-NEXT:   %114 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %113)
-// CHECK-NEXT:   %115 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %116 = load ptr, ptr %115, align 8
-// CHECK-NEXT:   %117 = icmp ne ptr %114, %116
-// CHECK-NEXT:   br i1 %117, label %_llgo_11, label %_llgo_12
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_10
-// CHECK-NEXT:   %118 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %118, align 8
-// CHECK-NEXT:   %119 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %118, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %119)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_10
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: insertvalue %"{{.*}}eface" { ptr @_llgo_main.T,
+// CHECK: insertvalue %"{{.*}}eface" { ptr @"_llgo_{{.*}}/runtime/abi.Type",
+// CHECK: call ptr @"{{.*}}/runtime/abi.(*Type).StructType"
+// CHECK: call ptr @"{{.*}}/runtime/abi.(*Type).Elem"
 
 type T struct {
 	p *T
@@ -248,12 +61,10 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define ptr @main.toEface(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %1, align 8
-// CHECK-NEXT:   ret ptr %1
-// CHECK-NEXT: }
 func toEface(i any) *eface {
+	// CHECK-LABEL: define ptr @main.toEface(%"{{.*}}eface" %{{[0-9]+}}){{.*}} {
+	// CHECK: [[TO_EFACE_ADDR:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+	// CHECK-NEXT: store %"{{.*}}eface" [[TO_EFACE_VALUE:%[0-9]+]], ptr [[TO_EFACE_ADDR]]
+	// CHECK-NEXT: ret ptr [[TO_EFACE_ADDR]]
 	return (*eface)(unsafe.Pointer(&i))
 }

--- a/cl/_testrt/abitype/in.go
+++ b/cl/_testrt/abitype/in.go
@@ -8,48 +8,23 @@ import (
 )
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 4)
-// CHECK-NEXT:   store i32 0, ptr %1, align 4
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int32, ptr undef }, ptr %1, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %2, ptr %0, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %main.eface, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
-// CHECK-NEXT:   %5 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %4)
-// CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %5, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 })
-// CHECK-NEXT:   %7 = xor i1 %6, true
-// CHECK-NEXT:   br i1 %7, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 14 }, ptr %8, align 8
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %8, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %9)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 1)
-// CHECK-NEXT:   store i8 0, ptr %10, align 1
-// CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_uint8, ptr undef }, ptr %10, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %11, ptr %0, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %main.eface, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   %14 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %13)
-// CHECK-NEXT:   %15 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %14, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 5 })
-// CHECK-NEXT:   %16 = xor i1 %15, true
-// CHECK-NEXT:   br i1 %16, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 14 }, ptr %17, align 8
-// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[EFACE_STORAGE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK: [[RUNE_EFACE:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int32, ptr undef }, ptr %{{[0-9]+}}, 1
+// CHECK-NEXT: store %"{{.*}}/runtime/internal/runtime.eface" [[RUNE_EFACE]], ptr [[EFACE_STORAGE]]
+// CHECK: [[RUNE_TYPE_SLOT:%[0-9]+]] = getelementptr inbounds %main.eface, ptr [[EFACE_STORAGE]], i32 0, i32 0
+// CHECK-NEXT: [[RUNE_TYPE:%[0-9]+]] = load ptr, ptr [[RUNE_TYPE_SLOT]]
+// CHECK-NEXT: [[RUNE_NAME:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr [[RUNE_TYPE]])
+// CHECK-NEXT: [[RUNE_MATCH:%[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" [[RUNE_NAME]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 5 })
+// CHECK-NEXT: [[RUNE_BAD:%[0-9]+]] = xor i1 [[RUNE_MATCH]], true
+// CHECK-NEXT: br i1 [[RUNE_BAD]], label %{{.*}}, label %{{.*}}
+// CHECK: [[BYTE_EFACE:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_uint8, ptr undef }, ptr %{{[0-9]+}}, 1
+// CHECK-NEXT: store %"{{.*}}/runtime/internal/runtime.eface" [[BYTE_EFACE]], ptr [[EFACE_STORAGE]]
+// CHECK: [[BYTE_TYPE_SLOT:%[0-9]+]] = getelementptr inbounds %main.eface, ptr [[EFACE_STORAGE]], i32 0, i32 0
+// CHECK-NEXT: [[BYTE_TYPE:%[0-9]+]] = load ptr, ptr [[BYTE_TYPE_SLOT]]
+// CHECK-NEXT: [[BYTE_NAME:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr [[BYTE_TYPE]])
+// CHECK-NEXT: [[BYTE_MATCH:%[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" [[BYTE_NAME]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 5 })
+// CHECK-NEXT: [[BYTE_BAD:%[0-9]+]] = xor i1 [[BYTE_MATCH]], true
+// CHECK-NEXT: br i1 [[BYTE_BAD]], label %{{.*}}, label %{{.*}}
 
 type eface struct {
 	typ  *abi.Type

--- a/cl/_testrt/alloca/in.go
+++ b/cl/_testrt/alloca/in.go
@@ -11,9 +11,9 @@ import (
 func main() {
 	s := c.Str("Hi\n")
 	s2 := c.Alloca(4)
-	// CHECK: alloca i8, i64 4, align 1
-	// CHECK-NEXT: @memcpy(ptr {{%[0-9]+}}, ptr @0, i64 4)
-	// CHECK-NEXT: @printf(ptr @1, ptr {{%[0-9]+}})
+	// CHECK: [[ALLOCA_BUF:%[0-9]+]] = alloca i8, i64 4, align 1
+	// CHECK-NEXT: [[ALLOCA_COPY:%[0-9]+]] = call ptr @memcpy(ptr [[ALLOCA_BUF]], ptr @0, i64 4)
+	// CHECK-NEXT: [[ALLOCA_PRINT:%[0-9]+]] = call i32 (ptr, ...) @printf(ptr @1, ptr [[ALLOCA_BUF]])
 	// CHECK-NEXT: ret void
 	c.Memcpy(s2, c.Pointer(s), 4)
 	c.Printf(c.Str("%s"), s2)

--- a/cl/_testrt/allocstr/in.go
+++ b/cl/_testrt/allocstr/in.go
@@ -5,27 +5,20 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK: {{^}}%"{{.*}}/runtime/internal/runtime.String" = type { ptr, i64 }{{$}}
-// CHECK: {{^}}@0 = private unnamed_addr constant [12 x i8] c"Hello world\0A", align 1{{$}}
-
+// CHECK: [[HELLO_TEXT:@[0-9]+]] = private unnamed_addr constant [12 x i8] c"Hello world\0A"
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.hello(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 12 }
-// CHECK-NEXT: }
+// CHECK: ret %"{{.*}}/runtime/internal/runtime.String" { ptr [[HELLO_TEXT]], i64 12 }
 func hello() string {
 	return "Hello world\n"
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.String" @main.hello()
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %0, 1
-// CHECK-NEXT:   %2 = add i64 %1, 1
-// CHECK-NEXT:   %3 = alloca i8, i64 %2, align 1
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.CStrCopy"(ptr %3, %"{{.*}}/runtime/internal/runtime.String" %0)
-// CHECK-NEXT:   %5 = call i32 (ptr, ...) @printf(ptr %4)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[TEXT:%[0-9]+]] = call %"{{.*}}String" @main.hello()
+// CHECK-NEXT: [[TEXT_LEN:%[0-9]+]] = extractvalue %"{{.*}}String" [[TEXT]], 1
+// CHECK-NEXT: [[CSTR_LEN:%[0-9]+]] = add i64 [[TEXT_LEN]], 1
+// CHECK-NEXT: [[CSTR_BUF:%[0-9]+]] = alloca i8, i64 [[CSTR_LEN]]
+// CHECK-NEXT: [[CSTR:%[0-9]+]] = call ptr @"{{.*}}CStrCopy"(ptr [[CSTR_BUF]], %"{{.*}}String" [[TEXT]])
+// CHECK-NEXT: call i32 (ptr, ...) @printf(ptr [[CSTR]])
 func main() {
 	c.Printf(c.AllocaCStr(hello()))
 }

--- a/cl/_testrt/asm/in.go
+++ b/cl/_testrt/asm/in.go
@@ -7,10 +7,7 @@ import _ "unsafe"
 func asm(instruction string)
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void asm sideeffect "nop", ""()
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void asm sideeffect "nop", ""()
 func main() {
 	asm("nop")
 }

--- a/cl/_testrt/asmfull/in.go
+++ b/cl/_testrt/asmfull/in.go
@@ -7,17 +7,12 @@ import _ "unsafe"
 func asmFull(instruction string, regs map[string]any) uintptr
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void asm sideeffect "nop", ""()
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_any", i64 1)
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 42, ptr {{%[0-9]+}}, align 8
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }
+// CHECK: call void asm sideeffect "nop", ""()
 // CHECK: call void asm sideeffect "# test value ${0}", "r"(i64 42)
-// CHECK: call i64 asm sideeffect "mov $0, ${1}", "=&r,r"(i64 42)
-// CHECK: call i64 asm sideeffect "# calc ${1} + ${2} -> $0", "=&r,r,r"(i64 25, i64 17)
-// CHECK: ret void
-// CHECK-NEXT: }
+// CHECK: [[ASM_RESULT:%[0-9]+]] = call i64 asm sideeffect "mov $0, ${1}", "=&r,r"(i64 42)
+// CHECK: call void @"{{.*}}.PrintUint"(i64 [[ASM_RESULT]])
+// CHECK: [[ASM_UNUSED:%[0-9]+]] = call i64 asm sideeffect "# calc ${1} + ${2} -> $0", "=&r,r,r"(i64 25, i64 17)
+// CHECK-NEXT: ret void
 func main() {
 	// no input,no return value
 	asmFull("nop", nil)

--- a/cl/_testrt/builtin/in.go
+++ b/cl/_testrt/builtin/in.go
@@ -5,12 +5,6 @@ import (
 	"unsafe"
 )
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
-// CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"def", align 1{{$}}
-// CHECK: {{^}}@3 = private unnamed_addr constant [4 x i8] c"ABCD", align 1{{$}}
-// CHECK: {{^}}@4 = private unnamed_addr constant [7 x i8] c"\E4\B8\ADabcd", align 1{{$}}
-// CHECK: {{^}}@5 = private unnamed_addr constant [2 x i8] c"fn", align 1{{$}}
-
 var a int64 = 1<<63 - 1
 var b int64 = -1 << 63
 var n uint64 = 1<<64 - 1
@@ -28,31 +22,19 @@ const (
 )
 
 // CHECK-LABEL: define double @main.Float64frombits(i64 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   store i64 %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = load double, ptr %1, align 8
-// CHECK-NEXT:   ret double %2
-// CHECK-NEXT: }
+// CHECK: [[BITS_ADDR:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK: store i64 %0, ptr [[BITS_ADDR]]
+// CHECK: [[FLOAT:%.*]] = load double, ptr [[BITS_ADDR]]
+// CHECK: ret double [[FLOAT]]
 
 func Float64frombits(b uint64) float64 { return *(*float64)(unsafe.Pointer(&b)) }
 
 // CHECK-LABEL: define double @main.Inf(i64 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp sge i64 %0, 0
-// CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
-// CHECK-NEXT:   %2 = phi i64 [ 9218868437227405312, %_llgo_1 ], [ -4503599627370496, %_llgo_3 ]
-// CHECK-NEXT:   %3 = call double @main.Float64frombits(i64 %2)
-// CHECK-NEXT:   ret double %3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-NEXT: }
+// CHECK: [[NONNEG:%.*]] = icmp sge i64 %0, 0
+// CHECK: br i1 [[NONNEG]], label %{{.*}}, label %{{.*}}
+// CHECK: [[INF_BITS:%.*]] = phi i64 [ 9218868437227405312, %{{.*}} ], [ -4503599627370496, %{{.*}} ]
+// CHECK: [[INF:%.*]] = call double @main.Float64frombits(i64 [[INF_BITS]])
+// CHECK: ret double [[INF]]
 
 // Inf returns positive infinity if sign >= 0, negative infinity if sign < 0.
 func Inf(sign int) float64 {
@@ -66,386 +48,69 @@ func Inf(sign int) float64 {
 }
 
 // CHECK-LABEL: define i1 @main.IsNaN(double %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = fcmp une double %0, %0
-// CHECK-NEXT:   ret i1 %1
-// CHECK-NEXT: }
+// CHECK: [[IS_NAN:%.*]] = fcmp une double %0, %0
+// CHECK: ret i1 [[IS_NAN]]
 
 func IsNaN(f float64) (is bool) {
 	return f != f
 }
 
 // CHECK-LABEL: define double @main.NaN(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call double @main.Float64frombits(i64 9221120237041090561)
-// CHECK-NEXT:   ret double %0
-// CHECK-NEXT: }
+// CHECK: [[NAN:%.*]] = call double @main.Float64frombits(i64 9221120237041090561)
+// CHECK: ret double [[NAN]]
 
 // NaN returns an IEEE 754 “not-a-number” value.
 func NaN() float64 { return Float64frombits(uvnan) }
-
-// CHECK-LABEL: define void @main.demo(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 
 func demo() {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
-// CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %0, i64 1
-// CHECK-NEXT:   store i64 2, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %0, i64 2
-// CHECK-NEXT:   store i64 3, ptr %3, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %0, i64 3
-// CHECK-NEXT:   store i64 4, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %5, i64 4, 1
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, i64 4, 2
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %9 = getelementptr inbounds i64, ptr %8, i64 0
-// CHECK-NEXT:   %10 = getelementptr inbounds i64, ptr %8, i64 1
-// CHECK-NEXT:   %11 = getelementptr inbounds i64, ptr %8, i64 2
-// CHECK-NEXT:   %12 = getelementptr inbounds i64, ptr %8, i64 3
-// CHECK-NEXT:   store i64 1, ptr %9, align 8
-// CHECK-NEXT:   store i64 2, ptr %10, align 8
-// CHECK-NEXT:   store i64 3, ptr %11, align 8
-// CHECK-NEXT:   store i64 4, ptr %12, align 8
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 10)
-// CHECK-NEXT:   %14 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   %16 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %16)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %14, 1
-// CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %14, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %14)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %17)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %18)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %20 = getelementptr inbounds i64, ptr %19, i64 0
-// CHECK-NEXT:   store i64 1, ptr %20, align 8
-// CHECK-NEXT:   %21 = getelementptr inbounds i64, ptr %19, i64 1
-// CHECK-NEXT:   store i64 2, ptr %21, align 8
-// CHECK-NEXT:   %22 = getelementptr inbounds i64, ptr %19, i64 2
-// CHECK-NEXT:   store i64 3, ptr %22, align 8
-// CHECK-NEXT:   %23 = getelementptr inbounds i64, ptr %19, i64 3
-// CHECK-NEXT:   store i64 4, ptr %23, align 8
-// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %19, 0
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %24, i64 4, 1
-// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %25, i64 4, 2
-// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %26, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %27)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %28 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   %29 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   %30 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %31 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %32 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 1
-// CHECK-NEXT:   %33 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   %34 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %36 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, 2
-// CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %40 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %40, 1
-// CHECK-NEXT:   %42 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %44 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %45 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %44, 2
-// CHECK-NEXT:   %46 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   %47 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %48 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %48, 1
-// CHECK-NEXT:   %50 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 2
-// CHECK-NEXT:   %51 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %52 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %52, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %37)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %41)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %45)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %49)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %53)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %54 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %54, 1
-// CHECK-NEXT:   %56 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %57 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %56, 2
-// CHECK-NEXT:   %58 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %59 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %58, 1
-// CHECK-NEXT:   %60 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %61 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %60, 2
-// CHECK-NEXT:   %62 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %63 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %62, 1
-// CHECK-NEXT:   %64 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %65 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %64, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %55)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %57)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %59)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %61)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %63)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %65)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %66 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"({{.*}})
-// CHECK-NEXT:   %67 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"({{.*}})
-// CHECK-NEXT:   %68 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"({{.*}})
-// CHECK-NEXT:   %69 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %68, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %66)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %67)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %69)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %70 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %71 = getelementptr inbounds i64, ptr %70, i64 0
-// CHECK-NEXT:   store i64 5, ptr %71, align 8
-// CHECK-NEXT:   %72 = getelementptr inbounds i64, ptr %70, i64 1
-// CHECK-NEXT:   store i64 6, ptr %72, align 8
-// CHECK-NEXT:   %73 = getelementptr inbounds i64, ptr %70, i64 2
-// CHECK-NEXT:   store i64 7, ptr %73, align 8
-// CHECK-NEXT:   %74 = getelementptr inbounds i64, ptr %70, i64 3
-// CHECK-NEXT:   store i64 8, ptr %74, align 8
-// CHECK-NEXT:   %75 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %70, 0
-// CHECK-NEXT:   %76 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %75, i64 4, 1
-// CHECK-NEXT:   %77 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, i64 4, 2
-// CHECK-NEXT:   %78 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %77, 0
-// CHECK-NEXT:   %79 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %77, 1
-// CHECK-NEXT:   %80 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %7, ptr %78, i64 %79, i64 8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %80)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %81 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 3)
-// CHECK-NEXT:   %82 = getelementptr inbounds i8, ptr %81, i64 0
-// CHECK-NEXT:   store i8 97, ptr %82, align 1
-// CHECK-NEXT:   %83 = getelementptr inbounds i8, ptr %81, i64 1
-// CHECK-NEXT:   store i8 98, ptr %83, align 1
-// CHECK-NEXT:   %84 = getelementptr inbounds i8, ptr %81, i64 2
-// CHECK-NEXT:   store i8 99, ptr %84, align 1
-// CHECK-NEXT:   %85 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %81, 0
-// CHECK-NEXT:   %86 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %85, i64 3, 1
-// CHECK-NEXT:   %87 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %86, i64 3, 2
-// CHECK-NEXT:   %88 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %87, ptr @1, i64 3, i64 1)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %88)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %90 = getelementptr inbounds { ptr, ptr }, ptr %89, i64 0
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"main.main$1", ptr null }, ptr %90, align 8
-// CHECK-NEXT:   %91 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %89, 0
-// CHECK-NEXT:   %92 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, i64 1, 1
-// CHECK-NEXT:   %93 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %92, i64 1, 2
-// CHECK-NEXT:   %94 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %93, 0
-// CHECK-NEXT:   %95 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %93, 1
-// CHECK-NEXT:   %96 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" { ptr @"__llgo.moduleZeroSizedAlloc$", i64 0, i64 0 }, ptr %94, i64 %95, i64 16)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %96)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %97 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %98 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 100, ptr %98, align 8
-// CHECK-NEXT:   %99 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %98, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %99, ptr %97, align 8
-// CHECK-NEXT:   %100 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %97, align 8
-// CHECK-NEXT:   %101 = ptrtoint ptr %97 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 100)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 -100)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 255)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 -100)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double 0.000000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double 1.005000e+02)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintEface"(%"{{.*}}/runtime/internal/runtime.eface" %100)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %97)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %101)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %102 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 3)
-// CHECK-NEXT:   %103 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %104 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %102, 0
-// CHECK-NEXT:   %105 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %104, i64 3, 1
-// CHECK-NEXT:   %106 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %105, i64 3, 2
-// CHECK-NEXT:   %107 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %88, 0
-// CHECK-NEXT:   %108 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %88, 1
-// CHECK-NEXT:   %109 = call i64 @"{{.*}}/runtime/internal/runtime.SliceCopy"(%"{{.*}}/runtime/internal/runtime.Slice" %106, ptr %107, i64 %108, i64 1)
-// CHECK-NEXT:   store i64 %109, ptr %103, align 8
-// CHECK-NEXT:   %110 = load i64, ptr %103, align 8
-// CHECK-NEXT:   %111 = getelementptr inbounds i8, ptr %102, i64 0
-// CHECK-NEXT:   %112 = load i8, ptr %111, align 1
-// CHECK-NEXT:   %113 = getelementptr inbounds i8, ptr %102, i64 1
-// CHECK-NEXT:   %114 = load i8, ptr %113, align 1
-// CHECK-NEXT:   %115 = getelementptr inbounds i8, ptr %102, i64 2
-// CHECK-NEXT:   %116 = load i8, ptr %115, align 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %110)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %117 = zext i8 %112 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %117)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %118 = zext i8 %114 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %118)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %119 = zext i8 %116 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %119)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %120 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   %121 = call i64 @"{{.*}}/runtime/internal/runtime.SliceCopy"(%"{{.*}}/runtime/internal/runtime.Slice" %120, ptr @3, i64 4, i64 1)
-// CHECK-NEXT:   store i64 %121, ptr %103, align 8
-// CHECK-NEXT:   %122 = load i64, ptr %103, align 8
-// CHECK-NEXT:   %123 = getelementptr inbounds i8, ptr %102, i64 0
-// CHECK-NEXT:   %124 = load i8, ptr %123, align 1
-// CHECK-NEXT:   %125 = getelementptr inbounds i8, ptr %102, i64 1
-// CHECK-NEXT:   %126 = load i8, ptr %125, align 1
-// CHECK-NEXT:   %127 = getelementptr inbounds i8, ptr %102, i64 2
-// CHECK-NEXT:   %128 = load i8, ptr %127, align 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %122)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %129 = zext i8 %124 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %129)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %130 = zext i8 %126 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %130)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %131 = zext i8 %128 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %131)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %132 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   %133 = getelementptr inbounds { ptr }, ptr %132, i32 0, i32 0
-// CHECK-NEXT:   store ptr %103, ptr %133, align 8
-// CHECK-NEXT:   %134 = insertvalue { ptr, ptr } { ptr @"main.main$3", ptr undef }, ptr %132, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @main.demo)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @main.demo)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @"main.main$2")
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %135 = extractvalue { ptr, ptr } %134, 0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %135)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %136 = call ptr @"{{.*}}/runtime/internal/runtime.NewStringIter"(%"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 7 })
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %137 = call { i1, i64, i32 } @"{{.*}}/runtime/internal/runtime.StringIterNext"(ptr %136)
-// CHECK-NEXT:   %138 = extractvalue { i1, i64, i32 } %137, 0
-// CHECK-NEXT:   br i1 %138, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %139 = extractvalue { i1, i64, i32 } %137, 1
-// CHECK-NEXT:   %140 = extractvalue { i1, i64, i32 } %137, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %139)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %141 = sext i32 %140 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %141)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %142 = call double @main.Inf(i64 1)
-// CHECK-NEXT:   %143 = call double @main.Inf(i64 -1)
-// CHECK-NEXT:   %144 = call double @main.NaN()
-// CHECK-NEXT:   %145 = call double @main.NaN()
-// CHECK-NEXT:   %146 = call i1 @main.IsNaN(double %145)
-// CHECK-NEXT:   %147 = call i1 @main.IsNaN(double 1.000000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double %142)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double %143)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double %144)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %146)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %147)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %148 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.StringToBytes"(%"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 7 })
-// CHECK-NEXT:   %149 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.StringToRunes"(%"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %148)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %149)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %150 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromBytes"(%"{{.*}}/runtime/internal/runtime.Slice" %148)
-// CHECK-NEXT:   %151 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromRunes"(%"{{.*}}/runtime/internal/runtime.Slice" %149)
-// CHECK-NEXT:   %152 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %148, 0
-// CHECK-NEXT:   %153 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %148, 1
-// CHECK-NEXT:   %154 = icmp uge i64 3, %153
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %154, {{.*}})
-// CHECK-NEXT:   %155 = getelementptr inbounds i8, ptr %152, i64 3
-// CHECK-NEXT:   %156 = load i8, ptr %155, align 1
-// CHECK-NEXT:   %157 = zext i8 %156 to i64
-// CHECK-NEXT:   %158 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromUint64"(i64 %157)
-// CHECK-NEXT:   %159 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %149, 0
-// CHECK-NEXT:   %160 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %149, 1
-// CHECK-NEXT:   %161 = icmp uge i64 0, %160
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %161, {{.*}})
-// CHECK-NEXT:   %162 = getelementptr inbounds i32, ptr %159, i64 0
-// CHECK-NEXT:   %163 = load i32, ptr %162, align 4
-// CHECK-NEXT:   %164 = sext i32 %163 to i64
-// CHECK-NEXT:   %165 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromInt64"(i64 %164)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %150)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %151)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %158)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %165)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// make([]byte, 4, 10) must preserve both the requested length and capacity.
+// CHECK: [[D_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 10)
+// CHECK: [[D:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[D_STORAGE]], i64 1, i64 10, i64 0, i64 4, i1 true, i1 true, i1 true)
+// append(s, 5, 6, 7, 8) forwards the materialized four-element tail.
+// CHECK: call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringSlice2"(%"{{.*}}String" { ptr @{{.*}}, i64 5 }, i64 5, i64 5, i1 true, i1 true)
+// CHECK: [[INT_TAIL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
+// CHECK: [[INT_TAIL_0:%.*]] = getelementptr inbounds i64, ptr [[INT_TAIL]], i64 0
+// CHECK: store i64 5, ptr [[INT_TAIL_0]]
+// CHECK: [[INT_TAIL_PTR:%.*]] = extractvalue %"{{.*}}Slice" %{{.*}}, 0
+// CHECK: [[INT_TAIL_LEN:%.*]] = extractvalue %"{{.*}}Slice" %{{.*}}, 1
+// CHECK: [[INT_APPEND:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}Slice" %{{.*}}, ptr [[INT_TAIL_PTR]], i64 [[INT_TAIL_LEN]], i64 8)
+// append(data, "def"...) uses three one-byte elements.
+// CHECK: [[DATA_APPEND:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}Slice" %{{.*}}, ptr @{{.*}}, i64 3, i64 1)
+// Appending a function closure uses the two-word function representation.
+// CHECK: [[FN_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[FN_SLICE:%.*]], 0
+// CHECK: [[FN_LEN:%.*]] = extractvalue %"{{.*}}Slice" [[FN_SLICE]], 1
+// CHECK: [[FN_APPEND:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}Slice" { ptr @"__llgo.moduleZeroSizedAlloc$", i64 0, i64 0 }, ptr [[FN_PTR]], i64 [[FN_LEN]], i64 16)
+// Both copy forms retain destination/source lengths and the byte element size.
+// CHECK: [[COPY_DATA:%.*]] = call i64 @"{{.*}}/runtime/internal/runtime.SliceCopy"(%"{{.*}}Slice" %{{.*}}, ptr %{{.*}}, i64 %{{.*}}, i64 1)
+// CHECK: store i64 [[COPY_DATA]], ptr [[COPY_N:%.*]]
+// CHECK: [[COPY_LITERAL:%.*]] = call i64 @"{{.*}}/runtime/internal/runtime.SliceCopy"(%"{{.*}}Slice" %{{.*}}, ptr @{{.*}}, i64 4, i64 1)
+// CHECK: store i64 [[COPY_LITERAL]], ptr [[COPY_N]]
+// String range is lowered to one iterator whose yielded index/rune are consumed.
+// CHECK: [[ITER:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.NewStringIter"(%"{{.*}}String" { ptr @{{.*}}, i64 7 })
+// CHECK: [[NEXT:%.*]] = call { i1, i64, i32 } @"{{.*}}/runtime/internal/runtime.StringIterNext"(ptr [[ITER]])
+// CHECK: [[HAS_NEXT:%.*]] = extractvalue { i1, i64, i32 } [[NEXT]], 0
+// CHECK: br i1 [[HAS_NEXT]], label %{{.*}}, label %{{.*}}
+// Floating-point helpers are exercised with both infinity signs and NaN results.
+// CHECK: [[POS_INF:%.*]] = call double @main.Inf(i64 1)
+// CHECK: [[NEG_INF:%.*]] = call double @main.Inf(i64 -1)
+// CHECK: [[NAN_VALUE:%.*]] = call double @main.NaN()
+// CHECK: [[NAN_INPUT:%.*]] = call double @main.NaN()
+// CHECK: [[NAN_TRUE:%.*]] = call i1 @main.IsNaN(double [[NAN_INPUT]])
+// CHECK: [[NAN_FALSE:%.*]] = call i1 @main.IsNaN(double 1.000000e+00)
+// Byte/rune conversions are round-tripped through their originating slices.
+// CHECK: [[BYTES:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.StringToBytes"(%"{{.*}}String" { ptr @{{.*}}, i64 7 })
+// CHECK: [[RUNES:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.StringToRunes"(%"{{.*}}String" { ptr @{{.*}}, i64 7 })
+// CHECK: call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringFromBytes"(%"{{.*}}Slice" [[BYTES]])
+// CHECK: call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringFromRunes"(%"{{.*}}Slice" [[RUNES]])
+// CHECK: [[BYTE_VALUE:%.*]] = load i8, ptr %{{.*}}
+// CHECK: [[BYTE64:%.*]] = zext i8 [[BYTE_VALUE]] to i64
+// CHECK: call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringFromUint64"(i64 [[BYTE64]])
+// CHECK: [[RUNE_VALUE:%.*]] = load i32, ptr %{{.*}}
+// CHECK: [[RUNE64:%.*]] = sext i32 [[RUNE_VALUE]] to i64
+// CHECK: call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringFromInt64"(i64 [[RUNE64]])
 
 func main() {
 	var s = []int{1, 2, 3, 4}
@@ -465,11 +130,6 @@ func main() {
 	println(data)
 	fns := []func(){}
 
-	// CHECK-LABEL: define void @"main.main$1"(){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
-
 	fns = append(fns, func() {})
 	println(fns)
 	var i any = 100
@@ -482,26 +142,9 @@ func main() {
 
 	fn1 := demo
 
-	// CHECK-LABEL: define void @"main.main$2"(){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 2 })
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
-
 	fn2 := func() {
 		println("fn")
 	}
-
-	// CHECK-LABEL: define void @"main.main$3"(ptr {{(nest|swiftself)}} %0){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
-	// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
-	// CHECK-NEXT:   %3 = load i64, ptr %2, align 8
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
 
 	fn3 := func() {
 		println(n)
@@ -522,3 +165,9 @@ func main() {
 	s2 := "abd"
 	println(s1 == "abc", s1 == s2, s1 != s2, s1 < s2, s1 <= s2, s1 > s2, s1 >= s2)
 }
+
+// CHECK-LABEL: define void @"main.main$3"(ptr {{(nest|swiftself)}} %0){{.*}} {
+// CHECK: [[CAPTURE:%.*]] = load { ptr }, ptr %0
+// CHECK: [[N_ADDR:%.*]] = extractvalue { ptr } [[CAPTURE]], 0
+// CHECK: [[N:%.*]] = load i64, ptr [[N_ADDR]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[N]])

--- a/cl/_testrt/callback/in.go
+++ b/cl/_testrt/callback/in.go
@@ -6,33 +6,23 @@ import (
 )
 
 // CHECK-LABEL: define void @main.callback(ptr %0, { ptr, ptr } %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = extractvalue { ptr, ptr } %1, 1
-// CHECK-NEXT:   %3 = extractvalue { ptr, ptr } %1, 0
-// CHECK-NEXT:   %__llgo_funcval_code = call ptr asm "", "=r,0"(ptr %3)
-// CHECK-NEXT:   call void %__llgo_funcval_code(ptr {{(nest|swiftself)}} %2, ptr %0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[CALLBACK_ENV:%[0-9]+]] = extractvalue { ptr, ptr } %1, 1
+// CHECK-NEXT: [[CALLBACK_CODE:%[0-9]+]] = extractvalue { ptr, ptr } %1, 0
+// CHECK: call void %__llgo_funcval_code(ptr {{(nest|swiftself)}} [[CALLBACK_ENV]], ptr %0)
 func callback(msg *c.Char, f func(*c.Char)) {
 	f(msg)
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @main.callback(ptr @0, { ptr, ptr } { ptr @main.print, ptr null })
-// CHECK-NEXT:   call void @main.callback(ptr @1, { ptr, ptr } { ptr @main.print, ptr null })
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @main.callback(ptr @{{[0-9]+}}, { ptr, ptr } { ptr @main.print, ptr null })
+// CHECK-NEXT: call void @main.callback(ptr @{{[0-9]+}}, { ptr, ptr } { ptr @main.print, ptr null })
 func main() {
 	callback(c.Str("Hello\n"), print)
 	callback(c.Str("callback\n"), print)
 }
 
 // CHECK-LABEL: define void @main.print(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call i32 (ptr, ...) @printf(ptr %0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call i32 (ptr, ...) @printf(ptr %0)
 
 func print(msg *c.Char) {
 	c.Printf(msg)

--- a/cl/_testrt/cast/in.go
+++ b/cl/_testrt/cast/in.go
@@ -3,33 +3,19 @@ package main
 
 //"github.com/goplus/lib/c"
 
-// CHECK: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
-
 // CHECK-LABEL: define void @main.cvt32Fto32(float %0, i32 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fcmp ole float %0, 0xC1E0000000000000
-// CHECK-NEXT:   %3 = fcmp oge float %0, 0x41E0000000000000
-// CHECK-NEXT:   %4 = fcmp uno float %0, %0
-// CHECK-NEXT:   %5 = select i1 %2, float 0.000000e+00, float %0
-// CHECK-NEXT:   %6 = select i1 %3, float 0.000000e+00, float %5
-// CHECK-NEXT:   %7 = select i1 %4, float 0.000000e+00, float %6
-// CHECK-NEXT:   %8 = fptosi float %7 to i32
-// CHECK-NEXT:   %9 = select i1 %2, i32 -2147483648, i32 %8
-// CHECK-NEXT:   %10 = select i1 %3, i32 2147483647, i32 %9
-// CHECK-NEXT:   %11 = select i1 %4, i32 0, i32 %10
-// CHECK-NEXT:   %12 = icmp ne i32 %11, %1
-// CHECK-NEXT:   br i1 %12, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %13, align 8
-// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %13, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %14)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F32_I32_BELOW:%.*]] = fcmp ole float %0, {{.*}}
+// CHECK-NEXT: [[F32_I32_ABOVE:%.*]] = fcmp oge float %0, {{.*}}
+// CHECK-NEXT: [[F32_I32_NAN:%.*]] = fcmp uno float %0, %0
+// CHECK-NEXT: [[F32_I32_CLAMP_LOW:%.*]] = select i1 [[F32_I32_BELOW]], float 0.000000e+00, float %0
+// CHECK-NEXT: [[F32_I32_CLAMP_HIGH:%.*]] = select i1 [[F32_I32_ABOVE]], float 0.000000e+00, float [[F32_I32_CLAMP_LOW]]
+// CHECK-NEXT: [[F32_I32_FINITE:%.*]] = select i1 [[F32_I32_NAN]], float 0.000000e+00, float [[F32_I32_CLAMP_HIGH]]
+// CHECK-NEXT: [[F32_I32_RAW:%.*]] = fptosi float [[F32_I32_FINITE]] to i32
+// CHECK-NEXT: [[F32_I32_LOW:%.*]] = select i1 [[F32_I32_BELOW]], i32 -2147483648, i32 [[F32_I32_RAW]]
+// CHECK-NEXT: [[F32_I32_HIGH:%.*]] = select i1 [[F32_I32_ABOVE]], i32 2147483647, i32 [[F32_I32_LOW]]
+// CHECK-NEXT: [[F32_I32_VALUE:%.*]] = select i1 [[F32_I32_NAN]], i32 0, i32 [[F32_I32_HIGH]]
+// CHECK: [[F32_I32_BAD:%.*]] = icmp ne i32 [[F32_I32_VALUE]], %1
+// CHECK: br i1 [[F32_I32_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt32Fto32(a float32, b int32) {
 	if int32(a) != b {
@@ -38,31 +24,19 @@ func cvt32Fto32(a float32, b int32) {
 }
 
 // CHECK-LABEL: define void @main.cvt32Fto32U(float %0, i32 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fcmp ole float %0, 0xC3E0000000000000
-// CHECK-NEXT:   %3 = fcmp oge float %0, 0x43E0000000000000
-// CHECK-NEXT:   %4 = fcmp uno float %0, %0
-// CHECK-NEXT:   %5 = select i1 %2, float 0.000000e+00, float %0
-// CHECK-NEXT:   %6 = select i1 %3, float 0.000000e+00, float %5
-// CHECK-NEXT:   %7 = select i1 %4, float 0.000000e+00, float %6
-// CHECK-NEXT:   %8 = fptosi float %7 to i64
-// CHECK-NEXT:   %9 = select i1 %2, i64 -9223372036854775808, i64 %8
-// CHECK-NEXT:   %10 = select i1 %3, i64 9223372036854775807, i64 %9
-// CHECK-NEXT:   %11 = select i1 %4, i64 0, i64 %10
-// CHECK-NEXT:   %12 = trunc i64 %11 to i32
-// CHECK-NEXT:   %13 = icmp ne i32 %12, %1
-// CHECK-NEXT:   br i1 %13, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %14, align 8
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %14, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %15)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F32_U32_BELOW:%.*]] = fcmp ole float %0, {{.*}}
+// CHECK-NEXT: [[F32_U32_ABOVE:%.*]] = fcmp oge float %0, {{.*}}
+// CHECK-NEXT: [[F32_U32_NAN:%.*]] = fcmp uno float %0, %0
+// CHECK-NEXT: [[F32_U32_CLAMP_LOW:%.*]] = select i1 [[F32_U32_BELOW]], float 0.000000e+00, float %0
+// CHECK-NEXT: [[F32_U32_CLAMP_HIGH:%.*]] = select i1 [[F32_U32_ABOVE]], float 0.000000e+00, float [[F32_U32_CLAMP_LOW]]
+// CHECK-NEXT: [[F32_U32_FINITE:%.*]] = select i1 [[F32_U32_NAN]], float 0.000000e+00, float [[F32_U32_CLAMP_HIGH]]
+// CHECK-NEXT: [[F32_U32_RAW:%.*]] = fptosi float [[F32_U32_FINITE]] to i64
+// CHECK-NEXT: [[F32_U32_LOW:%.*]] = select i1 [[F32_U32_BELOW]], i64 -9223372036854775808, i64 [[F32_U32_RAW]]
+// CHECK-NEXT: [[F32_U32_HIGH:%.*]] = select i1 [[F32_U32_ABOVE]], i64 9223372036854775807, i64 [[F32_U32_LOW]]
+// CHECK-NEXT: [[F32_U32_VALUE64:%.*]] = select i1 [[F32_U32_NAN]], i64 0, i64 [[F32_U32_HIGH]]
+// CHECK: [[F32_U32_VALUE:%.*]] = trunc i64 [[F32_U32_VALUE64]] to i32
+// CHECK: [[F32_U32_BAD:%.*]] = icmp ne i32 [[F32_U32_VALUE]], %1
+// CHECK: br i1 [[F32_U32_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt32Fto32U(a float32, b uint32) {
 	if uint32(a) != b {
@@ -71,21 +45,9 @@ func cvt32Fto32U(a float32, b uint32) {
 }
 
 // CHECK-LABEL: define void @main.cvt32Fto64F(float %0, double %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fpext float %0 to double
-// CHECK-NEXT:   %3 = fcmp une double %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F32_F64_VALUE:%.*]] = fpext float %0 to double
+// CHECK: [[F32_F64_BAD:%.*]] = fcmp une double [[F32_F64_VALUE]], %1
+// CHECK: br i1 [[F32_F64_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt32Fto64F(a float32, b float64) {
 	if float64(a) != b {
@@ -94,31 +56,19 @@ func cvt32Fto64F(a float32, b float64) {
 }
 
 // CHECK-LABEL: define void @main.cvt32Fto8(float %0, i8 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fcmp ole float %0, 0xC1E0000000000000
-// CHECK-NEXT:   %3 = fcmp oge float %0, 0x41E0000000000000
-// CHECK-NEXT:   %4 = fcmp uno float %0, %0
-// CHECK-NEXT:   %5 = select i1 %2, float 0.000000e+00, float %0
-// CHECK-NEXT:   %6 = select i1 %3, float 0.000000e+00, float %5
-// CHECK-NEXT:   %7 = select i1 %4, float 0.000000e+00, float %6
-// CHECK-NEXT:   %8 = fptosi float %7 to i32
-// CHECK-NEXT:   %9 = select i1 %2, i32 -2147483648, i32 %8
-// CHECK-NEXT:   %10 = select i1 %3, i32 2147483647, i32 %9
-// CHECK-NEXT:   %11 = select i1 %4, i32 0, i32 %10
-// CHECK-NEXT:   %12 = trunc i32 %11 to i8
-// CHECK-NEXT:   %13 = icmp ne i8 %12, %1
-// CHECK-NEXT:   br i1 %13, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %14, align 8
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %14, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %15)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F32_I8_BELOW:%.*]] = fcmp ole float %0, {{.*}}
+// CHECK-NEXT: [[F32_I8_ABOVE:%.*]] = fcmp oge float %0, {{.*}}
+// CHECK-NEXT: [[F32_I8_NAN:%.*]] = fcmp uno float %0, %0
+// CHECK-NEXT: [[F32_I8_CLAMP_LOW:%.*]] = select i1 [[F32_I8_BELOW]], float 0.000000e+00, float %0
+// CHECK-NEXT: [[F32_I8_CLAMP_HIGH:%.*]] = select i1 [[F32_I8_ABOVE]], float 0.000000e+00, float [[F32_I8_CLAMP_LOW]]
+// CHECK-NEXT: [[F32_I8_FINITE:%.*]] = select i1 [[F32_I8_NAN]], float 0.000000e+00, float [[F32_I8_CLAMP_HIGH]]
+// CHECK-NEXT: [[F32_I8_RAW:%.*]] = fptosi float [[F32_I8_FINITE]] to i32
+// CHECK-NEXT: [[F32_I8_LOW:%.*]] = select i1 [[F32_I8_BELOW]], i32 -2147483648, i32 [[F32_I8_RAW]]
+// CHECK-NEXT: [[F32_I8_HIGH:%.*]] = select i1 [[F32_I8_ABOVE]], i32 2147483647, i32 [[F32_I8_LOW]]
+// CHECK-NEXT: [[F32_I8_VALUE32:%.*]] = select i1 [[F32_I8_NAN]], i32 0, i32 [[F32_I8_HIGH]]
+// CHECK: [[F32_I8_VALUE:%.*]] = trunc i32 [[F32_I8_VALUE32]] to i8
+// CHECK: [[F32_I8_BAD:%.*]] = icmp ne i8 [[F32_I8_VALUE]], %1
+// CHECK: br i1 [[F32_I8_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt32Fto8(a float32, b int8) {
 	if int8(a) != b {
@@ -127,31 +77,19 @@ func cvt32Fto8(a float32, b int8) {
 }
 
 // CHECK-LABEL: define void @main.cvt32Fto8U(float %0, i8 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fcmp ole float %0, 0xC1E0000000000000
-// CHECK-NEXT:   %3 = fcmp oge float %0, 0x41E0000000000000
-// CHECK-NEXT:   %4 = fcmp uno float %0, %0
-// CHECK-NEXT:   %5 = select i1 %2, float 0.000000e+00, float %0
-// CHECK-NEXT:   %6 = select i1 %3, float 0.000000e+00, float %5
-// CHECK-NEXT:   %7 = select i1 %4, float 0.000000e+00, float %6
-// CHECK-NEXT:   %8 = fptosi float %7 to i32
-// CHECK-NEXT:   %9 = select i1 %2, i32 -2147483648, i32 %8
-// CHECK-NEXT:   %10 = select i1 %3, i32 2147483647, i32 %9
-// CHECK-NEXT:   %11 = select i1 %4, i32 0, i32 %10
-// CHECK-NEXT:   %12 = trunc i32 %11 to i8
-// CHECK-NEXT:   %13 = icmp ne i8 %12, %1
-// CHECK-NEXT:   br i1 %13, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %14, align 8
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %14, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %15)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F32_U8_BELOW:%.*]] = fcmp ole float %0, {{.*}}
+// CHECK-NEXT: [[F32_U8_ABOVE:%.*]] = fcmp oge float %0, {{.*}}
+// CHECK-NEXT: [[F32_U8_NAN:%.*]] = fcmp uno float %0, %0
+// CHECK-NEXT: [[F32_U8_CLAMP_LOW:%.*]] = select i1 [[F32_U8_BELOW]], float 0.000000e+00, float %0
+// CHECK-NEXT: [[F32_U8_CLAMP_HIGH:%.*]] = select i1 [[F32_U8_ABOVE]], float 0.000000e+00, float [[F32_U8_CLAMP_LOW]]
+// CHECK-NEXT: [[F32_U8_FINITE:%.*]] = select i1 [[F32_U8_NAN]], float 0.000000e+00, float [[F32_U8_CLAMP_HIGH]]
+// CHECK-NEXT: [[F32_U8_RAW:%.*]] = fptosi float [[F32_U8_FINITE]] to i32
+// CHECK-NEXT: [[F32_U8_LOW:%.*]] = select i1 [[F32_U8_BELOW]], i32 -2147483648, i32 [[F32_U8_RAW]]
+// CHECK-NEXT: [[F32_U8_HIGH:%.*]] = select i1 [[F32_U8_ABOVE]], i32 2147483647, i32 [[F32_U8_LOW]]
+// CHECK-NEXT: [[F32_U8_VALUE32:%.*]] = select i1 [[F32_U8_NAN]], i32 0, i32 [[F32_U8_HIGH]]
+// CHECK: [[F32_U8_VALUE:%.*]] = trunc i32 [[F32_U8_VALUE32]] to i8
+// CHECK: [[F32_U8_BAD:%.*]] = icmp ne i8 [[F32_U8_VALUE]], %1
+// CHECK: br i1 [[F32_U8_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt32Fto8U(a float32, b uint8) {
 	if uint8(a) != b {
@@ -160,21 +98,9 @@ func cvt32Fto8U(a float32, b uint8) {
 }
 
 // CHECK-LABEL: define void @main.cvt32to64(i32 %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = sext i32 %0 to i64
-// CHECK-NEXT:   %3 = icmp ne i64 %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[I32_I64_VALUE:%.*]] = sext i32 %0 to i64
+// CHECK: [[I32_I64_BAD:%.*]] = icmp ne i64 [[I32_I64_VALUE]], %1
+// CHECK: br i1 [[I32_I64_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt32to64(a int32, b int64) {
 	if int64(a) != b {
@@ -183,21 +109,9 @@ func cvt32to64(a int32, b int64) {
 }
 
 // CHECK-LABEL: define void @main.cvt64Fto32F(double %0, float %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fptrunc double %0 to float
-// CHECK-NEXT:   %3 = fcmp une float %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F64_F32_VALUE:%.*]] = fptrunc double %0 to float
+// CHECK: [[F64_F32_BAD:%.*]] = fcmp une float [[F64_F32_VALUE]], %1
+// CHECK: br i1 [[F64_F32_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt64Fto32F(a float64, b float32) {
 	if float32(a) != b {
@@ -206,21 +120,9 @@ func cvt64Fto32F(a float64, b float32) {
 }
 
 // CHECK-LABEL: define void @main.cvt64Uto64F(i64 %0, double %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = uitofp i64 %0 to double
-// CHECK-NEXT:   %3 = fcmp une double %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[U64_F64_VALUE:%.*]] = uitofp i64 %0 to double
+// CHECK: [[U64_F64_BAD:%.*]] = fcmp une double [[U64_F64_VALUE]], %1
+// CHECK: br i1 [[U64_F64_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt64Uto64F(a uint64, b float64) {
 	if float64(a) != b {
@@ -229,21 +131,9 @@ func cvt64Uto64F(a uint64, b float64) {
 }
 
 // CHECK-LABEL: define void @main.cvt64to64F(i64 %0, double %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = sitofp i64 %0 to double
-// CHECK-NEXT:   %3 = fcmp une double %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[I64_F64_VALUE:%.*]] = sitofp i64 %0 to double
+// CHECK: [[I64_F64_BAD:%.*]] = fcmp une double [[I64_F64_VALUE]], %1
+// CHECK: br i1 [[I64_F64_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt64to64F(a int64, b float64) {
 	if float64(a) != b {
@@ -252,21 +142,9 @@ func cvt64to64F(a int64, b float64) {
 }
 
 // CHECK-LABEL: define void @main.cvt64to8(i64 %0, i8 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = trunc i64 %0 to i8
-// CHECK-NEXT:   %3 = icmp ne i8 %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[I64_I8_VALUE:%.*]] = trunc i64 %0 to i8
+// CHECK: [[I64_I8_BAD:%.*]] = icmp ne i8 [[I64_I8_VALUE]], %1
+// CHECK: br i1 [[I64_I8_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt64to8(a int64, b int8) {
 	if int8(a) != b {
@@ -275,21 +153,9 @@ func cvt64to8(a int64, b int8) {
 }
 
 // CHECK-LABEL: define void @main.cvt64to8U(i64 %0, i8 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = trunc i64 %0 to i8
-// CHECK-NEXT:   %3 = icmp ne i8 %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[I64_U8_VALUE:%.*]] = trunc i64 %0 to i8
+// CHECK: [[I64_U8_BAD:%.*]] = icmp ne i8 [[I64_U8_VALUE]], %1
+// CHECK: br i1 [[I64_U8_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvt64to8U(a int, b uint8) {
 	if uint8(a) != b {
@@ -298,30 +164,18 @@ func cvt64to8U(a int, b uint8) {
 }
 
 // CHECK-LABEL: define void @main.cvtFtoUintptr(double %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = fcmp olt double %0, 0.000000e+00
-// CHECK-NEXT:   %3 = fcmp oge double %0, 0x43F0000000000000
-// CHECK-NEXT:   %4 = fcmp uno double %0, %0
-// CHECK-NEXT:   %5 = select i1 %2, double 0.000000e+00, double %0
-// CHECK-NEXT:   %6 = select i1 %3, double 0.000000e+00, double %5
-// CHECK-NEXT:   %7 = select i1 %4, double 0.000000e+00, double %6
-// CHECK-NEXT:   %8 = fptoui double %7 to i64
-// CHECK-NEXT:   %9 = select i1 %3, i64 -1, i64 %8
-// CHECK-NEXT:   %10 = select i1 %2, i64 0, i64 %9
-// CHECK-NEXT:   %11 = select i1 %4, i64 0, i64 %10
-// CHECK-NEXT:   %12 = icmp ne i64 %11, %1
-// CHECK-NEXT:   br i1 %12, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %13, align 8
-// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %13, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %14)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[F64_UINTPTR_BELOW:%.*]] = fcmp olt double %0, 0.000000e+00
+// CHECK-NEXT: [[F64_UINTPTR_ABOVE:%.*]] = fcmp oge double %0, {{.*}}
+// CHECK-NEXT: [[F64_UINTPTR_NAN:%.*]] = fcmp uno double %0, %0
+// CHECK-NEXT: [[F64_UINTPTR_CLAMP_LOW:%.*]] = select i1 [[F64_UINTPTR_BELOW]], double 0.000000e+00, double %0
+// CHECK-NEXT: [[F64_UINTPTR_CLAMP_HIGH:%.*]] = select i1 [[F64_UINTPTR_ABOVE]], double 0.000000e+00, double [[F64_UINTPTR_CLAMP_LOW]]
+// CHECK-NEXT: [[F64_UINTPTR_FINITE:%.*]] = select i1 [[F64_UINTPTR_NAN]], double 0.000000e+00, double [[F64_UINTPTR_CLAMP_HIGH]]
+// CHECK-NEXT: [[F64_UINTPTR_RAW:%.*]] = fptoui double [[F64_UINTPTR_FINITE]] to i64
+// CHECK-NEXT: [[F64_UINTPTR_HIGH:%.*]] = select i1 [[F64_UINTPTR_ABOVE]], i64 -1, i64 [[F64_UINTPTR_RAW]]
+// CHECK-NEXT: [[F64_UINTPTR_LOW:%.*]] = select i1 [[F64_UINTPTR_BELOW]], i64 0, i64 [[F64_UINTPTR_HIGH]]
+// CHECK-NEXT: [[F64_UINTPTR_VALUE:%.*]] = select i1 [[F64_UINTPTR_NAN]], i64 0, i64 [[F64_UINTPTR_LOW]]
+// CHECK: [[F64_UINTPTR_BAD:%.*]] = icmp ne i64 [[F64_UINTPTR_VALUE]], %1
+// CHECK: br i1 [[F64_UINTPTR_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvtFtoUintptr(a float64, b uintptr) {
 	if uintptr(a) != b {
@@ -330,33 +184,12 @@ func cvtFtoUintptr(a float64, b uintptr) {
 }
 
 // CHECK-LABEL: define void @main.cvtUinptr(i32 %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = sext i32 %0 to i64
-// CHECK-NEXT:   %3 = icmp ne i64 %2, %1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %6 = trunc i64 %1 to i32
-// CHECK-NEXT:   %7 = icmp ne i32 %6, %0
-// CHECK-NEXT:   br i1 %7, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %8, align 8
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %8, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %9)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[INT_UINTPTR_VALUE:%.*]] = sext i32 %0 to i64
+// CHECK: [[INT_UINTPTR_BAD:%.*]] = icmp ne i64 [[INT_UINTPTR_VALUE]], %1
+// CHECK: br i1 [[INT_UINTPTR_BAD]], label %{{.*}}, label %{{.*}}
+// CHECK: [[UINTPTR_INT_VALUE:%.*]] = trunc i64 %1 to i32
+// CHECK: [[UINTPTR_INT_BAD:%.*]] = icmp ne i32 [[UINTPTR_INT_VALUE]], %0
+// CHECK: br i1 [[UINTPTR_INT_BAD]], label %{{.*}}, label %{{.*}}
 
 func cvtUinptr(a int32, b uintptr) {
 	if uintptr(a) != b {
@@ -447,76 +280,3 @@ func main() {
 	cvtFtoUintptr(0.0, 0)
 	cvtFtoUintptr(1e5, 100000)
 }
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @main.cvt64to8(i64 0, i8 0)
-// CHECK-NEXT:   call void @main.cvt64to8(i64 127, i8 127)
-// CHECK-NEXT:   call void @main.cvt64to8(i64 128, i8 -128)
-// CHECK-NEXT:   call void @main.cvt64to8(i64 -128, i8 -128)
-// CHECK-NEXT:   call void @main.cvt64to8(i64 -129, i8 127)
-// CHECK-NEXT:   call void @main.cvt64to8(i64 256, i8 0)
-// CHECK-NEXT:   call void @main.cvt64to8U(i64 0, i8 0)
-// CHECK-NEXT:   call void @main.cvt64to8U(i64 255, i8 -1)
-// CHECK-NEXT:   call void @main.cvt64to8U(i64 256, i8 0)
-// CHECK-NEXT:   call void @main.cvt64to8U(i64 257, i8 1)
-// CHECK-NEXT:   call void @main.cvt64to8U(i64 -1, i8 -1)
-// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x3FB99999A0000000, i8 0)
-// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x405FC66660000000, i8 127)
-// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x4060033340000000, i8 -128)
-// CHECK-NEXT:   call void @main.cvt32Fto8(float 0xC060033340000000, i8 -128)
-// CHECK-NEXT:   call void @main.cvt32Fto8(float 0xC060233340000000, i8 127)
-// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x40700199A0000000, i8 0)
-// CHECK-NEXT:   call void @main.cvt32Fto8U(float 0.000000e+00, i8 0)
-// CHECK-NEXT:   call void @main.cvt32Fto8U(float 2.550000e+02, i8 -1)
-// CHECK-NEXT:   call void @main.cvt32Fto8U(float 2.560000e+02, i8 0)
-// CHECK-NEXT:   call void @main.cvt32Fto8U(float 2.570000e+02, i8 1)
-// CHECK-NEXT:   call void @main.cvt32Fto8U(float -1.000000e+00, i8 -1)
-// CHECK-NEXT:   call void @main.cvt32Fto32(float 0.000000e+00, i32 0)
-// CHECK-NEXT:   call void @main.cvt32Fto32(float 1.500000e+00, i32 1)
-// CHECK-NEXT:   call void @main.cvt32Fto32(float 0x41D1194D80000000, i32 1147483648)
-// CHECK-NEXT:   call void @main.cvt32Fto32(float 0xC1E0000000000000, i32 -2147483648)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0.000000e+00, i32 0)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 1.500000e+00, i32 1)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0x41F0000000000000, i32 0)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0x41F3B9ACA0000000, i32 1000000000)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0xC1F0000000000000, i32 0)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0xC1D34BE880000000, i32 -1294967296)
-// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0xBFF19999A0000000, i32 -1)
-// CHECK-NEXT:   call void @main.cvt32Fto64F(float 0.000000e+00, double 0.000000e+00)
-// CHECK-NEXT:   call void @main.cvt32Fto64F(float 1.500000e+00, double 1.500000e+00)
-// CHECK-NEXT:   call void @main.cvt32Fto64F(float 1.000000e+10, double 1.000000e+10)
-// CHECK-NEXT:   call void @main.cvt32Fto64F(float -1.000000e+10, double -1.000000e+10)
-// CHECK-NEXT:   call void @main.cvt64Fto32F(double 0.000000e+00, float 0.000000e+00)
-// CHECK-NEXT:   call void @main.cvt64Fto32F(double 1.500000e+00, float 1.500000e+00)
-// CHECK-NEXT:   call void @main.cvt64Fto32F(double 1.000000e+10, float 1.000000e+10)
-// CHECK-NEXT:   call void @main.cvt64Fto32F(double -1.000000e+10, float -1.000000e+10)
-// CHECK-NEXT:   call void @main.cvt64to64F(i64 0, double 0.000000e+00)
-// CHECK-NEXT:   call void @main.cvt64to64F(i64 10000000000, double 1.000000e+10)
-// CHECK-NEXT:   call void @main.cvt64to64F(i64 9223372036854775807, double 0x43E0000000000000)
-// CHECK-NEXT:   call void @main.cvt64to64F(i64 -9223372036854775807, double 0xC3E0000000000000)
-// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 0, double 0.000000e+00)
-// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 10000000000, double 1.000000e+10)
-// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 9223372036854775807, double 0x43E0000000000000)
-// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 -1, double 0x43F0000000000000)
-// CHECK-NEXT:   call void @main.cvt32to64(i32 0, i64 0)
-// CHECK-NEXT:   call void @main.cvt32to64(i32 2147483647, i64 2147483647)
-// CHECK-NEXT:   call void @main.cvtUinptr(i32 1024, i64 1024)
-// CHECK-NEXT:   call void @main.cvtFtoUintptr(double 1.000000e+02, i64 100)
-// CHECK-NEXT:   call void @main.cvtFtoUintptr(double 0.000000e+00, i64 0)
-// CHECK-NEXT:   call void @main.cvtFtoUintptr(double 1.000000e+05, i64 100000)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }

--- a/cl/_testrt/clear/in.go
+++ b/cl/_testrt/clear/in.go
@@ -2,44 +2,13 @@
 package clear
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/clear.Clear"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
-// CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %0, i64 1
-// CHECK-NEXT:   store i64 2, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %0, i64 2
-// CHECK-NEXT:   store i64 3, ptr %3, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %0, i64 3
-// CHECK-NEXT:   store i64 4, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %5, i64 4, 1
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, i64 4, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SliceClear"(ptr @"[]_llgo_int", %"{{.*}}/runtime/internal/runtime.Slice" %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_int", i64 4)
-// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %9, align 8
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr %8, ptr %9)
-// CHECK-NEXT:   store i64 1, ptr %10, align 8
-// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 2, ptr %11, align 8
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr %8, ptr %11)
-// CHECK-NEXT:   store i64 2, ptr %12, align 8
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 3, ptr %13, align 8
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr %8, ptr %13)
-// CHECK-NEXT:   store i64 3, ptr %14, align 8
-// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 4, ptr %15, align 8
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr %8, ptr %15)
-// CHECK-NEXT:   store i64 4, ptr %16, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.MapClear"(ptr @"map[_llgo_int]_llgo_int", ptr %8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[CLEAR_SLICE:%[0-9]+]] = insertvalue %"{{.*}}Slice" %{{[0-9]+}}, i64 4, 2
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.SliceClear"(ptr @"[]_llgo_int", %"{{.*}}Slice" [[CLEAR_SLICE]])
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}Slice" [[CLEAR_SLICE]])
+// CHECK: [[CLEAR_MAP:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_int", i64 4)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.MapClear"(ptr @"map[_llgo_int]_llgo_int", ptr [[CLEAR_MAP]])
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr [[CLEAR_MAP]])
+
 func Clear() {
 	a := []int{1, 2, 3, 4}
 	clear(a)

--- a/cl/_testrt/closurebound/in.go
+++ b/cl/_testrt/closurebound/in.go
@@ -1,20 +1,10 @@
 // LITTEST
 package main
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo1", align 1{{$}}
-// CHECK: {{^}}@1 = private unnamed_addr constant [6 x i8] c"encode", align 1{{$}}
-// CHECK: {{^}}@2 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo2", align 1{{$}}
-// CHECK: {{^}}@3 = private unnamed_addr constant [5 x i8] c"error", align 1{{$}}
-
 var my = demo2{}.encode
 
 type demo1 struct {
 }
-
-// CHECK-LABEL: define i64 @main.demo1.encode(%main.demo1 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret i64 1
-// CHECK-NEXT: }
 
 func (se demo1) encode() int {
 	return 1
@@ -35,74 +25,33 @@ func main() {
 	}
 }
 
+// Pointer receiver wrappers must guard nil before calling the value receiver.
 // CHECK-LABEL: define i64 @"main.(*demo1).encode"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
-// CHECK-NEXT:   %2 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
-// CHECK-NEXT:   ret i64 %3
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define i64 @main.demo2.encode(%main.demo2 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret i64 2
-// CHECK-NEXT: }
+// CHECK: %[[D1_NIL:[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %[[D1_NIL]],{{.*}})
+// CHECK: call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
 
 // CHECK-LABEL: define i64 @"main.(*demo2).encode"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
-// CHECK-NEXT:   %2 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
-// CHECK-NEXT:   ret i64 %3
-// CHECK-NEXT: }
+// CHECK: %[[D2_NIL:[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %[[D2_NIL]],{{.*}})
+// CHECK: call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
 
+// The package-global method value stores both the selected bound wrapper and
+// the zero-sized receiver in init.
 // CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"main.demo2.encode$bound", ptr @"__llgo.moduleZeroSizedAlloc$" }, ptr @main.my, align 8
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: store { ptr, ptr } { ptr @"main.demo2.encode$bound", ptr @"__llgo.moduleZeroSizedAlloc$" }, ptr @main.my
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"main.demo1.encode$bound"(ptr {{(nest|swiftself)}} @"__llgo.moduleZeroSizedAlloc$")
-// CHECK-NEXT:   %1 = icmp ne i64 %0, 1
-// CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %2, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %3)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: %[[RESULT:[0-9]+]] = call i64 @"main.demo1.encode$bound"(ptr {{(nest|swiftself)}} @"__llgo.moduleZeroSizedAlloc$")
+// CHECK: %[[BAD:[0-9]+]] = icmp ne i64 %[[RESULT]], 1
+// CHECK: br i1 %[[BAD]]
 
 // CHECK-LABEL: define i64 @"main.demo2.encode$bound"(ptr {{(nest|swiftself)}} %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-// CHECK-NEXT:   %2 = call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %{{[0-9]+}})
+// CHECK: %[[D2_RESULT:[0-9]+]] = call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
+// CHECK: ret i64 %[[D2_RESULT]]
 
 // CHECK-LABEL: define i64 @"main.demo1.encode$bound"(ptr {{(nest|swiftself)}} %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-// CHECK-NEXT:   %2 = call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %{{[0-9]+}})
+// CHECK: %[[D1_RESULT:[0-9]+]] = call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
+// CHECK: ret i64 %[[D1_RESULT]]

--- a/cl/_testrt/closureconv/in.go
+++ b/cl/_testrt/closureconv/in.go
@@ -9,45 +9,40 @@ type Call struct {
 	n  int
 }
 
+// The bound method must forward both call arguments and read n from the same
+// receiver captured in the function environment.
 // CHECK-LABEL: define i64 @"main.(*Call).add"(ptr %0, i64 %1, i64 %2){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = add i64 %1, %2
-// CHECK-NEXT:   %4 = getelementptr inbounds %main.Call, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %5 = load i64, ptr %4, align 8
-// CHECK-NEXT:   %6 = add i64 %3, %5
-// CHECK-NEXT:   ret i64 %6
-// CHECK-NEXT: }
+// CHECK: [[ADD_AB:%.*]] = add i64 %1, %2
+// CHECK: [[ADD_N_FIELD:%.*]] = getelementptr inbounds %main.Call, ptr %0, i32 0, i32 1
+// CHECK-NEXT: [[ADD_N:%.*]] = load i64, ptr [[ADD_N_FIELD]]
+// CHECK-NEXT: [[ADD_RESULT:%.*]] = add i64 [[ADD_AB]], [[ADD_N]]
+// CHECK-NEXT: ret i64 [[ADD_RESULT]]
 func (c *Call) add(a int, b int) int {
 	return a + b + c.n
 }
 
 // CHECK-LABEL: define i64 @main.add(i64 %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = add i64 %0, %1
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
+// CHECK: [[ADD_PLAIN_RESULT:%.*]] = add i64 %0, %1
+// CHECK-NEXT: ret i64 [[ADD_PLAIN_RESULT]]
 func add(a int, b int) int {
 	return a + b
 }
 
 // CHECK-LABEL: define %main.Func @main.demo1(i64 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 1
-// CHECK-NEXT:   store i64 %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
-// CHECK-NEXT:   store ptr %1, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %6 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %7 = alloca %main.Func, align 8
-// CHECK-NEXT:   store { ptr, ptr } %5, ptr %7, align 8
-// CHECK-NEXT:   %8 = load %main.Func, ptr %7, align 8
-// CHECK-NEXT:   store %main.Func %8, ptr %6, align 8
-// CHECK-NEXT:   %9 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %10 = load %main.Func, ptr %9, align 8
-// CHECK-NEXT:   ret %main.Func %10
-// CHECK-NEXT: }
+// CHECK: [[DEMO1_CALL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+// CHECK: [[DEMO1_N:%.*]] = getelementptr inbounds %main.Call, ptr [[DEMO1_CALL]], i32 0, i32 1
+// CHECK: store i64 %0, ptr [[DEMO1_N]]
+// CHECK: [[DEMO1_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO1_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[DEMO1_ENV]], i32 0, i32 0
+// CHECK: store ptr [[DEMO1_CALL]], ptr [[DEMO1_ENV_SLOT]]
+// CHECK: [[DEMO1_BOUND:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr [[DEMO1_ENV]], 1
+// CHECK: [[DEMO1_FN_FIELD:%.*]] = getelementptr inbounds %main.Call, ptr [[DEMO1_CALL]], i32 0, i32 0
+// CHECK: store { ptr, ptr } [[DEMO1_BOUND]], ptr [[DEMO1_BOUND_SLOT:%.*]]
+// CHECK-NEXT: [[DEMO1_BOUND_VALUE:%.*]] = load %main.Func, ptr [[DEMO1_BOUND_SLOT]]
+// CHECK-NEXT: store %main.Func [[DEMO1_BOUND_VALUE]], ptr [[DEMO1_FN_FIELD]]
+// CHECK: [[DEMO1_RET_FIELD:%.*]] = getelementptr inbounds %main.Call, ptr [[DEMO1_CALL]], i32 0, i32 0
+// CHECK: [[DEMO1_RET:%.*]] = load %main.Func, ptr [[DEMO1_RET_FIELD]]
+// CHECK: ret %main.Func [[DEMO1_RET]]
 func demo1(n int) Func {
 	m := &Call{n: n}
 	m.fn = m.add
@@ -55,17 +50,14 @@ func demo1(n int) Func {
 }
 
 // CHECK-LABEL: define %main.Func @main.demo2(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %4 = alloca %main.Func, align 8
-// CHECK-NEXT:   store { ptr, ptr } %3, ptr %4, align 8
-// CHECK-NEXT:   %5 = load %main.Func, ptr %4, align 8
-// CHECK-NEXT:   ret %main.Func %5
-// CHECK-NEXT: }
+// CHECK: [[DEMO2_CALL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+// CHECK: [[DEMO2_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO2_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[DEMO2_ENV]], i32 0, i32 0
+// CHECK: store ptr [[DEMO2_CALL]], ptr [[DEMO2_ENV_SLOT]]
+// CHECK: [[DEMO2_BOUND:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr [[DEMO2_ENV]], 1
+// CHECK: store { ptr, ptr } [[DEMO2_BOUND]], ptr [[DEMO2_OUT:%.*]]
+// CHECK: [[DEMO2_RET:%.*]] = load %main.Func, ptr [[DEMO2_OUT]]
+// CHECK: ret %main.Func [[DEMO2_RET]]
 
 func demo2() Func {
 	m := &Call{}
@@ -73,115 +65,78 @@ func demo2() Func {
 }
 
 // CHECK-LABEL: define %main.Func @main.demo3(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %main.Func { ptr @main.add, ptr null }
-// CHECK-NEXT: }
+// CHECK: ret %main.Func { ptr @main.add, ptr null }
 
 func demo3() Func {
 	return add
 }
 
 // CHECK-LABEL: define %main.Func @main.demo4(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %main.Func { ptr @"main.demo4$1", ptr null }
-// CHECK-NEXT: }
+// CHECK:   ret %main.Func { ptr @"main.demo4$1", ptr null }
 
 // CHECK-LABEL: define i64 @"main.demo4$1"(i64 %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = add i64 %0, %1
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
+// CHECK: [[DEMO4_RESULT:%.*]] = add i64 %0, %1
+// CHECK: ret i64 [[DEMO4_RESULT]]
 func demo4() Func {
 	return func(a, b int) int { return a + b }
 }
 
 // CHECK-LABEL: define %main.Func @main.demo5(i64 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   store i64 %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   store ptr %1, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"main.demo5$1", ptr undef }, ptr %2, 1
-// CHECK-NEXT:   %5 = alloca %main.Func, align 8
-// CHECK-NEXT:   store { ptr, ptr } %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = load %main.Func, ptr %5, align 8
-// CHECK-NEXT:   ret %main.Func %6
-// CHECK-NEXT: }
+// CHECK: [[DEMO5_CAPTURE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK: store i64 %0, ptr [[DEMO5_CAPTURE]]
+// CHECK: [[DEMO5_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO5_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[DEMO5_ENV]], i32 0, i32 0
+// CHECK: store ptr [[DEMO5_CAPTURE]], ptr [[DEMO5_ENV_SLOT]]
+// CHECK: [[DEMO5_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.demo5$1", ptr undef }, ptr [[DEMO5_ENV]], 1
+// CHECK: store { ptr, ptr } [[DEMO5_FN]], ptr [[DEMO5_OUT:%.*]]
+// CHECK: [[DEMO5_RET:%.*]] = load %main.Func, ptr [[DEMO5_OUT]]
+// CHECK: ret %main.Func [[DEMO5_RET]]
 
 // CHECK-LABEL: define i64 @"main.demo5$1"(ptr {{(nest|swiftself)}} %0, i64 %1, i64 %2){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = add i64 %1, %2
-// CHECK-NEXT:   %4 = load { ptr }, ptr %0, align 8
-// CHECK-NEXT:   %5 = extractvalue { ptr } %4, 0
-// CHECK-NEXT:   %6 = load i64, ptr %5, align 8
-// CHECK-NEXT:   %7 = add i64 %3, %6
-// CHECK-NEXT:   ret i64 %7
-// CHECK-NEXT: }
+// CHECK: [[DEMO5_SUM:%.*]] = add i64 %1, %2
+// CHECK: [[DEMO5_ENV_VALUE:%.*]] = load { ptr }, ptr %0
+// CHECK: [[DEMO5_CAPTURE_ADDR:%.*]] = extractvalue { ptr } [[DEMO5_ENV_VALUE]], 0
+// CHECK: [[DEMO5_CAPTURE_VALUE:%.*]] = load i64, ptr [[DEMO5_CAPTURE_ADDR]]
+// CHECK: [[DEMO5_RESULT:%.*]] = add i64 [[DEMO5_SUM]], [[DEMO5_CAPTURE_VALUE]]
+// CHECK: ret i64 [[DEMO5_RESULT]]
 func demo5(n int) Func {
 	return func(a, b int) int { return a + b + n }
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %main.Func @main.demo1(i64 1)
-// CHECK-NEXT:   %1 = extractvalue %main.Func %0, 1
-// CHECK-NEXT:   %2 = extractvalue %main.Func %0, 0
-// CHECK-NEXT:   %__llgo_funcval_code = call ptr asm "", "=r,0"(ptr %2)
-// CHECK-NEXT:   %3 = call i64 %__llgo_funcval_code(ptr {{(nest|swiftself)}} %1, i64 99, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = call %main.Func @main.demo2()
-// CHECK-NEXT:   %5 = extractvalue %main.Func %4, 1
-// CHECK-NEXT:   %6 = extractvalue %main.Func %4, 0
-// CHECK-NEXT:   %__llgo_funcval_code1 = call ptr asm "", "=r,0"(ptr %6)
-// CHECK-NEXT:   %7 = call i64 %__llgo_funcval_code1(ptr {{(nest|swiftself)}} %5, i64 100, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = call %main.Func @main.demo3()
-// CHECK-NEXT:   %9 = extractvalue %main.Func %8, 1
-// CHECK-NEXT:   %10 = extractvalue %main.Func %8, 0
-// CHECK-NEXT:   %__llgo_funcval_code2 = call ptr asm "", "=r,0"(ptr %10)
-// CHECK-NEXT:   %11 = call i64 %__llgo_funcval_code2(ptr {{(nest|swiftself)}} %9, i64 100, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %11)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = call %main.Func @main.demo4()
-// CHECK-NEXT:   %13 = extractvalue %main.Func %12, 1
-// CHECK-NEXT:   %14 = extractvalue %main.Func %12, 0
-// CHECK-NEXT:   %__llgo_funcval_code3 = call ptr asm "", "=r,0"(ptr %14)
-// CHECK-NEXT:   %15 = call i64 %__llgo_funcval_code3(ptr {{(nest|swiftself)}} %13, i64 100, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %16 = call %main.Func @main.demo5(i64 1)
-// CHECK-NEXT:   %17 = extractvalue %main.Func %16, 1
-// CHECK-NEXT:   %18 = extractvalue %main.Func %16, 0
-// CHECK-NEXT:   %__llgo_funcval_code4 = call ptr asm "", "=r,0"(ptr %18)
-// CHECK-NEXT:   %19 = call i64 %__llgo_funcval_code4(ptr {{(nest|swiftself)}} %17, i64 99, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %19)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %20 = call %main.Func @main.demo5(i64 1)
-// CHECK-NEXT:   %21 = alloca { ptr, ptr }, align 8
-// CHECK-NEXT:   store %main.Func %20, ptr %21, align 8
-// CHECK-NEXT:   %22 = load { ptr, ptr }, ptr %21, align 8
-// CHECK-NEXT:   %23 = extractvalue { ptr, ptr } %22, 1
-// CHECK-NEXT:   %24 = extractvalue { ptr, ptr } %22, 0
-// CHECK-NEXT:   %__llgo_funcval_code5 = call ptr asm "", "=r,0"(ptr %24)
-// CHECK-NEXT:   %25 = call i64 %__llgo_funcval_code5(ptr {{(nest|swiftself)}} %23, i64 99, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %25)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %26 = call %main.Func @main.demo5(i64 1)
-// CHECK-NEXT:   %27 = extractvalue %main.Func %26, 0
-// CHECK-NEXT:   %28 = insertvalue %main.Func2 undef, ptr %27, 0
-// CHECK-NEXT:   %29 = extractvalue %main.Func %26, 1
-// CHECK-NEXT:   %30 = insertvalue %main.Func2 %28, ptr %29, 1
-// CHECK-NEXT:   %31 = extractvalue %main.Func2 %30, 1
-// CHECK-NEXT:   %32 = extractvalue %main.Func2 %30, 0
-// CHECK-NEXT:   %__llgo_funcval_code6 = call ptr asm "", "=r,0"(ptr %32)
-// CHECK-NEXT:   %33 = call i64 %__llgo_funcval_code6(ptr {{(nest|swiftself)}} %31, i64 99, i64 200)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %33)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// Each returned function value supplies both the code and environment used by its call.
+// CHECK: [[MAIN_F1:%.*]] = call %main.Func @main.demo1(i64 1)
+// CHECK: [[MAIN_F1_ENV:%.*]] = extractvalue %main.Func [[MAIN_F1]], 1
+// CHECK: [[MAIN_F1_CODE_RAW:%.*]] = extractvalue %main.Func [[MAIN_F1]], 0
+// CHECK: [[MAIN_F1_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[MAIN_F1_CODE_RAW]])
+// CHECK: [[MAIN_R1:%.*]] = call i64 [[MAIN_F1_CODE]](ptr {{(nest|swiftself)}} [[MAIN_F1_ENV]], i64 99, i64 200)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[MAIN_R1]])
+// The individual demo2, demo3, and demo4 functions above check their distinct
+// construction forms; one captured closure is enough to cover invocation here.
+// CHECK: [[MAIN_F5:%.*]] = call %main.Func @main.demo5(i64 1)
+// CHECK: [[MAIN_F5_ENV:%.*]] = extractvalue %main.Func [[MAIN_F5]], 1
+// CHECK: [[MAIN_F5_CODE_RAW:%.*]] = extractvalue %main.Func [[MAIN_F5]], 0
+// CHECK: [[MAIN_F5_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[MAIN_F5_CODE_RAW]])
+// CHECK: [[MAIN_R5:%.*]] = call i64 [[MAIN_F5_CODE]](ptr {{(nest|swiftself)}} [[MAIN_F5_ENV]], i64 99, i64 200)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[MAIN_R5]])
+// Conversion to the unnamed function type preserves the two function words.
+// CHECK: [[PLAIN_SOURCE:%.*]] = call %main.Func @main.demo5(i64 1)
+// CHECK: store %main.Func [[PLAIN_SOURCE]], ptr [[PLAIN_SLOT:%.*]]
+// CHECK: [[PLAIN_FN:%.*]] = load { ptr, ptr }, ptr [[PLAIN_SLOT]]
+// CHECK: [[PLAIN_ENV:%.*]] = extractvalue { ptr, ptr } [[PLAIN_FN]], 1
+// CHECK: [[PLAIN_CODE_RAW:%.*]] = extractvalue { ptr, ptr } [[PLAIN_FN]], 0
+// CHECK: [[PLAIN_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[PLAIN_CODE_RAW]])
+// CHECK: call i64 [[PLAIN_CODE]](ptr {{(nest|swiftself)}} [[PLAIN_ENV]], i64 99, i64 200)
+// Conversion from Func to Func2 preserves code and environment independently.
+// CHECK: [[FUNC2_SOURCE:%.*]] = call %main.Func @main.demo5(i64 1)
+// CHECK: [[FUNC2_CODE:%.*]] = extractvalue %main.Func [[FUNC2_SOURCE]], 0
+// CHECK: [[FUNC2_0:%.*]] = insertvalue %main.Func2 undef, ptr [[FUNC2_CODE]], 0
+// CHECK: [[FUNC2_ENV:%.*]] = extractvalue %main.Func [[FUNC2_SOURCE]], 1
+// CHECK: [[FUNC2:%.*]] = insertvalue %main.Func2 [[FUNC2_0]], ptr [[FUNC2_ENV]], 1
+// CHECK: [[FUNC2_CALL_ENV:%.*]] = extractvalue %main.Func2 [[FUNC2]], 1
+// CHECK: [[FUNC2_CALL_CODE_RAW:%.*]] = extractvalue %main.Func2 [[FUNC2]], 0
+// CHECK: [[FUNC2_CALL_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[FUNC2_CALL_CODE_RAW]])
+// CHECK: call i64 [[FUNC2_CALL_CODE]](ptr {{(nest|swiftself)}} [[FUNC2_CALL_ENV]], i64 99, i64 200)
 
 func main() {
 	n1 := demo1(1)(99, 200)
@@ -207,9 +162,7 @@ func main() {
 }
 
 // CHECK-LABEL: define i64 @"main.(*Call).add$bound"(ptr {{(nest|swiftself)}} %0, i64 %1, i64 %2){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = load { ptr }, ptr %0, align 8
-// CHECK-NEXT:   %4 = extractvalue { ptr } %3, 0
-// CHECK-NEXT:   %5 = call i64 @"main.(*Call).add"(ptr %4, i64 %1, i64 %2)
-// CHECK-NEXT:   ret i64 %5
-// CHECK-NEXT: }
+// CHECK: [[BOUND_ENV:%.*]] = load { ptr }, ptr %0
+// CHECK: [[BOUND_CALL:%.*]] = extractvalue { ptr } [[BOUND_ENV]], 0
+// CHECK: [[BOUND_RESULT:%.*]] = call i64 @"main.(*Call).add"(ptr [[BOUND_CALL]], i64 %1, i64 %2)
+// CHECK: ret i64 [[BOUND_RESULT]]

--- a/cl/_testrt/constuptr/in.go
+++ b/cl/_testrt/constuptr/in.go
@@ -6,11 +6,7 @@ import (
 )
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr inttoptr (i64 100 to ptr))
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr inttoptr (i64 100 to ptr))
 func main() {
 	a := unsafe.Pointer(uintptr(100))
 	println(a)

--- a/cl/_testrt/cstr/in.go
+++ b/cl/_testrt/cstr/in.go
@@ -3,19 +3,15 @@ package main
 
 import _ "unsafe"
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [14 x i8] c"Hello, world\0A\00", align 1{{$}}
-
 //go:linkname cstr llgo.cstr
 func cstr(string) *int8
 
 //go:linkname printf C.printf
 func printf(format *int8, __llgo_va_list ...any)
 
+// CHECK: [[CSTR_TEXT:@[0-9]+]] = private unnamed_addr constant [14 x i8] c"Hello, world\0A\00"
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void (ptr, ...) @printf(ptr [[CSTR_TEXT]])
 func main() {
 	printf(cstr("Hello, world\n"))
 }

--- a/cl/_testrt/cvar/in.go
+++ b/cl/_testrt/cvar/in.go
@@ -3,7 +3,7 @@ package main
 
 import _ "unsafe"
 
-// CHECK: {{^}}@_bar_x = external global { [16 x i8], [2 x ptr] }, align 8{{$}}
+// CHECK: {{^}}@_bar_x = external global { [16 x i8], [2 x ptr] }
 //
 //go:linkname barX _bar_x
 var barX struct {
@@ -11,7 +11,7 @@ var barX struct {
 	Callbacks [2]func()
 }
 
-// CHECK: {{^}}@_bar_y = external global { [16 x i8] }, align 1{{$}}
+// CHECK: {{^}}@_bar_y = external global { [16 x i8] }
 //
 //go:linkname barY _bar_y
 var barY struct {
@@ -19,11 +19,8 @@ var barY struct {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load { [16 x i8], [2 x ptr] }, ptr @_bar_x, align 8
-// CHECK-NEXT:   %1 = load { [16 x i8] }, ptr @_bar_y, align 1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: load { [16 x i8], [2 x ptr] }, ptr @_bar_x
+// CHECK: load { [16 x i8] }, ptr @_bar_y
 func main() {
 	_ = barX
 	_ = barY

--- a/cl/_testrt/eface/in.go
+++ b/cl/_testrt/eface/in.go
@@ -7,104 +7,39 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
-// CHECK-LABEL: define void @"main.(*T).Invoke"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 6 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func (t *T) Invoke() {
 	println("invoke")
 }
 
 // CHECK-LABEL: define void @main.dump(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.eface, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   call void @main.dumpTyp(ptr %3, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: store %"{{.*}}eface" %0, ptr [[DUMP_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[DUMP_TYPE_FIELD:%.*]] = getelementptr inbounds %main.eface, ptr [[DUMP_ADDR]], i32 0, i32 0
+// CHECK: [[DUMP_TYPE:%.*]] = load ptr, ptr [[DUMP_TYPE_FIELD]]
+// CHECK: call void @main.dumpTyp(ptr [[DUMP_TYPE]], %"{{.*}}String" zeroinitializer)
 func dump(v any) {
 	e := (*eface)(unsafe.Pointer(&v))
 	dumpTyp(e._type, "")
 }
 
 // CHECK-LABEL: define void @main.dumpTyp(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %1)
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %0)
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/runtime/abi.(*Type).Kind"(ptr %0)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %5 = load i64, ptr %4, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %7 = load i64, ptr %6, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %9 = load i32, ptr %8, align 4
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 3
-// CHECK-NEXT:   %11 = load i8, ptr %10, align 1
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 4
-// CHECK-NEXT:   %13 = load i8, ptr %12, align 1
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 10
-// CHECK-NEXT:   %15 = load ptr, ptr %14, align 8
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %2)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %5)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %17 = zext i32 %9 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %17)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %18 = zext i8 %11 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %18)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %19 = zext i8 %13 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %19)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %16)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %0)
-// CHECK-NEXT:   %21 = icmp ne ptr %20, null
-// CHECK-NEXT:   br i1 %21, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %0)
-// CHECK-NEXT:   %23 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 7 })
-// CHECK-NEXT:   call void @main.dumpTyp(ptr %22, %"{{.*}}/runtime/internal/runtime.String" %23)
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
-// CHECK-NEXT:   %25 = icmp ne ptr %24, null
-// CHECK-NEXT:   br i1 %25, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
-// CHECK-NEXT:   %27 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 9 })
-// CHECK-NEXT:   call void @main.dumpUncommon(ptr %26, %"{{.*}}/runtime/internal/runtime.String" %27)
-// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 10
-// CHECK-NEXT:   %29 = load ptr, ptr %28, align 8
-// CHECK-NEXT:   %30 = icmp ne ptr %29, null
-// CHECK-NEXT:   br i1 %30, label %_llgo_5, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_5, %_llgo_3, %_llgo_2
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 10
-// CHECK-NEXT:   %32 = load ptr, ptr %31, align 8
-// CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %32)
-// CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 9 })
-// CHECK-NEXT:   call void @main.dumpUncommon(ptr %33, %"{{.*}}/runtime/internal/runtime.String" %34)
-// CHECK-NEXT:   br label %_llgo_4
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}String" %1)
+// CHECK: [[TYPE_NAME:%.*]] = call %"{{.*}}String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %0)
+// CHECK: [[TYPE_KIND:%.*]] = call i64 @"{{.*}}/runtime/abi.(*Type).Kind"(ptr %0)
+// CHECK: [[TYPE_UNCOMMON:%.*]] = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}String" [[TYPE_NAME]])
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 [[TYPE_KIND]])
+// CHECK: [[TYPE_ELEM:%.*]] = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %0)
+// CHECK: [[HAS_ELEM:%.*]] = icmp ne ptr [[TYPE_ELEM]], null
+// CHECK: br i1 [[HAS_ELEM]], label %{{.*}}, label %{{.*}}
+// CHECK: [[RECURSE_ELEM:%.*]] = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %0)
+// CHECK: [[ELEM_SEP:%.*]] = call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}String" %1, %"{{.*}}String" { ptr @{{.*}}, i64 7 })
+// CHECK: call void @main.dumpTyp(ptr [[RECURSE_ELEM]], %"{{.*}}String" [[ELEM_SEP]])
+// CHECK: [[RECHECK_UNCOMMON:%.*]] = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
+// CHECK: [[HAS_UNCOMMON:%.*]] = icmp ne ptr [[RECHECK_UNCOMMON]], null
+// CHECK: br i1 [[HAS_UNCOMMON]], label %{{.*}}, label %{{.*}}
+// CHECK: [[DUMP_UNCOMMON:%.*]] = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
+// CHECK: [[UNCOMMON_SEP:%.*]] = call %"{{.*}}String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}String" %1, %"{{.*}}String" { ptr @{{.*}}, i64 9 })
+// CHECK: call void @main.dumpUncommon(ptr [[DUMP_UNCOMMON]], %"{{.*}}String" [[UNCOMMON_SEP]])
 func dumpTyp(t *abi.Type, sep string) {
 	print(sep)
 	println(t.String(), t.Kind(), t.Size_, t.PtrBytes, t.Hash, t.TFlag, t.Align_, t.PtrToThis_, t.Uncommon())
@@ -120,24 +55,18 @@ func dumpTyp(t *abi.Type, sep string) {
 }
 
 // CHECK-LABEL: define void @main.dumpUncommon(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %1)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/runtime/abi.UncommonType", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.String", ptr %2, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/runtime/abi.UncommonType", ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %5 = load i16, ptr %4, align 2
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/abi.UncommonType", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %7 = load i16, ptr %6, align 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %8 = zext i16 %5 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %9 = zext i16 %7 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %9)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}String" %1)
+// CHECK: [[PKG_FIELD:%.*]] = getelementptr inbounds %"{{.*}}UncommonType", ptr %0, i32 0, i32 0
+// CHECK: [[PKG_PATH:%.*]] = load %"{{.*}}String", ptr [[PKG_FIELD]]
+// CHECK: [[MCOUNT_FIELD:%.*]] = getelementptr inbounds %"{{.*}}UncommonType", ptr %0, i32 0, i32 1
+// CHECK: [[MCOUNT:%.*]] = load i16, ptr [[MCOUNT_FIELD]]
+// CHECK: [[XCOUNT_FIELD:%.*]] = getelementptr inbounds %"{{.*}}UncommonType", ptr %0, i32 0, i32 2
+// CHECK: [[XCOUNT:%.*]] = load i16, ptr [[XCOUNT_FIELD]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}String" [[PKG_PATH]])
+// CHECK: [[MCOUNT64:%.*]] = zext i16 [[MCOUNT]] to i64
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 [[MCOUNT64]])
+// CHECK: [[XCOUNT64:%.*]] = zext i16 [[XCOUNT]] to i64
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 [[XCOUNT64]])
 
 func dumpUncommon(u *abi.UncommonType, sep string) {
 	print(sep)
@@ -152,21 +81,48 @@ type eface struct {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 1)
-// CHECK: store i1 true, ptr {{%[0-9]+}}, align 1
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_bool, ptr undef }
-// CHECK: call void @main.dump
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK: store i64 0, ptr {{%[0-9]+}}, align 8
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }
-// CHECK: call void @main.dump
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 80)
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[10]_llgo_int"
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[]_llgo_int"
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"{{.*}}/cl/_testrt/eface.struct
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T
-// CHECK: ret void
+// Every source value is boxed with its own descriptor and that exact eface is dumped.
+// CHECK: [[BOOL_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_bool, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[BOOL_BOX]])
+// CHECK: [[INT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[INT_BOX]])
+// CHECK: [[INT8_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int8, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[INT8_BOX]])
+// CHECK: [[INT16_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int16, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[INT16_BOX]])
+// CHECK: [[INT32_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int32, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[INT32_BOX]])
+// CHECK: [[INT64_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int64, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[INT64_BOX]])
+// CHECK: [[UINT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_uint, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[UINT_BOX]])
+// CHECK: [[UINT8_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_uint8, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[UINT8_BOX]])
+// CHECK: [[UINT16_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_uint16, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[UINT16_BOX]])
+// CHECK: [[UINT32_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_uint32, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[UINT32_BOX]])
+// CHECK: [[UINT64_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_uint64, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[UINT64_BOX]])
+// CHECK: [[UINTPTR_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_uintptr, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[UINTPTR_BOX]])
+// CHECK: [[FLOAT32_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_float32, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[FLOAT32_BOX]])
+// CHECK: [[FLOAT64_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_float64, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[FLOAT64_BOX]])
+// CHECK: [[ARRAY_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"[10]_llgo_int", ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[ARRAY_BOX]])
+// CHECK: [[CLOSURE_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[CLOSURE_BOX]])
+// CHECK: call void @main.dump(%"{{.*}}eface" { ptr @"*_llgo_int", ptr null })
+// CHECK: [[SLICE_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"[]_llgo_int", ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[SLICE_BOX]])
+// CHECK: [[STRING_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_string, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[STRING_BOX]])
+// CHECK: [[STRUCT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"{{.*}}/cl/_testrt/eface.struct${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[STRUCT_BOX]])
+// CHECK: [[NAMED_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.T, ptr undef }, ptr %{{.*}}, 1
+// CHECK: call void @main.dump(%"{{.*}}eface" [[NAMED_BOX]])
 func main() {
 	dump(true)
 	dump(0)
@@ -184,10 +140,6 @@ func main() {
 	dump(float64(0))
 	dump([10]int{})
 	dump(func() {})
-	// CHECK-LABEL: define void @"main.main$1"(){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
 	dump((*int)(nil))
 	dump([]int{})
 	dump("hello")

--- a/cl/_testrt/fprintf/in.go
+++ b/cl/_testrt/fprintf/in.go
@@ -3,7 +3,6 @@ package main
 
 import "unsafe"
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00", align 1{{$}}
 //
 //go:linkname cstr llgo.cstr
 func cstr(string) *int8
@@ -14,12 +13,10 @@ var stderr unsafe.Pointer
 //go:linkname fprintf C.fprintf
 func fprintf(fp unsafe.Pointer, format *int8, __llgo_va_list ...any)
 
+// CHECK: [[FPRINTF_FORMAT:@[0-9]+]] = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00"
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load ptr, ptr @__stderrp, align 8
-// CHECK-NEXT:   call void (ptr, ptr, ...) @fprintf(ptr %0, ptr @0, i64 100)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[STDERR:%[0-9]+]] = load ptr, ptr @__stderrp
+// CHECK-NEXT: call void (ptr, ptr, ...) @fprintf(ptr [[STDERR]], ptr [[FPRINTF_FORMAT]], i64 100)
 func main() {
 	fprintf(stderr, cstr("Hello %d\n"), 100)
 }

--- a/cl/_testrt/funcaddr/in.go
+++ b/cl/_testrt/funcaddr/in.go
@@ -11,43 +11,22 @@ import (
 type Add func(int, int) int
 
 // CHECK-LABEL: define i64 @main.add(i64 %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = add i64 %0, %1
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
+// CHECK: [[ADD_RESULT:%[0-9]+]] = add i64 %0, %1
+// CHECK-NEXT: ret i64 [[ADD_RESULT]]
 func add(a, b int) int {
 	return a + b
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   store ptr @main.add, ptr %0, align 8
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   store ptr @"main.main$1", ptr %1, align 8
-// CHECK-NEXT:   %2 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %3 = icmp eq ptr @main.add, %2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %5 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %6 = icmp eq ptr %4, %5
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %6)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %7 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %8 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %9 = icmp eq ptr %7, %8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %9)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: store ptr @main.add, ptr [[DECLARED_SLOT:%[0-9]+]]
+// CHECK: store ptr @"main.main$1", ptr [[LITERAL_SLOT:%[0-9]+]]
+// CHECK: [[DECLARED_CODE:%[0-9]+]] = load ptr, ptr [[DECLARED_SLOT]]
+// CHECK-NEXT: [[DECLARED_MATCH:%[0-9]+]] = icmp eq ptr @main.add, [[DECLARED_CODE]]
+// CHECK: [[LITERAL_CODE1:%[0-9]+]] = load ptr, ptr [[LITERAL_SLOT]]
+// CHECK-NEXT: [[LITERAL_CODE2:%[0-9]+]] = load ptr, ptr [[LITERAL_SLOT]]
+// CHECK-NEXT: [[LITERAL_MATCH:%[0-9]+]] = icmp eq ptr [[LITERAL_CODE1]], [[LITERAL_CODE2]]
 func main() {
 	var fn Add = add
-	// CHECK-LABEL: define i64 @"main.main$1"(i64 %0, i64 %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = add i64 %0, %1
-	// CHECK-NEXT:   ret i64 %2
-	// CHECK-NEXT: }
 	var myfn Add = func(a, b int) int {
 		return a + b
 	}
@@ -55,3 +34,7 @@ func main() {
 	println(c.Func(fn) == *(*unsafe.Pointer)(unsafe.Pointer(&fn)))
 	println(c.Func(myfn) == *(*unsafe.Pointer)(unsafe.Pointer(&myfn)))
 }
+
+// CHECK-LABEL: define i64 @"main.main$1"(i64 %0, i64 %1){{.*}} {
+// CHECK: [[LITERAL_SUM:%[0-9]+]] = add i64 %0, %1
+// CHECK-NEXT: ret i64 [[LITERAL_SUM]]

--- a/cl/_testrt/funcdecl/in.go
+++ b/cl/_testrt/funcdecl/in.go
@@ -5,8 +5,36 @@ import (
 	"unsafe"
 )
 
-// CHECK: {{^}}@4 = private unnamed_addr constant [4 x i8] c"demo", align 1{{$}}
-// CHECK: {{^}}@5 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
+// A declared function is represented as a closure pair with a nil environment,
+// and interface assertions use the closure type descriptor.
+// CHECK-LABEL: define void @main.check({ ptr, ptr } %0){{.*}} {
+// CHECK: %[[DECL_BOX:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT: store { ptr, ptr } { ptr @main.demo, ptr null }, ptr %[[DECL_BOX]]
+// CHECK: %[[DECL_EFACE:[0-9]+]] = insertvalue %"{{.*}}runtime.eface" { ptr @[[CLOSURE_TYPE:"_llgo_closure\$[^"]+"]], ptr undef }, ptr %[[DECL_BOX]], 1
+// CHECK: %[[ARG_BOX:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT: store { ptr, ptr } %0, ptr %[[ARG_BOX]]
+// CHECK: %[[ARG_EFACE:[0-9]+]] = insertvalue %"{{.*}}runtime.eface" { ptr @[[CLOSURE_TYPE]], ptr undef }, ptr %[[ARG_BOX]], 1
+// CHECK: %[[DECL_TYPE:[0-9]+]] = extractvalue %"{{.*}}runtime.eface" %[[DECL_EFACE]], 0
+// CHECK-NEXT: %[[DECL_MATCH:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @[[CLOSURE_TYPE]], ptr %[[DECL_TYPE]])
+// CHECK: %[[ARG_TYPE:[0-9]+]] = extractvalue %"{{.*}}runtime.eface" %[[ARG_EFACE]], 0
+// CHECK-NEXT: %[[ARG_MATCH:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @[[CLOSURE_TYPE]], ptr %[[ARG_TYPE]])
+// CHECK: %[[DECL_PTR:[0-9]+]] = call ptr @main.closurePtr(%"{{.*}}runtime.eface" %[[DECL_EFACE]])
+// CHECK-NEXT: %[[ARG_PTR:[0-9]+]] = call ptr @main.closurePtr(%"{{.*}}runtime.eface" %[[ARG_EFACE]])
+// CHECK-NEXT: %[[SAME_PTR:[0-9]+]] = icmp eq ptr %[[DECL_PTR]], %[[ARG_PTR]]
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %[[SAME_PTR]])
+// CHECK-LABEL: define ptr @main.closurePtr(%"{{.*}}runtime.eface" %0){{.*}} {
+// CHECK: %[[EFACE_BOX:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT: store %"{{.*}}runtime.eface" %0, ptr %[[EFACE_BOX]]
+// CHECK: %[[CLOSURE_SLOT:[0-9]+]] = getelementptr inbounds %main.rtype, ptr %[[EFACE_BOX]], i32 0, i32 1
+// CHECK-NEXT: %[[CLOSURE:[0-9]+]] = load ptr, ptr %[[CLOSURE_SLOT]]
+// CHECK-NEXT: %[[CODE_SLOT:[0-9]+]] = getelementptr inbounds { ptr, ptr }, ptr %[[CLOSURE]], i32 0, i32 0
+// CHECK-NEXT: %[[CODE:[0-9]+]] = load ptr, ptr %[[CODE_SLOT]]
+// CHECK-NEXT: ret ptr %[[CODE]]
+// CHECK-LABEL: define void @main.demo(){{.*}} {
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}runtime.String" { ptr @{{[0-9]+}}, i64 4 })
+// CHECK: ret void
+// CHECK-LABEL: define void @main.main(){{.*}} {
+// CHECK: call void @main.check({ ptr, ptr } { ptr @main.demo, ptr null })
 
 func check(fn func()) {
 	var a any = demo
@@ -37,95 +65,3 @@ func main() {
 	println("hello")
 	check(demo)
 }
-
-// CHECK-LABEL: define void @main.check({ ptr, ptr } %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @main.demo, ptr null }, ptr %1, align 8
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } %0, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %2, 0
-// CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr %5)
-// CHECK-NEXT:   br i1 %6, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %2, 1
-// CHECK-NEXT:   %8 = load { ptr, ptr }, ptr %7, align 8
-// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %4, 0
-// CHECK-NEXT:   %10 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr %9)
-// CHECK-NEXT:   br i1 %10, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %5, ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8")
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %4, 1
-// CHECK-NEXT:   %12 = load { ptr, ptr }, ptr %11, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintEface"(%"{{.*}}/runtime/internal/runtime.eface" %2)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintEface"(%"{{.*}}/runtime/internal/runtime.eface" %4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %0, 0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %8, 0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %14)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %12, 0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @main.demo)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %16 = call ptr @main.closurePtr(%"{{.*}}/runtime/internal/runtime.eface" %2)
-// CHECK-NEXT:   %17 = call ptr @main.closurePtr(%"{{.*}}/runtime/internal/runtime.eface" %4)
-// CHECK-NEXT:   %18 = icmp eq ptr %16, %17
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %18)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %9, ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8")
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define ptr @main.closurePtr(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.rtype, ptr %1, i32 0, i32 1
-// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 0
-// CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
-// CHECK-NEXT:   ret ptr %5
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.demo(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 5 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   call void @main.check({ ptr, ptr } { ptr @main.demo, ptr null })
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }

--- a/cl/_testrt/gotypes/in.go
+++ b/cl/_testrt/gotypes/in.go
@@ -1,25 +1,10 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @main.foo(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK-LABEL: define void @main.foo(%"{{.*}}iface" %0){{.*}} {
+// CHECK: ret void
 func foo(bar) {
 }
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 
 type base interface {
 	f(m map[string]func())
@@ -31,10 +16,7 @@ type bar interface {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @main.foo(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @main.foo(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
 func main() {
 	foo(nil)
 }

--- a/cl/_testrt/hello/in.go
+++ b/cl/_testrt/hello/in.go
@@ -3,28 +3,13 @@ package main
 
 import "github.com/goplus/llgo/cl/_testrt/hello/libc"
 
-// CHECK: {{^}}@main.format = global [10 x i8] c"Hello %d\0A\00", align 1{{$}}
+// CHECK: {{^}}@main.format = global [10 x i8] c"Hello %d\0A\00"
 
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 @strlen(ptr @main.format)
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[LEN:%[0-9]+]] = call i32 @strlen(ptr @main.format)
+// CHECK-NEXT: call void (ptr, ...) @printf(ptr @main.format, i32 [[LEN]])
 func main() {
 	sfmt := &format[0]
 	libc.Printf(sfmt, libc.Strlen(sfmt))

--- a/cl/_testrt/index/in.go
+++ b/cl/_testrt/index/in.go
@@ -1,21 +1,6 @@
 // LITTEST
 package main
 
-// CHECK: @0 = private unnamed_addr constant [6 x i8] c"123456", align 1
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
 type point struct {
 	x int
 	y int
@@ -26,132 +11,76 @@ type T *N
 type S []int
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %main.point, align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = alloca [3 x %main.point], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 48, i1 false)
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.point, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %main.point, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %main.point, ptr %2, i32 0, i32 1
-// CHECK-NEXT:   %5 = getelementptr inbounds %main.point, ptr %1, i64 1
-// CHECK-NEXT:   %6 = getelementptr inbounds %main.point, ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %7 = getelementptr inbounds %main.point, ptr %5, i32 0, i32 1
-// CHECK-NEXT:   %8 = getelementptr inbounds %main.point, ptr %1, i64 2
-// CHECK-NEXT:   %9 = getelementptr inbounds %main.point, ptr %8, i32 0, i32 0
-// CHECK-NEXT:   %10 = getelementptr inbounds %main.point, ptr %8, i32 0, i32 1
-// CHECK-NEXT:   store i64 1, ptr %3, align 8
-// CHECK-NEXT:   store i64 2, ptr %4, align 8
-// CHECK-NEXT:   store i64 3, ptr %6, align 8
-// CHECK-NEXT:   store i64 4, ptr %7, align 8
-// CHECK-NEXT:   store i64 5, ptr %9, align 8
-// CHECK-NEXT:   store i64 6, ptr %10, align 8
-// CHECK-NEXT:   %11 = load [3 x %main.point], ptr %1, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %main.point, ptr %1, i64 2
-// CHECK-NEXT:   %13 = load %main.point, ptr %12, align 8
-// CHECK-NEXT:   store %main.point %13, ptr %0, align 8
-// CHECK-NEXT:   %14 = getelementptr inbounds %main.point, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %15 = load i64, ptr %14, align 8
-// CHECK-NEXT:   %16 = getelementptr inbounds %main.point, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %17 = load i64, ptr %16, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %17)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %18 = alloca [2 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %19 = alloca [2 x [2 x i64]], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %19, i8 0, i64 32, i1 false)
-// CHECK-NEXT:   %20 = getelementptr inbounds [2 x i64], ptr %19, i64 0
-// CHECK-NEXT:   %21 = icmp eq ptr %20, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %21)
-// CHECK-NEXT:   %22 = getelementptr inbounds i64, ptr %20, i64 0
-// CHECK-NEXT:   %23 = icmp eq ptr %20, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %23)
-// CHECK-NEXT:   %24 = getelementptr inbounds i64, ptr %20, i64 1
-// CHECK-NEXT:   %25 = getelementptr inbounds [2 x i64], ptr %19, i64 1
-// CHECK-NEXT:   %26 = icmp eq ptr %25, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %26)
-// CHECK-NEXT:   %27 = getelementptr inbounds i64, ptr %25, i64 0
-// CHECK-NEXT:   %28 = icmp eq ptr %25, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %28)
-// CHECK-NEXT:   %29 = getelementptr inbounds i64, ptr %25, i64 1
-// CHECK-NEXT:   store i64 1, ptr %22, align 8
-// CHECK-NEXT:   store i64 2, ptr %24, align 8
-// CHECK-NEXT:   store i64 3, ptr %27, align 8
-// CHECK-NEXT:   store i64 4, ptr %29, align 8
-// CHECK-NEXT:   %30 = load [2 x [2 x i64]], ptr %19, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds [2 x i64], ptr %19, i64 1
-// CHECK-NEXT:   %32 = load [2 x i64], ptr %31, align 8
-// CHECK-NEXT:   store [2 x i64] %32, ptr %18, align 8
-// CHECK-NEXT:   %33 = getelementptr inbounds i64, ptr %18, i64 0
-// CHECK-NEXT:   %34 = load i64, ptr %33, align 8
-// CHECK-NEXT:   %35 = getelementptr inbounds i64, ptr %18, i64 1
-// CHECK-NEXT:   %36 = load i64, ptr %35, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %34)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %36)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %37 = alloca [5 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %37, i8 0, i64 40, i1 false)
-// CHECK-NEXT:   %38 = getelementptr inbounds i64, ptr %37, i64 0
-// CHECK-NEXT:   %39 = getelementptr inbounds i64, ptr %37, i64 1
-// CHECK-NEXT:   %40 = getelementptr inbounds i64, ptr %37, i64 2
-// CHECK-NEXT:   %41 = getelementptr inbounds i64, ptr %37, i64 3
-// CHECK-NEXT:   %42 = getelementptr inbounds i64, ptr %37, i64 4
-// CHECK-NEXT:   store i64 1, ptr %38, align 8
-// CHECK-NEXT:   store i64 2, ptr %39, align 8
-// CHECK-NEXT:   store i64 3, ptr %40, align 8
-// CHECK-NEXT:   store i64 4, ptr %41, align 8
-// CHECK-NEXT:   store i64 5, ptr %42, align 8
-// CHECK-NEXT:   %43 = load [5 x i64], ptr %37, align 8
-// CHECK-NEXT:   %44 = getelementptr inbounds i64, ptr %37, i64 2
-// CHECK-NEXT:   %45 = load i64, ptr %44, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %45)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %46 = load i8, ptr getelementptr inbounds (i8, ptr @0, i64 2), align 1
-// CHECK-NEXT:   %47 = zext i8 %46 to i64
-// CHECK-NEXT:   %48 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromUint64"(i64 %47)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %48)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %49 = load i8, ptr getelementptr inbounds (i8, ptr @0, i64 1), align 1
-// CHECK-NEXT:   %50 = zext i8 %49 to i64
-// CHECK-NEXT:   %51 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromUint64"(i64 %50)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %51)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %52 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %53 = getelementptr inbounds i64, ptr %52, i64 0
-// CHECK-NEXT:   %54 = getelementptr inbounds i64, ptr %52, i64 1
-// CHECK-NEXT:   store i64 1, ptr %53, align 8
-// CHECK-NEXT:   store i64 2, ptr %54, align 8
-// CHECK-NEXT:   %55 = getelementptr inbounds i64, ptr %52, i64 1
-// CHECK-NEXT:   %56 = load i64, ptr %55, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %56)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %57 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %58 = getelementptr inbounds i64, ptr %57, i64 0
-// CHECK-NEXT:   store i64 1, ptr %58, align 8
-// CHECK-NEXT:   %59 = getelementptr inbounds i64, ptr %57, i64 1
-// CHECK-NEXT:   store i64 2, ptr %59, align 8
-// CHECK-NEXT:   %60 = getelementptr inbounds i64, ptr %57, i64 2
-// CHECK-NEXT:   store i64 3, ptr %60, align 8
-// CHECK-NEXT:   %61 = getelementptr inbounds i64, ptr %57, i64 3
-// CHECK-NEXT:   store i64 4, ptr %61, align 8
-// CHECK-NEXT:   %62 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %57, 0
-// CHECK-NEXT:   %63 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %62, i64 4, 1
-// CHECK-NEXT:   %64 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %63, i64 4, 2
-// CHECK-NEXT:   %65 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %64, 0
-// CHECK-NEXT:   %66 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %64, 1
-// CHECK-NEXT:   %67 = icmp uge i64 1, %66
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %67, i64 1, i1 true, i64 %66)
-// CHECK-NEXT:   %68 = getelementptr inbounds i64, ptr %65, i64 1
-// CHECK-NEXT:   %69 = load i64, ptr %68, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %69)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// Array-of-struct selection: index 2 is loaded as a point, then both fields of
+// that selected value are consumed.
+// CHECK: %[[POINT:[0-9]+]] = alloca %main.point
+// CHECK: %[[POINTS:[0-9]+]] = alloca [3 x %main.point]
+// CHECK: %[[POINT2_INIT:[0-9]+]] = getelementptr inbounds %main.point, ptr %[[POINTS]], i64 2
+// CHECK: %[[POINT2_X:[0-9]+]] = getelementptr inbounds %main.point, ptr %[[POINT2_INIT]], i32 0, i32 0
+// CHECK: %[[POINT2_Y:[0-9]+]] = getelementptr inbounds %main.point, ptr %[[POINT2_INIT]], i32 0, i32 1
+// CHECK: store i64 5, ptr %[[POINT2_X]]
+// CHECK: store i64 6, ptr %[[POINT2_Y]]
+// CHECK: %[[POINT2:[0-9]+]] = getelementptr inbounds %main.point, ptr %[[POINTS]], i64 2
+// CHECK: %[[SELECTED_POINT:[0-9]+]] = load %main.point, ptr %[[POINT2]]
+// CHECK: store %main.point %[[SELECTED_POINT]], ptr %[[POINT]]
+// CHECK: %[[POINT_X:[0-9]+]] = getelementptr inbounds %main.point, ptr %[[POINT]], i32 0, i32 0
+// CHECK: load i64, ptr %[[POINT_X]]
+// CHECK: %[[POINT_Y:[0-9]+]] = getelementptr inbounds %main.point, ptr %[[POINT]], i32 0, i32 1
+// CHECK: load i64, ptr %[[POINT_Y]]
+
+// Nested arrays select row 1 before indexing its two elements.
+// CHECK: %[[ROW:[0-9]+]] = alloca [2 x i64]
+// CHECK: %[[MATRIX:[0-9]+]] = alloca [2 x [2 x i64]]
+// CHECK: %[[ROW1_INIT:[0-9]+]] = getelementptr inbounds [2 x i64], ptr %[[MATRIX]], i64 1
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"
+// CHECK: %[[ROW1_ELEM0:[0-9]+]] = getelementptr inbounds i64, ptr %[[ROW1_INIT]], i64 0
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"
+// CHECK: %[[ROW1_ELEM1:[0-9]+]] = getelementptr inbounds i64, ptr %[[ROW1_INIT]], i64 1
+// CHECK: store i64 3, ptr %[[ROW1_ELEM0]]
+// CHECK: store i64 4, ptr %[[ROW1_ELEM1]]
+// CHECK: %[[ROW1:[0-9]+]] = getelementptr inbounds [2 x i64], ptr %[[MATRIX]], i64 1
+// CHECK: %[[SELECTED_ROW:[0-9]+]] = load [2 x i64], ptr %[[ROW1]]
+// CHECK: store [2 x i64] %[[SELECTED_ROW]], ptr %[[ROW]]
+// CHECK: getelementptr inbounds i64, ptr %[[ROW]], i64 0
+// CHECK: getelementptr inbounds i64, ptr %[[ROW]], i64 1
+
+// The SSA-known array index is folded to element 2 without losing the selected
+// element load.
+// CHECK: %[[INTS:[0-9]+]] = alloca [5 x i64]
+// CHECK: %[[INT2_INIT:[0-9]+]] = getelementptr inbounds i64, ptr %[[INTS]], i64 2
+// CHECK: store i64 3, ptr %[[INT2_INIT]]
+// CHECK: %[[INT2:[0-9]+]] = getelementptr inbounds i64, ptr %[[INTS]], i64 2
+// CHECK: load i64, ptr %[[INT2]]
+
+// String indexes are byte loads converted through StringFromUint64. Capture
+// each byte so an unrelated conversion cannot satisfy the check.
+// CHECK: %[[BYTE2:[0-9]+]] = load i8, ptr getelementptr inbounds (i8, ptr @[[TEXT:[0-9]+]], i64 2)
+// CHECK: %[[RUNE2:[0-9]+]] = zext i8 %[[BYTE2]] to i64
+// CHECK: call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromUint64"(i64 %[[RUNE2]])
+// CHECK: %[[BYTE1:[0-9]+]] = load i8, ptr getelementptr inbounds (i8, ptr @[[TEXT]], i64 1)
+// CHECK: %[[RUNE1:[0-9]+]] = zext i8 %[[BYTE1]] to i64
+// CHECK: call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromUint64"(i64 %[[RUNE1]])
+
+// Named pointer-to-array indexing and named-slice indexing use different
+// lowering. The slice predicate, length and data pointer must stay associated.
+// CHECK: %[[NAMED_ARRAY:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK: %[[NAMED_ELEM_INIT:[0-9]+]] = getelementptr inbounds i64, ptr %[[NAMED_ARRAY]], i64 1
+// CHECK: store i64 2, ptr %[[NAMED_ELEM_INIT]]
+// CHECK: %[[NAMED_ELEM:[0-9]+]] = getelementptr inbounds i64, ptr %[[NAMED_ARRAY]], i64 1
+// CHECK: load i64, ptr %[[NAMED_ELEM]]
+// CHECK: %[[SLICE_DATA_RAW:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
+// CHECK: %[[SLICE0:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %[[SLICE_DATA_RAW]], 0
+// CHECK: %[[SLICE1:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE0]], i64 4, 1
+// CHECK: %[[SLICE:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE1]], i64 4, 2
+// CHECK: %[[SLICE_DATA:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
+// CHECK: %[[SLICE_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 1
+// CHECK: %[[SLICE_OOB:[0-9]+]] = icmp uge i64 1, %[[SLICE_LEN]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[SLICE_OOB]], i64 1, i1 true, i64 %[[SLICE_LEN]])
+// CHECK: %[[SLICE_ELEM:[0-9]+]] = getelementptr inbounds i64, ptr %[[SLICE_DATA]], i64 1
+// CHECK: load i64, ptr %[[SLICE_ELEM]]
+
+// A zero array indexed at constant zero folds to its zero value.
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
 
 func main() {
 	a := [...]point{{1, 2}, {3, 4}, {5, 6}}[2]

--- a/cl/_testrt/len/in.go
+++ b/cl/_testrt/len/in.go
@@ -9,95 +9,54 @@ type data struct {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 56)
-// CHECK-NEXT:   %1 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
-// CHECK-NEXT:   %3 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %2, 1
-// CHECK-NEXT:   %4 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
-// CHECK-NEXT:   %6 = call i64 @"{{.*}}/runtime/internal/runtime.ChanLen"(ptr %5)
-// CHECK-NEXT:   %7 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
-// CHECK-NEXT:   %9 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %8)
-// CHECK-NEXT:   %10 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 3
-// CHECK-NEXT:   %11 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %10, align 8
-// CHECK-NEXT:   %12 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %11, 1
-// CHECK-NEXT:   %13 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %14 = load ptr, ptr %13, align 8
-// CHECK-NEXT:   %15 = call i64 @"{{.*}}/runtime/internal/runtime.ChanCap"(ptr %14)
-// CHECK-NEXT:   %16 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 3
-// CHECK-NEXT:   %17 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %16, align 8
-// CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %6)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %9)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %12)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %18)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 56)
-// CHECK-NEXT:   %20 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 0
-// CHECK-NEXT:   %21 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 1
-// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 2)
-// CHECK-NEXT:   %23 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 2
-// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 1)
-// CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %25, align 8
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %24, ptr %25)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %26, align 8
-// CHECK-NEXT:   %27 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 3
-// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %29 = getelementptr inbounds i64, ptr %28, i64 0
-// CHECK-NEXT:   store i64 1, ptr %29, align 8
-// CHECK-NEXT:   %30 = getelementptr inbounds i64, ptr %28, i64 1
-// CHECK-NEXT:   store i64 2, ptr %30, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds i64, ptr %28, i64 2
-// CHECK-NEXT:   store i64 3, ptr %31, align 8
-// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %28, 0
-// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %32, i64 3, 1
-// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %33, i64 3, 2
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %20, align 8
-// CHECK-NEXT:   store ptr %22, ptr %21, align 8
-// CHECK-NEXT:   store ptr %24, ptr %23, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %34, ptr %27, align 8
-// CHECK-NEXT:   %35 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 0
-// CHECK-NEXT:   %36 = load %"{{.*}}/runtime/internal/runtime.String", ptr %35, align 8
-// CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %36, 1
-// CHECK-NEXT:   %38 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 1
-// CHECK-NEXT:   %39 = load ptr, ptr %38, align 8
-// CHECK-NEXT:   %40 = call i64 @"{{.*}}/runtime/internal/runtime.ChanLen"(ptr %39)
-// CHECK-NEXT:   %41 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 2
-// CHECK-NEXT:   %42 = load ptr, ptr %41, align 8
-// CHECK-NEXT:   %43 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %42)
-// CHECK-NEXT:   %44 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 3
-// CHECK-NEXT:   %45 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %44, align 8
-// CHECK-NEXT:   %46 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %45, 1
-// CHECK-NEXT:   %47 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 1
-// CHECK-NEXT:   %48 = load ptr, ptr %47, align 8
-// CHECK-NEXT:   %49 = call i64 @"{{.*}}/runtime/internal/runtime.ChanCap"(ptr %48)
-// CHECK-NEXT:   %50 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 3
-// CHECK-NEXT:   %51 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %50, align 8
-// CHECK-NEXT:   %52 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %37)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %40)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %43)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %46)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %49)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %52)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// First read every len/cap operation from the same zero-valued struct.
+// CHECK: [[ZERO_DATA:%.*]] = call ptr @"{{.*}}AllocZ"(i64 56)
+// CHECK: [[ZERO_STRING:%.*]] = load %"{{.*}}String", ptr {{%.*}}
+// CHECK-NEXT: [[ZERO_STRING_LEN:%.*]] = extractvalue %"{{.*}}String" [[ZERO_STRING]], 1
+// CHECK: [[ZERO_CHAN:%.*]] = load ptr, ptr {{%.*}}
+// CHECK-NEXT: [[ZERO_CHAN_LEN:%.*]] = call i64 @"{{.*}}ChanLen"(ptr [[ZERO_CHAN]])
+// CHECK: [[ZERO_MAP:%.*]] = load ptr, ptr {{%.*}}
+// CHECK-NEXT: [[ZERO_MAP_LEN:%.*]] = call i64 @"{{.*}}MapLen"(ptr [[ZERO_MAP]])
+// CHECK: [[ZERO_SLICE:%.*]] = load %"{{.*}}Slice", ptr {{%.*}}
+// CHECK-NEXT: [[ZERO_SLICE_LEN:%.*]] = extractvalue %"{{.*}}Slice" [[ZERO_SLICE]], 1
+// CHECK: [[ZERO_CHAN_FOR_CAP:%.*]] = load ptr, ptr {{%.*}}
+// CHECK-NEXT: [[ZERO_CHAN_CAP:%.*]] = call i64 @"{{.*}}ChanCap"(ptr [[ZERO_CHAN_FOR_CAP]])
+// CHECK: [[ZERO_SLICE_FOR_CAP:%.*]] = load %"{{.*}}Slice", ptr {{%.*}}
+// CHECK-NEXT: [[ZERO_SLICE_CAP:%.*]] = extractvalue %"{{.*}}Slice" [[ZERO_SLICE_FOR_CAP]], 2
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[ZERO_STRING_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[ZERO_CHAN_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[ZERO_MAP_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[ZERO_SLICE_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[ZERO_CHAN_CAP]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[ZERO_SLICE_CAP]])
+// Then construct and query the populated value, preserving channel/map/slice identities.
+// CHECK: [[VALUE_DATA:%.*]] = call ptr @"{{.*}}AllocZ"(i64 56)
+// CHECK: [[VALUE_CHAN:%.*]] = call ptr @"{{.*}}NewChan"(i64 8, i64 2)
+// CHECK: [[VALUE_MAP:%.*]] = call ptr @"{{.*}}MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 1)
+// CHECK: [[VALUE_SLICE0:%.*]] = insertvalue %"{{.*}}Slice" undef, ptr {{%.*}}, 0
+// CHECK-NEXT: [[VALUE_SLICE1:%.*]] = insertvalue %"{{.*}}Slice" [[VALUE_SLICE0]], i64 3, 1
+// CHECK-NEXT: [[VALUE_SLICE:%.*]] = insertvalue %"{{.*}}Slice" [[VALUE_SLICE1]], i64 3, 2
+// CHECK: store ptr [[VALUE_CHAN]], ptr {{%.*}}
+// CHECK: store ptr [[VALUE_MAP]], ptr {{%.*}}
+// CHECK: store %"{{.*}}Slice" [[VALUE_SLICE]], ptr {{%.*}}
+// CHECK: [[VALUE_STRING:%.*]] = load %"{{.*}}String", ptr {{%.*}}
+// CHECK-NEXT: [[VALUE_STRING_LEN:%.*]] = extractvalue %"{{.*}}String" [[VALUE_STRING]], 1
+// CHECK: [[VALUE_CHAN_LOAD:%.*]] = load ptr, ptr {{%.*}}
+// CHECK-NEXT: [[VALUE_CHAN_LEN:%.*]] = call i64 @"{{.*}}ChanLen"(ptr [[VALUE_CHAN_LOAD]])
+// CHECK: [[VALUE_MAP_LOAD:%.*]] = load ptr, ptr {{%.*}}
+// CHECK-NEXT: [[VALUE_MAP_LEN:%.*]] = call i64 @"{{.*}}MapLen"(ptr [[VALUE_MAP_LOAD]])
+// CHECK: [[VALUE_SLICE_LOAD:%.*]] = load %"{{.*}}Slice", ptr {{%.*}}
+// CHECK-NEXT: [[VALUE_SLICE_LEN:%.*]] = extractvalue %"{{.*}}Slice" [[VALUE_SLICE_LOAD]], 1
+// CHECK: [[VALUE_CHAN_CAP_LOAD:%.*]] = load ptr, ptr {{%.*}}
+// CHECK-NEXT: [[VALUE_CHAN_CAP:%.*]] = call i64 @"{{.*}}ChanCap"(ptr [[VALUE_CHAN_CAP_LOAD]])
+// CHECK: [[VALUE_SLICE_CAP_LOAD:%.*]] = load %"{{.*}}Slice", ptr {{%.*}}
+// CHECK-NEXT: [[VALUE_SLICE_CAP:%.*]] = extractvalue %"{{.*}}Slice" [[VALUE_SLICE_CAP_LOAD]], 2
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[VALUE_STRING_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[VALUE_CHAN_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[VALUE_MAP_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[VALUE_SLICE_LEN]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[VALUE_CHAN_CAP]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[VALUE_SLICE_CAP]])
 func main() {
 	d := &data{}
 	println(len(d.s), len(d.c), len(d.m), len(d.a), cap(d.c), cap(d.a))

--- a/cl/_testrt/linkname/in.go
+++ b/cl/_testrt/linkname/in.go
@@ -21,18 +21,23 @@ func setInfo(*m, string)
 //go:linkname info github.com/goplus/llgo/cl/_testrt/linkname/linktarget.m.info
 func info(m) string
 
+// CHECK: @[[A:[0-9]+]] = private unnamed_addr constant [2 x i8] c"a\00"
+// CHECK: @[[B:[0-9]+]] = private unnamed_addr constant [2 x i8] c"b\00"
+// CHECK: @[[C:[0-9]+]] = private unnamed_addr constant [2 x i8] c"c\00"
+// CHECK: @[[D:[0-9]+]] = private unnamed_addr constant [2 x i8] c"d\00"
+// CHECK: @[[ONE:[0-9]+]] = private unnamed_addr constant [2 x i8] c"1\00"
+// CHECK: @[[TWO:[0-9]+]] = private unnamed_addr constant [2 x i8] c"2\00"
+// CHECK: @[[THREE:[0-9]+]] = private unnamed_addr constant [2 x i8] c"3\00"
+// CHECK: @[[FOUR:[0-9]+]] = private unnamed_addr constant [2 x i8] c"4\00"
+// CHECK: @[[HELLO:[0-9]+]] = private unnamed_addr constant [5 x i8] c"hello"
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/linkname/linktarget.F"(ptr @0, ptr @1, ptr @2, ptr @3)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/linkname/linktarget.F"(ptr @4, ptr @5, ptr @6, ptr @7)
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/linkname/linktarget.(*m).setInfo"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 5 })
-// CHECK-NEXT:   %1 = load %main.m, ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/linkname/linktarget.m.info"(%main.m %1)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %2)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}/cl/_testrt/linkname/linktarget.F"(ptr @[[A]], ptr @[[B]], ptr @[[C]], ptr @[[D]])
+// CHECK-NEXT: call void @"{{.*}}/cl/_testrt/linkname/linktarget.F"(ptr @[[ONE]], ptr @[[TWO]], ptr @[[THREE]], ptr @[[FOUR]])
+// CHECK: [[INFO_STORAGE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT: call void @"{{.*}}/cl/_testrt/linkname/linktarget.(*m).setInfo"(ptr [[INFO_STORAGE]], %"{{.*}}/runtime/internal/runtime.String" { ptr @[[HELLO]], i64 5 })
+// CHECK-NEXT: [[INFO_RECEIVER:%[0-9]+]] = load %main.m, ptr [[INFO_STORAGE]]
+// CHECK-NEXT: [[INFO:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/linkname/linktarget.m.info"(%main.m [[INFO_RECEIVER]])
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" [[INFO]])
 func main() {
 	print(c.Str("a"), c.Str("b"), c.Str("c"), c.Str("d"))
 	print(c.Str("1"), c.Str("2"), c.Str("3"), c.Str("4"))

--- a/cl/_testrt/makemap/in.go
+++ b/cl/_testrt/makemap/in.go
@@ -1,13 +1,86 @@
 // LITTEST
 package main
 
-// CHECK: {{^}}@16 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
-// CHECK: {{^}}@17 = private unnamed_addr constant [5 x i8] c"world", align 1{{$}}
-// CHECK: {{^}}@18 = private unnamed_addr constant [4 x i8] c"llgo", align 1{{$}}
-// CHECK: {{^}}@19 = private unnamed_addr constant [1 x i8] c":", align 1{{$}}
-// CHECK: {{^}}@22 = private unnamed_addr constant [2 x i8] c"go", align 1{{$}}
-// CHECK: {{^}}@23 = private unnamed_addr constant [7 x i8] c"bad key", align 1{{$}}
-// CHECK: {{^}}@24 = private unnamed_addr constant [7 x i8] c"bad len", align 1{{$}}
+// main must retain every scenario; each helper below then checks the map
+// descriptor and dataflow specific to its key/value contract.
+// CHECK-LABEL: define void @main.main(){{.*}} {
+// CHECK: call void @main.make1()
+// CHECK: call void @main.make2()
+// CHECK: call void @main.make3()
+// CHECK: call void @main.make4()
+// CHECK: call void @main.make5()
+// CHECK: call void @main.make6()
+// CHECK: call void @main.make7()
+
+// make1 covers the full lifecycle. Tie every operation to the map returned by
+// MakeMap and carry iterator/access results forward instead of matching helper
+// names in isolation.
+// CHECK-LABEL: define void @main.make1(){{.*}} {
+// CHECK: %[[MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
+// CHECK: %[[ASSIGN:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %[[MAP]], ptr %{{[0-9]+}})
+// CHECK: store %"{{.*}}/runtime/internal/runtime.String" {{.*}}, ptr %[[ASSIGN]]
+// CHECK: %[[VALUE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_string", ptr %[[MAP]], ptr %{{[0-9]+}})
+// CHECK: load %"{{.*}}/runtime/internal/runtime.String", ptr %[[VALUE]]
+// CHECK: %[[ITER:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_int]_llgo_string", ptr %[[MAP]])
+// CHECK: %[[NEXT:[0-9]+]] = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %[[ITER]])
+// CHECK: extractvalue { i1, ptr, ptr } %[[NEXT]], 0
+// CHECK: %[[MAP_LEN:[0-9]+]] = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %[[MAP]])
+// CHECK: %[[REVERSE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_int", i64 %[[MAP_LEN]])
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_string]_llgo_int", ptr %[[REVERSE]], ptr %{{[0-9]+}})
+// CHECK: %[[FOUND:[0-9]+]] = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_string]_llgo_int", ptr %[[REVERSE]], ptr %{{[0-9]+}})
+// CHECK: extractvalue { ptr, i1 } %[[FOUND]], 1
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.MapDelete"(ptr @"map[_llgo_string]_llgo_int", ptr %[[REVERSE]], ptr %{{[0-9]+}})
+// CHECK: %[[DELETED:[0-9]+]] = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_string]_llgo_int", ptr %[[REVERSE]], ptr %{{[0-9]+}})
+// CHECK: %[[STILL_PRESENT:[0-9]+]] = extractvalue { ptr, i1 } %[[DELETED]], 1
+// CHECK: %[[PAIR_OK:[0-9]+]] = insertvalue { i64, i1 } %{{[0-9]+}}, i1 %[[STILL_PRESENT]], 1
+// CHECK: %[[BRANCH_OK:[0-9]+]] = extractvalue { i64, i1 } %[[PAIR_OK]], 1
+// CHECK: br i1 %[[BRANCH_OK]]
+
+// Interface keys retain their dynamic type while assignment and iteration use
+// the same any-key map.
+// CHECK-LABEL: define void @main.make2(){{.*}} {
+// CHECK: %[[ANY_MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
+// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %{{[0-9]+}}, 1
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %[[ANY_MAP]], ptr %{{[0-9]+}})
+// CHECK: %[[ANY_ITER:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %[[ANY_MAP]])
+// CHECK: call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %[[ANY_ITER]])
+
+// Array-of-value and array-of-pointer interface keys both go through dynamic
+// equality, but remain separate source scenarios.
+// CHECK-LABEL: define void @main.make3(){{.*}} {
+// CHECK: %[[VALUE_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %[[VALUE_EQ]])
+// CHECK: %[[VALUE_MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %[[VALUE_MAP]], ptr %{{[0-9]+}})
+
+// CHECK-LABEL: define void @main.make4(){{.*}} {
+// CHECK: %[[POINTER_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %[[POINTER_EQ]])
+// CHECK: %[[POINTER_MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %[[POINTER_MAP]], ptr %{{[0-9]+}})
+
+// Channel identity is used both through interface equality and as a direct map
+// key; both operations must consume the channel created here.
+// CHECK-LABEL: define void @main.make5(){{.*}} {
+// CHECK: %[[CHAN:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
+// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"chan _llgo_int", ptr undef }, ptr %[[CHAN]], 1
+// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK: %[[CHAN_MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[chan _llgo_int]_llgo_int", i64 0)
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[chan _llgo_int]_llgo_int", ptr %[[CHAN_MAP]], ptr %{{[0-9]+}})
+
+// A named map uses its named descriptor for operations even though allocation
+// uses the identical underlying map layout.
+// CHECK-LABEL: define void @main.make6(){{.*}} {
+// CHECK: %[[NAMED_MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @_llgo_main.M, ptr %[[NAMED_MAP]], ptr %{{[0-9]+}})
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @_llgo_main.M, ptr %[[NAMED_MAP]])
+
+// A local named key has its own descriptor and the literal's two entries are
+// reflected in the allocation hint.
+// CHECK-LABEL: define void @main.make7(){{.*}} {
+// CHECK: %[[LOCAL_MAP:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_main.N.7.0]_llgo_string", i64 2)
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %[[LOCAL_MAP]], ptr %{{[0-9]+}})
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %[[LOCAL_MAP]], ptr %{{[0-9]+}})
 
 func main() {
 	make1()
@@ -135,718 +208,3 @@ func make7() {
 	}
 	println(m[1])
 }
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @main.make1()
-// CHECK-NEXT:   call void @main.make2()
-// CHECK-NEXT:   call void @main.make3()
-// CHECK-NEXT:   call void @main.make4()
-// CHECK-NEXT:   call void @main.make5()
-// CHECK-NEXT:   call void @main.make6()
-// CHECK-NEXT:   call void @main.make7()
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make1(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %1)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 2, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %3)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 3, ptr %5, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %5)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 4 }, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %7, align 8
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %7)
-// CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.String", ptr %8, align 8
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 2, ptr %10, align 8
-// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %10)
-// CHECK-NEXT:   %12 = load %"{{.*}}/runtime/internal/runtime.String", ptr %11, align 8
-// CHECK-NEXT:   %13 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %9)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %12)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_int]_llgo_string", ptr %0)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %15 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %14)
-// CHECK-NEXT:   %16 = extractvalue { i1, ptr, ptr } %15, 0
-// CHECK-NEXT:   br i1 %16, label %_llgo_11, label %_llgo_12
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_13
-// CHECK-NEXT:   %17 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %68, 1
-// CHECK-NEXT:   %18 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %68, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %17)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 1 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %18)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_13
-// CHECK-NEXT:   %19 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %0)
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_int", i64 %19)
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_int]_llgo_string", ptr %0)
-// CHECK-NEXT:   br label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_5, %_llgo_3
-// CHECK-NEXT:   %22 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %21)
-// CHECK-NEXT:   %23 = extractvalue { i1, ptr, ptr } %22, 0
-// CHECK-NEXT:   br i1 %23, label %_llgo_14, label %_llgo_15
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_16
-// CHECK-NEXT:   %24 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %76, 1
-// CHECK-NEXT:   %25 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %76, 2
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %25, ptr %26, align 8
-// CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_string]_llgo_int", ptr %20, ptr %26)
-// CHECK-NEXT:   store i64 %24, ptr %27, align 8
-// CHECK-NEXT:   br label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_16
-// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 4 }, ptr %28, align 8
-// CHECK-NEXT:   %29 = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_string]_llgo_int", ptr %20, ptr %28)
-// CHECK-NEXT:   %30 = extractvalue { ptr, i1 } %29, 0
-// CHECK-NEXT:   %31 = load i64, ptr %30, align 8
-// CHECK-NEXT:   %32 = extractvalue { ptr, i1 } %29, 1
-// CHECK-NEXT:   %33 = insertvalue { i64, i1 } undef, i64 %31, 0
-// CHECK-NEXT:   %34 = insertvalue { i64, i1 } %33, i1 %32, 1
-// CHECK-NEXT:   %35 = extractvalue { i64, i1 } %34, 0
-// CHECK-NEXT:   %36 = extractvalue { i64, i1 } %34, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %35)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %36)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 2 }, ptr %37, align 8
-// CHECK-NEXT:   %38 = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_string]_llgo_int", ptr %20, ptr %37)
-// CHECK-NEXT:   %39 = extractvalue { ptr, i1 } %38, 0
-// CHECK-NEXT:   %40 = load i64, ptr %39, align 8
-// CHECK-NEXT:   %41 = extractvalue { ptr, i1 } %38, 1
-// CHECK-NEXT:   %42 = insertvalue { i64, i1 } undef, i64 %40, 0
-// CHECK-NEXT:   %43 = insertvalue { i64, i1 } %42, i1 %41, 1
-// CHECK-NEXT:   %44 = extractvalue { i64, i1 } %43, 0
-// CHECK-NEXT:   %45 = extractvalue { i64, i1 } %43, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 2 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %44)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %45)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %46 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 4 }, ptr %46, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.MapDelete"(ptr @"map[_llgo_string]_llgo_int", ptr %20, ptr %46)
-// CHECK-NEXT:   %47 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 4 }, ptr %47, align 8
-// CHECK-NEXT:   %48 = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_string]_llgo_int", ptr %20, ptr %47)
-// CHECK-NEXT:   %49 = extractvalue { ptr, i1 } %48, 0
-// CHECK-NEXT:   %50 = load i64, ptr %49, align 8
-// CHECK-NEXT:   %51 = extractvalue { ptr, i1 } %48, 1
-// CHECK-NEXT:   %52 = insertvalue { i64, i1 } undef, i64 %50, 0
-// CHECK-NEXT:   %53 = insertvalue { i64, i1 } %52, i1 %51, 1
-// CHECK-NEXT:   %54 = extractvalue { i64, i1 } %53, 0
-// CHECK-NEXT:   %55 = extractvalue { i64, i1 } %53, 1
-// CHECK-NEXT:   br i1 %55, label %_llgo_7, label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %56 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 7 }, ptr %56, align 8
-// CHECK-NEXT:   %57 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %56, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %57)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %58 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %20)
-// CHECK-NEXT:   %59 = icmp ne i64 %58, 2
-// CHECK-NEXT:   br i1 %59, label %_llgo_9, label %_llgo_10
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_8
-// CHECK-NEXT:   %60 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 7 }, ptr %60, align 8
-// CHECK-NEXT:   %61 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %60, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %61)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_1
-// CHECK-NEXT:   %62 = extractvalue { i1, ptr, ptr } %15, 1
-// CHECK-NEXT:   %63 = extractvalue { i1, ptr, ptr } %15, 2
-// CHECK-NEXT:   %64 = load i64, ptr %62, align 8
-// CHECK-NEXT:   %65 = load %"{{.*}}/runtime/internal/runtime.String", ptr %63, align 8
-// CHECK-NEXT:   %66 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } { i1 true, i64 undef, %"{{.*}}/runtime/internal/runtime.String" undef }, i64 %64, 1
-// CHECK-NEXT:   %67 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %66, %"{{.*}}/runtime/internal/runtime.String" %65, 2
-// CHECK-NEXT:   br label %_llgo_13
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_13
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_12, %_llgo_11
-// CHECK-NEXT:   %68 = phi { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } [ %67, %_llgo_11 ], [ zeroinitializer, %_llgo_12 ]
-// CHECK-NEXT:   %69 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %68, 0
-// CHECK-NEXT:   br i1 %69, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_4
-// CHECK-NEXT:   %70 = extractvalue { i1, ptr, ptr } %22, 1
-// CHECK-NEXT:   %71 = extractvalue { i1, ptr, ptr } %22, 2
-// CHECK-NEXT:   %72 = load i64, ptr %70, align 8
-// CHECK-NEXT:   %73 = load %"{{.*}}/runtime/internal/runtime.String", ptr %71, align 8
-// CHECK-NEXT:   %74 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } { i1 true, i64 undef, %"{{.*}}/runtime/internal/runtime.String" undef }, i64 %72, 1
-// CHECK-NEXT:   %75 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %74, %"{{.*}}/runtime/internal/runtime.String" %73, 2
-// CHECK-NEXT:   br label %_llgo_16
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_4
-// CHECK-NEXT:   br label %_llgo_16
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-// CHECK-NEXT:   %76 = phi { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } [ %75, %_llgo_14 ], [ zeroinitializer, %_llgo_15 ]
-// CHECK-NEXT:   %77 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %76, 0
-// CHECK-NEXT:   br i1 %77, label %_llgo_5, label %_llgo_6
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make2(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
-// CHECK-NEXT:   %1 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %0)
-// CHECK-NEXT:   %2 = icmp eq ptr %0, null
-// CHECK-NEXT:   %3 = icmp ne ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %1)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %2)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr null)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr null)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %4)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %6 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %6, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %6, i64 0
-// CHECK-NEXT:   store i64 1, ptr %7, align 8
-// CHECK-NEXT:   %8 = load [1 x i64], ptr %6, align 8
-// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store [1 x i64] %8, ptr %9, align 8
-// CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %9, 1
-// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %10, ptr %11, align 8
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %11)
-// CHECK-NEXT:   store i64 100, ptr %12, align 8
-// CHECK-NEXT:   %13 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %13, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %14 = getelementptr inbounds i64, ptr %13, i64 0
-// CHECK-NEXT:   store i64 2, ptr %14, align 8
-// CHECK-NEXT:   %15 = load [1 x i64], ptr %13, align 8
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store [1 x i64] %15, ptr %16, align 8
-// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %16, 1
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %17, ptr %18, align 8
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %18)
-// CHECK-NEXT:   store i64 200, ptr %19, align 8
-// CHECK-NEXT:   %20 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %20, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %21 = getelementptr inbounds i64, ptr %20, i64 0
-// CHECK-NEXT:   store i64 3, ptr %21, align 8
-// CHECK-NEXT:   %22 = load [1 x i64], ptr %20, align 8
-// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store [1 x i64] %22, ptr %23, align 8
-// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %23, 1
-// CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %24, ptr %25, align 8
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %25)
-// CHECK-NEXT:   store i64 300, ptr %26, align 8
-// CHECK-NEXT:   %27 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %27, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %28 = getelementptr inbounds i64, ptr %27, i64 0
-// CHECK-NEXT:   store i64 2, ptr %28, align 8
-// CHECK-NEXT:   %29 = load [1 x i64], ptr %27, align 8
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store [1 x i64] %29, ptr %30, align 8
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %30, 1
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %31, ptr %32, align 8
-// CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %32)
-// CHECK-NEXT:   store i64 -200, ptr %33, align 8
-// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %5)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-// CHECK-NEXT:   %35 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %34)
-// CHECK-NEXT:   %36 = extractvalue { i1, ptr, ptr } %35, 0
-// CHECK-NEXT:   br i1 %36, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %37 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 1
-// CHECK-NEXT:   %38 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 2
-// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 0
-// CHECK-NEXT:   %40 = icmp eq ptr %39, @_llgo_main.N1
-// CHECK-NEXT:   br i1 %40, label %_llgo_7, label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %41 = extractvalue { i1, ptr, ptr } %35, 1
-// CHECK-NEXT:   %42 = extractvalue { i1, ptr, ptr } %35, 2
-// CHECK-NEXT:   %43 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %41, align 8
-// CHECK-NEXT:   %44 = load i64, ptr %42, align 8
-// CHECK-NEXT:   %45 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %43, 1
-// CHECK-NEXT:   %46 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %45, i64 %44, 2
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %47 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %46, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %48 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 0
-// CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
-// CHECK-NEXT:   %50 = load [1 x i64], ptr %49, align 8
-// CHECK-NEXT:   %51 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %51, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store [1 x i64] %50, ptr %51, align 8
-// CHECK-NEXT:   %52 = getelementptr inbounds i64, ptr %51, i64 0
-// CHECK-NEXT:   %53 = load i64, ptr %52, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %53)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %38)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %39, ptr @_llgo_main.N1)
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make3(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca [1 x %main.N], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %main.N, ptr %0, i64 0
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.N, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %main.N, ptr %1, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %2, align 1
-// CHECK-NEXT:   store i8 2, ptr %3, align 1
-// CHECK-NEXT:   %4 = load [1 x %main.N], ptr %0, align 1
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %main.N] %4, ptr %5, align 1
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %5, 1
-// CHECK-NEXT:   %7 = alloca [1 x %main.N], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %7, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %8 = getelementptr inbounds %main.N, ptr %7, i64 0
-// CHECK-NEXT:   %9 = getelementptr inbounds %main.N, ptr %8, i32 0, i32 0
-// CHECK-NEXT:   %10 = getelementptr inbounds %main.N, ptr %8, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %9, align 1
-// CHECK-NEXT:   store i8 2, ptr %10, align 1
-// CHECK-NEXT:   %11 = load [1 x %main.N], ptr %7, align 1
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %main.N] %11, ptr %12, align 1
-// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %12, 1
-// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %6, %"{{.*}}/runtime/internal/runtime.eface" %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %14)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %16 = alloca [1 x %main.N], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %16, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %17 = getelementptr inbounds %main.N, ptr %16, i64 0
-// CHECK-NEXT:   %18 = getelementptr inbounds %main.N, ptr %17, i32 0, i32 0
-// CHECK-NEXT:   %19 = getelementptr inbounds %main.N, ptr %17, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %18, align 1
-// CHECK-NEXT:   store i8 2, ptr %19, align 1
-// CHECK-NEXT:   %20 = load [1 x %main.N], ptr %16, align 1
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %main.N] %20, ptr %21, align 1
-// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %21, 1
-// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %22, ptr %23, align 8
-// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %23)
-// CHECK-NEXT:   store i64 100, ptr %24, align 8
-// CHECK-NEXT:   %25 = alloca [1 x %main.N], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %25, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %26 = getelementptr inbounds %main.N, ptr %25, i64 0
-// CHECK-NEXT:   %27 = getelementptr inbounds %main.N, ptr %26, i32 0, i32 0
-// CHECK-NEXT:   %28 = getelementptr inbounds %main.N, ptr %26, i32 0, i32 1
-// CHECK-NEXT:   store i8 3, ptr %27, align 1
-// CHECK-NEXT:   store i8 4, ptr %28, align 1
-// CHECK-NEXT:   %29 = load [1 x %main.N], ptr %25, align 1
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %main.N] %29, ptr %30, align 1
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %30, 1
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %31, ptr %32, align 8
-// CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %32)
-// CHECK-NEXT:   store i64 200, ptr %33, align 8
-// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %15)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-// CHECK-NEXT:   %35 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %34)
-// CHECK-NEXT:   %36 = extractvalue { i1, ptr, ptr } %35, 0
-// CHECK-NEXT:   br i1 %36, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %37 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 1
-// CHECK-NEXT:   %38 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 2
-// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 0
-// CHECK-NEXT:   %40 = icmp eq ptr %39, @_llgo_main.K
-// CHECK-NEXT:   br i1 %40, label %_llgo_7, label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %41 = extractvalue { i1, ptr, ptr } %35, 1
-// CHECK-NEXT:   %42 = extractvalue { i1, ptr, ptr } %35, 2
-// CHECK-NEXT:   %43 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %41, align 8
-// CHECK-NEXT:   %44 = load i64, ptr %42, align 8
-// CHECK-NEXT:   %45 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %43, 1
-// CHECK-NEXT:   %46 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %45, i64 %44, 2
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %47 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %46, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %48 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 0
-// CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
-// CHECK-NEXT:   %50 = load [1 x %main.N], ptr %49, align 1
-// CHECK-NEXT:   %51 = alloca [1 x %main.N], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %51, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   store [1 x %main.N] %50, ptr %51, align 1
-// CHECK-NEXT:   %52 = getelementptr inbounds %main.N, ptr %51, i64 0
-// CHECK-NEXT:   %53 = load %main.N, ptr %52, align 1
-// CHECK-NEXT:   %54 = extractvalue %main.N %53, 0
-// CHECK-NEXT:   %55 = sext i8 %54 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %55)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %38)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %39, ptr @_llgo_main.K)
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make4(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 0
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %3 = getelementptr inbounds %main.N, ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %main.N, ptr %2, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %3, align 1
-// CHECK-NEXT:   store i8 2, ptr %4, align 1
-// CHECK-NEXT:   store ptr %2, ptr %1, align 8
-// CHECK-NEXT:   %5 = load [1 x ptr], ptr %0, align 8
-// CHECK-NEXT:   %6 = extractvalue [1 x ptr] %5, 0
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %6, 1
-// CHECK-NEXT:   %8 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %8, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %9 = getelementptr inbounds ptr, ptr %8, i64 0
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %11 = getelementptr inbounds %main.N, ptr %10, i32 0, i32 0
-// CHECK-NEXT:   %12 = getelementptr inbounds %main.N, ptr %10, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %11, align 1
-// CHECK-NEXT:   store i8 2, ptr %12, align 1
-// CHECK-NEXT:   store ptr %10, ptr %9, align 8
-// CHECK-NEXT:   %13 = load [1 x ptr], ptr %8, align 8
-// CHECK-NEXT:   %14 = extractvalue [1 x ptr] %13, 0
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %14, 1
-// CHECK-NEXT:   %16 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %7, %"{{.*}}/runtime/internal/runtime.eface" %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %16)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %18 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %19 = getelementptr inbounds ptr, ptr %18, i64 0
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %21 = getelementptr inbounds %main.N, ptr %20, i32 0, i32 0
-// CHECK-NEXT:   %22 = getelementptr inbounds %main.N, ptr %20, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %21, align 1
-// CHECK-NEXT:   store i8 2, ptr %22, align 1
-// CHECK-NEXT:   store ptr %20, ptr %19, align 8
-// CHECK-NEXT:   %23 = load [1 x ptr], ptr %18, align 8
-// CHECK-NEXT:   %24 = extractvalue [1 x ptr] %23, 0
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %24, 1
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %25, ptr %26, align 8
-// CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %26)
-// CHECK-NEXT:   store i64 100, ptr %27, align 8
-// CHECK-NEXT:   %28 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %28, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %29 = getelementptr inbounds ptr, ptr %28, i64 0
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %31 = getelementptr inbounds %main.N, ptr %30, i32 0, i32 0
-// CHECK-NEXT:   %32 = getelementptr inbounds %main.N, ptr %30, i32 0, i32 1
-// CHECK-NEXT:   store i8 3, ptr %31, align 1
-// CHECK-NEXT:   store i8 4, ptr %32, align 1
-// CHECK-NEXT:   store ptr %30, ptr %29, align 8
-// CHECK-NEXT:   %33 = load [1 x ptr], ptr %28, align 8
-// CHECK-NEXT:   %34 = extractvalue [1 x ptr] %33, 0
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %34, 1
-// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %35, ptr %36, align 8
-// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %36)
-// CHECK-NEXT:   store i64 200, ptr %37, align 8
-// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %17)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-// CHECK-NEXT:   %39 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %38)
-// CHECK-NEXT:   %40 = extractvalue { i1, ptr, ptr } %39, 0
-// CHECK-NEXT:   br i1 %40, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %41 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 1
-// CHECK-NEXT:   %42 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 2
-// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 0
-// CHECK-NEXT:   %44 = icmp eq ptr %43, @_llgo_main.K2
-// CHECK-NEXT:   br i1 %44, label %_llgo_7, label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %45 = extractvalue { i1, ptr, ptr } %39, 1
-// CHECK-NEXT:   %46 = extractvalue { i1, ptr, ptr } %39, 2
-// CHECK-NEXT:   %47 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %45, align 8
-// CHECK-NEXT:   %48 = load i64, ptr %46, align 8
-// CHECK-NEXT:   %49 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %47, 1
-// CHECK-NEXT:   %50 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %49, i64 %48, 2
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %51 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %50, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %52 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 0
-// CHECK-NEXT:   br i1 %52, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 1
-// CHECK-NEXT:   %54 = insertvalue [1 x ptr] undef, ptr %53, 0
-// CHECK-NEXT:   %55 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %55, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store [1 x ptr] %54, ptr %55, align 8
-// CHECK-NEXT:   %56 = getelementptr inbounds ptr, ptr %55, i64 0
-// CHECK-NEXT:   %57 = load ptr, ptr %56, align 8
-// CHECK-NEXT:   %58 = getelementptr inbounds %main.N, ptr %57, i32 0, i32 0
-// CHECK-NEXT:   %59 = load i8, ptr %58, align 1
-// CHECK-NEXT:   %60 = sext i8 %59 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %60)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %42)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %43, ptr @_llgo_main.K2)
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make5(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"chan _llgo_int", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"chan _llgo_int", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %3 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %1, %"{{.*}}/runtime/internal/runtime.eface" %2)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %3)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[chan _llgo_int]_llgo_int", i64 0)
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store ptr %0, ptr %5, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[chan _llgo_int]_llgo_int", ptr %4, ptr %5)
-// CHECK-NEXT:   store i64 100, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store ptr %0, ptr %7, align 8
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[chan _llgo_int]_llgo_int", ptr %4, ptr %7)
-// CHECK-NEXT:   store i64 200, ptr %8, align 8
-// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[chan _llgo_int]_llgo_int", ptr %4)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %10 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %9)
-// CHECK-NEXT:   %11 = extractvalue { i1, ptr, ptr } %10, 0
-// CHECK-NEXT:   br i1 %11, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %12 = extractvalue { i1, ptr, i64 } %20, 1
-// CHECK-NEXT:   %13 = extractvalue { i1, ptr, i64 } %20, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %12)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %14 = extractvalue { i1, ptr, ptr } %10, 1
-// CHECK-NEXT:   %15 = extractvalue { i1, ptr, ptr } %10, 2
-// CHECK-NEXT:   %16 = load ptr, ptr %14, align 8
-// CHECK-NEXT:   %17 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %18 = insertvalue { i1, ptr, i64 } { i1 true, ptr undef, i64 undef }, ptr %16, 1
-// CHECK-NEXT:   %19 = insertvalue { i1, ptr, i64 } %18, i64 %17, 2
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %20 = phi { i1, ptr, i64 } [ %19, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %21 = extractvalue { i1, ptr, i64 } %20, 0
-// CHECK-NEXT:   br i1 %21, label %_llgo_2, label %_llgo_3
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make6(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @_llgo_main.M, ptr %0, ptr %1)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @_llgo_main.M, ptr %0)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %4 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %3)
-// CHECK-NEXT:   %5 = extractvalue { i1, ptr, ptr } %4, 0
-// CHECK-NEXT:   br i1 %5, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %6 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %14, 1
-// CHECK-NEXT:   %7 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %14, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %6)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %7)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %8 = extractvalue { i1, ptr, ptr } %4, 1
-// CHECK-NEXT:   %9 = extractvalue { i1, ptr, ptr } %4, 2
-// CHECK-NEXT:   %10 = load i64, ptr %8, align 8
-// CHECK-NEXT:   %11 = load %"{{.*}}/runtime/internal/runtime.String", ptr %9, align 8
-// CHECK-NEXT:   %12 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } { i1 true, i64 undef, %"{{.*}}/runtime/internal/runtime.String" undef }, i64 %10, 1
-// CHECK-NEXT:   %13 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %12, %"{{.*}}/runtime/internal/runtime.String" %11, 2
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %14 = phi { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } [ %13, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %15 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %14, 0
-// CHECK-NEXT:   br i1 %15, label %_llgo_2, label %_llgo_3
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.make7(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_main.N.7.0]_llgo_string", i64 2)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0, ptr %1)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 2, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0, ptr %3)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %6 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %5)
-// CHECK-NEXT:   %7 = extractvalue { i1, ptr, ptr } %6, 0
-// CHECK-NEXT:   br i1 %7, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %8 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %19, 1
-// CHECK-NEXT:   %9 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %19, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %9)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %10, align 8
-// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0, ptr %10)
-// CHECK-NEXT:   %12 = load %"{{.*}}/runtime/internal/runtime.String", ptr %11, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %12)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %13 = extractvalue { i1, ptr, ptr } %6, 1
-// CHECK-NEXT:   %14 = extractvalue { i1, ptr, ptr } %6, 2
-// CHECK-NEXT:   %15 = load i64, ptr %13, align 8
-// CHECK-NEXT:   %16 = load %"{{.*}}/runtime/internal/runtime.String", ptr %14, align 8
-// CHECK-NEXT:   %17 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } { i1 true, i64 undef, %"{{.*}}/runtime/internal/runtime.String" undef }, i64 %15, 1
-// CHECK-NEXT:   %18 = insertvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %17, %"{{.*}}/runtime/internal/runtime.String" %16, 2
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %19 = phi { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } [ %18, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %20 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %19, 0
-// CHECK-NEXT:   br i1 %20, label %_llgo_2, label %_llgo_3
-// CHECK-NEXT: }

--- a/cl/_testrt/map/in.go
+++ b/cl/_testrt/map/in.go
@@ -6,23 +6,20 @@ import (
 )
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_int", i64 2)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 23, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr %0, ptr %1)
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 7, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr %0, ptr %3)
-// CHECK-NEXT:   store i64 29, ptr %4, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 23, ptr %5, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr %0, ptr %5)
-// CHECK-NEXT:   %7 = load i64, ptr %6, align 8
-// CHECK-NEXT:   %8 = call i32 (ptr, ...) @printf(ptr @13, i64 %7)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[MAP:%[0-9]+]] = call ptr @"{{.*}}MakeMap"(ptr @"map[_llgo_int]_llgo_int", i64 2)
+// CHECK-NEXT: [[KEY23:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 8)
+// CHECK-NEXT: store i64 23, ptr [[KEY23]]
+// CHECK-NEXT: [[VALUE100:%[0-9]+]] = call ptr @"{{.*}}MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr [[MAP]], ptr [[KEY23]])
+// CHECK-NEXT: store i64 100, ptr [[VALUE100]]
+// CHECK-NEXT: [[KEY7:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 8)
+// CHECK-NEXT: store i64 7, ptr [[KEY7]]
+// CHECK-NEXT: [[VALUE29:%[0-9]+]] = call ptr @"{{.*}}MapAssign"(ptr @"map[_llgo_int]_llgo_int", ptr [[MAP]], ptr [[KEY7]])
+// CHECK-NEXT: store i64 29, ptr [[VALUE29]]
+// CHECK-NEXT: [[LOOKUP_KEY:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 8)
+// CHECK-NEXT: store i64 23, ptr [[LOOKUP_KEY]]
+// CHECK-NEXT: [[LOOKUP_ADDR:%[0-9]+]] = call ptr @"{{.*}}MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr [[MAP]], ptr [[LOOKUP_KEY]])
+// CHECK-NEXT: [[LOOKUP:%[0-9]+]] = load i64, ptr [[LOOKUP_ADDR]]
+// CHECK-NEXT: call i32 (ptr, ...) @printf(ptr @{{[0-9]+}}, i64 [[LOOKUP]])
 func main() {
 	a := map[int]int{23: 100, 7: 29}
 	c.Printf(c.Str("Hello %d\n"), a[23])

--- a/cl/_testrt/mapclosure/in.go
+++ b/cl/_testrt/mapclosure/in.go
@@ -6,18 +6,12 @@ type Type interface {
 }
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.demo(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 0
-// CHECK-NEXT:   %3 = getelementptr ptr, ptr %2, i64 3
-// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
-// CHECK-NEXT:   %5 = insertvalue { ptr, ptr } undef, ptr %4, 0
-// CHECK-NEXT:   %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
-// CHECK-NEXT:   %7 = extractvalue { ptr, ptr } %6, 1
-// CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %6, 0
-// CHECK-NEXT:   %9 = call %"{{.*}}/runtime/internal/runtime.String" %8(ptr %7)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %9
-// CHECK-NEXT: }
+// CHECK: [[DEMO_DATA:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
+// CHECK: [[DEMO_METHOD:%[0-9]+]] = load ptr, ptr %{{[0-9]+}}
+// CHECK: [[DEMO_PAIR0:%[0-9]+]] = insertvalue { ptr, ptr } undef, ptr [[DEMO_METHOD]], 0
+// CHECK-NEXT: [[DEMO_PAIR:%[0-9]+]] = insertvalue { ptr, ptr } [[DEMO_PAIR0]], ptr [[DEMO_DATA]], 1
+// CHECK: [[DEMO_RESULT:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" %{{[0-9]+}}(ptr %{{[0-9]+}})
+// CHECK-NEXT: ret %"{{.*}}/runtime/internal/runtime.String" [[DEMO_RESULT]]
 func demo(t Type) string {
 	return t.String()
 }
@@ -33,51 +27,38 @@ var (
 	list = []func(Type) string{demo}
 )
 
+// CHECK-LABEL: define void @main.init(){{.*}} {
+// CHECK: [[OP_MAP:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_closure${{[-A-Za-z0-9_]+}}", i64 1)
+// CHECK: [[OP_SLOT:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_string]_llgo_closure${{[-A-Za-z0-9_]+}}", ptr [[OP_MAP]], ptr %{{[0-9]+}})
+// CHECK-NEXT: store { ptr, ptr } { ptr @main.demo, ptr null }, ptr [[OP_SLOT]]
+// CHECK-NEXT: store ptr [[OP_MAP]], ptr @main.op
+// CHECK: store { ptr, ptr } { ptr @main.demo, ptr null }, ptr [[LIST_ELEM:%[0-9]+]]
+// CHECK: store %"{{.*}}/runtime/internal/runtime.Slice" [[LIST:%[0-9]+]], ptr @main.list
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds %main.typ, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 }, ptr %1, align 8
-// CHECK-NEXT:   %2 = load ptr, ptr @main.op, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 4 }, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_string]_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %2, ptr %3)
-// CHECK-NEXT:   %5 = load { ptr, ptr }, ptr %4, align 8
-// CHECK-NEXT:   %6 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @main.list, align 8
-// CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 1
-// CHECK-NEXT:   %9 = icmp uge i64 0, %8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %9, {{.*}})
-// CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr }, ptr %7, i64 0
-// CHECK-NEXT:   %11 = load { ptr, ptr }, ptr %10, align 8
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*_llgo_main.typ")
-// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %12, 0
-// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %13, ptr %0, 1
-// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %5, 1
-// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %5, 0
-// CHECK-NEXT:   %__llgo_funcval_code = call ptr asm "", "=r,0"(ptr %16)
-// CHECK-NEXT:   %17 = call %"{{.*}}/runtime/internal/runtime.String" %__llgo_funcval_code(ptr {{(nest|swiftself)}} %15, %"{{.*}}/runtime/internal/runtime.iface" %14)
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*_llgo_main.typ")
-// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %18, 0
-// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %19, ptr %0, 1
-// CHECK-NEXT:   %21 = extractvalue { ptr, ptr } %11, 1
-// CHECK-NEXT:   %22 = extractvalue { ptr, ptr } %11, 0
-// CHECK-NEXT:   %__llgo_funcval_code1 = call ptr asm "", "=r,0"(ptr %22)
-// CHECK-NEXT:   %23 = call %"{{.*}}/runtime/internal/runtime.String" %__llgo_funcval_code1(ptr {{(nest|swiftself)}} %21, %"{{.*}}/runtime/internal/runtime.iface" %20)
-// CHECK-NEXT:   %24 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %17, %"{{.*}}/runtime/internal/runtime.String" %23)
-// CHECK-NEXT:   %25 = xor i1 %24, true
-// CHECK-NEXT:   br i1 %25, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 5 }, ptr %26, align 8
-// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %26, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %27)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[TYP:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK: [[LOADED_MAP:%[0-9]+]] = load ptr, ptr @main.op
+// CHECK: [[MAP_SLOT:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_string]_llgo_closure${{[-A-Za-z0-9_]+}}", ptr [[LOADED_MAP]], ptr %{{[0-9]+}})
+// CHECK-NEXT: [[MAP_FN:%[0-9]+]] = load { ptr, ptr }, ptr [[MAP_SLOT]]
+// CHECK-NEXT: [[LOADED_LIST:%[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @main.list
+// CHECK-NEXT: [[LIST_DATA:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[LOADED_LIST]], 0
+// CHECK-NEXT: [[LIST_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[LOADED_LIST]], 1
+// CHECK: [[LIST_SLOT:%[0-9]+]] = getelementptr inbounds { ptr, ptr }, ptr [[LIST_DATA]], i64 0
+// CHECK-NEXT: [[LIST_FN:%[0-9]+]] = load { ptr, ptr }, ptr [[LIST_SLOT]]
+// CHECK-NEXT: [[ITAB1:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.typ")
+// CHECK: [[MAP_ENV:%[0-9]+]] = extractvalue { ptr, ptr } [[MAP_FN]], 1
+// CHECK-NEXT: [[MAP_CODE:%[0-9]+]] = extractvalue { ptr, ptr } [[MAP_FN]], 0
+// CHECK: [[MAP_RESULT:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" %__llgo_funcval_code(ptr {{(nest|swiftself)}} [[MAP_ENV]], %"{{.*}}/runtime/internal/runtime.iface" [[MAP_ARG:%[0-9]+]])
+// CHECK: [[ITAB2:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.typ")
+// CHECK: [[LIST_ENV:%[0-9]+]] = extractvalue { ptr, ptr } [[LIST_FN]], 1
+// CHECK-NEXT: [[LIST_CODE:%[0-9]+]] = extractvalue { ptr, ptr } [[LIST_FN]], 0
+// CHECK: [[LIST_RESULT:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" %__llgo_funcval_code1(ptr {{(nest|swiftself)}} [[LIST_ENV]], %"{{.*}}/runtime/internal/runtime.iface" [[LIST_ARG:%[0-9]+]])
+// CHECK-NEXT: [[SAME_RESULT:%[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" [[MAP_RESULT]], %"{{.*}}/runtime/internal/runtime.String" [[LIST_RESULT]])
+// CHECK-NEXT: [[RESULT_MISMATCH:%[0-9]+]] = xor i1 [[SAME_RESULT]], true
+// CHECK-NEXT: br i1 [[RESULT_MISMATCH]], label %{{.*}}, label %{{.*}}
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*typ).String"(ptr %0){{.*}} {
+// CHECK: [[STRING_FIELD:%[0-9]+]] = getelementptr inbounds %main.typ, ptr %0, i32 0, i32 0
+// CHECK-NEXT: [[STRING_VALUE:%[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr [[STRING_FIELD]]
+// CHECK-NEXT: ret %"{{.*}}/runtime/internal/runtime.String" [[STRING_VALUE]]
 func main() {
 	t := &typ{"hello"}
 	fn1 := op["demo"]
@@ -86,13 +67,6 @@ func main() {
 		panic("error")
 	}
 }
-
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*typ).String"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %main.typ, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
-// CHECK-NEXT: }
 
 func (t *typ) String() string {
 	return t.s

--- a/cl/_testrt/namedslice/in.go
+++ b/cl/_testrt/namedslice/in.go
@@ -4,13 +4,18 @@ package main
 type MyBytes []byte
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %{{[0-9]+}} = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"__llgo.moduleZeroSizedAlloc$", i64 0, i64 0 }, ptr %{{[0-9]+}}, align 8
-// CHECK-NEXT:   %{{[0-9]+}} = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.MyBytes, ptr undef }, ptr %{{[0-9]+}}, 1
-// CHECK: icmp eq ptr %{{[0-9]+}}, @_llgo_main.MyBytes
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %{{[0-9]+}})
-// CHECK: }
+// CHECK: [[DATA:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 24)
+// CHECK-NEXT: store %"{{.*}}Slice" { ptr @"__llgo.moduleZeroSizedAlloc$", i64 0, i64 0 }, ptr [[DATA]]
+// CHECK-NEXT: [[BOXED:%[0-9]+]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.MyBytes, ptr undef }, ptr [[DATA]], 1
+// CHECK-NEXT: [[TYPE:%[0-9]+]] = extractvalue %"{{.*}}eface" [[BOXED]], 0
+// CHECK-NEXT: [[MATCH:%[0-9]+]] = icmp eq ptr [[TYPE]], @_llgo_main.MyBytes
+// CHECK: call void @"{{.*}}Panic"(%"{{.*}}eface" {{.*}})
+// CHECK: [[ASSERT_DATA:%[0-9]+]] = extractvalue %"{{.*}}eface" [[BOXED]], 1
+// CHECK-NEXT: [[ASSERT_VALUE:%[0-9]+]] = load %"{{.*}}Slice", ptr [[ASSERT_DATA]]
+// CHECK: [[ASSERT_PAIR:%[0-9]+]] = phi { %"{{.*}}Slice", i1 } [ {{.*}}, %{{.*}} ], [ zeroinitializer, %{{.*}} ]
+// CHECK-NEXT: extractvalue { %"{{.*}}Slice", i1 } [[ASSERT_PAIR]], 0
+// CHECK-NEXT: [[OK:%[0-9]+]] = extractvalue { %"{{.*}}Slice", i1 } [[ASSERT_PAIR]], 1
+// CHECK-NEXT: br i1 [[OK]], label %{{[^,]+}}, label %{{[^ ]+}}
 func main() {
 	var i any = MyBytes{}
 	_, ok := i.(MyBytes)

--- a/cl/_testrt/nextblock/in.go
+++ b/cl/_testrt/nextblock/in.go
@@ -1,7 +1,48 @@
 // LITTEST
 package main
 
-// CHECK: {{^}}@{{[0-9]+}} = private unnamed_addr constant [3 x i8] c"bye", align 1{{$}}
+// The defer must survive the loop/control-flow joins and be released on the
+// shared exit path.
+// CHECK: [[BYE:@[0-9]+]] = private unnamed_addr constant [3 x i8] c"bye"
+// CHECK-LABEL: define void @main.main(){{.*}} {
+// CHECK: [[PREV_DEFER:%.*]] = call ptr @"{{.*}}GetThreadDefer"()
+// CHECK: [[FRAME:%.*]] = call ptr @"{{.*}}AllocU"(i64 48)
+// CHECK: store ptr [[PREV_DEFER]], ptr {{%.*}}
+// CHECK: call void @"{{.*}}SetThreadDefer"(ptr [[FRAME]])
+// CHECK: [[FLAGS:%.*]] = getelementptr inbounds %"{{.*}}Defer", ptr [[FRAME]], i32 0, i32 1
+// CHECK: [[HEAD:%.*]] = getelementptr inbounds %"{{.*}}Defer", ptr [[FRAME]], i32 0, i32 5
+// The first empty range still forms a valid loop and reaches defer registration.
+// CHECK: [[FIRST_I:%.*]] = phi i64 [ -1, %{{.*}} ], [ [[FIRST_NEXT:%.*]], %{{.*}} ]
+// CHECK-NEXT: [[FIRST_NEXT]] = add i64 [[FIRST_I]], 1
+// CHECK-NEXT: [[FIRST_MORE:%.*]] = icmp slt i64 [[FIRST_NEXT]], 0
+// CHECK-NEXT: br i1 [[FIRST_MORE]], label %{{.*}}, label %{{.*}}
+// CHECK: [[OLD_FLAGS:%.*]] = load i64, ptr [[FLAGS]]
+// CHECK-NEXT: [[DEFER_FLAGS:%.*]] = or i64 [[OLD_FLAGS]], 1
+// CHECK-NEXT: store i64 [[DEFER_FLAGS]], ptr [[FLAGS]]
+// CHECK: [[OLD_HEAD:%.*]] = load ptr, ptr [[HEAD]]
+// CHECK: [[NODE:%.*]] = call ptr @"{{.*}}AllocU"(i64 32)
+// CHECK: [[NODE_PREV:%.*]] = getelementptr inbounds { ptr, i64, %"{{.*}}String" }, ptr [[NODE]], i32 0, i32 0
+// CHECK-NEXT: store ptr [[OLD_HEAD]], ptr [[NODE_PREV]]
+// CHECK: [[NODE_TEXT:%.*]] = getelementptr inbounds { ptr, i64, %"{{.*}}String" }, ptr [[NODE]], i32 0, i32 2
+// CHECK-NEXT: store %"{{.*}}String" { ptr [[BYE]], i64 3 }, ptr [[NODE_TEXT]]
+// CHECK-NEXT: store ptr [[NODE]], ptr [[HEAD]]
+// The second empty range exits through the shared cleanup instead of bypassing it.
+// CHECK: [[SECOND_I:%.*]] = phi i64 [ -1, %{{.*}} ], [ [[SECOND_NEXT:%.*]], %{{.*}} ]
+// CHECK-NEXT: [[SECOND_NEXT]] = add i64 [[SECOND_I]], 1
+// CHECK-NEXT: [[SECOND_MORE:%.*]] = icmp slt i64 [[SECOND_NEXT]], 0
+// CHECK-NEXT: br i1 [[SECOND_MORE]], label %{{.*}}, label %{{.*}}
+// CHECK: [[EXIT_FLAGS:%.*]] = load i64, ptr [[FLAGS]]
+// CHECK-NEXT: [[DEFER_BIT:%.*]] = and i64 [[EXIT_FLAGS]], 1
+// CHECK-NEXT: [[HAS_DEFER:%.*]] = icmp ne i64 [[DEFER_BIT]], 0
+// CHECK: [[NODE_CANDIDATE:%.*]] = load ptr, ptr [[HEAD]]
+// CHECK-NEXT: icmp ne ptr [[NODE_CANDIDATE]], null
+// CHECK: [[ACTIVE_NODE:%.*]] = load ptr, ptr [[HEAD]]
+// CHECK: [[NODE_VALUE:%.*]] = load { ptr, i64, %"{{.*}}String" }, ptr [[ACTIVE_NODE]]
+// CHECK: [[NEXT_NODE:%.*]] = extractvalue { ptr, i64, %"{{.*}}String" } [[NODE_VALUE]], 0
+// CHECK-NEXT: store ptr [[NEXT_NODE]], ptr [[HEAD]]
+// CHECK: [[DEFER_TEXT:%.*]] = extractvalue { ptr, i64, %"{{.*}}String" } [[NODE_VALUE]], 2
+// CHECK-NEXT: call void @"{{.*}}FreeDeferNode"(ptr [[ACTIVE_NODE]])
+// CHECK-NEXT: call void @"{{.*}}PrintString"(%"{{.*}}String" [[DEFER_TEXT]])
 
 func main() {
 	syms := []int{}
@@ -11,128 +52,3 @@ func main() {
 	for range syms {
 	}
 }
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
-// CHECK-NEXT:   %1 = alloca i8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   store ptr %1, ptr %3, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 1
-// CHECK-NEXT:   store i64 0, ptr %4, align 8
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 2
-// CHECK-NEXT:   store ptr %0, ptr %5, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 3
-// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_9), ptr %6, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %2)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 1
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 3
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 4
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 5
-// CHECK-NEXT:   store ptr null, ptr %10, align 8
-// CHECK-NEXT:   %11 = call i32 @{{(__)?}}sigsetjmp(ptr %1, i32 0)
-// CHECK-NEXT:   %12 = icmp eq i32 %11, 0
-// CHECK-NEXT:   br i1 %12, label %_llgo_8, label %_llgo_11
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_8
-// CHECK-NEXT:   %13 = phi i64 [ -1, %_llgo_8 ], [ %14, %_llgo_2 ]
-// CHECK-NEXT:   %14 = add i64 %13, 1
-// CHECK-NEXT:   %15 = icmp slt i64 %14, 0
-// CHECK-NEXT:   br i1 %15, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %16 = load i64, ptr %7, align 8
-// CHECK-NEXT:   %17 = or i64 %16, 1
-// CHECK-NEXT:   store i64 %17, ptr %7, align 8
-// CHECK-NEXT:   %18 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 32)
-// CHECK-NEXT:   %20 = getelementptr inbounds { ptr, i64, %"{{.*}}/runtime/internal/runtime.String" }, ptr %19, i32 0, i32 0
-// CHECK-NEXT:   store ptr %18, ptr %20, align 8
-// CHECK-NEXT:   %21 = getelementptr inbounds { ptr, i64, %"{{.*}}/runtime/internal/runtime.String" }, ptr %19, i32 0, i32 1
-// CHECK-NEXT:   store i64 0, ptr %21, align 8
-// CHECK-NEXT:   %22 = getelementptr inbounds { ptr, i64, %"{{.*}}/runtime/internal/runtime.String" }, ptr %19, i32 0, i32 2
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 3 }, ptr %22, align 8
-// CHECK-NEXT:   store ptr %19, ptr %10, align 8
-// CHECK-NEXT:   br label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_10
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_6, %_llgo_3
-// CHECK-NEXT:   %23 = phi i64 [ -1, %_llgo_3 ], [ %24, %_llgo_6 ]
-// CHECK-NEXT:   %24 = add i64 %23, 1
-// CHECK-NEXT:   %25 = icmp slt i64 %24, 0
-// CHECK-NEXT:   br i1 %25, label %_llgo_6, label %_llgo_7
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   br label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_12), ptr %9, align 8
-// CHECK-NEXT:   br label %_llgo_9
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_11, %_llgo_7
-// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_10), ptr %8, align 8
-// CHECK-NEXT:   %26 = load i64, ptr %7, align 8
-// CHECK-NEXT:   %27 = and i64 %26, 1
-// CHECK-NEXT:   %28 = icmp ne i64 %27, 0
-// CHECK-NEXT:   br i1 %28, label %_llgo_13, label %_llgo_14
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_11, %_llgo_14
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Rethrow"(ptr %0)
-// CHECK-NEXT:   br label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_0
-// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_10), ptr %9, align 8
-// CHECK-NEXT:   %29 = load ptr, ptr %8, align 8
-// CHECK-NEXT:   indirectbr ptr %29, [label %_llgo_10, label %_llgo_9]
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_14
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_9
-// CHECK-NEXT:   %30 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   %31 = icmp ne ptr %30, null
-// CHECK-NEXT:   br i1 %31, label %_llgo_15, label %_llgo_16
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_16, %_llgo_9
-// CHECK-NEXT:   %32 = load %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, align 8
-// CHECK-NEXT:   %33 = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %32, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %33)
-// CHECK-NEXT:   %34 = load ptr, ptr %9, align 8
-// CHECK-NEXT:   indirectbr ptr %34, [label %_llgo_10, label %_llgo_12]
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_13
-// CHECK-NEXT:   %35 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   %36 = load { ptr, i64, %"{{.*}}/runtime/internal/runtime.String" }, ptr %35, align 8
-// CHECK-NEXT:   %37 = extractvalue { ptr, i64, %"{{.*}}/runtime/internal/runtime.String" } %36, 0
-// CHECK-NEXT:   store ptr %37, ptr %10, align 8
-// CHECK-NEXT:   %38 = extractvalue { ptr, i64, %"{{.*}}/runtime/internal/runtime.String" } %36, 2
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.FreeDeferNode"(ptr %35)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %38)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_16
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_15, %_llgo_13
-// CHECK-NEXT:   br label %_llgo_14
-// CHECK-NEXT: }

--- a/cl/_testrt/panic/in.go
+++ b/cl/_testrt/panic/in.go
@@ -2,13 +2,12 @@
 package main
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 13 }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %0, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %1)
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
+// CHECK: [[PANIC_DATA:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 16)
+// CHECK-NEXT: store %"{{.*}}String" { ptr @{{[0-9]+}}, i64 13 }, ptr [[PANIC_DATA]]
+// CHECK-NEXT: [[PANIC_VALUE:%[0-9]+]] = insertvalue %"{{.*}}eface" { ptr @_llgo_string, ptr undef }, ptr [[PANIC_DATA]], 1
+// CHECK-NEXT: call void @"{{.*}}Panic"(%"{{.*}}eface" [[PANIC_VALUE]])
+// CHECK-NEXT: unreachable
+
 func main() {
 	panic("panic message")
 }

--- a/cl/_testrt/qsortfn/in.go
+++ b/cl/_testrt/qsortfn/in.go
@@ -9,19 +9,16 @@ import (
 )
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @main.sort1a()
-// CHECK-NEXT:   call void @main.sort1b()
-// CHECK-NEXT:   call void @main.sort2a()
-// CHECK-NEXT:   call void @main.sort2b()
-// CHECK-NEXT:   call void @main.sort3a()
-// CHECK-NEXT:   call void @main.sort3b()
-// CHECK-NEXT:   call void @main.sort4a()
-// CHECK-NEXT:   call void @main.sort4b()
-// CHECK-NEXT:   call void @main.sort5a()
-// CHECK-NEXT:   call void @main.sort5b()
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @main.sort1a()
+// CHECK:   call void @main.sort1b()
+// CHECK:   call void @main.sort2a()
+// CHECK:   call void @main.sort2b()
+// CHECK:   call void @main.sort3a()
+// CHECK:   call void @main.sort3b()
+// CHECK:   call void @main.sort4a()
+// CHECK:   call void @main.sort4b()
+// CHECK:   call void @main.sort5a()
+// CHECK:   call void @main.sort5b()
 func main() {
 	sort1a()
 	sort1b()
@@ -36,54 +33,16 @@ func main() {
 }
 
 // CHECK-LABEL: define void @main.sort1a(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @0)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort1a$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @1, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort1a$1")
 func sort1a() {
 	c.Printf(c.Str("Comp => Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort1a$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S1A_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S1A_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S1A_DIFF:%[0-9]+]] = sub i64 [[S1A_A]], [[S1A_B]]
+	// CHECK-NEXT: [[S1A_RESULT:%[0-9]+]] = trunc i64 [[S1A_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S1A_RESULT]]
 	var fn Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -94,54 +53,16 @@ func sort1a() {
 }
 
 // CHECK-LABEL: define void @main.sort1b(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @2)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort1b$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @3, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort1b$1")
 func sort1b() {
 	c.Printf(c.Str("fn => Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort1b$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S1B_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S1B_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S1B_DIFF:%[0-9]+]] = sub i64 [[S1B_A]], [[S1B_B]]
+	// CHECK-NEXT: [[S1B_RESULT:%[0-9]+]] = trunc i64 [[S1B_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S1B_RESULT]]
 	var fn = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -152,54 +73,16 @@ func sort1b() {
 }
 
 // CHECK-LABEL: define void @main.sort2a(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @4)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort2a$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @5, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort2a$1")
 func sort2a() {
 	c.Printf(c.Str("Comp => fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort2a$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S2A_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S2A_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S2A_DIFF:%[0-9]+]] = sub i64 [[S2A_A]], [[S2A_B]]
+	// CHECK-NEXT: [[S2A_RESULT:%[0-9]+]] = trunc i64 [[S2A_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S2A_RESULT]]
 	var fn Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -210,54 +93,16 @@ func sort2a() {
 }
 
 // CHECK-LABEL: define void @main.sort2b(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @6)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort2b$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @7, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort2b$1")
 func sort2b() {
 	c.Printf(c.Str("fn => fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort2b$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S2B_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S2B_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S2B_DIFF:%[0-9]+]] = sub i64 [[S2B_A]], [[S2B_B]]
+	// CHECK-NEXT: [[S2B_RESULT:%[0-9]+]] = trunc i64 [[S2B_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S2B_RESULT]]
 	var fn = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -268,54 +113,16 @@ func sort2b() {
 }
 
 // CHECK-LABEL: define void @main.sort3a(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @8)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort3a$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @9, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort3a$1")
 func sort3a() {
 	c.Printf(c.Str("qsort.Comp => qsort.Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort3a$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S3A_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S3A_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S3A_DIFF:%[0-9]+]] = sub i64 [[S3A_A]], [[S3A_B]]
+	// CHECK-NEXT: [[S3A_RESULT:%[0-9]+]] = trunc i64 [[S3A_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S3A_RESULT]]
 	var fn q.Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -326,54 +133,16 @@ func sort3a() {
 }
 
 // CHECK-LABEL: define void @main.sort3b(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @10)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort3b$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @11, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort3b$1")
 func sort3b() {
 	c.Printf(c.Str("fn => qsort.Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort3b$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S3B_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S3B_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S3B_DIFF:%[0-9]+]] = sub i64 [[S3B_A]], [[S3B_B]]
+	// CHECK-NEXT: [[S3B_RESULT:%[0-9]+]] = trunc i64 [[S3B_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S3B_RESULT]]
 	var fn = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -384,54 +153,16 @@ func sort3b() {
 }
 
 // CHECK-LABEL: define void @main.sort4a(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @12)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort4a$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @13, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort4a$1")
 func sort4a() {
 	c.Printf(c.Str("qsort.Comp => fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort4a$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S4A_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S4A_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S4A_DIFF:%[0-9]+]] = sub i64 [[S4A_A]], [[S4A_B]]
+	// CHECK-NEXT: [[S4A_RESULT:%[0-9]+]] = trunc i64 [[S4A_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S4A_RESULT]]
 	var fn q.Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -442,54 +173,16 @@ func sort4a() {
 }
 
 // CHECK-LABEL: define void @main.sort4b(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @14)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort4b$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @15, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort4b$1")
 func sort4b() {
 	c.Printf(c.Str("Comp => qsort.fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort4b$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S4B_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S4B_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S4B_DIFF:%[0-9]+]] = sub i64 [[S4B_A]], [[S4B_B]]
+	// CHECK-NEXT: [[S4B_RESULT:%[0-9]+]] = trunc i64 [[S4B_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S4B_RESULT]]
 	var fn Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -500,54 +193,16 @@ func sort4b() {
 }
 
 // CHECK-LABEL: define void @main.sort5a(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @16)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort5a$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @17, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort5a$1")
 func sort5a() {
 	c.Printf(c.Str("qsort.Comp => Comp()\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort5a$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S5A_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S5A_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S5A_DIFF:%[0-9]+]] = sub i64 [[S5A_A]], [[S5A_B]]
+	// CHECK-NEXT: [[S5A_RESULT:%[0-9]+]] = trunc i64 [[S5A_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S5A_RESULT]]
 	var fn q.Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	}
@@ -558,54 +213,16 @@ func sort5a() {
 }
 
 // CHECK-LABEL: define void @main.sort5b(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @18)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %1, i64 1
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr %1, i64 2
-// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %1, i64 3
-// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %1, i64 4
-// CHECK-NEXT:   store i64 100, ptr %2, align 8
-// CHECK-NEXT:   store i64 8, ptr %3, align 8
-// CHECK-NEXT:   store i64 23, ptr %4, align 8
-// CHECK-NEXT:   store i64 2, ptr %5, align 8
-// CHECK-NEXT:   store i64 7, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort5b$1")
-// CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-// CHECK-NEXT:   %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
-// CHECK-NEXT:   %10 = add i64 %9, 1
-// CHECK-NEXT:   %11 = icmp slt i64 %10, 5
-// CHECK-NEXT:   br i1 %11, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
-// CHECK-NEXT:   %14 = or i1 %13, %12
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %14, {{.*}})
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
-// CHECK-NEXT:   %16 = load i64, ptr %15, align 8
-// CHECK-NEXT:   %17 = call i32 (ptr, ...) @printf(ptr @19, i64 %16)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK:   call void @qsort(ptr %{{[0-9]+}}, i64 5, i64 8, ptr @"main.sort5b$1")
 func sort5b() {
 	c.Printf(c.Str("Comp => qsort.Comp()\n"))
 	a := [...]int{100, 8, 23, 2, 7}
 	// CHECK-LABEL: define i32 @"main.sort5b$1"(ptr %0, ptr %1){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
-	// CHECK-NEXT:   %4 = sub i64 %2, %3
-	// CHECK-NEXT:   %5 = trunc i64 %4 to i32
-	// CHECK-NEXT:   ret i32 %5
-	// CHECK-NEXT: }
+	// CHECK: [[S5B_A:%[0-9]+]] = load i64, ptr %0
+	// CHECK-NEXT: [[S5B_B:%[0-9]+]] = load i64, ptr %1
+	// CHECK-NEXT: [[S5B_DIFF:%[0-9]+]] = sub i64 [[S5B_A]], [[S5B_B]]
+	// CHECK-NEXT: [[S5B_RESULT:%[0-9]+]] = trunc i64 [[S5B_DIFF]] to i32
+	// CHECK-NEXT: ret i32 [[S5B_RESULT]]
 	//
 	var fn Comp = func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))

--- a/cl/_testrt/reflectclosureenv/in.go
+++ b/cl/_testrt/reflectclosureenv/in.go
@@ -7,13 +7,205 @@ type receiver struct {
 	base int
 }
 
+// CHECK-LABEL: define void @main.checkInt(%reflect.Value %0, %"{{.*}}Slice" %1){{.*}} {
+// CHECK: [[CHECK_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value %0, %"{{.*}}Slice" %1)
+// CHECK: [[CHECK_RESULTS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[CHECK_RESULTS]], 0
+// CHECK: [[CHECK_RESULTS_LEN:%.*]] = extractvalue %"{{.*}}Slice" [[CHECK_RESULTS]], 1
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{.*}}, i64 0, i1 true, i64 [[CHECK_RESULTS_LEN]])
+// CHECK: [[CHECK_FIRST_PTR:%.*]] = getelementptr inbounds %reflect.Value, ptr [[CHECK_RESULTS_PTR]], i64 0
+// CHECK: [[CHECK_FIRST_SAFE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[CHECK_FIRST_PTR]])
+// CHECK: [[CHECK_FIRST:%.*]] = load %reflect.Value, ptr [[CHECK_FIRST_SAFE]]
+// CHECK: [[CHECK_GOT:%.*]] = call i64 @reflect.Value.Int(%reflect.Value [[CHECK_FIRST]])
+// CHECK: [[CHECK_BAD:%.*]] = icmp ne i64 [[CHECK_GOT]], 55
+// CHECK: br i1 [[CHECK_BAD]], label %{{.*}}, label %{{.*}}
+// CHECK: store i64 [[CHECK_GOT]], ptr %{{.*}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.Panic"
+
+// CHECK-LABEL: define %"{{.*}}Slice" @main.floatArgs(){{.*}} {
+// CHECK: [[FLOAT_ARG_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
+// CHECK: [[FLOAT_ARGS:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[FLOAT_ARG_STORAGE]], i64 24, i64 9, i64 0, i64 9, i1 true, i1 true, i1 true)
+// CHECK: [[FLOAT_INDEX:%.*]] = add i64 %{{.*}}, 1
+// CHECK: [[FLOAT_ORDINAL:%.*]] = add i64 [[FLOAT_INDEX]], 1
+// CHECK: [[FLOAT_NUMBER:%.*]] = sitofp i64 [[FLOAT_ORDINAL]] to double
+// CHECK: store double [[FLOAT_NUMBER]], ptr [[FLOAT_BOX_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[FLOAT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_float64, ptr undef }, ptr [[FLOAT_BOX_ADDR]], 1
+// CHECK: [[FLOAT_REFLECT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[FLOAT_BOX]])
+// CHECK: [[FLOAT_ARGS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[FLOAT_ARGS]], 0
+// CHECK: [[FLOAT_DEST:%.*]] = getelementptr inbounds %reflect.Value, ptr [[FLOAT_ARGS_PTR]], i64 [[FLOAT_INDEX]]
+// CHECK: store %reflect.Value [[FLOAT_REFLECT]], ptr [[FLOAT_DEST]]
+// CHECK: ret %"{{.*}}Slice" [[FLOAT_ARGS]]
+
+// CHECK-LABEL: define %"{{.*}}Slice" @main.intArgs(){{.*}} {
+// CHECK: [[INT_ARG_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
+// CHECK: [[INT_ARGS:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[INT_ARG_STORAGE]], i64 24, i64 9, i64 0, i64 9, i1 true, i1 true, i1 true)
+// CHECK: [[INT_INDEX:%.*]] = add i64 %{{.*}}, 1
+// CHECK: [[INT_ORDINAL:%.*]] = add i64 [[INT_INDEX]], 1
+// CHECK: store i64 [[INT_ORDINAL]], ptr [[INT_BOX_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[INT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[INT_BOX_ADDR]], 1
+// CHECK: [[INT_REFLECT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[INT_BOX]])
+// CHECK: [[INT_ARGS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[INT_ARGS]], 0
+// CHECK: [[INT_DEST:%.*]] = getelementptr inbounds %reflect.Value, ptr [[INT_ARGS_PTR]], i64 [[INT_INDEX]]
+// CHECK: store %reflect.Value [[INT_REFLECT]], ptr [[INT_DEST]]
+// CHECK: ret %"{{.*}}Slice" [[INT_ARGS]]
+
+// CHECK-LABEL: define void @main.main(){{.*}} {
+// The direct and nested integer closures are boxed and called with the same nine arguments.
+// CHECK: [[MAIN_INTS:%.*]] = call %"{{.*}}Slice" @main.intArgs()
+// CHECK: [[MAIN_SUM_FN:%.*]] = call { ptr, ptr } @main.makeSum(i64 10)
+// CHECK: store { ptr, ptr } [[MAIN_SUM_FN]], ptr [[MAIN_SUM_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[MAIN_SUM_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_SUM_ADDR]], 1
+// CHECK: [[MAIN_SUM_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_SUM_BOX]])
+// CHECK: call void @main.checkInt(%reflect.Value [[MAIN_SUM_VALUE]], %"{{.*}}Slice" [[MAIN_INTS]])
+// CHECK: [[MAIN_NESTED_FN:%.*]] = call { ptr, ptr } @main.makeNestedSum(i64 10)
+// CHECK: store { ptr, ptr } [[MAIN_NESTED_FN]], ptr [[MAIN_NESTED_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[MAIN_NESTED_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_NESTED_ADDR]], 1
+// CHECK: [[MAIN_NESTED_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_NESTED_BOX]])
+// CHECK: call void @main.checkInt(%reflect.Value [[MAIN_NESTED_VALUE]], %"{{.*}}Slice" [[MAIN_INTS]])
+// MakeFunc receives the type of the nine-argument literal and the slice callback main$2.
+// CHECK: [[FUNC_TYPE:%.*]] = call %"{{.*}}iface" @reflect.TypeOf(%"{{.*}}eface" %{{.*}})
+// CHECK: [[MADE:%.*]] = call %reflect.Value @reflect.MakeFunc(%"{{.*}}iface" [[FUNC_TYPE]], { ptr, ptr } { ptr @"main.main$2", ptr null })
+// CHECK: call void @main.checkInt(%reflect.Value [[MADE]], %"{{.*}}Slice" [[MAIN_INTS]])
+// MethodByName is performed on receiver{base: 10} and checked with the same arguments.
+// CHECK: store i64 10, ptr %{{.*}}
+// CHECK: [[RECEIVER_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.receiver, ptr undef }, ptr %{{.*}}, 1
+// CHECK: [[RECEIVER_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[RECEIVER_BOX]])
+// CHECK: [[METHOD:%.*]] = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value [[RECEIVER_VALUE]], %"{{.*}}String" { ptr @{{.*}}, i64 3 })
+// CHECK: call void @main.checkInt(%reflect.Value [[METHOD]], %"{{.*}}Slice" [[MAIN_INTS]])
+// CHECK: [[METHOD_IFACE:%.*]] = call %"{{.*}}eface" @reflect.Value.Interface(%reflect.Value [[METHOD]])
+// CHECK: [[METHOD_TYPE:%.*]] = extractvalue %"{{.*}}eface" [[METHOD_IFACE]], 0
+// CHECK: [[METHOD_MATCH:%.*]] = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr [[METHOD_TYPE]])
+// CHECK: br i1 [[METHOD_MATCH]], label %{{.*}}, label %{{.*}}
+// The floating closure is reflect-called with floatArgs and compared with 55.
+// CHECK: [[MAIN_FLOAT_FN:%.*]] = call { ptr, ptr } @main.makeFloatSum(double 1.000000e+01)
+// CHECK: store { ptr, ptr } [[MAIN_FLOAT_FN]], ptr [[MAIN_FLOAT_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[MAIN_FLOAT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_FLOAT_ADDR]], 1
+// CHECK: [[MAIN_FLOAT_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_FLOAT_BOX]])
+// CHECK: [[MAIN_FLOAT_ARGS:%.*]] = call %"{{.*}}Slice" @main.floatArgs()
+// CHECK: [[MAIN_FLOAT_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value [[MAIN_FLOAT_VALUE]], %"{{.*}}Slice" [[MAIN_FLOAT_ARGS]])
+// CHECK: [[MAIN_FLOAT_GOT:%.*]] = call double @reflect.Value.Float(%reflect.Value %{{.*}})
+// CHECK: [[MAIN_FLOAT_BAD:%.*]] = fcmp une double [[MAIN_FLOAT_GOT]], 5.500000e+01
+// CHECK: br i1 [[MAIN_FLOAT_BAD]], label %{{.*}}, label %{{.*}}
+// The asserted method closure keeps code and environment through the direct nine-argument call.
+// CHECK: [[METHOD_DATA:%.*]] = extractvalue %"{{.*}}eface" [[METHOD_IFACE]], 1
+// CHECK: [[METHOD_FN:%.*]] = load { ptr, ptr }, ptr [[METHOD_DATA]]
+// CHECK: [[METHOD_ENV:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 1
+// CHECK: [[METHOD_CODE_RAW:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 0
+// CHECK: [[METHOD_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[METHOD_CODE_RAW]])
+// CHECK: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr {{(nest|swiftself)}} [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
+// CHECK: [[METHOD_BAD:%.*]] = icmp ne i64 [[METHOD_GOT]], 55
+
+// CHECK-LABEL: define i64 @"main.main$1"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8){{.*}} {
+// CHECK: ret i64 0
+
+// CHECK-LABEL: define %"{{.*}}Slice" @"main.main$2"(%"{{.*}}Slice" %0){{.*}} {
+// CHECK: [[MAKEFUNC_ARGS_LEN:%.*]] = extractvalue %"{{.*}}Slice" %0, 1
+// CHECK: [[MAKEFUNC_SUM:%.*]] = phi i64 [ 10, %{{.*}} ], [ [[MAKEFUNC_NEXT:%.*]], %{{.*}} ]
+// CHECK: [[MAKEFUNC_ARG:%.*]] = call i64 @reflect.Value.Int(%reflect.Value %{{.*}})
+// CHECK: [[MAKEFUNC_NEXT]] = add i64 [[MAKEFUNC_SUM]], [[MAKEFUNC_ARG]]
+// CHECK: store i64 [[MAKEFUNC_SUM]], ptr [[MAKEFUNC_RESULT_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[MAKEFUNC_RESULT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[MAKEFUNC_RESULT_ADDR]], 1
+// CHECK: [[MAKEFUNC_RESULT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAKEFUNC_RESULT_BOX]])
+// CHECK: store %reflect.Value [[MAKEFUNC_RESULT]], ptr %{{.*}}
+// CHECK: ret %"{{.*}}Slice" %{{.*}}
+
+// CHECK-LABEL: define { ptr, ptr } @main.makeFloatSum(double %0){{.*}} {
+// CHECK: store double %0, ptr [[FLOAT_BASE_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: store ptr [[FLOAT_BASE_ADDR]], ptr %{{.*}}
+// CHECK: [[FLOAT_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.makeFloatSum$1", ptr undef }, ptr %{{.*}}, 1
+// CHECK: ret { ptr, ptr } [[FLOAT_CLOSURE]]
+
+// CHECK-LABEL: define double @"main.makeFloatSum$1"(ptr {{(nest|swiftself)}} %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, double %8, double %9){{.*}} {
+// CHECK: [[FLOAT_ENV:%.*]] = load { ptr }, ptr %0
+// CHECK: [[FLOAT_BASE_PTR:%.*]] = extractvalue { ptr } [[FLOAT_ENV]], 0
+// CHECK: [[FLOAT_BASE_VALUE:%.*]] = load double, ptr [[FLOAT_BASE_PTR]]
+// CHECK: [[FLOAT_S1:%.*]] = fadd double [[FLOAT_BASE_VALUE]], %1
+// CHECK: [[FLOAT_S2:%.*]] = fadd double [[FLOAT_S1]], %2
+// CHECK: [[FLOAT_S3:%.*]] = fadd double [[FLOAT_S2]], %3
+// CHECK: [[FLOAT_S4:%.*]] = fadd double [[FLOAT_S3]], %4
+// CHECK: [[FLOAT_S5:%.*]] = fadd double [[FLOAT_S4]], %5
+// CHECK: [[FLOAT_S6:%.*]] = fadd double [[FLOAT_S5]], %6
+// CHECK: [[FLOAT_S7:%.*]] = fadd double [[FLOAT_S6]], %7
+// CHECK: [[FLOAT_S8:%.*]] = fadd double [[FLOAT_S7]], %8
+// CHECK: [[FLOAT_S9:%.*]] = fadd double [[FLOAT_S8]], %9
+// CHECK: ret double [[FLOAT_S9]]
+
+// CHECK-LABEL: define { ptr, ptr } @main.makeNestedSum(i64 %0){{.*}} {
+// CHECK: store i64 %0, ptr [[NESTED_BASE_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: store ptr [[NESTED_BASE_ADDR]], ptr %{{.*}}
+// CHECK: [[NESTED_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.makeNestedSum$1", ptr undef }, ptr %{{.*}}, 1
+// CHECK: ret { ptr, ptr } [[NESTED_CLOSURE]]
+
+// CHECK-LABEL: define i64 @"main.makeNestedSum$1"(ptr {{(nest|swiftself)}} %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9){{.*}} {
+// CHECK: [[NESTED_VALUES:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
+// CHECK: [[NESTED_FIRST_PTR:%.*]] = getelementptr inbounds %reflect.Value, ptr [[NESTED_VALUES]], i64 0
+// CHECK: store i64 %1, ptr [[NESTED_FIRST_BOX_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[NESTED_FIRST_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[NESTED_FIRST_BOX_ADDR]], 1
+// CHECK: [[NESTED_FIRST_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[NESTED_FIRST_BOX]])
+// CHECK: store %reflect.Value [[NESTED_FIRST_VALUE]], ptr [[NESTED_FIRST_PTR]]
+// CHECK: [[NESTED_NINTH_PTR:%.*]] = getelementptr inbounds %reflect.Value, ptr [[NESTED_VALUES]], i64 8
+// CHECK: store i64 %9, ptr [[NESTED_NINTH_BOX_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[NESTED_NINTH_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[NESTED_NINTH_BOX_ADDR]], 1
+// CHECK: [[NESTED_NINTH_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[NESTED_NINTH_BOX]])
+// CHECK: store %reflect.Value [[NESTED_NINTH_VALUE]], ptr [[NESTED_NINTH_PTR]]
+// CHECK: [[NESTED_ARGS_0:%.*]] = insertvalue %"{{.*}}Slice" undef, ptr [[NESTED_VALUES]], 0
+// CHECK: [[NESTED_ARGS_1:%.*]] = insertvalue %"{{.*}}Slice" [[NESTED_ARGS_0]], i64 9, 1
+// CHECK: [[NESTED_ARGS:%.*]] = insertvalue %"{{.*}}Slice" [[NESTED_ARGS_1]], i64 9, 2
+// CHECK: [[NESTED_ENV:%.*]] = load { ptr }, ptr %0
+// CHECK: [[NESTED_CAPTURE_ADDR:%.*]] = extractvalue { ptr } [[NESTED_ENV]], 0
+// CHECK: [[NESTED_CAPTURE:%.*]] = load i64, ptr [[NESTED_CAPTURE_ADDR]]
+// CHECK: [[NESTED_SUM_FN:%.*]] = call { ptr, ptr } @main.makeSum(i64 [[NESTED_CAPTURE]])
+// CHECK: store { ptr, ptr } [[NESTED_SUM_FN]], ptr [[NESTED_SUM_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: [[NESTED_SUM_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[NESTED_SUM_ADDR]], 1
+// CHECK: [[NESTED_SUM_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[NESTED_SUM_BOX]])
+// CHECK: [[NESTED_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value [[NESTED_SUM_VALUE]], %"{{.*}}Slice" [[NESTED_ARGS]])
+// CHECK: [[NESTED_RESULT:%.*]] = call i64 @reflect.Value.Int(%reflect.Value %{{.*}})
+// CHECK: ret i64 [[NESTED_RESULT]]
+
+// CHECK-LABEL: define { ptr, ptr } @main.makeSum(i64 %0){{.*}} {
+// CHECK: store i64 %0, ptr [[SUM_BASE_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK: store ptr [[SUM_BASE_ADDR]], ptr %{{.*}}
+// CHECK: [[SUM_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.makeSum$1", ptr undef }, ptr %{{.*}}, 1
+// CHECK: ret { ptr, ptr } [[SUM_CLOSURE]]
+
+// CHECK-LABEL: define i64 @"main.makeSum$1"(ptr {{(nest|swiftself)}} %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9){{.*}} {
+// CHECK: [[SUM_ENV:%.*]] = load { ptr }, ptr %0
+// CHECK: [[SUM_BASE_PTR:%.*]] = extractvalue { ptr } [[SUM_ENV]], 0
+// CHECK: [[SUM_BASE_VALUE:%.*]] = load i64, ptr [[SUM_BASE_PTR]]
+// CHECK: [[SUM_S1:%.*]] = add i64 [[SUM_BASE_VALUE]], %1
+// CHECK: [[SUM_S2:%.*]] = add i64 [[SUM_S1]], %2
+// CHECK: [[SUM_S3:%.*]] = add i64 [[SUM_S2]], %3
+// CHECK: [[SUM_S4:%.*]] = add i64 [[SUM_S3]], %4
+// CHECK: [[SUM_S5:%.*]] = add i64 [[SUM_S4]], %5
+// CHECK: [[SUM_S6:%.*]] = add i64 [[SUM_S5]], %6
+// CHECK: [[SUM_S7:%.*]] = add i64 [[SUM_S6]], %7
+// CHECK: [[SUM_S8:%.*]] = add i64 [[SUM_S7]], %8
+// CHECK: [[SUM_S9:%.*]] = add i64 [[SUM_S8]], %9
+// CHECK: ret i64 [[SUM_S9]]
+
+// CHECK-LABEL: define i64 @main.receiver.Sum(%main.receiver %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9){{.*}} {
+// CHECK: store %main.receiver %0, ptr [[RECEIVER_ADDR:%.*]]
+// CHECK: [[RECEIVER_BASE:%.*]] = load i64, ptr %{{.*}}
+// CHECK: [[RECEIVER_S1:%.*]] = add i64 [[RECEIVER_BASE]], %1
+// CHECK: [[RECEIVER_S2:%.*]] = add i64 [[RECEIVER_S1]], %2
+// CHECK: [[RECEIVER_S3:%.*]] = add i64 [[RECEIVER_S2]], %3
+// CHECK: [[RECEIVER_S4:%.*]] = add i64 [[RECEIVER_S3]], %4
+// CHECK: [[RECEIVER_S5:%.*]] = add i64 [[RECEIVER_S4]], %5
+// CHECK: [[RECEIVER_S6:%.*]] = add i64 [[RECEIVER_S5]], %6
+// CHECK: [[RECEIVER_S7:%.*]] = add i64 [[RECEIVER_S6]], %7
+// CHECK: [[RECEIVER_S8:%.*]] = add i64 [[RECEIVER_S7]], %8
+// CHECK: [[RECEIVER_S9:%.*]] = add i64 [[RECEIVER_S8]], %9
+// CHECK: ret i64 [[RECEIVER_S9]]
+
+// CHECK-LABEL: define i64 @"main.(*receiver).Sum"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9){{.*}} {
+// CHECK: [[RECEIVER_NIL:%.*]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[RECEIVER_NIL]], %"{{.*}}String" {{.*}}, %"{{.*}}String" {{.*}})
+// CHECK: [[RECEIVER_VALUE_LOAD:%.*]] = load %main.receiver, ptr %0
+// CHECK: [[RECEIVER_WRAPPER_RESULT:%.*]] = call i64 @main.receiver.Sum(%main.receiver [[RECEIVER_VALUE_LOAD]], i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9)
+// CHECK: ret i64 [[RECEIVER_WRAPPER_RESULT]]
+
 func (r receiver) Sum(a, b, c, d, e, f, g, h, i int) int {
 	return r.base + a + b + c + d + e + f + g + h + i
 }
-
-// CHECK-LABEL: define double @"main.makeFloatSum$1"(ptr {{(nest|swiftself)}} %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, double %8, double %9){{.*}} {
-
-// CHECK-LABEL: define i64 @"main.makeSum$1"(ptr {{(nest|swiftself)}} %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9){{.*}} {
 
 func makeSum(base int) func(int, int, int, int, int, int, int, int, int) int {
 	return func(a, b, c, d, e, f, g, h, i int) int {

--- a/cl/_testrt/slice2array/in.go
+++ b/cl/_testrt/slice2array/in.go
@@ -2,84 +2,28 @@
 package main
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
-// CHECK-NEXT:   %1 = getelementptr inbounds i8, ptr %0, i64 0
-// CHECK-NEXT:   %2 = getelementptr inbounds i8, ptr %0, i64 1
-// CHECK-NEXT:   %3 = getelementptr inbounds i8, ptr %0, i64 2
-// CHECK-NEXT:   %4 = getelementptr inbounds i8, ptr %0, i64 3
-// CHECK-NEXT:   store i8 1, ptr %1, align 1
-// CHECK-NEXT:   store i8 2, ptr %2, align 1
-// CHECK-NEXT:   store i8 3, ptr %3, align 1
-// CHECK-NEXT:   store i8 4, ptr %4, align 1
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %5, i64 4, 1
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, i64 4, 2
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   %9 = icmp slt i64 %8, 4
-// CHECK-NEXT:   br i1 %9, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicSliceConvert"(i64 4, i64 %10)
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %12 = load [4 x i8], ptr %0, align 1
-// CHECK-NEXT:   %13 = load [4 x i8], ptr %11, align 1
-// CHECK-NEXT:   %14 = extractvalue [4 x i8] %12, 0
-// CHECK-NEXT:   %15 = extractvalue [4 x i8] %13, 0
-// CHECK-NEXT:   %16 = icmp eq i8 %14, %15
-// CHECK-NEXT:   %17 = and i1 true, %16
-// CHECK-NEXT:   %18 = extractvalue [4 x i8] %12, 1
-// CHECK-NEXT:   %19 = extractvalue [4 x i8] %13, 1
-// CHECK-NEXT:   %20 = icmp eq i8 %18, %19
-// CHECK-NEXT:   %21 = and i1 %17, %20
-// CHECK-NEXT:   %22 = extractvalue [4 x i8] %12, 2
-// CHECK-NEXT:   %23 = extractvalue [4 x i8] %13, 2
-// CHECK-NEXT:   %24 = icmp eq i8 %22, %23
-// CHECK-NEXT:   %25 = and i1 %21, %24
-// CHECK-NEXT:   %26 = extractvalue [4 x i8] %12, 3
-// CHECK-NEXT:   %27 = extractvalue [4 x i8] %13, 3
-// CHECK-NEXT:   %28 = icmp eq i8 %26, %27
-// CHECK-NEXT:   %29 = and i1 %25, %28
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %29)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %30, i64 4, 1
-// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, i64 4, 2
-// CHECK-NEXT:   %33 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %32, 1
-// CHECK-NEXT:   %34 = icmp slt i64 %33, 2
-// CHECK-NEXT:   br i1 %34, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %32, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicSliceConvert"(i64 2, i64 %35)
-// CHECK-NEXT:   br label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-// CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %32, 0
-// CHECK-NEXT:   %37 = load [2 x i8], ptr %36, align 1
-// CHECK-NEXT:   %38 = alloca [2 x i8], align 1
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %38, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %39 = getelementptr inbounds i8, ptr %38, i64 0
-// CHECK-NEXT:   %40 = getelementptr inbounds i8, ptr %38, i64 1
-// CHECK-NEXT:   store i8 1, ptr %39, align 1
-// CHECK-NEXT:   store i8 2, ptr %40, align 1
-// CHECK-NEXT:   %41 = load [2 x i8], ptr %38, align 1
-// CHECK-NEXT:   %42 = extractvalue [2 x i8] %37, 0
-// CHECK-NEXT:   %43 = extractvalue [2 x i8] %41, 0
-// CHECK-NEXT:   %44 = icmp eq i8 %42, %43
-// CHECK-NEXT:   %45 = and i1 true, %44
-// CHECK-NEXT:   %46 = extractvalue [2 x i8] %37, 1
-// CHECK-NEXT:   %47 = extractvalue [2 x i8] %41, 1
-// CHECK-NEXT:   %48 = icmp eq i8 %46, %47
-// CHECK-NEXT:   %49 = and i1 %45, %48
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %49)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[SLICE4_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[SLICE4:%[0-9]+]], 1
+// CHECK-NEXT: [[SHORT4:%[0-9]+]] = icmp slt i64 [[SLICE4_LEN]], 4
+// CHECK-NEXT: br i1 [[SHORT4]], label %{{.*}}, label %{{.*}}
+// CHECK: [[PANIC4_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[SLICE4]], 1
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicSliceConvert"(i64 4, i64 [[PANIC4_LEN]])
+// CHECK: [[SLICE4_DATA:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[SLICE4]], 0
+// CHECK: [[ARRAY4:%[0-9]+]] = load [4 x i8], ptr [[SLICE4_DATA]]
+// CHECK: [[ARRAY4_LAST:%[0-9]+]] = extractvalue [4 x i8] [[ARRAY4]], 3
+// CHECK: [[EQUAL4_LAST:%[0-9]+]] = icmp eq i8 %{{[0-9]+}}, [[ARRAY4_LAST]]
+// CHECK-NEXT: [[EQUAL4:%[0-9]+]] = and i1 %{{[0-9]+}}, [[EQUAL4_LAST]]
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 [[EQUAL4]])
+// CHECK: [[SLICE2_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[SLICE2:%[0-9]+]], 1
+// CHECK-NEXT: [[SHORT2:%[0-9]+]] = icmp slt i64 [[SLICE2_LEN]], 2
+// CHECK-NEXT: br i1 [[SHORT2]], label %{{.*}}, label %{{.*}}
+// CHECK: [[PANIC2_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[SLICE2]], 1
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicSliceConvert"(i64 2, i64 [[PANIC2_LEN]])
+// CHECK: [[SLICE2_DATA:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" [[SLICE2]], 0
+// CHECK-NEXT: [[ARRAY2:%[0-9]+]] = load [2 x i8], ptr [[SLICE2_DATA]]
+// CHECK: [[ARRAY2_LAST:%[0-9]+]] = extractvalue [2 x i8] [[ARRAY2]], 1
+// CHECK: [[EQUAL2_LAST:%[0-9]+]] = icmp eq i8 [[ARRAY2_LAST]], %{{[0-9]+}}
+// CHECK-NEXT: [[EQUAL2:%[0-9]+]] = and i1 %{{[0-9]+}}, [[EQUAL2_LAST]]
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 [[EQUAL2]])
 func main() {
 	array := [4]byte{1, 2, 3, 4}
 	ptr := (*[4]byte)(array[:])

--- a/cl/_testrt/slicelen/in.go
+++ b/cl/_testrt/slicelen/in.go
@@ -5,10 +5,6 @@ import (
 	"unsafe"
 )
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1{{$}}
-// CHECK: {{^}}@1 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1{{$}}
-// CHECK: {{^}}@2 = private unnamed_addr constant [7 x i8] c"len > 0", align 1{{$}}
-
 func main() {
 	var s *int
 	var lens uint32
@@ -20,34 +16,12 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
+// A nil pointer is valid for unsafe.Slice only because the length is zero; the
+// compiler must fold all guards and the resulting length/branch consistently.
+// CHECK: [[LEN_RANGE:@[0-9]+]] = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range"
+// CHECK: [[NIL_NONZERO:@[0-9]+]] = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length"
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 46 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}AssertRuntimeError"(i1 false, %"{{.*}}String" { ptr [[LEN_RANGE]], i64 30 })
+// CHECK-NEXT: call void @"{{.*}}AssertRuntimeError"(i1 false, %"{{.*}}String" { ptr [[NIL_NONZERO]], i64 46 })
+// CHECK: call void @"{{.*}}PrintInt"(i64 0)
+// CHECK: br i1 false, label %{{.*}}, label %{{.*}}

--- a/cl/_testrt/stacksave/in.go
+++ b/cl/_testrt/stacksave/in.go
@@ -6,16 +6,13 @@ import (
 	_ "unsafe"
 )
 
+// CHECK-LABEL: define void @main.main(){{.*}} {
+// CHECK: [[STACK_POINTER:%[0-9]+]] = call ptr @llvm.stacksave.p0()
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr [[STACK_POINTER]])
+
 //go:linkname getsp llgo.stackSave
 func getsp() unsafe.Pointer
 
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @llvm.stacksave.p0()
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func main() {
 	sp := getsp()
 	println(sp)

--- a/cl/_testrt/strlen/in.go
+++ b/cl/_testrt/strlen/in.go
@@ -13,11 +13,8 @@ func strlen(str *int8) C.int
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 @strlen(ptr @main.format)
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[STRLEN:%[0-9]+]] = call i32 @strlen(ptr @main.format)
+// CHECK-NEXT: call void (ptr, ...) @printf(ptr @main.format, i32 [[STRLEN]])
 func main() {
 	sfmt := &format[0]
 	printf(sfmt, strlen(sfmt))

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -4,28 +4,14 @@ package main
 import "C"
 import _ "unsafe"
 
-// CHECK-DAG: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1{{$}}
-// CHECK-DAG: {{^}}@1 = private unnamed_addr constant [5 x i8] c"Print", align 1{{$}}
-// CHECK-DAG: @main.format = global [10 x i8] c"Hello %d\0A\00", align 1
-
 // CHECK-LABEL: define void @main.Foo.Print(%main.Foo %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %main.Foo, align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %main.Foo %0, ptr %1, align 4
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.Foo, ptr %1, i32 0, i32 1
-// CHECK-NEXT:   %3 = load i1, ptr %2, align 1
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = getelementptr inbounds %main.Foo, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %5 = load i32, ptr %4, align 4
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %5)
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: store %main.Foo %0, ptr [[PRINT_RECEIVER:%[0-9]+]]
+// CHECK: [[PRINT_OK_FIELD:%[0-9]+]] = getelementptr inbounds %main.Foo, ptr [[PRINT_RECEIVER]], i32 0, i32 1
+// CHECK-NEXT: [[PRINT_OK:%[0-9]+]] = load i1, ptr [[PRINT_OK_FIELD]]
+// CHECK-NEXT: br i1 [[PRINT_OK]], label %{{.*}}, label %{{.*}}
+// CHECK: [[PRINT_VALUE_FIELD:%[0-9]+]] = getelementptr inbounds %main.Foo, ptr [[PRINT_RECEIVER]], i32 0, i32 0
+// CHECK-NEXT: [[PRINT_VALUE:%[0-9]+]] = load i32, ptr [[PRINT_VALUE_FIELD]]
+// CHECK-NEXT: call void (ptr, ...) @printf(ptr @main.format, i32 [[PRINT_VALUE]])
 
 func (p Foo) Print() {
 	if p.ok {
@@ -49,42 +35,16 @@ func main() {
 }
 
 // CHECK-LABEL: define void @"main.(*Foo).Print"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 5 })
-// CHECK-NEXT:   %2 = load %main.Foo, ptr %0, align 4
-// CHECK-NEXT:   call void @main.Foo.Print(%main.Foo %2)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[WRAPPER_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[WRAPPER_NIL]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 5 })
+// CHECK-NEXT: [[WRAPPER_VALUE:%[0-9]+]] = load %main.Foo, ptr %0
+// CHECK-NEXT: call void @main.Foo.Print(%main.Foo [[WRAPPER_VALUE]])
 
 // CHECK-LABEL: define ptr @main._Cgo_ptr(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret ptr %0
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   call void @syscall.init()
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: ret ptr %0
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %main.Foo, align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %main.Foo, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds %main.Foo, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   store i32 100, ptr %1, align 4
-// CHECK-NEXT:   store i1 true, ptr %2, align 1
-// CHECK-NEXT:   %3 = load %main.Foo, ptr %0, align 4
-// CHECK-NEXT:   call void @main.Foo.Print(%main.Foo %3)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: store i32 100, ptr [[MAIN_A:%[0-9]+]]
+// CHECK-NEXT: store i1 true, ptr [[MAIN_OK:%[0-9]+]]
+// CHECK-NEXT: [[MAIN_FOO:%[0-9]+]] = load %main.Foo, ptr %{{[0-9]+}}
+// CHECK-NEXT: call void @main.Foo.Print(%main.Foo [[MAIN_FOO]])

--- a/cl/_testrt/structsize/in.go
+++ b/cl/_testrt/structsize/in.go
@@ -16,10 +16,7 @@ type Foo struct {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @0, i64 14)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call i32 (ptr, ...) @printf(ptr @{{[0-9]+}}, i64 14)
 func main() {
 	c.Printf(c.Str("%d"), unsafe.Sizeof(Foo{}))
 }

--- a/cl/_testrt/tpfunc/in.go
+++ b/cl/_testrt/tpfunc/in.go
@@ -5,19 +5,6 @@ import (
 	"unsafe"
 )
 
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
 type Func func(*int)
 
 //llgo:type C
@@ -26,55 +13,39 @@ type CFunc func(*int)
 //llgo:type C
 type Callback[T any] func(*T)
 
+// The Go function value is two words, while both llgo:type C forms are one word.
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 16)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 8)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 16)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 8)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 8)
+
+// All three source literals still dereference and print the same *int argument.
+// CHECK-LABEL: define void @"main.main$1"(ptr %0){{.*}} {
+// CHECK: [[GO_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[GO_NIL]])
+// CHECK: [[GO_VALUE:%[0-9]+]] = load i64, ptr %0
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[GO_VALUE]])
+
+// CHECK-LABEL: define void @"main.main$2"(ptr %0){{.*}} {
+// CHECK: [[C_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[C_NIL]])
+// CHECK: [[C_VALUE:%[0-9]+]] = load i64, ptr %0
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[C_VALUE]])
+
+// CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
+// CHECK: [[GENERIC_C_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[GENERIC_C_NIL]])
+// CHECK: [[GENERIC_C_VALUE:%[0-9]+]] = load i64, ptr %0
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[GENERIC_C_VALUE]])
 
 func main() {
-	// CHECK-LABEL: define void @"main.main$1"(ptr %0){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %2)
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
-
 	var fn1 Func = func(v *int) {
 		println(*v)
 	}
 
-	// CHECK-LABEL: define void @"main.main$2"(ptr %0){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %2)
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
-
 	var fn2 CFunc = func(v *int) {
 		println(*v)
 	}
-
-	// CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
-	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = icmp eq ptr %0, null
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %2)
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   ret void
-	// CHECK-NEXT: }
 
 	var fn3 Callback[int] = func(v *int) {
 		println(*v)

--- a/cl/_testrt/typalias/in.go
+++ b/cl/_testrt/typalias/in.go
@@ -15,20 +15,12 @@ type Foo = struct {
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
 // CHECK-LABEL: define void @main.Print(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = load i1, ptr %1, align 1
-// CHECK-NEXT:   br i1 %2, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %3 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %4 = load i32, ptr %3, align 4
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %4)
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[PRINT_OK_FIELD:%[0-9]+]] = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 1
+// CHECK-NEXT: [[PRINT_OK:%[0-9]+]] = load i1, ptr [[PRINT_OK_FIELD]]
+// CHECK-NEXT: br i1 [[PRINT_OK]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: [[PRINT_A_FIELD:%[0-9]+]] = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 0
+// CHECK-NEXT: [[PRINT_A:%[0-9]+]] = load i32, ptr [[PRINT_A_FIELD]]
+// CHECK-NEXT: call void (ptr, ...) @printf(ptr @main.format, i32 [[PRINT_A]])
 
 func Print(p *Foo) {
 	if p.ok {
@@ -37,15 +29,12 @@ func Print(p *Foo) {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   store i32 100, ptr %1, align 4
-// CHECK-NEXT:   store i1 true, ptr %2, align 1
-// CHECK-NEXT:   call void @main.Print(ptr %0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK: [[MAIN_FOO:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT: [[MAIN_A:%[0-9]+]] = getelementptr inbounds { i32, i1 }, ptr [[MAIN_FOO]], i32 0, i32 0
+// CHECK-NEXT: [[MAIN_OK:%[0-9]+]] = getelementptr inbounds { i32, i1 }, ptr [[MAIN_FOO]], i32 0, i32 1
+// CHECK-NEXT: store i32 100, ptr [[MAIN_A]]
+// CHECK-NEXT: store i1 true, ptr [[MAIN_OK]]
+// CHECK-NEXT: call void @main.Print(ptr [[MAIN_FOO]])
 func main() {
 	foo := &Foo{100, true}
 	Print(foo)

--- a/cl/_testrt/typed/in.go
+++ b/cl/_testrt/typed/in.go
@@ -1,8 +1,6 @@
 // LITTEST
 package main
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
-
 type T string
 type A [2]int
 
@@ -17,99 +15,39 @@ func main() {
 	println(ar[0], ar[1], ok)
 }
 
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T, ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %1, 0
-// CHECK-NEXT:   %3 = icmp eq ptr %2, @_llgo_main.T
-// CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %1, 1
-// CHECK-NEXT:   %5 = load %"{{.*}}/runtime/internal/runtime.String", ptr %4, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %5)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %1, 0
-// CHECK-NEXT:   %7 = icmp eq ptr %6, @_llgo_string
-// CHECK-NEXT:   br i1 %7, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %2, ptr @_llgo_main.T)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %1, 1
-// CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.String", ptr %8, align 8
-// CHECK-NEXT:   %10 = insertvalue { %"{{.*}}/runtime/internal/runtime.String", i1 } undef, %"{{.*}}/runtime/internal/runtime.String" %9, 0
-// CHECK-NEXT:   %11 = insertvalue { %"{{.*}}/runtime/internal/runtime.String", i1 } %10, i1 true, 1
-// CHECK-NEXT:   br label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   br label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-// CHECK-NEXT:   %12 = phi { %"{{.*}}/runtime/internal/runtime.String", i1 } [ %11, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
-// CHECK-NEXT:   %13 = extractvalue { %"{{.*}}/runtime/internal/runtime.String", i1 } %12, 0
-// CHECK-NEXT:   %14 = extractvalue { %"{{.*}}/runtime/internal/runtime.String", i1 } %12, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %14)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %15 = alloca [2 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %15, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %16 = getelementptr inbounds i64, ptr %15, i64 0
-// CHECK-NEXT:   %17 = getelementptr inbounds i64, ptr %15, i64 1
-// CHECK-NEXT:   store i64 1, ptr %16, align 8
-// CHECK-NEXT:   store i64 2, ptr %17, align 8
-// CHECK-NEXT:   %18 = load [2 x i64], ptr %15, align 8
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store [2 x i64] %18, ptr %19, align 8
-// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.A, ptr undef }, ptr %19, 1
-// CHECK-NEXT:   %21 = alloca [2 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %21, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %22 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %20, 0
-// CHECK-NEXT:   %23 = icmp eq ptr %22, @_llgo_main.A
-// CHECK-NEXT:   br i1 %23, label %_llgo_6, label %_llgo_7
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %24 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %20, 1
-// CHECK-NEXT:   %25 = load [2 x i64], ptr %24, align 8
-// CHECK-NEXT:   %26 = insertvalue { [2 x i64], i1 } undef, [2 x i64] %25, 0
-// CHECK-NEXT:   %27 = insertvalue { [2 x i64], i1 } %26, i1 true, 1
-// CHECK-NEXT:   br label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   br label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-// CHECK-NEXT:   %28 = phi { [2 x i64], i1 } [ %27, %_llgo_6 ], [ zeroinitializer, %_llgo_7 ]
-// CHECK-NEXT:   %29 = extractvalue { [2 x i64], i1 } %28, 0
-// CHECK-NEXT:   store [2 x i64] %29, ptr %21, align 8
-// CHECK-NEXT:   %30 = extractvalue { [2 x i64], i1 } %28, 1
-// CHECK-NEXT:   %31 = getelementptr inbounds i64, ptr %21, i64 0
-// CHECK-NEXT:   %32 = load i64, ptr %31, align 8
-// CHECK-NEXT:   %33 = getelementptr inbounds i64, ptr %21, i64 1
-// CHECK-NEXT:   %34 = load i64, ptr %33, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %34)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %30)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// The named string uses an exact (panicking) assertion, then deliberately fails
+// a comma-ok assertion to the underlying unnamed string type.
+// CHECK: [[T_DATA:%.*]] = call ptr @"{{.*}}AllocU"(i64 16)
+// CHECK: [[T_EFACE:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.T, ptr undef }, ptr [[T_DATA]], 1
+// CHECK: [[T_DYN_TYPE:%.*]] = extractvalue %"{{.*}}eface" [[T_EFACE]], 0
+// CHECK-NEXT: [[IS_T:%.*]] = icmp eq ptr [[T_DYN_TYPE]], @_llgo_main.T
+// CHECK: br i1 [[IS_T]], label %{{.*}}, label %{{.*}}
+// CHECK: [[T_DYN_DATA:%.*]] = extractvalue %"{{.*}}eface" [[T_EFACE]], 1
+// CHECK-NEXT: [[T_VALUE:%.*]] = load %"{{.*}}String", ptr [[T_DYN_DATA]]
+// CHECK-NEXT: call void @"{{.*}}PrintString"(%"{{.*}}String" [[T_VALUE]])
+// CHECK: [[STRING_DYN_TYPE:%.*]] = extractvalue %"{{.*}}eface" [[T_EFACE]], 0
+// CHECK-NEXT: [[IS_STRING:%.*]] = icmp eq ptr [[STRING_DYN_TYPE]], @_llgo_string
+// CHECK: call void @"{{.*}}PanicTypeAssert"(ptr null, ptr [[T_DYN_TYPE]], ptr @_llgo_main.T)
+// CHECK-NEXT: unreachable
+// CHECK: [[STRING_OK_RESULT:%.*]] = phi { %"{{.*}}String", i1 } [ {{%.*}}, %{{.*}} ], [ zeroinitializer, %{{.*}} ]
+// CHECK: [[STRING_VALUE:%.*]] = extractvalue { %"{{.*}}String", i1 } [[STRING_OK_RESULT]], 0
+// CHECK-NEXT: [[STRING_OK:%.*]] = extractvalue { %"{{.*}}String", i1 } [[STRING_OK_RESULT]], 1
+// CHECK-NEXT: call void @"{{.*}}PrintString"(%"{{.*}}String" [[STRING_VALUE]])
+// CHECK: call void @"{{.*}}PrintBool"(i1 [[STRING_OK]])
+// The named array is boxed, matched by its named type, copied out, and returned
+// together with the comma-ok bit used by the print.
+// CHECK: [[A_DATA:%.*]] = call ptr @"{{.*}}AllocU"(i64 16)
+// CHECK: [[A_EFACE:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.A, ptr undef }, ptr [[A_DATA]], 1
+// CHECK: [[A_DYN_TYPE:%.*]] = extractvalue %"{{.*}}eface" [[A_EFACE]], 0
+// CHECK-NEXT: [[IS_A:%.*]] = icmp eq ptr [[A_DYN_TYPE]], @_llgo_main.A
+// CHECK: [[A_DYN_DATA:%.*]] = extractvalue %"{{.*}}eface" [[A_EFACE]], 1
+// CHECK-NEXT: [[A_VALUE:%.*]] = load [2 x i64], ptr [[A_DYN_DATA]]
+// CHECK: [[A_OK_RESULT:%.*]] = phi { [2 x i64], i1 } [ {{%.*}}, %{{.*}} ], [ zeroinitializer, %{{.*}} ]
+// CHECK: [[A_RESULT:%.*]] = extractvalue { [2 x i64], i1 } [[A_OK_RESULT]], 0
+// CHECK: [[A_OK:%.*]] = extractvalue { [2 x i64], i1 } [[A_OK_RESULT]], 1
+// CHECK: [[A0:%.*]] = load i64, ptr {{%.*}}
+// CHECK: [[A1:%.*]] = load i64, ptr {{%.*}}
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[A0]])
+// CHECK: call void @"{{.*}}PrintInt"(i64 [[A1]])
+// CHECK: call void @"{{.*}}PrintBool"(i1 [[A_OK]])

--- a/cl/_testrt/unreachable/in.go
+++ b/cl/_testrt/unreachable/in.go
@@ -1,25 +1,17 @@
 // LITTEST
 package main
 
+// CHECK-LABEL: define void @main.foo(){{.*}} {
+// CHECK: unreachable
+
 import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @main.foo(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func foo() {
 	c.Unreachable()
 }
 
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @main.foo()
-// CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func main() {
 	foo()
 	c.Printf(c.Str("Hello\n"))

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -7,27 +7,6 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"error", align 1{{$}}
-// CHECK: {{^}}@2 = private unnamed_addr constant [4 x i8] c"abc\00", align 1{{$}}
-// CHECK: {{^}}@3 = private unnamed_addr constant [31 x i8] c"unsafe.String: len out of range", align 1{{$}}
-// CHECK: {{^}}@4 = private unnamed_addr constant [47 x i8] c"unsafe.String: nil pointer with non-zero length", align 1{{$}}
-// CHECK: {{^}}@5 = private unnamed_addr constant [3 x i8] c"abc", align 1{{$}}
-// CHECK: {{^}}@6 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1{{$}}
-// CHECK: {{^}}@7 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1{{$}}
-
-// CHECK-LABEL: define void @main.init(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
-
 //llgo:type C
 type T func()
 
@@ -42,219 +21,60 @@ type N struct {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %0, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %1)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   br i1 false, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %2, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %3)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   br i1 false, label %_llgo_5, label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   br i1 false, label %_llgo_7, label %_llgo_8
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %6, align 8
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %6, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %7)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   br i1 false, label %_llgo_9, label %_llgo_10
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_8
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %8, align 8
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %8, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %9)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
-// CHECK-NEXT:   br i1 false, label %_llgo_11, label %_llgo_12
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_10
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %10, align 8
-// CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %10, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %11)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_10
-// CHECK-NEXT:   br i1 false, label %_llgo_13, label %_llgo_14
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_12
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %12, align 8
-// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %12, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %13)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_12
-// CHECK-NEXT:   br i1 false, label %_llgo_15, label %_llgo_16
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_14
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %14, align 8
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %14, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %15)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_14
-// CHECK-NEXT:   br i1 false, label %_llgo_17, label %_llgo_18
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_16
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %16, align 8
-// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %17)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_16
-// CHECK-NEXT:   br i1 false, label %_llgo_19, label %_llgo_20
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_19:                                         ; preds = %_llgo_18
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %18, align 8
-// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_18
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 47 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 })
-// CHECK-NEXT:   %20 = icmp ult i64 add (i64 ptrtoint (ptr @2 to i64), i64 2), ptrtoint (ptr @2 to i64)
-// CHECK-NEXT:   %21 = and i1 true, %20
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %21, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 })
-// CHECK-NEXT:   %22 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 })
-// CHECK-NEXT:   %23 = xor i1 %22, true
-// CHECK-NEXT:   br i1 %23, label %_llgo_21, label %_llgo_22
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %24, align 8
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %24, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %25)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %26 = load i8, ptr @2, align 1
-// CHECK-NEXT:   %27 = icmp ne i8 %26, 97
-// CHECK-NEXT:   br i1 %27, label %_llgo_23, label %_llgo_26
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_25, %_llgo_26, %_llgo_22
-// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %28, align 8
-// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %28, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %29)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_25
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %31 = getelementptr inbounds i64, ptr %30, i64 0
-// CHECK-NEXT:   %32 = getelementptr inbounds i64, ptr %30, i64 1
-// CHECK-NEXT:   store i64 1, ptr %31, align 8
-// CHECK-NEXT:   store i64 2, ptr %32, align 8
-// CHECK-NEXT:   %33 = getelementptr inbounds i64, ptr %30, i64 0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 30 })
-// CHECK-NEXT:   %34 = icmp eq ptr %33, null
-// CHECK-NEXT:   %35 = and i1 %34, true
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %35, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 46 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 30 })
-// CHECK-NEXT:   %36 = ptrtoint ptr %33 to i64
-// CHECK-NEXT:   %37 = add i64 %36, 15
-// CHECK-NEXT:   %38 = icmp ult i64 %37, %36
-// CHECK-NEXT:   %39 = and i1 true, %38
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %39, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 30 })
-// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %33, 0
-// CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %40, i64 2, 1
-// CHECK-NEXT:   %42 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %41, i64 2, 2
-// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 0
-// CHECK-NEXT:   %44 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 1
-// CHECK-NEXT:   %45 = icmp uge i64 0, %44
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %45, i64 0, i1 true, i64 %44)
-// CHECK-NEXT:   %46 = getelementptr inbounds i64, ptr %43, i64 0
-// CHECK-NEXT:   %47 = load i64, ptr %46, align 8
-// CHECK-NEXT:   %48 = icmp ne i64 %47, 1
-// CHECK-NEXT:   br i1 %48, label %_llgo_27, label %_llgo_29
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_26
-// CHECK-NEXT:   %49 = load i8, ptr getelementptr inbounds (i8, ptr @2, i64 2), align 1
-// CHECK-NEXT:   %50 = icmp ne i8 %49, 99
-// CHECK-NEXT:   br i1 %50, label %_llgo_23, label %_llgo_24
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_26:                                         ; preds = %_llgo_22
-// CHECK-NEXT:   %51 = load i8, ptr getelementptr inbounds (i8, ptr @2, i64 1), align 1
-// CHECK-NEXT:   %52 = icmp ne i8 %51, 98
-// CHECK-NEXT:   br i1 %52, label %_llgo_23, label %_llgo_25
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_27:                                         ; preds = %_llgo_29, %_llgo_24
-// CHECK-NEXT:   %53 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %53, align 8
-// CHECK-NEXT:   %54 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %53, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %54)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_28:                                         ; preds = %_llgo_29
-// CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 0
-// CHECK-NEXT:   %56 = load i64, ptr %55, align 8
-// CHECK-NEXT:   %57 = icmp ne i64 %56, 1
-// CHECK-NEXT:   br i1 %57, label %_llgo_30, label %_llgo_31
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_29:                                         ; preds = %_llgo_24
-// CHECK-NEXT:   %58 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 0
-// CHECK-NEXT:   %59 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 1
-// CHECK-NEXT:   %60 = icmp uge i64 1, %59
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %60, i64 1, i1 true, i64 %59)
-// CHECK-NEXT:   %61 = getelementptr inbounds i64, ptr %58, i64 1
-// CHECK-NEXT:   %62 = load i64, ptr %61, align 8
-// CHECK-NEXT:   %63 = icmp ne i64 %62, 2
-// CHECK-NEXT:   br i1 %63, label %_llgo_27, label %_llgo_28
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_30:                                         ; preds = %_llgo_28
-// CHECK-NEXT:   %64 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %64, align 8
-// CHECK-NEXT:   %65 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %64, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %65)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_31:                                         ; preds = %_llgo_28
-// CHECK-NEXT:   %66 = icmp ne i64 ptrtoint (ptr getelementptr (i8, ptr null, i64 1) to i64), 1
-// CHECK-NEXT:   br i1 %66, label %_llgo_32, label %_llgo_33
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_32:                                         ; preds = %_llgo_31
-// CHECK-NEXT:   %67 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %67, align 8
-// CHECK-NEXT:   %68 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %67, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %68)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_33:                                         ; preds = %_llgo_31
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// Sizeof, Alignof, and Offsetof are compile-time constants. Each of the ten
+// source comparisons must fold to the non-panic edge.
+// CHECK-COUNT-10: br i1 false
+
+// unsafe.String checks pointer arithmetic overflow and uses the resulting
+// pointer/length pair as the string value.
+// CHECK: %[[STRING_OVERFLOW:[0-9]+]] = icmp ult i64 add (i64 ptrtoint (ptr @[[CSTR:[0-9]+]] to i64), i64 2), ptrtoint (ptr @[[CSTR]] to i64)
+// CHECK: %[[STRING_INVALID:[0-9]+]] = and i1 true, %[[STRING_OVERFLOW]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %[[STRING_INVALID]], %"{{.*}}/runtime/internal/runtime.String" {{.*}})
+// CHECK: %[[STRING_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @[[CSTR]], i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 3 })
+// CHECK: %[[STRING_NE:[0-9]+]] = xor i1 %[[STRING_EQ]], true
+// CHECK: br i1 %[[STRING_NE]]
+
+// unsafe.StringData starts from the same backing pointer.
+// CHECK: load i8, ptr @[[CSTR]]
+
+// unsafe.Slice validates pointer/length overflow, then constructs a slice whose
+// data and length are the values consumed by ordinary bounds checks.
+// CHECK: %[[ARRAY:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK: %[[ELEM0:[0-9]+]] = getelementptr inbounds i64, ptr %[[ARRAY]], i64 0
+// CHECK: %[[ELEM1:[0-9]+]] = getelementptr inbounds i64, ptr %[[ARRAY]], i64 1
+// CHECK: store i64 1, ptr %[[ELEM0]]
+// CHECK: store i64 2, ptr %[[ELEM1]]
+// CHECK: %[[BASE:[0-9]+]] = getelementptr inbounds i64, ptr %[[ARRAY]], i64 0
+// CHECK: %[[BASE_INT:[0-9]+]] = ptrtoint ptr %[[BASE]] to i64
+// CHECK: %[[SLICE_END:[0-9]+]] = add i64 %[[BASE_INT]], 15
+// CHECK: %[[SLICE_OVERFLOW:[0-9]+]] = icmp ult i64 %[[SLICE_END]], %[[BASE_INT]]
+// CHECK: %[[SLICE_INVALID:[0-9]+]] = and i1 true, %[[SLICE_OVERFLOW]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %[[SLICE_INVALID]], %"{{.*}}/runtime/internal/runtime.String" {{.*}})
+// CHECK: %[[SLICE_PTR:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %[[BASE]], 0
+// CHECK: %[[SLICE_LEN:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE_PTR]], i64 2, 1
+// CHECK: %[[SLICE:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE_LEN]], i64 2, 2
+// CHECK: %[[DATA0:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
+// CHECK: %[[LEN0:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 1
+// CHECK: %[[OOB0:[0-9]+]] = icmp uge i64 0, %[[LEN0]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[OOB0]], i64 0, i1 true, i64 %[[LEN0]])
+// CHECK: getelementptr inbounds i64, ptr %[[DATA0]], i64 0
+// The remaining StringData loads may be printed in predecessor block order,
+// but must still use the captured string backing pointer.
+// CHECK: load i8, ptr getelementptr inbounds (i8, ptr @[[CSTR]], i64 2)
+// CHECK: load i8, ptr getelementptr inbounds (i8, ptr @[[CSTR]], i64 1)
+
+// unsafe.SliceData reads from the constructed slice data pointer.
+// CHECK: %[[SLICE_DATA:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
+// CHECK: load i64, ptr %[[SLICE_DATA]]
+
+// CHECK: %[[DATA1:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
+// CHECK: %[[LEN1:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 1
+// CHECK: %[[OOB1:[0-9]+]] = icmp uge i64 1, %[[LEN1]]
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[OOB1]], i64 1, i1 true, i64 %[[LEN1]])
+// CHECK: getelementptr inbounds i64, ptr %[[DATA1]], i64 1
+
+// unsafe.Add(nil, 1) remains a byte-wise pointer addition.
+// CHECK: icmp ne i64 ptrtoint (ptr getelementptr (i8, ptr null, i64 1) to i64), 1
 
 func main() {
 	if unsafe.Sizeof(*(*T)(nil)) != unsafe.Sizeof(0) {


### PR DESCRIPTION
## Summary

- rewrite the remaining handwritten `_testrt` FileCheck fixtures around runtime lowering contracts
- preserve function boundaries and argument/result/data-flow relationships while removing incidental IR noise
- retain larger handwritten checks when their groups correspond to distinct runtime contracts
- make closure-environment assertions portable across Darwin and Linux
- move the 21 broad autogenerated runtime fixtures to #2307

## Validation

- `go fmt ./...`
- `go test ./cl -run '^TestRunAndTestFromTestrt$' -count=1`
- `git diff --check`

## Split series

- #2307 — litgen tool, documentation, and 40 curated autogenerated fixtures
- #2308 — handwritten library and support fixtures
- #2309 — handwritten control-flow and C interop fixtures
- #2310 — handwritten language, interface, and reflection fixtures
- #2311 — handwritten runtime lowering fixtures

All five PRs target `main` independently. The 40 autogenerated fixtures live only in #2307; the other four PRs contain no generated snapshot overlap.