### PR TITLE
cl: preserve unnamed rangefunc defer results

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1820,16 +1820,17 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		if n := len(v.Results); n > 0 {
 			results = make([]llssa.Expr, n)
 			for i, r := range v.Results {
-				// A deferred call may change a named result independently of
-				// the SSA value in Return.Results. Reload the result's storage
-				// in the RunDefers continuation instead of depending on the
-				// particular SSA node used to form the return tuple.
+				// A deferred call may change a named result independently of the
+				// SSA value in Return.Results. An unnamed result, conversely,
+				// must retain its pre-defer SSA value even though that value may
+				// not dominate the shared RunDefers continuation. Reload either
+				// kind from its entry-block storage after RunDefers.
 				if runDefers {
 					if slot := p.namedResultSlot(i); slot != nil {
 						results[i] = b.Load(p.compileValue(b, slot))
 						continue
 					}
-					results[i] = b.Load(p.implicitDeferResults[i])
+					results[i] = b.Load(p.implicitDeferResultSlot(i))
 					continue
 				}
 				results[i] = p.compileValue(b, r)
@@ -2071,12 +2072,28 @@ func (p *context) prepareImplicitDeferResults(b llssa.Builder, fn *ssa.Function)
 	}
 }
 
+// spillImplicitDeferResults stores unnamed return values before RunDefers so
+// its continuation can reload the pre-defer values from entry-block slots.
 func (p *context) spillImplicitDeferResults(b llssa.Builder, ret *ssa.Return) {
 	for i, result := range ret.Results {
 		if p.namedResultSlot(i) == nil {
-			b.Store(p.implicitDeferResults[i], p.compileValue(b, result))
+			b.Store(p.implicitDeferResultSlot(i), p.compileValue(b, result))
 		}
 	}
+}
+
+// implicitDeferResultSlot makes the entry-block preparation invariant explicit:
+// compileBlock visits block 0 before any return block and reserves every unnamed
+// result slot needed by the same memoized defer predicate used at the return.
+func (p *context) implicitDeferResultSlot(index int) llssa.Expr {
+	if index < 0 || index >= len(p.implicitDeferResults) {
+		panic(fmt.Sprintf("missing implicit defer result slot %d", index))
+	}
+	slot := p.implicitDeferResults[index]
+	if slot.IsNil() {
+		panic(fmt.Sprintf("missing implicit defer result slot %d", index))
+	}
+	return slot
 }
 
 func (p *context) returnNeedsImplicitRunDefers(ret *ssa.Return) bool {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -168,6 +168,7 @@ type context struct {
 	pcLineSeq            uint64
 	options              Options
 	recoverSlots         map[*ssa.Alloc]none
+	implicitDeferResults []llssa.Expr
 
 	patches          Patches
 	blkInfos         []blocks.Info
@@ -656,7 +657,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		p.inits = append(p.inits, func() {
 			oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark := p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark
 			oldLocalityFunction := p.locality.function
-			oldRecoverSlots := p.recoverSlots
+			oldRecoverSlots, oldImplicitDeferResults := p.recoverSlots, p.implicitDeferResults
 			p.fn = fn
 			p.goFn = f
 			p.callerFrameMark = llssa.Nil
@@ -671,6 +672,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 				p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark = oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark
 				p.locality.function = oldLocalityFunction
 				p.recoverSlots = oldRecoverSlots
+				p.implicitDeferResults = oldImplicitDeferResults
 			}()
 			p.phis = nil
 			if dbgSymsEnabled {
@@ -901,6 +903,9 @@ func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, do
 	var instrs = block.Instrs[n:]
 	var ret = fn.Block(block.Index)
 	b.SetBlock(ret)
+	if block.Index == 0 {
+		p.prepareImplicitDeferResults(b, block.Parent())
+	}
 	if block.Index == 0 && p.functionUsesRecover(block.Parent()) {
 		b.BindRecoverFrame()
 	}
@@ -1806,6 +1811,7 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 	case *ssa.Return:
 		runDefers := p.returnNeedsImplicitRunDefers(v)
 		if runDefers {
+			p.spillImplicitDeferResults(b, v)
 			p.recordPanicLocation(b, v.Pos())
 			p.emitPCLineLabel(b, p.deferRunPos(v.Pos()))
 			b.RunDefers()
@@ -1823,6 +1829,8 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 						results[i] = b.Load(p.compileValue(b, slot))
 						continue
 					}
+					results[i] = b.Load(p.implicitDeferResults[i])
+					continue
 				}
 				results[i] = p.compileValue(b, r)
 			}
@@ -2044,6 +2052,31 @@ func (p *context) deferRunPos(fallback token.Pos) token.Pos {
 		}
 	}
 	return fallback
+}
+
+// prepareImplicitDeferResults reserves entry-block storage for unnamed return
+// values that must survive the shared range-defer dispatcher. Named results
+// already have source-level slots that deferred calls are allowed to update.
+func (p *context) prepareImplicitDeferResults(b llssa.Builder, fn *ssa.Function) {
+	p.implicitDeferResults = nil
+	if !p.functionHasExplicitStackDeferInAnon(fn) {
+		return
+	}
+	results := fn.Signature.Results()
+	p.implicitDeferResults = make([]llssa.Expr, results.Len())
+	for i := 0; i < results.Len(); i++ {
+		if p.namedResultSlot(i) == nil {
+			p.implicitDeferResults[i] = b.Alloc(p.type_(results.At(i).Type(), llssa.InGo), false)
+		}
+	}
+}
+
+func (p *context) spillImplicitDeferResults(b llssa.Builder, ret *ssa.Return) {
+	for i, result := range ret.Results {
+		if p.namedResultSlot(i) == nil {
+			b.Store(p.implicitDeferResults[i], p.compileValue(b, result))
+		}
+	}
 }
 
 func (p *context) returnNeedsImplicitRunDefers(ret *ssa.Return) bool {

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -1004,6 +1004,22 @@ func lifted() (result int) { return }
 	}
 }
 
+func TestImplicitDeferResultSlotRejectsMissingSlot(t *testing.T) {
+	for _, ctx := range []*context{
+		{},
+		{implicitDeferResults: make([]llssa.Expr, 1)},
+	} {
+		func() {
+			defer func() {
+				if got := recover(); got != "missing implicit defer result slot 0" {
+					t.Fatalf("implicitDeferResultSlot panic = %v", got)
+				}
+			}()
+			ctx.implicitDeferResultSlot(0)
+		}()
+	}
+}
+
 func TestDeferStackOwnerUsesEnclosingSourceFunction(t *testing.T) {
 	const src = `package foo
 

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -938,6 +938,16 @@ func namedResult(stop bool) (result *int) {
 	}
 	return nil
 }
+
+func unnamedResult(stop bool) int {
+	if stop {
+		return 1
+	}
+	for v := range seq {
+		defer func() { _ = v }()
+	}
+	return 2
+}
 `)
 
 	ir := m.String()

--- a/test/go/rangefunc_defer_test.go
+++ b/test/go/rangefunc_defer_test.go
@@ -98,6 +98,40 @@ func TestRangeFuncDefersRunAfterReturn(t *testing.T) {
 	}
 }
 
+func rangefuncDeferReturnValue(stop int, saved *[]int) int {
+	if stop == 0 {
+		return 10
+	}
+	for i := range rangefuncDeferYield4 {
+		defer func() { *saved = append(*saved, i) }()
+		if i == stop {
+			return 10 + i
+		}
+	}
+	return 20
+}
+
+func TestRangeFuncDefersPreserveUnnamedReturnValue(t *testing.T) {
+	tests := []struct {
+		stop      int
+		wantValue int
+		wantSaved []int
+	}{
+		{stop: 0, wantValue: 10},
+		{stop: 2, wantValue: 12, wantSaved: []int{2, 1}},
+		{stop: 9, wantValue: 20, wantSaved: []int{4, 3, 2, 1}},
+	}
+	for _, test := range tests {
+		var saved []int
+		if got := rangefuncDeferReturnValue(test.stop, &saved); got != test.wantValue {
+			t.Errorf("stop %d: return value = %d, want %d", test.stop, got, test.wantValue)
+		}
+		if !reflect.DeepEqual(saved, test.wantSaved) {
+			t.Errorf("stop %d: deferred values = %v, want %v", test.stop, saved, test.wantSaved)
+		}
+	}
+}
+
 func TestRangeFuncDefersRunAfterLabeledBreak(t *testing.T) {
 	var saved []int
 	save := func(v int) {

--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -48,6 +48,20 @@ not_applicable:
   - directive: run
     case: nilptr.go
     reason: "not applicable: this case requires explicit nil checks for large-offset array, slice, and struct operations whose derived address may be mapped and therefore not fault; LLGo relies on LLVM and target memory faults for these non-load forms, so reproducing cmd/compile's large-offset nil-check strategy is not currently an LLGo compatibility goal"
+  - platform: darwin/arm64
+    directive: runoutput
+    case: rangegen.go
+    reason: "not applicable: after the LLGo rangefunc return fix, this case is blocked by the upstream golang.org/x/tools/go/ssa labeled-goto defect tracked at https://github.com/golang/go/issues/80860 and fixed by https://github.com/golang/tools/pull/666; duplicating the dependency fix inside LLGo is not an LLGo compatibility goal while LLGo waits to update x/tools"
+  - version: go1.24
+    platform: linux/amd64
+    directive: runoutput
+    case: rangegen.go
+    reason: "not applicable: after the LLGo rangefunc return fix, this case is blocked by the upstream golang.org/x/tools/go/ssa labeled-goto defect tracked at https://github.com/golang/go/issues/80860 and fixed by https://github.com/golang/tools/pull/666; duplicating the dependency fix inside LLGo is not an LLGo compatibility goal while LLGo waits to update x/tools"
+  - version: go1.26
+    platform: linux/amd64
+    directive: runoutput
+    case: rangegen.go
+    reason: "not applicable: after the LLGo rangefunc return fix, this case is blocked by the upstream golang.org/x/tools/go/ssa labeled-goto defect tracked at https://github.com/golang/go/issues/80860 and fixed by https://github.com/golang/tools/pull/666; duplicating the dependency fix inside LLGo is not an LLGo compatibility goal while LLGo waits to update x/tools"
   - version: go1.26
     directive: errorcheck
     case: escape_array.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1294,20 +1294,6 @@ xfails:
     case: convert5.go
     reason: out-of-range float-to-uint32 conversions wrap instead of producing zero on linux/amd64
   - platform: darwin/arm64
-    directive: runoutput
-    case: rangegen.go
-    reason: current main goroot runoutput failure on darwin/arm64
-  - version: go1.24
-    platform: linux/amd64
-    directive: runoutput
-    case: rangegen.go
-    reason: go1.24 goroot ci-mode runoutput failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: runoutput
-    case: rangegen.go
-    reason: go1.26 goroot ci-mode runoutput failure on linux/amd64
-  - platform: darwin/arm64
     directive: run
     case: heapsampling.go
     reason: latest main goroot run failure on darwin/arm64


### PR DESCRIPTION
## Summary

- Preserve unnamed return values across the shared rangefunc defer dispatcher.
- Allocate spill slots only for functions whose range-over-func yield owns an explicit defer stack; named results continue to use their source result slots.
- Add verifier coverage and a `test/go` runtime test that passes with both Go and LLGo.

## Why

Multiple unnamed return paths previously fed one `RunDefers` continuation with path-local SSA values. LLVM correctly rejected generated programs where a return-value definition did not dominate that continuation. Spilling before defer dispatch gives every path a valid value and also preserves the value while deferred calls run.

This was reduced from Go's generated `rangegen.go` test. Its separate labeled-`goto` failure is the upstream x/tools SSA issue [golang/go#80860](https://github.com/golang/go/issues/80860), with the fix under review in [golang/tools#666](https://github.com/golang/tools/pull/666).

The three affected `rangegen.go` correctness entries remain `runoutput`, but move from LLGo compatibility xfails to `notapplicable.yaml` while that dependency fix is pending. Resource timeout entries remain unchanged.

## Tests

- `go test ./cl -run 'TestCompileRangeFuncDeferModule|TestNamedResultSlot' -count=1`
- `go test -vet=off ./test/go -run '^TestRangeFuncDefersPreserveUnnamedReturnValue$' -count=1`
- LLGo execution of `TestRangeFuncDefersPreserveUnnamedReturnValue`
- Full generated Go 1.26 `rangegen.go` source passes LLVM verification and code generation with this fix
