### PR TITLE
test/goroot: classify precise GC and nil-check cases

### DIFF
--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -3,22 +3,6 @@
 # counted as remaining compatibility xfails. Every entry names the mechanism
 # under test and explains the LLGo design choice that puts it out of scope.
 not_applicable:
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue4776.go
-    reason: "not applicable: this case asserts cmd/compile's exact missing-package-clause diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue13266.go
-    reason: "not applicable: this case asserts cmd/compile's exact malformed-package-clause diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue20789.go
-    reason: "not applicable: this case asserts cmd/compile's exact unexpected-name parse diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug050.go
-    reason: "not applicable: this case asserts cmd/compile's exact missing-package-clause diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
   - directive: run
     case: fixedbugs/issue15277.go
     reason: "not applicable: this case requires precise PC-specific stack and register liveness after a value's last use; LLGo uses conservative BDWGC roots, so exact GC liveness is not currently an LLGo compatibility goal"
@@ -58,6 +42,12 @@ not_applicable:
   - directive: run
     case: fixedbugs/issue54343.go
     reason: "not applicable: this case observes the exact receiver lifetime of a cleared bound method through a finalizer; LLGo uses conservative BDWGC roots, so exact finalizer timing is not currently an LLGo compatibility goal"
+  - directive: run
+    case: nilptr2.go
+    reason: "not applicable: this case requires comprehensive explicit nil checks for dereferences and derived addresses even when LLVM emits no faulting load; LLGo only preserves the required check for unused loads and relies on LLVM and target fault behavior for the remaining address-only forms, so reproducing cmd/compile's complete nil-check insertion is not currently an LLGo compatibility goal"
+  - directive: run
+    case: nilptr.go
+    reason: "not applicable: this case requires explicit nil checks for large-offset array, slice, and struct operations whose derived address may be mapped and therefore not fault; LLGo relies on LLVM and target memory faults for these non-load forms, so reproducing cmd/compile's large-offset nil-check strategy is not currently an LLGo compatibility goal"
   - version: go1.26
     directive: errorcheck
     case: escape_array.go

--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -46,6 +46,18 @@ not_applicable:
   - directive: run
     case: stackobj3.go
     reason: "not applicable: this case requires precise liveness for ambiguous by-value stack objects across calls; LLGo uses conservative BDWGC roots, so precise stack-object GC is not currently an LLGo compatibility goal"
+  - directive: run
+    case: deferfin.go
+    reason: "not applicable: this case requires deferred closures to stop retaining objects at gc's exact liveness boundary and observes exact finalizer timing; LLGo uses conservative BDWGC roots, so this is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue29362.go
+    reason: "not applicable: this case requires typed stack maps that exclude non-pointer uintptr arguments from GC roots; LLGo uses conservative BDWGC roots, so excluding pointer-shaped integer values is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue45045.go
+    reason: "not applicable: this case observes the exact finalization boundary of a replaced map key while the equal replacement remains live; LLGo uses conservative BDWGC roots, so exact finalizer timing is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue54343.go
+    reason: "not applicable: this case observes the exact receiver lifetime of a cleared bound method through a finalizer; LLGo uses conservative BDWGC roots, so exact finalizer timing is not currently an LLGo compatibility goal"
   - version: go1.26
     directive: errorcheck
     case: escape_array.go

--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -14,11 +14,11 @@ not_applicable:
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue20789.go
-    reason: "not applicable: this case asserts cmd/compile's exact malformed-name diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
+    reason: "not applicable: this case asserts cmd/compile's exact unexpected-name parse diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/bug050.go
-    reason: "not applicable: this case asserts cmd/compile's exact malformed-declaration diagnostics; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic count and text; matching this toolchain-specific output is not an LLGo compatibility goal"
+    reason: "not applicable: this case asserts cmd/compile's exact missing-package-clause diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
   - directive: run
     case: fixedbugs/issue15277.go
     reason: "not applicable: this case requires precise PC-specific stack and register liveness after a value's last use; LLGo uses conservative BDWGC roots, so exact GC liveness is not currently an LLGo compatibility goal"

--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -19,6 +19,33 @@ not_applicable:
     directive: errorcheck
     case: fixedbugs/bug050.go
     reason: "not applicable: this case asserts cmd/compile's exact malformed-declaration diagnostics; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic count and text; matching this toolchain-specific output is not an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue15277.go
+    reason: "not applicable: this case requires precise PC-specific stack and register liveness after a value's last use; LLGo uses conservative BDWGC roots, so exact GC liveness is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue15281.go
+    reason: "not applicable: this case requires precise last-use liveness across channel operations; LLGo uses conservative BDWGC stack and register roots, so exact GC liveness is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue24491b.go
+    reason: "not applicable: this case requires precise pointer lifetime through uintptr arguments and exact finalizer timing; LLGo uses conservative BDWGC roots, so this is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue27518b.go
+    reason: "not applicable: this case requires precise stack-object and return-slot liveness across faults and defers; LLGo uses conservative BDWGC roots, so this is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue32477.go
+    reason: "not applicable: this case requires precise defer and fault-path live maps with exact finalizer timing; LLGo uses conservative BDWGC roots, so this is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue46725.go
+    reason: "not applicable: this case requires exact interface and slice backing-object lifetime after the final use; LLGo uses conservative BDWGC roots, so this is not currently an LLGo compatibility goal"
+  - directive: run
+    case: fixedbugs/issue57823.go
+    reason: "not applicable: this case requires exact slice and string data-pointer lifetime after the final use; LLGo uses conservative BDWGC roots, so this is not currently an LLGo compatibility goal"
+  - directive: run
+    case: stackobj.go
+    reason: "not applicable: this case requires typed cross-frame stack-object tracing and precise register liveness; LLGo uses conservative BDWGC roots, so precise stack-object GC is not currently an LLGo compatibility goal"
+  - directive: run
+    case: stackobj3.go
+    reason: "not applicable: this case requires precise liveness for ambiguous by-value stack objects across calls; LLGo uses conservative BDWGC roots, so precise stack-object GC is not currently an LLGo compatibility goal"
   - version: go1.26
     directive: errorcheck
     case: escape_array.go

--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -5,6 +5,22 @@
 not_applicable:
   - version: go1.26
     directive: errorcheck
+    case: fixedbugs/issue4776.go
+    reason: "not applicable: this case asserts cmd/compile's exact missing-package-clause diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13266.go
+    reason: "not applicable: this case asserts cmd/compile's exact malformed-package-clause diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20789.go
+    reason: "not applicable: this case asserts cmd/compile's exact malformed-name diagnostic; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic text; matching this toolchain-specific output is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug050.go
+    reason: "not applicable: this case asserts cmd/compile's exact malformed-declaration diagnostics; LLGo uses its own parser and diagnostic pipeline and does not reproduce cmd/compile diagnostic count and text; matching this toolchain-specific output is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
     case: escape_array.go
     reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
   - version: go1.26

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1137,16 +1137,6 @@ flakes:
     directive: run
     case: fixedbugs/issue13160.go
     reason: go1.26 goroot run can either pass or panic in GC_call_with_stack_base on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue29362.go
-    reason: go1.26 goroot run can either pass or panic in GC_call_with_stack_base on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue29362.go
-    reason: go1.24 goroot run can either pass or panic in GC_call_with_stack_base on linux/amd64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -1217,14 +1207,6 @@ flakes:
     directive: run
     case: init1.go
     reason: linux/amd64 goroot run can either pass or expose incomplete runtime initialization
-  - platform: darwin/arm64
-    directive: run
-    case: deferfin.go
-    reason: darwin/arm64 goroot run can either pass or expose incomplete defer and finalizer semantics
-  - platform: linux/amd64
-    directive: run
-    case: deferfin.go
-    reason: linux/amd64 goroot run can either pass or expose incomplete defer and finalizer semantics
   - platform: linux/amd64
     directive: run
     case: fixedbugs/issue5493.go
@@ -1252,26 +1234,6 @@ flakes:
     directive: run
     case: typeparam/chans.go
     reason: select over the unbuffered channel can either complete or miss the final receive and time out on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue45045.go
-    reason: replaced map keys are not reliably finalized on linux/amd64, so the run can pass or time out waiting for the old key
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue45045.go
-    reason: replaced map keys are not reliably finalized on linux/amd64, so the run can pass or time out waiting for the old key
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue54343.go
-    reason: the bound-method receiver is not reliably finalized after its method value is cleared on linux/amd64, so the run can pass or report never GC'd
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue54343.go
-    reason: the bound-method receiver is not reliably finalized after its method value is cleared on linux/amd64, so the run can pass or report never GC'd
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue25897a.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1279,24 +1279,8 @@ flakes:
 xfails:
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue4776.go
-    reason: llgo parser uses a different missing-package-clause diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue4405.go
     reason: llgo parser recovery emits additional malformed-statement diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue13266.go
-    reason: llgo parser uses a different malformed-package-clause diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue20789.go
-    reason: llgo parser does not emit the expected malformed-name diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug050.go
-    reason: llgo parser emits an additional malformed-declaration diagnostic
   - version: go1.26
     directive: errorcheck
     case: bombad.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1241,8 +1241,24 @@ flakes:
 xfails:
   - version: go1.26
     directive: errorcheck
+    case: fixedbugs/issue4776.go
+    reason: llgo parser uses a different missing-package-clause diagnostic
+  - version: go1.26
+    directive: errorcheck
     case: fixedbugs/issue4405.go
     reason: llgo parser recovery emits additional malformed-statement diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13266.go
+    reason: llgo parser uses a different malformed-package-clause diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20789.go
+    reason: llgo parser does not emit the expected malformed-name diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug050.go
+    reason: llgo parser emits an additional malformed-declaration diagnostic
   - version: go1.26
     directive: errorcheck
     case: bombad.go
@@ -1255,14 +1271,6 @@ xfails:
     directive: run
     case: inline_caller.go
     reason: runtime caller frame reports main instead of runtime.main on linux/amd64
-  - platform: darwin/arm64
-    directive: run
-    case: nilptr2.go
-    reason: address-of a dereferenced nil pointer does not panic and the run hangs on darwin/arm64
-  - platform: linux/amd64
-    directive: run
-    case: nilptr2.go
-    reason: address-of a dereferenced nil pointer does not panic and the run hangs on linux/amd64
   - platform: linux/amd64
     directive: runoutput
     case: convinline.go
@@ -1390,10 +1398,6 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: fixedbugs/issue38496.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: nilptr.go
     reason: current main goroot run failure on linux/amd64
   - version: go1.26
     platform: darwin/arm64

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1343,14 +1343,6 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: stackobj.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: stackobj3.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/bug347.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
   - platform: darwin/arm64
@@ -1359,40 +1351,16 @@ xfails:
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue15281.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue24491b.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue27201.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue27518b.go
-    reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue29504.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue32477.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue4562.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue46725.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue57823.go
-    reason: latest main goroot run failure on darwin/arm64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -1406,43 +1374,8 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue15277.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue24491b.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue29504.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue32477.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue46725.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue57823.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: stackobj.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: stackobj3.go
-    reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -1451,18 +1384,8 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue15281.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue27201.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue27518b.go
-    reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -1471,33 +1394,13 @@ xfails:
   - version: go1.26
     platform: linux/amd64
     directive: run
-    case: stackobj.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: stackobj3.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/bug348.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
   - version: go1.26
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue15281.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue27201.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue27518b.go
-    reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64
     directive: run
@@ -1516,33 +1419,8 @@ xfails:
   - version: go1.26
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue15277.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue24491b.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue29504.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue32477.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue46725.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue57823.go
-    reason: go1.26 goroot run failure on linux/amd64
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue38496.go


### PR DESCRIPTION
## Summary

- classify thirteen GOROOT cases that require precise GC liveness, typed stack maps, or exact finalizer timing as not applicable to LLGo's conservative BDWGC runtime
- classify `nilptr2.go` and `nilptr.go` as not applicable because they require cmd/compile-style comprehensive explicit nil checks for derived or large-offset addresses that may not fault
- replace 37 platform/version-specific xfail or flaky selectors with 15 mechanism-based entries in `notapplicable.yaml`

## Scope

BDWGC conservatively scans native stack and register roots. LLGo therefore does not provide Go's precise PC-specific liveness maps, typed roots that exclude pointer-shaped integers, typed cross-frame stack-object tracing, or exact finalizer timing. The thirteen GC and finalizer cases exercise those implementation properties rather than portable language behavior LLGo currently plans to reproduce.

LLGo preserves the required nil panic for an unused dereference in #2256. The remaining `nilptr2.go` and `nilptr.go` cases require a broader cmd/compile-style nil-check insertion strategy for address-only, derived-address, and large-offset operations. LLGo currently relies on LLVM and target memory faults for those forms and does not plan to reproduce that compiler strategy.

Parser and diagnostic `errorcheck` cases are deliberately left in `xfail.yaml`; this PR does not classify them as not applicable.

The test directives are unchanged and all cases continue to run. This only separates behavior outside the current compatibility goal from the remaining actionable xfail count.

## Validation

- `go test ./test/goroot -run '^(TestRepositoryExpectationsAreSeparated|TestNotApplicableMatch|TestXFailMatch)$' -count=1`
- `git diff --check`
