### PR TITLE
runtime: restore native process-entry caller tail

### DIFF
--- a/internal/build/funcinfo_table_test.go
+++ b/internal/build/funcinfo_table_test.go
@@ -53,6 +53,7 @@ func TestFuncInfoTableMaterializesMetadataWithoutFunctionPointers(t *testing.T) 
 			BuildMode: BuildModeExe,
 			Goos:      "linux",
 			Goarch:    "amd64",
+			PCLNMode:  PCLNNone, // Keep exact table assertions limited to supplied records.
 		},
 	}
 	entry := genMainModule(ctx, llssa.PkgRuntime, &packages.Package{
@@ -381,6 +382,7 @@ func TestFuncInfoTableMaterializesPCLineMetadata(t *testing.T) {
 			BuildMode: BuildModeExe,
 			Goos:      "linux",
 			Goarch:    "amd64",
+			PCLNMode:  PCLNNone, // Keep exact table assertions limited to supplied records.
 		},
 	}
 	entry := genMainModule(ctx, llssa.PkgRuntime, &packages.Package{
@@ -463,6 +465,7 @@ func TestFuncInfoTableEmptyDefinitions(t *testing.T) {
 			BuildMode: BuildModeExe,
 			Goos:      "linux",
 			Goarch:    "amd64",
+			PCLNMode:  PCLNNone, // Keep exact table assertions limited to supplied records.
 		},
 	}
 	entry := genMainModule(ctx, llssa.PkgRuntime, &packages.Package{

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -48,7 +48,11 @@ type genConfig struct {
 	pcLineInfo    []pcLineRecord
 }
 
-const runtimeMainSymbol = "runtime.main"
+const (
+	processEntrySymbol = "main"
+	runtimeMainSymbol  = "runtime.main"
+	runtimeGoexitName  = "runtime.goexit"
+)
 
 func needsRuntimeMainFrame(ctx *context) bool {
 	conf := ctx.buildConf
@@ -75,15 +79,17 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 		// The native process entry is the physical frame below runtime.main,
 		// which is runtime.goexit in a Go traceback. Keep the required C symbol
 		// while giving both generated frames their logical Go names.
-		funcInfo = append(funcInfo,
-			funcInfoRecord{symbol: runtimeMainSymbol, name: runtimeMainSymbol},
-			funcInfoRecord{symbol: "main", name: "runtime.goexit"},
-		)
+		tailRecords := []funcInfoRecord{
+			{symbol: runtimeMainSymbol, name: runtimeMainSymbol},
+			{symbol: processEntrySymbol, name: runtimeGoexitName},
+		}
+		funcInfo = append(funcInfo, tailRecords...)
 		// Entry sites are emitted after these generated functions have bodies.
 		// Keep matching metadata in this module so the generic site emitter can
 		// attach the symbol IDs without adding a special PCLN path.
-		mainPkg.EmitFuncInfo(runtimeMainSymbol, runtimeMainSymbol, "", 0, 0)
-		mainPkg.EmitFuncInfo("main", "runtime.goexit", "", 0, 0)
+		for _, rec := range tailRecords {
+			mainPkg.EmitFuncInfo(rec.symbol, rec.name, "", 0, 0)
+		}
 	}
 	emitFuncInfoTable(ctx, mainPkg, funcInfo, cfg.pcLineInfo)
 
@@ -273,14 +279,14 @@ type entryFunctions struct {
 // finalizes Python if it was initialized, and returns 0.
 func defineEntryFunction(ctx *context, pkg llssa.Package, argcVar, argvVar llssa.Global, argvType llssa.Type, fns entryFunctions) llssa.Function {
 	prog := pkg.Prog
-	entryName := "main"
+	entryName := processEntrySymbol
 	if !needStart(ctx) && isWasmTarget(ctx.buildConf.Goos) {
 		entryName = "__main_argc_argv"
 	}
 	sig := newEntrySignature(argvType.RawType())
 	fn := pkg.NewFunc(entryName, sig, llssa.InC)
 	fnVal := pkg.Module().NamedFunction(entryName)
-	if entryName != "main" {
+	if entryName != processEntrySymbol {
 		fnVal.SetVisibility(llvm.HiddenVisibility)
 		fnVal.SetUnnamedAddr(true)
 	}

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -274,9 +274,11 @@ type entryFunctions struct {
 // "main" for standard targets, or "__main_argc_argv" with hidden visibility
 // for WASM targets that don't require _start.
 //
-// The entry stores argc/argv, optionally disables stdio buffering, runs
-// initialization hooks (Python, runtime, package init), calls main.main,
-// finalizes Python if it was initialized, and returns 0.
+// The entry stores argc/argv, optionally disables stdio buffering, and manages
+// the local context. Native PCLN builds run the common startup sequence through
+// runtime.main; other builds run it inline. That sequence initializes Python,
+// the runtime stub/package, ABI types, and packages, calls main.main, and then
+// finalizes Python. The entry leaves the local context and returns 0.
 func defineEntryFunction(ctx *context, pkg llssa.Package, argcVar, argvVar llssa.Global, argvType llssa.Type, fns entryFunctions) llssa.Function {
 	prog := pkg.Prog
 	entryName := processEntrySymbol

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -48,6 +48,13 @@ type genConfig struct {
 	pcLineInfo    []pcLineRecord
 }
 
+const runtimeMainSymbol = "runtime.main"
+
+func needsRuntimeMainFrame(ctx *context) bool {
+	conf := ctx.buildConf
+	return conf.BuildMode == BuildModeExe && !isWasmTarget(conf.Goos) && conf.PCLNMode != PCLNNone
+}
+
 // genMainModule generates the main entry module for an llgo program.
 //
 // The module contains argc/argv globals and, for executable build modes,
@@ -63,7 +70,22 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	argvValueType := prog.Pointer(prog.CStr())
 	argvVar := mainPkg.NewVarEx("__llgo_argv", prog.Pointer(argvValueType))
 	argvVar.InitNil()
-	emitFuncInfoTable(ctx, mainPkg, cfg.funcInfo, cfg.pcLineInfo)
+	funcInfo := cfg.funcInfo
+	if needsRuntimeMainFrame(ctx) {
+		// The native process entry is the physical frame below runtime.main,
+		// which is runtime.goexit in a Go traceback. Keep the required C symbol
+		// while giving both generated frames their logical Go names.
+		funcInfo = append(funcInfo,
+			funcInfoRecord{symbol: runtimeMainSymbol, name: runtimeMainSymbol},
+			funcInfoRecord{symbol: "main", name: "runtime.goexit"},
+		)
+		// Entry sites are emitted after these generated functions have bodies.
+		// Keep matching metadata in this module so the generic site emitter can
+		// attach the symbol IDs without adding a special PCLN path.
+		mainPkg.EmitFuncInfo(runtimeMainSymbol, runtimeMainSymbol, "", 0, 0)
+		mainPkg.EmitFuncInfo("main", "runtime.goexit", "", 0, 0)
+	}
+	emitFuncInfoTable(ctx, mainPkg, funcInfo, cfg.pcLineInfo)
 
 	exportFile := pkg.ExportFile
 	if exportFile == "" {
@@ -149,6 +171,7 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	if needStart(ctx) {
 		defineStart(mainPkg, entryFn, argvValueType)
 	}
+	emitFuncInfoEntrySites(ctx, mainPkg)
 
 	return mainAPkg
 }
@@ -272,6 +295,33 @@ func defineEntryFunction(ctx *context, pkg llssa.Package, argcVar, argvVar llssa
 	if IsStdioNobuf() {
 		emitStdioNobuf(b, pkg, ctx.buildConf.Goos)
 	}
+	if needsRuntimeMainFrame(ctx) {
+		runtimeMain := defineRuntimeMainFunction(pkg, fns)
+		b.Call(runtimeMain.Expr)
+	} else {
+		emitRuntimeMainBody(b, fns)
+	}
+	if hasLocalContext {
+		b.LeaveLocalContext(localCtx, previousLocalCtx)
+	}
+	b.Return(prog.IntVal(0, prog.Int32()))
+	return fn
+}
+
+// defineRuntimeMainFunction gives native executables the same logical tail as
+// gc: user code is called by runtime.main, while the C entry below it is named
+// runtime.goexit in funcinfo metadata. The wrapper is a startup-only call.
+func defineRuntimeMainFunction(pkg llssa.Package, fns entryFunctions) llssa.Function {
+	fn := pkg.NewFunc(runtimeMainSymbol, llssa.NoArgsNoRet, llssa.InGo)
+	fn.Inline(llssa.NoInline)
+	fn.DisableTailCalls()
+	b := fn.MakeBody(1)
+	emitRuntimeMainBody(b, fns)
+	b.Return()
+	return fn
+}
+
+func emitRuntimeMainBody(b llssa.Builder, fns entryFunctions) {
 	if fns.pyInit != nil {
 		b.Call(fns.pyInit.Expr)
 	}
@@ -290,11 +340,6 @@ func defineEntryFunction(ctx *context, pkg llssa.Package, argcVar, argvVar llssa
 	if fns.pyFinalize != nil {
 		b.Call(fns.pyFinalize.Expr)
 	}
-	if hasLocalContext {
-		b.LeaveLocalContext(localCtx, previousLocalCtx)
-	}
-	b.Return(prog.IntVal(0, prog.Int32()))
-	return fn
 }
 
 func defineStart(pkg llssa.Package, entry llssa.Function, argvType llssa.Type) {

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -33,6 +33,8 @@ func TestGenMainModuleExecutable(t *testing.T) {
 			Goarch:    "amd64",
 		},
 	}
+	ctx.prog.EnableFuncInfoMetadata(true)
+	ctx.prog.EnableFuncInfoSites(true)
 	pkg := &packages.Package{PkgPath: "example.com/foo", ExportFile: "foo.a"}
 	mod := genMainModule(ctx, llssa.PkgRuntime, pkg,
 		&genConfig{rtInit: true, pyInit: true, packageInits: []string{"example.com/b.init", "example.com/z.init", "example.com/a.init"}})
@@ -42,6 +44,11 @@ func TestGenMainModuleExecutable(t *testing.T) {
 	ir := mod.LPkg.String()
 	checks := []string{
 		"define i32 @main(",
+		"define void @runtime.main()",
+		`runtime\00goexit\00main`,
+		".pushsection llgo_funcinfo_entry",
+		".quad " + uint64Hex(funcInfoSymbolID(runtimeMainSymbol)),
+		".quad " + uint64Hex(funcInfoSymbolID("main")),
 		"call void @Py_Initialize()",
 		"call void @Py_Finalize()",
 		"call void @\"example.com/foo.init\"()",
@@ -328,8 +335,7 @@ func TestGenMainModuleInstallsLocalContextWhenNeeded(t *testing.T) {
 	ir := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{}).LPkg.String()
 	assertInOrder(t, ir,
 		"EnterLocalContext",
-		`call void @"example.com/foo.init"()`,
-		`call void @"example.com/foo.main"()`,
+		"call void @runtime.main()",
 		"LeaveLocalContext",
 	)
 }

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -43,12 +43,11 @@ func TestGenMainModuleExecutable(t *testing.T) {
 	}
 	ir := mod.LPkg.String()
 	checks := []string{
-		"define i32 @main(",
+		"define i32 @" + processEntrySymbol + "(",
 		"define void @runtime.main()",
-		`runtime\00goexit\00main`,
 		".pushsection llgo_funcinfo_entry",
 		".quad " + uint64Hex(funcInfoSymbolID(runtimeMainSymbol)),
-		".quad " + uint64Hex(funcInfoSymbolID("main")),
+		".quad " + uint64Hex(funcInfoSymbolID(processEntrySymbol)),
 		"call void @Py_Initialize()",
 		"call void @Py_Finalize()",
 		"call void @\"example.com/foo.init\"()",
@@ -58,6 +57,18 @@ func TestGenMainModuleExecutable(t *testing.T) {
 	for _, want := range checks {
 		if !strings.Contains(ir, want) {
 			t.Fatalf("main module IR missing %q:\n%s", want, ir)
+		}
+	}
+	funcNames := make(map[string]string)
+	for _, rec := range readFuncInfo(mod.LPkg.Module()) {
+		funcNames[rec.symbol] = rec.name
+	}
+	for symbol, want := range map[string]string{
+		processEntrySymbol: runtimeGoexitName,
+		runtimeMainSymbol:  runtimeMainSymbol,
+	} {
+		if got := funcNames[symbol]; got != want {
+			t.Fatalf("funcinfo name for %q = %q, want %q", symbol, got, want)
 		}
 	}
 	assertInOrder(t, ir,

--- a/test/go/caller_acceptance_test.go
+++ b/test/go/caller_acceptance_test.go
@@ -466,6 +466,74 @@ func main() {
 	}
 }
 
+// Scenario: the process-entry tail has gc's logical runtime.main and
+// runtime.goexit frames, including while an imported package is initialized.
+// The same module is executed by gc and LLGo.
+func TestCallerAcceptanceLogicalRuntimeTail(t *testing.T) {
+	dir := t.TempDir()
+	const mainSrc = `package main
+
+import (
+	"os"
+	"runtime"
+	_ "caller-tail/probe"
+)
+
+func main() {
+	want := []string{"main.main", "runtime.main", "runtime.goexit"}
+	for skip, name := range want {
+		pc, _, _, ok := runtime.Caller(skip)
+		if !ok || runtime.FuncForPC(pc).Name() != name {
+			panic("bad runtime caller tail")
+		}
+	}
+	os.Stdout.WriteString("CALLER_TAIL_OK\n")
+}
+`
+	const probeSrc = `package probe
+
+import (
+	"runtime"
+	"strings"
+)
+
+func init() {
+	var pcs [32]uintptr
+	n := runtime.Callers(0, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+	seenInit := false
+	var names []string
+	for {
+		frame, more := frames.Next()
+		names = append(names, frame.Function)
+		if strings.Contains(frame.Function, "/probe.init") {
+			seenInit = true
+		} else if seenInit && strings.HasPrefix(frame.Function, "runtime.") {
+			return
+		}
+		if !more {
+			panic("runtime initialization driver missing: " + strings.Join(names, ", "))
+		}
+	}
+}
+`
+	writeCallerAcceptanceModule(t, dir, map[string]string{
+		"main.go":        mainSrc,
+		"probe/probe.go": probeSrc,
+		"go.mod":         "module caller-tail\n\ngo 1.21\n",
+	})
+
+	goCmd := exec.Command("go", "run", ".")
+	goCmd.Dir = dir
+	if out, err := goCmd.CombinedOutput(); err != nil || !strings.Contains(string(out), "CALLER_TAIL_OK") {
+		t.Fatalf("gc caller-tail probe failed: %v\n%s", err, out)
+	}
+	out, err := runLLGoInModule(t, dir, "run", ".")
+	if err != nil || !strings.Contains(out, "CALLER_TAIL_OK") {
+		t.Fatalf("LLGo caller-tail probe failed: %v\n%s", err, out)
+	}
+}
+
 // Scenario: a hardware fault inside C code called from Go (NULL store in a
 // C helper) converts to a Go panic that recover observes with gc's error
 // text; the process must not die on the raw signal.

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1263,35 +1263,19 @@ xfails:
     directive: errorcheck
     case: bombad.go
     reason: llgo parser recovery emits additional byte-order-mark diagnostics
-  - platform: darwin/arm64
-    directive: run
-    case: inline_caller.go
-    reason: runtime caller frame reports main instead of runtime.main on darwin/arm64
-  - platform: linux/amd64
-    directive: run
-    case: inline_caller.go
-    reason: runtime caller frame reports main instead of runtime.main on linux/amd64
 
   - platform: darwin/arm64
     directive: run
     case: heapsampling.go
     reason: latest main goroot run failure on darwin/arm64
-
   - version: go1.24
     platform: linux/amd64
     directive: run
     case: heapsampling.go
     reason: go1.24 goroot run failure on linux/amd64
-
-
   - version: go1.26
     platform: linux/amd64
     directive: run
     case: heapsampling.go
     reason: go1.26 goroot run failure on linux/amd64
 
-  - version: go1.26
-    platform: darwin/arm64
-    directive: rundir
-    case: fixedbugs/issue29919.go
-    reason: runtime CallersFrames reports llgo package names and initialization line metadata differently


### PR DESCRIPTION
## Summary

- add a startup-only `runtime.main` frame for native executables and map the required C `main` entry to the logical Go name `runtime.goexit`;
- publish both generated frames through the existing funcinfo and entry-site pipeline, without changing the PCLN data layout or adding per-`Caller` synthesis;
- keep Wasm and builds without PCLN on the existing direct entry path;
- remove the `inline_caller.go` and `fixedbugs/issue29919.go` xfails.

The actual native symbols remain `main.main -> @runtime.main -> @main`. Funcinfo presents the final C ABI entry as `runtime.goexit`, so Go stack inspection observes the gc-compatible logical tail `main.main -> runtime.main -> runtime.goexit`.

## Generated LLVM IR shape

Previously, the C ABI entry directly ran the complete startup sequence:

```llvm
define i32 @main(i32 %argc, ptr %argv) {
  store i32 %argc, ptr @__llgo_argc
  store ptr %argv, ptr @__llgo_argv
  call void @Py_Initialize()
  call void @"runtime.init"()
  call void @"main.init"()
  call void @"main.main"()
  call void @Py_Finalize()
  ret i32 0
}
```

The native PCLN path now separates the C entry from the Go startup driver:

```llvm
define i32 @main(i32 %argc, ptr %argv) {
  ; EnterLocalContext when required
  store i32 %argc, ptr @__llgo_argc
  store ptr %argv, ptr @__llgo_argv
  call void @runtime.main()
  ; LeaveLocalContext when required
  ret i32 0
}

define void @runtime.main() #attrs {
  call void @Py_Initialize()
  call void @"runtime.init"()
  call void @"main.init"()
  call void @"main.main"()
  call void @Py_Finalize()
  ret void
}

attributes #attrs = { noinline "disable-tail-calls"="true" }
```

Package and ABI initialization calls omitted above remain in their previous order. `noinline` and `disable-tail-calls` ensure LLVM cannot remove the required `runtime.main` frame.

The generated funcinfo mappings are:

```text
physical @runtime.main -> logical runtime.main
physical @main         -> logical runtime.goexit
```

The linker-facing symbol is still the required C `main`; this PR does not generate a separate physical `@runtime.goexit` function.

## Runtime impact

- Initialization, `main.main`, Python initialization/finalization, argc/argv handling, and local-context ordering are unchanged.
- A native process enters one additional non-inlined wrapper call. It remains below package initialization and `main.main`, then returns once when startup execution finishes.
- `runtime.Caller`, `runtime.CallersFrames`, and panic tracebacks now see the Go-compatible process-entry tail, including during imported-package initialization.
- The cost is one call/return per process plus two static funcinfo/entry-site records. There is no additional work on ordinary function calls and no per-`Caller` or per-traceback synthesis.
- The change applies only to non-Wasm executable builds with PCLN enabled. Wasm, builds without PCLN, and library build modes retain the direct entry path.

## Validation

- `go test ./internal/build -run TestGenMainModule -count=1`
- `go test -vet=off ./test/go -run TestCallerAcceptanceLogicalRuntimeTail -count=1 -timeout=20m`
- direct Go 1.26.5 GOROOT run of `inline_caller.go` without xfail on macOS/arm64
- direct Go 1.26.5 GOROOT rundir of `fixedbugs/issue29919.go` without xfail on macOS/arm64
- `go test ./test/goroot -run "TestRepositoryExpectationsAreSeparated|TestXFailMatch" -count=1`