### PR TITLE
cl: preserve nil checks for unused dereferences

### DIFF
--- a/cl/_testrt/cvar/in.go
+++ b/cl/_testrt/cvar/in.go
@@ -18,9 +18,6 @@ var barY struct {
 	Arr [16]int8
 }
 
-// CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK: load { [16 x i8], [2 x ptr] }, ptr @_bar_x
-// CHECK: load { [16 x i8] }, ptr @_bar_y
 func main() {
 	_ = barX
 	_ = barY

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1331,28 +1331,17 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 				b.AssertNilDeref(x)
 			}
 			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 0 {
-				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
-					if p.isLargeNonPointerValue(t) {
-						x := p.compileValue(b, v.X)
-						p.recordPanicLocation(b, v.Pos())
-						p.assertNilDerefBase(b, v.X)
-						b.AssertNilDeref(x)
-						return
-					}
-				}
 				if skipUnusedArrayDeref(v) {
 					p.compileValue(b, v.X)
 					return
 				}
-				if _, ok := types.Unalias(v.Type()).Underlying().(*types.Slice); ok {
-					// Zero-length slice-to-array conversions can leave only
-					// an unused slice deref; preserve its required nil check.
-					x := p.compileValue(b, v.X)
-					p.recordPanicLocation(b, v.Pos())
-					p.assertNilDerefBase(b, v.X)
-					b.AssertNilDeref(x)
-					return
-				}
+				// LLVM may eliminate an unused load, but evaluating a Go
+				// dereference must still panic when its pointer is nil.
+				x := p.compileValue(b, v.X)
+				p.recordPanicLocation(b, v.Pos())
+				p.assertNilDerefBase(b, v.X)
+				b.AssertNilDeref(x)
+				return
 			}
 			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 1 {
 				if _, ok := refs[0].(*ssa.MakeInterface); ok {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1325,23 +1325,28 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			if _, ok := p.methodNilDerefChecks[v]; ok {
 				return p.compileCheckedDeref(b, v)
 			}
-			if isEffectfulArrayPointerDeref(v) {
-				x := p.compileValue(b, v.X)
-				p.recordPanicLocation(b, v.Pos())
-				b.AssertNilDeref(x)
-			}
+			effectfulArrayDeref := isEffectfulArrayPointerDeref(v)
 			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 0 {
 				if skipUnusedArrayDeref(v) {
-					p.compileValue(b, v.X)
+					x := p.compileValue(b, v.X)
+					if effectfulArrayDeref {
+						p.recordPanicLocation(b, v.Pos())
+						b.AssertNilDeref(x)
+					}
 					return
 				}
-				// LLVM may eliminate an unused load, but evaluating a Go
-				// dereference must still panic when its pointer is nil.
+				// Elide the unused load, but keep an explicit nil check so the
+				// Go dereference still panics instead of relying on a trapping load.
 				x := p.compileValue(b, v.X)
 				p.recordPanicLocation(b, v.Pos())
 				p.assertNilDerefBase(b, v.X)
 				b.AssertNilDeref(x)
 				return
+			}
+			if effectfulArrayDeref {
+				x := p.compileValue(b, v.X)
+				p.recordPanicLocation(b, v.Pos())
+				b.AssertNilDeref(x)
 			}
 			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 1 {
 				if _, ok := refs[0].(*ssa.MakeInterface); ok {

--- a/cl/range_array_compile_test.go
+++ b/cl/range_array_compile_test.go
@@ -143,8 +143,8 @@ func rangeArrayReceive(ch <-chan *[3]int) {
 
 	for _, name := range []string{"rangeArrayCall", "rangeArrayReceive"} {
 		ir := mustNamedFunction(t, m, "foo."+name).String()
-		if !strings.Contains(ir, "AssertNilDeref") {
-			t.Fatalf("%s should preserve its required array pointer nil check:\n%s", name, ir)
+		if got := strings.Count(ir, "AssertNilDeref"); got != 1 {
+			t.Fatalf("%s nil-check count = %d, want 1:\n%s", name, got, ir)
 		}
 	}
 }

--- a/cl/range_array_compile_test.go
+++ b/cl/range_array_compile_test.go
@@ -373,6 +373,41 @@ func copyArray(p *[5]int) [5]int {
 	}
 }
 
+func TestEffectfulArrayDerefWithBuiltinRefKeepsNilCheck(t *testing.T) {
+	ssaPkg, _, files := buildGoSSAPkg(t, `
+package foo
+
+func nextArray() *[3]int { return nil }
+
+func discard() { _ = *nextArray() }
+
+func lenSlice(s []int) int { return len(s) }
+`)
+
+	load := findUnOp(t, ssaPkg.Func("discard"), token.MUL, true)
+	refs := load.Referrers()
+	if refs == nil {
+		t.Fatal("array deref has no referrer list")
+	}
+	oldRefs := *refs
+	// Current x/tools folds len(*nextArray()) to a static constant and leaves
+	// the deref unused. Model the builtin ref shape retained by other supported
+	// SSA versions so the compiler compatibility path remains covered.
+	builtin := findBuiltinCall(t, ssaPkg.Func("lenSlice"), "len")
+	*refs = []ssa.Instruction{&ssa.Call{Call: ssa.CallCommon{Value: builtin}}}
+	defer func() { *refs = oldRefs }()
+
+	prog := newLLSSAProg(t)
+	pkg, err := NewPackage(prog, ssaPkg, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir := mustNamedFunction(t, pkg.Module(), "foo.discard").String()
+	if !strings.Contains(ir, "foo.nextArray") || !strings.Contains(ir, "AssertNilDeref") {
+		t.Fatalf("builtin-referenced array deref should retain its call and nil check:\n%s", ir)
+	}
+}
+
 func findUnOp(t *testing.T, fn *ssa.Function, op token.Token, wantArray bool) *ssa.UnOp {
 	t.Helper()
 	for _, block := range fn.Blocks {

--- a/cl/zero_size_deref_test.go
+++ b/cl/zero_size_deref_test.go
@@ -71,3 +71,24 @@ func keepPointer(pointer *struct{}) func() bool {
 		})
 	}
 }
+
+func TestUnusedDerefEmitsNilGuard(t *testing.T) {
+	const src = `package unusedderef
+func LoadArrayElement() {
+	var values [2]*int
+	_ = *values[1]
+}
+func LoadPointer(p *int) {
+	_ = *p
+}
+`
+	ir := compileWithRewrites(t, src, nil)
+	arrayLoad := llvmFunction(t, ir, "unusedderef.LoadArrayElement")
+	if !strings.Contains(arrayLoad, "AssertNilDeref") {
+		t.Fatalf("unused array-element dereference should retain a nil guard:\n%s", arrayLoad)
+	}
+	directLoad := llvmFunction(t, ir, "unusedderef.LoadPointer")
+	if !strings.Contains(directLoad, "AssertNilDeref") {
+		t.Fatalf("unused direct dereference should retain a nil guard:\n%s", directLoad)
+	}
+}

--- a/test/go/nil_deref_address_test.go
+++ b/test/go/nil_deref_address_test.go
@@ -47,6 +47,33 @@ func TestNilDerefAddressOperationsPanic(t *testing.T) {
 	}
 }
 
+func TestUnusedNilDerefOperationsPanic(t *testing.T) {
+	tests := []struct {
+		name string
+		f    func()
+	}{
+		{
+			name: "direct pointer",
+			f: func() {
+				var p *int
+				_ = *p
+			},
+		},
+		{
+			name: "pointer loaded from array",
+			f: func() {
+				var values [2]*int
+				_ = *values[1]
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectNilDerefAddressPanic(t, tt.f)
+		})
+	}
+}
+
 func TestNilDerefPrintedCompositeLoadsPanic(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1391,14 +1391,6 @@ xfails:
     directive: run
     case: fixedbugs/issue29504.go
     reason: panic/fault statement-line granularity in untracked functions (P4b prebuilt pcline)
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue38496.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue38496.go
-    reason: current main goroot run failure on linux/amd64
   - version: go1.26
     platform: darwin/arm64
     directive: rundir


### PR DESCRIPTION
## Summary

- preserve the Go-required nil panic when an unused dereference would otherwise be discarded before LLVM emits a load
- apply the same rule to direct pointer dereferences and pointers loaded from aggregate addresses
- remove the GOROOT xfail for `fixedbugs/issue38496.go`

## Implementation

When a Go SSA dereference has no non-debug referrers, LLGo no longer emits an unused load and relies on LLVM to retain it. It evaluates the pointer expression, records the panic location, checks any dereference base, and emits `AssertNilDeref` directly.

The existing range-over-array exception remains unchanged because that synthetic unused dereference does not represent a source-level dereference that must panic.

This PR intentionally does not implement the broader explicit nil-check strategy required by derived-address and large-offset cases in `nilptr2.go` and `nilptr.go`. Those cases are classified separately by #2313. It also contains no nil-check liveness optimization, receiver analysis, or CI change.

## Golden changes

Only two existing LLVM snapshots change:

- `_testdata/varinit`: remove an unused global scalar load
- `_testrt/cvar`: remove two unused aggregate C-variable loads

No additional golden updates are required on the latest `main`.

## Validation

- `go test ./cl -run '^TestUnusedDerefEmitsNilGuard$' -count=1`
- `go test ./cl -run '^TestRunAndTestFromTestdata$/^varinit$' -count=1`
- `go test ./cl -run '^TestRunAndTestFromTestrt$/^cvar$' -count=1`
- fresh LLGo build: `LLGO_BUILD_CACHE=off llgo test -run '^TestUnusedNilDerefOperationsPanic$' ./test/go`
- GOROOT `fixedbugs/issue38496.go` passed on Darwin/arm64 with Go 1.26.5
- full GOROOT workflow: [run 31699512427](https://github.com/cpunion/llgo/actions/runs/31699512427)
- targeted coverage run confirms every changed `cl/compile.go` statement block is hit, including the builtin-referenced effectful-array path
- `git diff --check`