### PR TITLE
build(deps): bump benchmark publisher to 1.0.4

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     if: github.event.workflow_run.conclusion == 'success'
-    uses: xgo-dev/setup-benchmark-go-action/.github/workflows/publish.yml@v1.0.4
+    uses: xgo-dev/setup-benchmark-go-action/.github/workflows/publish.yml@cdb431bcea967f83660d20fe8b3185e71d5d3f0e # v1.0.4
     with:
       run_id: ${{ github.event.workflow_run.id }}
       config_path: .github/llgo-benchmark.yml

--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     if: github.event.workflow_run.conclusion == 'success'
-    uses: xgo-dev/setup-benchmark-go-action/.github/workflows/publish.yml@cdb431bcea967f83660d20fe8b3185e71d5d3f0e # v1.0.4
+    uses: xgo-dev/setup-benchmark-go-action/.github/workflows/publish.yml@v1.0.4
     with:
       run_id: ${{ github.event.workflow_run.id }}
       config_path: .github/llgo-benchmark.yml

--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     if: github.event.workflow_run.conclusion == 'success'
-    uses: xgo-dev/setup-benchmark-go-action/.github/workflows/publish.yml@v1.0.3
+    uses: xgo-dev/setup-benchmark-go-action/.github/workflows/publish.yml@v1.0.4
     with:
       run_id: ${{ github.event.workflow_run.id }}
       config_path: .github/llgo-benchmark.yml

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,7 +78,7 @@ jobs:
             "$GITHUB_WORKSPACE/.benchmark/results"
 
       - name: Record benchmark result
-        uses: xgo-dev/setup-benchmark-go-action@cdb431bcea967f83660d20fe8b3185e71d5d3f0e # v1.0.4
+        uses: xgo-dev/setup-benchmark-go-action@v1.0.4
         with:
           config: .github/llgo-benchmark.yml
           benchmark-file: .benchmark/results/benchmark.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,7 +78,7 @@ jobs:
             "$GITHUB_WORKSPACE/.benchmark/results"
 
       - name: Record benchmark result
-        uses: xgo-dev/setup-benchmark-go-action@v1.0.4
+        uses: xgo-dev/setup-benchmark-go-action@cdb431bcea967f83660d20fe8b3185e71d5d3f0e # v1.0.4
         with:
           config: .github/llgo-benchmark.yml
           benchmark-file: .benchmark/results/benchmark.txt


### PR DESCRIPTION
## Summary

- bump the reusable benchmark publisher from v1.0.3 to v1.0.4
- restore benchmark comments for pull requests whose head commit is in a fork

## Why

The v1.0.3 publisher falls back to the upstream commit-to-pulls endpoint when a workflow-run payload has no pull request number. GitHub returns no association for these fork commit SHAs, so publishing stops at `Classify source series` with `cannot resolve pull request` before downloading artifacts or creating a comment.

v1.0.4 resolves the open pull request by the fork owner and branch, then verifies the repository, branch, and head SHA. This directly addresses the failed publisher runs for #2312 and #2313.

Dependabot PR #2278 was created while v1.0.3 was the latest release. v1.0.4 was published later and was still inside GitHub's default three-day version-update cooldown when these failures occurred, so Dependabot had not proposed the publisher update yet.

The source benchmark jobs already succeeded. Because the publisher is triggered through `workflow_run` from the default branch, affected benchmark runs should be rerun after this change reaches main.

## Validation

- verified that the v1.0.4 lookup resolves the current heads to #2312 and #2313
- parsed `.github/workflows/benchmark-publish.yml`
- `git diff --check`