### PR TITLE
windows: establish the MSVC host compiler foundation

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,6 @@ jobs:
     env:
       LLVM_VERSION: "19.1.7"
       MSYS2_LLVM_PACKAGE_VERSION: "19.1.7-1"
-      MSYS2_LIBXML2_PACKAGE_VERSION: "2.13.8-3"
     steps:
       - uses: actions/checkout@v7
 
@@ -42,13 +41,37 @@ jobs:
 
           repo=https://repo.msys2.org/mingw/clang64
           prefix=mingw-w64-clang-x86_64
-          packages=(clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind)
+          packages=(
+            "clang-$MSYS2_LLVM_PACKAGE_VERSION"
+            "clang-libs-$MSYS2_LLVM_PACKAGE_VERSION"
+            "compiler-rt-$MSYS2_LLVM_PACKAGE_VERSION"
+            "llvm-$MSYS2_LLVM_PACKAGE_VERSION"
+            "llvm-libs-$MSYS2_LLVM_PACKAGE_VERSION"
+            "lld-$MSYS2_LLVM_PACKAGE_VERSION"
+            "libc++-$MSYS2_LLVM_PACKAGE_VERSION"
+            "libunwind-$MSYS2_LLVM_PACKAGE_VERSION"
+            "gettext-runtime-0.22.5-2"
+            "libffi-3.4.6-1"
+            "libiconv-1.17-4"
+            "libxml2-2.12.9-2"
+            "xz-5.6.3-3"
+            "zlib-1.3.1-1"
+            "zstd-1.5.6-2"
+          )
           urls=()
           for package in "${packages[@]}"; do
-            urls+=("$repo/$prefix-$package-$MSYS2_LLVM_PACKAGE_VERSION-any.pkg.tar.zst")
+            urls+=("$repo/$prefix-$package-any.pkg.tar.zst")
           done
-          urls+=("$repo/$prefix-libxml2-$MSYS2_LIBXML2_PACKAGE_VERSION-any.pkg.tar.zst")
           pacman --noconfirm -U "${urls[@]}"
+
+          for package in clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind; do
+            installed="$(pacman -Q "$prefix-$package" | awk '{print $2}')"
+            if [[ "$installed" != "$MSYS2_LLVM_PACKAGE_VERSION" ]]; then
+              echo "expected $package $MSYS2_LLVM_PACKAGE_VERSION, got $installed" >&2
+              exit 1
+            fi
+          done
+          clang --version
 
       - name: Build and test the Windows host compiler
         shell: msys2 {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,10 +101,10 @@ jobs:
             ./internal/meta \
             ./internal/xtool/llvm
           go test -tags="$build_tags" \
-            -run '^TestAcquire(AndReleaseLock|LockConcurrency)$' \
+            -run '^TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)$' \
             ./internal/crosscompile
           go test -tags="$build_tags" \
-            -run '^TestWindowsTargetTriple$' \
+            -run '^Test(WindowsTargetTriple|ARMTargetSpec)$' \
             ./ssa
 
           go build -tags="$build_tags" -o llgo-windows-smoke.exe ./cmd/llgo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: CLANG64
+          path-type: inherit
           update: true
           install: >-
             mingw-w64-clang-x86_64-clang

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,8 @@ jobs:
           go-version: "1.26.5"
 
       - name: Set up LLVM
+        # CLANG64 supplies Windows-hosted LLVM libraries used to build llgo.
+        # LLGo-generated Windows code independently selects the MSVC target ABI.
         uses: msys2/setup-msys2@v2
         with:
           msystem: CLANG64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,9 +13,13 @@ concurrency:
 
 jobs:
   host-smoke:
-    name: host smoke (windows-amd64, LLVM 22, Go 1.26.5)
+    name: host smoke (windows-amd64, LLVM 19, Go 1.26.5)
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      LLVM_VERSION: "19.1.7"
+      MSYS2_LLVM_PACKAGE_VERSION: "19.1.7-1"
+      MSYS2_LIBXML2_PACKAGE_VERSION: "2.13.8-3"
     steps:
       - uses: actions/checkout@v7
 
@@ -30,9 +34,21 @@ jobs:
           msystem: CLANG64
           path-type: inherit
           update: true
-          install: >-
-            mingw-w64-clang-x86_64-clang
-            mingw-w64-clang-x86_64-llvm
+
+      - name: Install LLVM 19
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+
+          repo=https://repo.msys2.org/mingw/clang64
+          prefix=mingw-w64-clang-x86_64
+          packages=(clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind)
+          urls=()
+          for package in "${packages[@]}"; do
+            urls+=("$repo/$prefix-$package-$MSYS2_LLVM_PACKAGE_VERSION-any.pkg.tar.zst")
+          done
+          urls+=("$repo/$prefix-libxml2-$MSYS2_LIBXML2_PACKAGE_VERSION-any.pkg.tar.zst")
+          pacman --noconfirm -U "${urls[@]}"
 
       - name: Build and test the Windows host compiler
         shell: msys2 {0}
@@ -48,13 +64,11 @@ jobs:
           export CGO_LDFLAGS="$(llvm-config --ldflags --libs all --system-libs)"
 
           llvm_version="$(llvm-config --version)"
-          case "$llvm_version" in
-            22.*) build_tags=byollvm,llvm22 ;;
-            *)
-              echo "unsupported MSYS2 LLVM version: $llvm_version" >&2
-              exit 1
-              ;;
-          esac
+          if [[ "$llvm_version" != "$LLVM_VERSION" ]]; then
+            echo "expected LLVM $LLVM_VERSION, got $llvm_version" >&2
+            exit 1
+          fi
+          build_tags=byollvm,llvm19
 
           go version
           llvm-config --version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,62 @@
+name: Windows
+
+on:
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  host-smoke:
+    name: host smoke (windows-amd64, LLVM 22, Go 1.26.5)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.5"
+
+      - name: Set up LLVM
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: true
+          install: >-
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-llvm
+
+      - name: Build and test the Windows host compiler
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+
+          export CC=clang
+          export CXX=clang++
+          export CGO_ENABLED=1
+          export CGO_CFLAGS="$(llvm-config --cflags)"
+          export CGO_CXXFLAGS="$(llvm-config --cxxflags)"
+          export CGO_LDFLAGS="$(llvm-config --ldflags --libs all --system-libs)"
+
+          llvm_version="$(llvm-config --version)"
+          case "$llvm_version" in
+            22.*) build_tags=byollvm,llvm22 ;;
+            *)
+              echo "unsupported MSYS2 LLVM version: $llvm_version" >&2
+              exit 1
+              ;;
+          esac
+
+          go version
+          llvm-config --version
+          go test -tags="$build_tags" \
+            ./internal/meta \
+            ./internal/crosscompile \
+            ./internal/xtool/llvm
+
+          go build -tags="$build_tags" -o llgo-windows-smoke.exe ./cmd/llgo
+          LLGO_ROOT="$PWD" ./llgo-windows-smoke.exe version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,6 +39,7 @@ jobs:
           export CC=clang
           export CXX=clang++
           export CGO_ENABLED=1
+          export LLGO_ROOT="$PWD"
           export CGO_CFLAGS="$(llvm-config --cflags)"
           export CGO_CXXFLAGS="$(llvm-config --cxxflags)"
           export CGO_LDFLAGS="$(llvm-config --ldflags --libs all --system-libs)"
@@ -56,8 +57,13 @@ jobs:
           llvm-config --version
           go test -tags="$build_tags" \
             ./internal/meta \
-            ./internal/crosscompile \
             ./internal/xtool/llvm
+          go test -tags="$build_tags" \
+            -run '^TestAcquire(AndReleaseLock|LockConcurrency)$' \
+            ./internal/crosscompile
+          go test -tags="$build_tags" \
+            -run '^TestWindowsTargetTriple$' \
+            ./ssa
 
           go build -tags="$build_tags" -o llgo-windows-smoke.exe ./cmd/llgo
-          LLGO_ROOT="$PWD" ./llgo-windows-smoke.exe version
+          ./llgo-windows-smoke.exe version

--- a/cl/_testdata/method/in.go
+++ b/cl/_testdata/method/in.go
@@ -25,7 +25,7 @@ func main() {
 
 // CHECK-LABEL: define i64 @"main.(*T).Add"(ptr %0, i64 %1){{.*}} {
 // CHECK: [[NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK-NEXT: call void @"{{.*}}PanicWrapNilPointer"(i1 [[NIL]], %"{{.*}}String" { ptr @{{[0-9]+}}, i64 44 }, %"{{.*}}String" { ptr @{{[0-9]+}}, i64 3 })
+// CHECK-NEXT: call void @"{{.*}}PanicWrapNilPointer"(i1 [[NIL]], %"{{.*}}String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} }, %"{{.*}}String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} })
 // CHECK-NEXT: [[RECEIVER:%[0-9]+]] = load i64, ptr %0
 // CHECK-NEXT: [[WRAPPED_SUM:%[0-9]+]] = call i64 @main.T.Add(i64 [[RECEIVER]], i64 %1)
 // CHECK-NEXT: ret i64 [[WRAPPED_SUM]]

--- a/cl/_testmeta/reflect_named/meta-expect.txt
+++ b/cl/_testmeta/reflect_named/meta-expect.txt
@@ -44,8 +44,8 @@ main.main:
 
 [UseIfaceMethod]
 main.main:
-    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
-    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$bReUJH2_12QVkFcde1SpCUgXqmhRT8DRulK5lXtpIkY MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$bReUJH2_12QVkFcde1SpCUgXqmhRT8DRulK5lXtpIkY MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
 
 [UseNamedMethod]
 main.main:
@@ -61,7 +61,7 @@ _llgo_main.T:
     1 main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).m main.T.m
 
 [InterfaceInfo]
-github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw:
+github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$bReUJH2_12QVkFcde1SpCUgXqmhRT8DRulK5lXtpIkY:
     Align _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
     AssignableTo _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
     Bits _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
@@ -101,6 +101,6 @@ github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFp
     PkgPath _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
     Size _llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s
     String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
-    reflect.common _llgo_func$w6XuV-1SmW103DbauPseXBpW50HpxXAEsUsGFibl0Uw
-    reflect.uncommon _llgo_func$iG49bujiXjI2lVflYdE0hPXlCAABL-XKRANSNJEKOio
+    reflect.common _llgo_func$_FtQJl7A5s1VI_ob-KR67FLMXbIG5TjcVaEFuqM5Lo4
+    reflect.uncommon _llgo_func$tpkXXN4h9pcUPRsL9rq-8-w7qAx06dW7DgXtepA0U1E
 

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -36,7 +36,7 @@ func main() {
 
 // CHECK-LABEL: define void @"main.(*Foo).Print"(ptr %0){{.*}} {
 // CHECK: [[WRAPPER_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[WRAPPER_NIL]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 5 })
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[WRAPPER_NIL]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} }, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} })
 // CHECK-NEXT: [[WRAPPER_VALUE:%[0-9]+]] = load %main.Foo, ptr %0
 // CHECK-NEXT: call void @main.Foo.Print(%main.Foo [[WRAPPER_VALUE]])
 

--- a/internal/abi/large.go
+++ b/internal/abi/large.go
@@ -114,6 +114,7 @@ func (l largeAggregateLowerer) transformFunc(m llvm.Module, fn llvm.Value) {
 	fn.SetName("")
 	nfn := llvm.AddFunction(m, name, newType)
 	nfn.SetLinkage(fn.Linkage())
+	nfn.SetComdat(fn.Comdat())
 	nfn.SetFunctionCallConv(fn.FunctionCallConv())
 	nfn.AddAttributeAtIndex(1, sretAttribute(ctx, retType))
 	for _, attr := range fn.GetFunctionAttributes() {

--- a/internal/abi/large_test.go
+++ b/internal/abi/large_test.go
@@ -33,8 +33,9 @@ func TestLowerLargeAggregates(t *testing.T) {
 	const testIR = `
 %Large = type [65537 x i8]
 %Small = type [65536 x i8]
+$callee = comdat any
 
-define %Large @callee(ptr nonnull %src) #1 {
+define linkonce_odr %Large @callee(ptr nonnull %src) #1 comdat {
 entry:
   %value = load %Large, ptr %src, align 1
   %first = getelementptr inbounds %Large, ptr %src, i64 0, i64 0
@@ -103,8 +104,14 @@ attributes #1 = { noinline }
 	LowerLargeAggregates(td, mod)
 
 	callee := mod.NamedFunction("callee").String()
-	if !strings.Contains(callee, "define void @callee(ptr sret([65537 x i8])") {
+	if !strings.Contains(callee, "define linkonce_odr void @callee(ptr sret([65537 x i8])") {
 		t.Fatalf("large return was not lowered to sret:\n%s", callee)
+	}
+	if !strings.Contains(callee, "comdat") {
+		t.Fatalf("large return lowering lost COMDAT metadata:\n%s", callee)
+	}
+	if kind := mod.NamedFunction("callee").Comdat().SelectionKind(); kind != llvm.AnyComdatSelectionKind {
+		t.Fatalf("large return COMDAT selection = %v, want any", kind)
 	}
 	if !strings.Contains(callee, "ptr nonnull %") || !strings.Contains(callee, "noinline") {
 		t.Fatalf("callee attributes were not preserved:\n%s", callee)

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -387,6 +387,7 @@ func (p *Transformer) transformFunc(m llvm.Module, fn llvm.Value) bool {
 		nfn.AddAttributeAtIndex(1, preloweredSRet)
 	}
 	nfn.SetLinkage(fn.Linkage())
+	nfn.SetComdat(fn.Comdat())
 	nfn.SetFunctionCallConv(fn.FunctionCallConv())
 	for _, attr := range fn.GetFunctionAttributes() {
 		nfn.AddAttributeAtIndex(-1, attr)
@@ -696,7 +697,7 @@ func (p *Transformer) transformCallbackFunc(m llvm.Module, fn llvm.Value) (wrap 
 		return wrapFunc, true
 	}
 	wrapFunc := llvm.AddFunction(m, wrapName, nft)
-	wrapFunc.SetLinkage(llvm.LinkOnceAnyLinkage)
+	p.setODRLinkage(m, wrapFunc, llvm.LinkOnceAnyLinkage)
 	wrapFunc.AddFunctionAttr(funcInlineHint(ctx))
 
 	for i, attr := range attrs {
@@ -772,6 +773,20 @@ func (p *Transformer) transformCallbackFunc(m llvm.Module, fn llvm.Value) (wrap 
 		b.CreateRet(ret)
 	}
 	return wrapFunc, true
+}
+
+// setODRLinkage gives multiply emitted definitions the COMDAT metadata that
+// COFF linkers require. LLVM weak/linkonce linkage alone becomes a weak
+// external fallback in COFF, which lld-link cannot coalesce across objects.
+func (p *Transformer) setODRLinkage(m llvm.Module, value llvm.Value, linkage llvm.Linkage) {
+	value.SetLinkage(linkage)
+	target := p.prog.Target()
+	if target == nil || target.GOOS != "windows" {
+		return
+	}
+	comdat := m.Comdat(value.Name())
+	comdat.SetSelectionKind(llvm.AnyComdatSelectionKind)
+	value.SetComdat(comdat)
 }
 
 var closureEnvAttributeKinds = []uint{

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -235,6 +235,90 @@ entry:
 	}
 }
 
+func TestCABILoweringPreservesWindowsCOMDAT(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := ctx.NewModule("windows-comdat")
+	defer mod.Dispose()
+	aggregate := ctx.StructType([]llvm.Type{
+		ctx.Int64Type(), ctx.Int64Type(), ctx.Int64Type(),
+	}, false)
+	fn := llvm.AddFunction(mod, "shared", llvm.FunctionType(
+		ctx.VoidType(), []llvm.Type{aggregate}, false,
+	))
+	fn.SetLinkage(llvm.LinkOnceODRLinkage)
+	comdat := mod.Comdat(fn.Name())
+	comdat.SetSelectionKind(llvm.AnyComdatSelectionKind)
+	fn.SetComdat(comdat)
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	b.SetInsertPointAtEnd(ctx.AddBasicBlock(fn, "entry"))
+	b.CreateRetVoid()
+
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "windows", GOARCH: "amd64"})
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "amd64-unknown-linux-gnu", "", ModeAllFunc, true)
+	tr.TransformModule("test", mod)
+
+	got := mod.NamedFunction("shared")
+	ir := got.String()
+	if !strings.Contains(ir, "ptr") {
+		t.Fatalf("C ABI did not lower the aggregate parameter:\n%s", ir)
+	}
+	if !strings.Contains(ir, "comdat") {
+		t.Fatalf("C ABI lowering lost Windows COMDAT metadata:\n%s", ir)
+	}
+	if kind := got.Comdat().SelectionKind(); kind != llvm.AnyComdatSelectionKind {
+		t.Fatalf("C ABI COMDAT selection = %v, want any", kind)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("transformed Windows COMDAT module is invalid: %v\n%s", err, mod.String())
+	}
+}
+
+func TestWindowsCallbackWrapperUsesCOMDAT(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := ctx.NewModule("windows-callback-comdat")
+	defer mod.Dispose()
+	aggregate := ctx.StructType([]llvm.Type{
+		ctx.Int64Type(), ctx.Int64Type(), ctx.Int64Type(),
+	}, false)
+	callback := llvm.AddFunction(mod, "callback", llvm.FunctionType(
+		ctx.VoidType(), []llvm.Type{aggregate}, false,
+	))
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	b.SetInsertPointAtEnd(ctx.AddBasicBlock(callback, "entry"))
+	b.CreateRetVoid()
+
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "windows", GOARCH: "amd64"})
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "amd64-unknown-linux-gnu", "", ModeAllFunc, true)
+	wrapper, ok := tr.transformCallbackFunc(mod, callback)
+	if !ok {
+		t.Fatalf("callback wrapper was not required:\n%s", mod.String())
+	}
+	ir := wrapper.String()
+	if !strings.Contains(ir, "comdat") {
+		t.Fatalf("Windows callback wrapper lacks COMDAT metadata:\n%s", ir)
+	}
+	if kind := wrapper.Comdat().SelectionKind(); kind != llvm.AnyComdatSelectionKind {
+		t.Fatalf("Windows callback COMDAT selection = %v, want any", kind)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("Windows callback COMDAT module is invalid: %v\n%s", err, mod.String())
+	}
+}
+
 func TestSetSkipFuncsAndShouldSkipCall(t *testing.T) {
 	tr := &Transformer{}
 	tr.SetSkipFuncs([]string{" foo ", "", "bar"})

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -142,7 +142,7 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 	}
 
 	// Try to download ESP Clang if platform is supported
-	platformSuffix := getESPClangPlatform(runtime.GOOS, runtime.GOARCH)
+	platformSuffix := getESPClangHostPlatform(runtime.GOOS, runtime.GOARCH)
 	if platformSuffix != "" {
 		cacheClangDir := filepath.Join(cacheRoot(), "crosscompile", "esp-clang-"+espClangVersion)
 		if _, err = os.Stat(cacheClangDir); err != nil {
@@ -162,8 +162,11 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 	return
 }
 
-// getESPClangPlatform returns the platform suffix for ESP Clang downloads
-func getESPClangPlatform(goos, goarch string) string {
+// getESPClangHostPlatform returns the host-platform suffix of an ESP Clang
+// distribution. For example, x86_64-w64-mingw32 describes the ABI of the
+// downloaded compiler executable; it does not select the ABI of code that
+// compiler emits for LLGo's target triple.
+func getESPClangHostPlatform(goos, goarch string) string {
 	switch goos {
 	case "darwin":
 		switch goarch {

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 // checkDownloadAndExtractWasiSDK downloads and extracts WASI SDK
@@ -133,22 +132,28 @@ func acquireLock(lockPath string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lock file: %w", err)
 	}
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+	if err := lockFileHandle(lockFile); err != nil {
 		lockFile.Close()
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
 	return lockFile, nil
 }
 
-// releaseLock unlocks and removes the lock file
+// releaseLock unlocks and closes the lock file. The file must remain in place:
+// removing it could let a new caller lock a different file while another caller
+// still holds the original one.
 func releaseLock(lockFile *os.File) error {
 	if lockFile == nil {
 		return nil
 	}
-	lockPath := lockFile.Name()
-	syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
-	lockFile.Close()
-	os.Remove(lockPath)
+	unlockErr := unlockFileHandle(lockFile)
+	closeErr := lockFile.Close()
+	if unlockErr != nil {
+		return fmt.Errorf("failed to release lock: %w", unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("failed to close lock file: %w", closeErr)
+	}
 	return nil
 }
 

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -123,6 +123,10 @@ func checkDownloadAndExtractLib(url, dstDir, internalArchiveSrcDir string) error
 
 // acquireLock creates and locks a file to prevent concurrent operations
 func acquireLock(lockPath string) (*os.File, error) {
+	return acquireLockWith(lockPath, lockFileHandle)
+}
+
+func acquireLockWith(lockPath string, lock func(*os.File) error) (*os.File, error) {
 	// Ensure the parent directory exists
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
 		return nil, fmt.Errorf("failed to create lock directory: %w", err)
@@ -132,7 +136,7 @@ func acquireLock(lockPath string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lock file: %w", err)
 	}
-	if err := lockFileHandle(lockFile); err != nil {
+	if err := lock(lockFile); err != nil {
 		lockFile.Close()
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
@@ -148,6 +152,10 @@ func releaseLock(lockFile *os.File) error {
 	}
 	unlockErr := unlockFileHandle(lockFile)
 	closeErr := lockFile.Close()
+	return lockReleaseError(unlockErr, closeErr)
+}
+
+func lockReleaseError(unlockErr, closeErr error) error {
 	if unlockErr != nil {
 		return fmt.Errorf("failed to release lock: %w", unlockErr)
 	}

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -133,8 +133,8 @@ func TestAcquireAndReleaseLockErrors(t *testing.T) {
 		if opened == nil {
 			t.Fatal("lock callback did not receive the opened file")
 		}
-		if _, err := opened.Stat(); !errors.Is(err, os.ErrClosed) {
-			t.Fatalf("failed lock file remained open: Stat error = %v", err)
+		if err := opened.Close(); err == nil {
+			t.Fatal("failed lock file remained open")
 		}
 	})
 

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -65,6 +65,10 @@ func createTestServer(t *testing.T, files map[string]string) *httptest.Server {
 }
 
 func TestAcquireAndReleaseLock(t *testing.T) {
+	if err := releaseLock(nil); err != nil {
+		t.Fatalf("releaseLock(nil) = %v, want nil", err)
+	}
+
 	tempDir := t.TempDir()
 	lockPath := filepath.Join(tempDir, "test.lock")
 

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -116,6 +117,33 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "failed to release lock") {
 		t.Fatalf("Unexpected closed lock release error: %v", err)
 	}
+}
+
+func TestAcquireAndReleaseLockErrors(t *testing.T) {
+	t.Run("acquire", func(t *testing.T) {
+		wantErr := errors.New("injected lock failure")
+		var opened *os.File
+		got, err := acquireLockWith(filepath.Join(t.TempDir(), "failed.lock"), func(file *os.File) error {
+			opened = file
+			return wantErr
+		})
+		if got != nil || !errors.Is(err, wantErr) {
+			t.Fatalf("acquireLockWith = (%v, %v), want (nil, %v)", got, err, wantErr)
+		}
+		if opened == nil {
+			t.Fatal("lock callback did not receive the opened file")
+		}
+		if _, err := opened.Stat(); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("failed lock file remained open: Stat error = %v", err)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		wantErr := errors.New("injected close failure")
+		if err := lockReleaseError(nil, wantErr); !errors.Is(err, wantErr) {
+			t.Fatalf("lockReleaseError = %v, want wrapped %v", err, wantErr)
+		}
+	})
 }
 
 func TestAcquireLockConcurrency(t *testing.T) {

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -83,9 +84,18 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 		t.Errorf("Failed to release lock: %v", err)
 	}
 
-	// Check lock file is removed
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Error("Lock file should be removed after release")
+	// The lock file remains so every caller continues to lock the same file.
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("Lock file should remain after release: %v", err)
+	}
+
+	// A retained lock file can be acquired again.
+	lockFile, err = acquireLock(lockPath)
+	if err != nil {
+		t.Fatalf("Failed to reacquire lock: %v", err)
+	}
+	if err := releaseLock(lockFile); err != nil {
+		t.Errorf("Failed to release reacquired lock: %v", err)
 	}
 }
 
@@ -96,6 +106,7 @@ func TestAcquireLockConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	var results []int
 	var resultsMu sync.Mutex
+	var active atomic.Int32
 
 	// Start multiple goroutines trying to acquire the same lock
 	for i := 0; i < 5; i++ {
@@ -109,12 +120,17 @@ func TestAcquireLockConcurrency(t *testing.T) {
 				return
 			}
 
+			if n := active.Add(1); n != 1 {
+				t.Errorf("Goroutine %d entered an occupied critical section (%d active)", id, n)
+			}
+
 			// Hold the lock for a short time
 			resultsMu.Lock()
 			results = append(results, id)
 			resultsMu.Unlock()
 
 			time.Sleep(10 * time.Millisecond)
+			active.Add(-1)
 
 			if err := releaseLock(lockFile); err != nil {
 				t.Errorf("Goroutine %d failed to release lock: %v", id, err)

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -97,6 +97,21 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 	if err := releaseLock(lockFile); err != nil {
 		t.Errorf("Failed to release reacquired lock: %v", err)
 	}
+
+	// A closed handle exercises the platform unlock failure path and verifies
+	// that releaseLock preserves enough context for callers to diagnose it.
+	closedLock, err := acquireLock(filepath.Join(tempDir, "closed.lock"))
+	if err != nil {
+		t.Fatalf("Failed to acquire lock for error test: %v", err)
+	}
+	if err := closedLock.Close(); err != nil {
+		t.Fatalf("Failed to close lock for error test: %v", err)
+	}
+	if err := releaseLock(closedLock); err == nil {
+		t.Fatal("Expected release of a closed lock to fail")
+	} else if !strings.Contains(err.Error(), "failed to release lock") {
+		t.Fatalf("Unexpected closed lock release error: %v", err)
+	}
 }
 
 func TestAcquireLockConcurrency(t *testing.T) {

--- a/internal/crosscompile/filelock_unix.go
+++ b/internal/crosscompile/filelock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package crosscompile
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFileHandle(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFileHandle(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/crosscompile/filelock_windows.go
+++ b/internal/crosscompile/filelock_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package crosscompile
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFileHandle(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+}
+
+func unlockFileHandle(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/internal/meta/builder.go
+++ b/internal/meta/builder.go
@@ -282,7 +282,7 @@ func (b *Builder) Build() (*PackageMeta, error) {
 	writeMethodInfo(raw[offsets[secMethodInfo]:], b, nsyms)
 	writeIfaceInfo(raw[offsets[secIfaceInfo]:], b, nsyms)
 
-	return newPackageMeta(raw)
+	return packageMetaView(raw, offsets, nsyms), nil
 }
 
 // ── section writers ───────────────────────────────────────────────────────────

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -169,7 +169,7 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	if fi.Size() <= 0 || fi.Size() > int64(^uint(0)>>1) {
+	if fi.Size() < headerSize || fi.Size() > int64(^uint(0)>>1) {
 		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
 	}
 	size := int(fi.Size())
@@ -303,6 +303,9 @@ func (pm *PackageMeta) hasFuncDemand(sym Symbol) bool {
 // newPackageMeta checks the magic and version, then decodes the section offsets
 // from the fixed header.
 func newPackageMeta(raw []byte) (*PackageMeta, error) {
+	if len(raw) < headerSize {
+		return nil, fmt.Errorf("meta: file too small: %d bytes", len(raw))
+	}
 	if string(raw[0:4]) != magic {
 		return nil, fmt.Errorf("meta: bad magic %q", raw[0:4])
 	}
@@ -311,14 +314,30 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 		return nil, fmt.Errorf("meta: unsupported version %d", ver)
 	}
 
-	pm := &PackageMeta{raw: raw}
-	pm.strOff = binary.LittleEndian.Uint32(raw[8+secStringTable*4:])
-	pm.symOff = binary.LittleEndian.Uint32(raw[8+secSymbols*4:])
-	pm.ordinaryOff = binary.LittleEndian.Uint32(raw[8+secOrdinaryEdges*4:])
-	pm.demandOff = binary.LittleEndian.Uint32(raw[8+secFuncDemand*4:])
-	pm.childOff = binary.LittleEndian.Uint32(raw[8+secTypeChildren*4:])
-	pm.methodOff = binary.LittleEndian.Uint32(raw[8+secMethodInfo*4:])
-	pm.ifaceOff = binary.LittleEndian.Uint32(raw[8+secIfaceInfo*4:])
+	var offsets [numSections]uint32
+	prev := uint32(headerSize)
+	for sec := range offsets {
+		off := binary.LittleEndian.Uint32(raw[8+sec*4:])
+		if off < prev || uint64(off) > uint64(len(raw)) || off%4 != 0 {
+			return nil, fmt.Errorf("meta: invalid section %d offset %d", sec, off)
+		}
+		offsets[sec] = off
+		prev = off
+	}
+	if offsets[secOrdinaryEdges]-offsets[secSymbols] < 4 {
+		return nil, fmt.Errorf("meta: truncated symbols section")
+	}
+
+	pm := &PackageMeta{
+		raw:         raw,
+		strOff:      offsets[secStringTable],
+		symOff:      offsets[secSymbols],
+		ordinaryOff: offsets[secOrdinaryEdges],
+		demandOff:   offsets[secFuncDemand],
+		childOff:    offsets[secTypeChildren],
+		methodOff:   offsets[secMethodInfo],
+		ifaceOff:    offsets[secIfaceInfo],
+	}
 
 	// read nsyms from Symbols section header
 	pm.nsyms = binary.LittleEndian.Uint32(raw[pm.symOff:])

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -169,7 +169,7 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	if fi.Size() < headerSize || fi.Size() > int64(^uint(0)>>1) {
+	if fi.Size() < headerSize || uint64(fi.Size()) > uint64(^uint32(0)) || fi.Size() > int64(^uint(0)>>1) {
 		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
 	}
 	size := int(fi.Size())
@@ -306,6 +306,9 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 	if len(raw) < headerSize {
 		return nil, fmt.Errorf("meta: file too small: %d bytes", len(raw))
 	}
+	if uint64(len(raw)) > uint64(^uint32(0)) {
+		return nil, fmt.Errorf("meta: file too large: %d bytes", len(raw))
+	}
 	if string(raw[0:4]) != magic {
 		return nil, fmt.Errorf("meta: bad magic %q", raw[0:4])
 	}
@@ -327,9 +330,21 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 	if offsets[secOrdinaryEdges]-offsets[secSymbols] < 4 {
 		return nil, fmt.Errorf("meta: truncated symbols section")
 	}
+	nsyms := binary.LittleEndian.Uint32(raw[offsets[secSymbols]:])
+	pm := packageMetaView(raw, offsets, nsyms)
+	if err := pm.validate(); err != nil {
+		return nil, err
+	}
+	return pm, nil
+}
 
-	pm := &PackageMeta{
+// packageMetaView constructs a view over a layout whose header has already
+// been decoded. Builder uses it for bytes it just wrote; Open validates the
+// returned view before exposing mapped, file-controlled bytes.
+func packageMetaView(raw []byte, offsets [numSections]uint32, nsyms uint32) *PackageMeta {
+	return &PackageMeta{
 		raw:         raw,
+		nsyms:       nsyms,
 		strOff:      offsets[secStringTable],
 		symOff:      offsets[secSymbols],
 		ordinaryOff: offsets[secOrdinaryEdges],
@@ -338,10 +353,120 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 		methodOff:   offsets[secMethodInfo],
 		ifaceOff:    offsets[secIfaceInfo],
 	}
+}
 
-	// read nsyms from Symbols section header
-	pm.nsyms = binary.LittleEndian.Uint32(raw[pm.symOff:])
-	return pm, nil
+type csrLayout struct {
+	dataOff  uint32
+	nrecords uint32
+}
+
+func (pm *PackageMeta) validate() error {
+	symSize := uint64(pm.ordinaryOff - pm.symOff)
+	wantSymSize := uint64(4) + uint64(pm.nsyms)*12
+	if symSize != wantSymSize {
+		return fmt.Errorf("meta: invalid symbols section size %d for %d symbols", symSize, pm.nsyms)
+	}
+
+	sections := [...]struct {
+		name       string
+		start      uint32
+		end        uint32
+		recordSize uint32
+	}{
+		{name: "OrdinaryEdges", start: pm.ordinaryOff, end: pm.demandOff, recordSize: 4},
+		{name: "FuncDemand", start: pm.demandOff, end: pm.childOff, recordSize: 12},
+		{name: "TypeChildren", start: pm.childOff, end: pm.methodOff, recordSize: 4},
+		{name: "MethodInfo", start: pm.methodOff, end: pm.ifaceOff, recordSize: 20},
+		{name: "InterfaceInfo", start: pm.ifaceOff, end: uint32(len(pm.raw)), recordSize: 12},
+	}
+	var layouts [len(sections)]csrLayout
+	for i, section := range sections {
+		layout, err := validateCSRSection(pm.raw, section.name, section.start, section.end, pm.nsyms, section.recordSize)
+		if err != nil {
+			return err
+		}
+		layouts[i] = layout
+	}
+
+	strSize := pm.symOff - pm.strOff
+	if err := pm.validateNameRecords("Symbols", pm.symOff+4, pm.nsyms, 12, strSize); err != nil {
+		return err
+	}
+	if err := pm.validateFuncDemandNames(layouts[1], strSize); err != nil {
+		return err
+	}
+	if err := pm.validateNameRecords(sections[3].name, layouts[3].dataOff, layouts[3].nrecords, 20, strSize); err != nil {
+		return err
+	}
+	return pm.validateNameRecords(sections[4].name, layouts[4].dataOff, layouts[4].nrecords, 12, strSize)
+}
+
+func validNameRef(ref nameRef, strSize uint32) bool {
+	return uint64(ref.Off)+uint64(ref.Len) <= uint64(strSize)
+}
+
+func validateCSRSection(raw []byte, name string, start, end, nsyms, recordSize uint32) (csrLayout, error) {
+	sectionSize := uint64(end - start)
+	headerSize := uint64(4) + (uint64(nsyms)+1)*4
+	if sectionSize < headerSize {
+		return csrLayout{}, fmt.Errorf("meta: truncated %s CSR header", name)
+	}
+	if got := binary.LittleEndian.Uint32(raw[start:]); got != nsyms {
+		return csrLayout{}, fmt.Errorf("meta: %s has %d symbols, want %d", name, got, nsyms)
+	}
+	dataSize := sectionSize - headerSize
+	if dataSize%uint64(recordSize) != 0 {
+		return csrLayout{}, fmt.Errorf("meta: invalid %s data size %d", name, dataSize)
+	}
+	nrecords := dataSize / uint64(recordSize)
+	offsetsBase := start + 4
+	prev := binary.LittleEndian.Uint32(raw[offsetsBase:])
+	if prev != 0 {
+		return csrLayout{}, fmt.Errorf("meta: %s CSR first offset is %d, want 0", name, prev)
+	}
+	for sym := uint32(0); sym < nsyms; sym++ {
+		cur := binary.LittleEndian.Uint32(raw[offsetsBase+(sym+1)*4:])
+		if cur < prev || uint64(cur) > nrecords {
+			return csrLayout{}, fmt.Errorf("meta: invalid %s CSR offset %d at symbol %d", name, cur, sym)
+		}
+		prev = cur
+	}
+	if uint64(prev) != nrecords {
+		return csrLayout{}, fmt.Errorf("meta: %s CSR covers %d records, section contains %d", name, prev, nrecords)
+	}
+	return csrLayout{dataOff: uint32(uint64(start) + headerSize), nrecords: uint32(nrecords)}, nil
+}
+
+func (pm *PackageMeta) validateFuncDemandNames(layout csrLayout, strSize uint32) error {
+	for i := uint32(0); i < layout.nrecords; i++ {
+		base := layout.dataOff + i*12
+		kind := DemandKind(binary.LittleEndian.Uint32(pm.raw[base:]))
+		if kind != DemandNamedMethod {
+			continue
+		}
+		ref := nameRef{
+			Off: binary.LittleEndian.Uint32(pm.raw[base+4:]),
+			Len: binary.LittleEndian.Uint32(pm.raw[base+8:]),
+		}
+		if !validNameRef(ref, strSize) {
+			return fmt.Errorf("meta: FuncDemand record %d has invalid name range [%d,%d)", i, ref.Off, uint64(ref.Off)+uint64(ref.Len))
+		}
+	}
+	return nil
+}
+
+func (pm *PackageMeta) validateNameRecords(section string, dataOff, nrecords, recordSize, strSize uint32) error {
+	for i := uint32(0); i < nrecords; i++ {
+		base := dataOff + i*recordSize
+		ref := nameRef{
+			Off: binary.LittleEndian.Uint32(pm.raw[base:]),
+			Len: binary.LittleEndian.Uint32(pm.raw[base+4:]),
+		}
+		if !validNameRef(ref, strSize) {
+			return fmt.Errorf("meta: %s record %d has invalid name range [%d,%d)", section, i, ref.Off, uint64(ref.Off)+uint64(ref.Len))
+		}
+	}
+	return nil
 }
 
 // csrSlice returns the records for package-local sym from a CSR section, or nil

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -303,11 +303,8 @@ func (pm *PackageMeta) hasFuncDemand(sym Symbol) bool {
 // newPackageMeta checks the magic and version, then decodes the section offsets
 // from the fixed header.
 func newPackageMeta(raw []byte) (*PackageMeta, error) {
-	if len(raw) < headerSize {
-		return nil, fmt.Errorf("meta: file too small: %d bytes", len(raw))
-	}
-	if uint64(len(raw)) > uint64(^uint32(0)) {
-		return nil, fmt.Errorf("meta: file too large: %d bytes", len(raw))
+	if err := validateMetaSize(uint64(len(raw))); err != nil {
+		return nil, err
 	}
 	if string(raw[0:4]) != magic {
 		return nil, fmt.Errorf("meta: bad magic %q", raw[0:4])
@@ -336,6 +333,16 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 		return nil, err
 	}
 	return pm, nil
+}
+
+func validateMetaSize(size uint64) error {
+	if size < headerSize {
+		return fmt.Errorf("meta: file too small: %d bytes", size)
+	}
+	if size > uint64(^uint32(0)) {
+		return fmt.Errorf("meta: file too large: %d bytes", size)
+	}
+	return nil
 }
 
 // packageMetaView constructs a view over a layout whose header has already

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 	"unsafe"
 )
 
@@ -170,16 +169,19 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
+	if fi.Size() <= 0 || fi.Size() > int64(^uint(0)>>1) {
+		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
+	}
 	size := int(fi.Size())
 
-	raw, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+	raw, err := mapFile(f, size)
 	if err != nil {
 		return nil, fmt.Errorf("meta: mmap %s: %w", path, err)
 	}
 
 	pm, err := newPackageMeta(raw)
 	if err != nil {
-		_ = syscall.Munmap(raw)
+		_ = unmapFile(raw)
 		return nil, err
 	}
 	pm.mmap = true
@@ -199,8 +201,9 @@ func (pm *PackageMeta) WriteTo(w io.Writer) (int64, error) {
 // It is a no-op for PackageMeta values returned from Builder.Build.
 func (pm *PackageMeta) Close() error {
 	if pm.mmap && pm.raw != nil {
-		err := syscall.Munmap(pm.raw)
+		err := unmapFile(pm.raw)
 		pm.raw = nil
+		pm.mmap = false
 		return err
 	}
 	return nil

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -237,6 +237,7 @@ func TestRoundTripFile(t *testing.T) {
 	fn := b.Sym("pkg.Fn")
 	dep := b.Sym("runtime.X")
 	b.AddOrdinaryEdge(fn, dep)
+	b.AddIfaceUse(fn, dep)
 
 	pm, err := b.Build()
 	if err != nil {
@@ -268,6 +269,10 @@ func TestRoundTripFile(t *testing.T) {
 	if len(edges) != 1 || edges[0] != dep {
 		t.Errorf("OrdinaryEdges after file round-trip = %v", edges)
 	}
+	demands := pm2.funcDemands(fn)
+	if len(demands) != 1 || demands[0].Kind != DemandUseIface || Symbol(demands[0].Target) != dep {
+		t.Errorf("FuncDemand after file round-trip = %v", demands)
+	}
 	if err := pm2.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -280,6 +285,13 @@ func TestOpenErrors(t *testing.T) {
 	t.Run("short in-memory header", func(t *testing.T) {
 		if _, err := newPackageMeta(make([]byte, headerSize-1)); err == nil || !strings.Contains(err.Error(), "meta: file too small") {
 			t.Fatalf("newPackageMeta error = %v, want short-file error", err)
+		}
+	})
+
+	t.Run("oversized in-memory metadata", func(t *testing.T) {
+		size := uint64(^uint32(0)) + 1
+		if err := validateMetaSize(size); err == nil || !strings.Contains(err.Error(), "meta: file too large") {
+			t.Fatalf("validateMetaSize error = %v, want large-file error", err)
 		}
 	})
 

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -299,6 +299,8 @@ func TestOpenErrors(t *testing.T) {
 		}
 	})
 
+	validRaw := validationMetaBytes(t)
+	cloneValid := func() []byte { return append([]byte(nil), validRaw...) }
 	tests := []struct {
 		name string
 		raw  func() []byte
@@ -365,6 +367,111 @@ func TestOpenErrors(t *testing.T) {
 			},
 			want: "meta: truncated symbols section",
 		},
+		{
+			name: "symbol count exceeds section",
+			raw: func() []byte {
+				raw := cloneValid()
+				symOff := metaSectionOffset(raw, secSymbols)
+				nsyms := binary.LittleEndian.Uint32(raw[symOff:])
+				binary.LittleEndian.PutUint32(raw[symOff:], nsyms+1)
+				return raw
+			},
+			want: "meta: invalid symbols section size",
+		},
+		{
+			name: "truncated csr offsets",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				binary.LittleEndian.PutUint32(raw[8+secFuncDemand*4:], ordinaryOff+4)
+				return raw
+			},
+			want: "meta: truncated OrdinaryEdges CSR header",
+		},
+		{
+			name: "csr symbol count mismatch",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				nsyms := binary.LittleEndian.Uint32(raw[ordinaryOff:])
+				binary.LittleEndian.PutUint32(raw[ordinaryOff:], nsyms+1)
+				return raw
+			},
+			want: "meta: OrdinaryEdges has",
+		},
+		{
+			name: "descending csr offsets",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				offsetsBase := ordinaryOff + 4
+				binary.LittleEndian.PutUint32(raw[offsetsBase+4:], 1)
+				binary.LittleEndian.PutUint32(raw[offsetsBase+8:], 0)
+				return raw
+			},
+			want: "meta: invalid OrdinaryEdges CSR offset",
+		},
+		{
+			name: "csr offset past data",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				nsyms := binary.LittleEndian.Uint32(raw[ordinaryOff:])
+				offsetsBase := ordinaryOff + 4
+				last := offsetsBase + nsyms*4
+				nrecords := binary.LittleEndian.Uint32(raw[last:])
+				binary.LittleEndian.PutUint32(raw[last:], nrecords+1)
+				return raw
+			},
+			want: "meta: invalid OrdinaryEdges CSR offset",
+		},
+		{
+			name: "symbol name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				binary.LittleEndian.PutUint32(raw[symOff+4:], symOff-strOff)
+				return raw
+			},
+			want: "meta: Symbols record 0 has invalid name range",
+		},
+		{
+			name: "demand name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				dataOff := metaCSRDataOffset(raw, secFuncDemand)
+				binary.LittleEndian.PutUint32(raw[dataOff+4:], symOff-strOff)
+				return raw
+			},
+			want: "meta: FuncDemand record 0 has invalid name range",
+		},
+		{
+			name: "method name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				dataOff := metaCSRDataOffset(raw, secMethodInfo)
+				binary.LittleEndian.PutUint32(raw[dataOff:], symOff-strOff)
+				return raw
+			},
+			want: "meta: MethodInfo record 0 has invalid name range",
+		},
+		{
+			name: "interface name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				dataOff := metaCSRDataOffset(raw, secIfaceInfo)
+				binary.LittleEndian.PutUint32(raw[dataOff:], symOff-strOff)
+				return raw
+			},
+			want: "meta: InterfaceInfo record 0 has invalid name range",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -377,6 +484,37 @@ func TestOpenErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validationMetaBytes(t *testing.T) []byte {
+	t.Helper()
+	b := NewBuilder()
+	src := b.Sym("pkg.src")
+	dst := b.Sym("pkg.dst")
+	iface := b.Sym("pkg.iface")
+	mtype := b.Sym("pkg.mtype")
+	ifn := b.Sym("pkg.ifn")
+	tfn := b.Sym("pkg.tfn")
+	b.AddOrdinaryEdge(src, dst)
+	b.AddNamedMethodUse(src, "Method")
+	b.AddTypeChild(src, dst)
+	b.AddMethodSlot(src, "Method", mtype, ifn, tfn)
+	b.AddIfaceMethod(iface, "Method", mtype)
+	pm, err := b.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append([]byte(nil), pm.raw...)
+}
+
+func metaSectionOffset(raw []byte, section int) uint32 {
+	return binary.LittleEndian.Uint32(raw[8+section*4:])
+}
+
+func metaCSRDataOffset(raw []byte, section int) uint32 {
+	sectionOff := metaSectionOffset(raw, section)
+	nsyms := binary.LittleEndian.Uint32(raw[sectionOff:])
+	return sectionOff + 4 + (nsyms+1)*4
 }
 
 func validEmptyMetaHeader(size int) []byte {

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -277,6 +277,12 @@ func TestRoundTripFile(t *testing.T) {
 }
 
 func TestOpenErrors(t *testing.T) {
+	t.Run("short in-memory header", func(t *testing.T) {
+		if _, err := newPackageMeta(make([]byte, headerSize-1)); err == nil || !strings.Contains(err.Error(), "meta: file too small") {
+			t.Fatalf("newPackageMeta error = %v, want short-file error", err)
+		}
+	})
+
 	t.Run("open", func(t *testing.T) {
 		if _, err := Open(filepath.Join(t.TempDir(), "missing.meta")); err == nil {
 			t.Fatal("Open succeeded for a missing file")
@@ -299,6 +305,13 @@ func TestOpenErrors(t *testing.T) {
 		want string
 	}{
 		{
+			name: "short header",
+			raw: func() []byte {
+				return make([]byte, headerSize-1)
+			},
+			want: "meta: mmap",
+		},
+		{
 			name: "magic",
 			raw: func() []byte {
 				raw := make([]byte, headerSize)
@@ -317,6 +330,41 @@ func TestOpenErrors(t *testing.T) {
 			},
 			want: "meta: unsupported version 2",
 		},
+		{
+			name: "section offset past end",
+			raw: func() []byte {
+				raw := validEmptyMetaHeader(headerSize)
+				binary.LittleEndian.PutUint32(raw[8+secIfaceInfo*4:], headerSize+4)
+				return raw
+			},
+			want: "meta: invalid section 6 offset 40",
+		},
+		{
+			name: "section offsets out of order",
+			raw: func() []byte {
+				raw := validEmptyMetaHeader(headerSize + 4)
+				binary.LittleEndian.PutUint32(raw[8+secSymbols*4:], headerSize+4)
+				binary.LittleEndian.PutUint32(raw[8+secOrdinaryEdges*4:], headerSize)
+				return raw
+			},
+			want: "meta: invalid section 2 offset 36",
+		},
+		{
+			name: "unaligned section offset",
+			raw: func() []byte {
+				raw := validEmptyMetaHeader(headerSize + 4)
+				binary.LittleEndian.PutUint32(raw[8+secSymbols*4:], headerSize+1)
+				return raw
+			},
+			want: "meta: invalid section 1 offset 37",
+		},
+		{
+			name: "truncated symbols section",
+			raw: func() []byte {
+				return validEmptyMetaHeader(headerSize)
+			},
+			want: "meta: truncated symbols section",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -329,4 +377,14 @@ func TestOpenErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validEmptyMetaHeader(size int) []byte {
+	raw := make([]byte, size)
+	copy(raw, magic)
+	binary.LittleEndian.PutUint32(raw[4:8], version)
+	for sec := range numSections {
+		binary.LittleEndian.PutUint32(raw[8+sec*4:], headerSize)
+	}
+	return raw
 }

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -486,6 +486,48 @@ func TestOpenErrors(t *testing.T) {
 	}
 }
 
+func TestValidateCSRSectionErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   []byte
+		nsyms uint32
+		want  string
+	}{
+		{
+			name: "misaligned data size",
+			raw:  make([]byte, 9),
+			want: "invalid Test data size",
+		},
+		{
+			name: "nonzero first offset",
+			raw: func() []byte {
+				raw := make([]byte, 8)
+				binary.LittleEndian.PutUint32(raw[4:], 1)
+				return raw
+			}(),
+			want: "Test CSR first offset is 1, want 0",
+		},
+		{
+			name: "terminal offset before data end",
+			raw: func() []byte {
+				raw := make([]byte, 16)
+				binary.LittleEndian.PutUint32(raw, 1)
+				return raw
+			}(),
+			nsyms: 1,
+			want:  "Test CSR covers 0 records, section contains 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateCSRSection(tt.raw, "Test", 0, uint32(len(tt.raw)), tt.nsyms, 4)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateCSRSection error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func validationMetaBytes(t *testing.T) []byte {
 	t.Helper()
 	b := NewBuilder()

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -260,7 +260,6 @@ func TestRoundTripFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer pm2.Close()
 
 	if got := pm2.symbolName(fn); got != "pkg.Fn" {
 		t.Errorf("SymbolName after file round-trip = %q, want \"pkg.Fn\"", got)
@@ -268,6 +267,12 @@ func TestRoundTripFile(t *testing.T) {
 	edges := pm2.ordinaryEdges(fn)
 	if len(edges) != 1 || edges[0] != dep {
 		t.Errorf("OrdinaryEdges after file round-trip = %v", edges)
+	}
+	if err := pm2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := pm2.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
 	}
 }
 

--- a/internal/meta/mmap_unix.go
+++ b/internal/meta/mmap_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package meta
+
+import (
+	"os"
+	"syscall"
+)
+
+func mapFile(f *os.File, size int) ([]byte, error) {
+	return syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func unmapFile(raw []byte) error {
+	return syscall.Munmap(raw)
+}

--- a/internal/meta/mmap_windows.go
+++ b/internal/meta/mmap_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package meta
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func mapFile(f *os.File, size int) ([]byte, error) {
+	mapping, err := windows.CreateFileMapping(
+		windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, 0, 0, nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(mapping)
+
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_READ, 0, 0, uintptr(size))
+	if err != nil {
+		return nil, err
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
+}
+
+func unmapFile(raw []byte) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return windows.UnmapViewOfFile(uintptr(unsafe.Pointer(&raw[0])))
+}

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -3,6 +3,12 @@ package llvm
 import "runtime"
 
 func GetTargetTriple(goos, goarch string) string {
+	return GetTargetTripleWithGOARM(goos, goarch, "")
+}
+
+// GetTargetTripleWithGOARM returns the LLVM target triple for a Go target.
+// goarm selects the ARM version for GOARCH=arm and defaults to ARMv7.
+func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	var llvmarch string
 	if goarch == "" {
 		goarch = runtime.GOARCH
@@ -22,9 +28,14 @@ func GetTargetTriple(goos, goarch string) string {
 	case "arm64":
 		llvmarch = "aarch64"
 	case "arm":
-		// Keep the default in sync with ssa.Target.Spec when GOARM is not
-		// explicitly modeled by this helper.
-		llvmarch = "armv7"
+		switch goarm {
+		case "5":
+			llvmarch = "armv5"
+		case "6":
+			llvmarch = "armv6"
+		default:
+			llvmarch = "armv7"
+		}
 	case "wasm":
 		llvmarch = "wasm32"
 	default:
@@ -41,7 +52,6 @@ func GetTargetTriple(goos, goarch string) string {
 			// Looks like Apple prefers to call this architecture ARM64
 			// instead of AArch64.
 			llvmarch = "arm64"
-			llvmos = "macosx"
 		}
 		llvmvendor = "apple"
 	case "wasip1":

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -12,7 +12,11 @@ func GetTargetTriple(goos, goarch string) string {
 	}
 	switch goarch {
 	case "386":
-		llvmarch = "i386"
+		if goos == "windows" {
+			llvmarch = "i686"
+		} else {
+			llvmarch = "i386"
+		}
 	case "amd64":
 		llvmarch = "x86_64"
 	case "arm64":
@@ -42,13 +46,18 @@ func GetTargetTriple(goos, goarch string) string {
 		llvmvendor = "apple"
 	case "wasip1":
 		llvmos = "wasip1"
+	case "windows":
+		// GOOS=windows defaults to the native Microsoft ABI. MinGW is a
+		// separate target toolchain and must not be inferred from the host
+		// shell.
+		llvmvendor = "pc"
 	}
 	// Target triples (which actually have four components, but are called
 	// triples for historical reasons) have the form:
 	//   arch-vendor-os-environment
 	triple := llvmarch + "-" + llvmvendor + "-" + llvmos
 	if llvmos == "windows" {
-		triple += "-gnu"
+		triple += "-msvc"
 	} else if goarch == "arm" {
 		triple += "-gnueabihf"
 	}

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -19,6 +19,7 @@ func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	switch goarch {
 	case "386":
 		if goos == "windows" {
+			// LLVM's 32-bit MSVC target spelling uses i686.
 			llvmarch = "i686"
 		} else {
 			llvmarch = "i386"

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -70,7 +70,12 @@ func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	if llvmos == "windows" {
 		triple += "-msvc"
 	} else if goarch == "arm" {
-		triple += "-gnueabihf"
+		// Match Go's defaults: GOARM=5 uses software floating point, while
+		// GOARM=6 and GOARM=7 use hardware floating point.
+		triple += "-gnueabi"
+		if goarm != "5" {
+			triple += "hf"
+		}
 	}
 	return triple
 }

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -42,6 +42,7 @@ func TestGetTargetTriple(t *testing.T) {
 	clangArchMap := map[string][]string{
 		"x86_64":  {"x86-64", "x86_64"},
 		"i386":    {"x86", "i386"},
+		"i686":    {"x86", "i386"},
 		"aarch64": {"aarch64", "arm64"},
 		"arm64":   {"arm64", "aarch64"},
 		"armv7":   {"arm", "thumb"},
@@ -144,7 +145,8 @@ func TestGetTargetTriple(t *testing.T) {
 	checkTriple(t, "linux/arm", "linux", "arm", "armv7-unknown-linux-gnueabihf")
 	checkTriple(t, "darwin/amd64", "darwin", "amd64", "x86_64-apple-macosx")
 	checkTriple(t, "darwin/arm64", "darwin", "arm64", "arm64-apple-macosx")
-	checkTriple(t, "windows/amd64", "windows", "amd64", "x86_64-unknown-windows-gnu")
-	checkTriple(t, "windows/386", "windows", "386", "i386-unknown-windows-gnu")
+	checkTriple(t, "windows/amd64", "windows", "amd64", "x86_64-pc-windows-msvc")
+	checkTriple(t, "windows/386", "windows", "386", "i686-pc-windows-msvc")
+	checkTriple(t, "windows/arm64", "windows", "arm64", "aarch64-pc-windows-msvc")
 	checkTriple(t, "js/wasm", "js", "wasm", "wasm32-unknown-js")
 }

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -156,7 +156,7 @@ func TestGetTargetTripleWithGOARM(t *testing.T) {
 		goarm string
 		want  string
 	}{
-		{"5", "armv5-unknown-linux-gnueabihf"},
+		{"5", "armv5-unknown-linux-gnueabi"},
 		{"6", "armv6-unknown-linux-gnueabihf"},
 		{"7", "armv7-unknown-linux-gnueabihf"},
 		{"", "armv7-unknown-linux-gnueabihf"},

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -150,3 +150,19 @@ func TestGetTargetTriple(t *testing.T) {
 	checkTriple(t, "windows/arm64", "windows", "arm64", "aarch64-pc-windows-msvc")
 	checkTriple(t, "js/wasm", "js", "wasm", "wasm32-unknown-js")
 }
+
+func TestGetTargetTripleWithGOARM(t *testing.T) {
+	for _, test := range []struct {
+		goarm string
+		want  string
+	}{
+		{"5", "armv5-unknown-linux-gnueabihf"},
+		{"6", "armv6-unknown-linux-gnueabihf"},
+		{"7", "armv7-unknown-linux-gnueabihf"},
+		{"", "armv7-unknown-linux-gnueabihf"},
+	} {
+		if got := GetTargetTripleWithGOARM("linux", "arm", test.goarm); got != test.want {
+			t.Errorf("GetTargetTripleWithGOARM(linux, arm, %q) = %q, want %q", test.goarm, got, test.want)
+		}
+	}
+}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2700,6 +2700,26 @@ func TestWindowsTargetTriple(t *testing.T) {
 	}
 }
 
+func TestARMTargetSpec(t *testing.T) {
+	for _, test := range []struct {
+		goarm       string
+		wantTriple  string
+		wantFeature string
+	}{
+		{"5", "armv5-unknown-linux-gnueabi", "+armv5t"},
+		{"6", "armv6-unknown-linux-gnueabihf", "+armv6"},
+		{"7", "armv7-unknown-linux-gnueabihf", "+armv7-a"},
+	} {
+		spec := (&Target{GOOS: "linux", GOARCH: "arm", GOARM: test.goarm}).Spec()
+		if spec.Triple != test.wantTriple {
+			t.Errorf("linux/arm GOARM=%s triple = %q, want %q", test.goarm, spec.Triple, test.wantTriple)
+		}
+		if !strings.Contains(spec.Features, test.wantFeature) {
+			t.Errorf("linux/arm GOARM=%s features = %q, want %q", test.goarm, spec.Features, test.wantFeature)
+		}
+	}
+}
+
 func TestAbiTables(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2684,6 +2684,22 @@ func TestTargetMachineAndDataLayout(t *testing.T) {
 	}
 }
 
+func TestWindowsTargetTriple(t *testing.T) {
+	for _, test := range []struct {
+		goarch string
+		want   string
+	}{
+		{"386", "i686-pc-windows-msvc"},
+		{"amd64", "x86_64-pc-windows-msvc"},
+		{"arm64", "aarch64-pc-windows-msvc"},
+	} {
+		target := &Target{GOOS: "windows", GOARCH: test.goarch}
+		if got := target.Spec().Triple; got != test.want {
+			t.Errorf("windows/%s target triple = %q, want %q", test.goarch, got, test.want)
+		}
+	}
+}
+
 func TestAbiTables(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -130,30 +130,8 @@ type TargetSpec struct {
 func (p *Target) Spec() (spec TargetSpec) {
 	// Configure based on GOOS/GOARCH environment variables (falling back to
 	// runtime.GOOS/runtime.GOARCH), and generate a LLVM target based on it.
-	var llvmarch string
 	goarch := p.effectiveGOARCH()
 	goos := p.effectiveGOOS()
-	switch goarch {
-	case "386":
-		llvmarch = "i386"
-	case "amd64":
-		llvmarch = "x86_64"
-	case "arm64":
-		llvmarch = "aarch64"
-	case "arm":
-		switch p.GOARM {
-		case "5":
-			llvmarch = "armv5"
-		case "6":
-			llvmarch = "armv6"
-		default:
-			llvmarch = "armv7"
-		}
-	case "wasm":
-		llvmarch = "wasm32"
-	default:
-		llvmarch = goarch
-	}
 	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, p.GOARM)
 	switch goarch {
 	case "386":
@@ -164,12 +142,12 @@ func (p *Target) Spec() (spec TargetSpec) {
 		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
-		switch llvmarch {
-		case "armv5":
+		switch p.GOARM {
+		case "5":
 			spec.Features = "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
-		case "armv6":
+		case "6":
 			spec.Features = "+armv6,+dsp,+fp64,+strict-align,+vfp2,+vfp2sp,-aes,-d32,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-neon,-sha2,-thumb-mode,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
-		case "armv7":
+		default:
 			spec.Features = "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-aes,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-sha2,-thumb-mode,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 		}
 	case "arm64":

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/xgo-dev/llgo/internal/optlevel"
+	intllvm "github.com/xgo-dev/llgo/internal/xtool/llvm"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -153,32 +154,7 @@ func (p *Target) Spec() (spec TargetSpec) {
 	default:
 		llvmarch = goarch
 	}
-	llvmvendor := "unknown"
-	llvmos := goos
-	switch goos {
-	case "darwin":
-		// Use macosx* instead of darwin, otherwise darwin/arm64 will refer
-		// to iOS!
-		llvmos = "macosx"
-		if llvmarch == "aarch64" {
-			// Looks like Apple prefers to call this architecture ARM64
-			// instead of AArch64.
-			llvmarch = "arm64"
-			llvmos = "macosx"
-		}
-		llvmvendor = "apple"
-	case "wasip1":
-		llvmos = "wasip1"
-	}
-	// Target triples (which actually have four components, but are called
-	// triples for historical reasons) have the form:
-	//   arch-vendor-os-environment
-	spec.Triple = llvmarch + "-" + llvmvendor + "-" + llvmos
-	if llvmos == "windows" {
-		spec.Triple += "-gnu"
-	} else if goarch == "arm" {
-		spec.Triple += "-gnueabihf"
-	}
+	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, p.GOARM)
 	switch goarch {
 	case "386":
 		spec.CPU = "pentium4"


### PR DESCRIPTION
Part of #2325, the MSVC-first Windows support proposal.

## Summary

- default Go's official Windows targets (386, amd64, and arm64) to LLVM's MSVC environment
- share target-triple construction between SSA modules and clang invocations
- keep ARM version/float defaults aligned with Go (`GOARM=5` soft-float; `GOARM=6/7` hard-float)
- map package metadata with Windows file mappings while retaining the Unix mmap backend
- implement Windows cache locking with LockFileEx/UnlockFileEx while retaining Unix flock
- preserve COFF COMDAT ownership when aggregate/C ABI lowering replaces functions and when C ABI callback wrappers are synthesized
- add a native windows-amd64 host smoke job using a matching MSYS2 CLANG64 LLVM toolchain
- build llgo.exe and run its version command on Windows

The COMDAT preservation prevents Go ODR symbols such as generic instantiations from degrading into COFF weak fallbacks with `NoDuplicates` section selection after ABI lowering. Without it, linking larger standard-library programs can report duplicate symbols even though SSA originally emitted `comdat any`.

This consolidates the former #2328, #2330, and #2332 into one foundation PR so later Windows work has a single dependency.

## Dependency

None. The branch is based directly on xgo-dev/llgo main.

## Commit structure

1. select MSVC target triples
2. share triple construction with SSA and preserve GOARM handling
3. document the Windows 386 i686 choice
4. add Windows package-metadata mapping
5. add Windows cache-file locking
6. add and harden the native Windows host smoke job
7. remove duplicate SSA architecture mapping and match Go's ARM float defaults
8. preserve COFF COMDAT through aggregate/C ABI lowering
9. cover metadata-size, cache-lock cleanup, and GOARM 5/6 edge cases

## Scope

This is the host/toolchain foundation for #2325. It does not yet claim that LLGo-generated Windows programs, the Windows runtime, goroutines/threads, GC, closure environments, defer/panic/recover, debug information, FFI/CABI, or cross-compilation SDKs are complete. Those remain follow-up work.

The native smoke deliberately runs the tests owned by this PR. It does not run unrelated embedded libc, ESP download, Unix-permission, or full crosscompile tests whose assumptions are not yet Windows-portable.

## Local validation

- `go test -race ./internal/meta`
- `go test -race -count=20 -run '^TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)$' ./internal/crosscompile`
- `go test ./internal/crosscompile ./internal/meta ./internal/xtool/llvm`
- `go test ./ssa`
- `go test -tags=byollvm,llvm19 ./internal/abi ./internal/cabi`
- `go vet ./internal/meta ./internal/crosscompile ./internal/xtool/llvm ./ssa`
- ran the affected target-triple and SSA tests with Go 1.24.11 and Go 1.26.5
- compiled the affected packages for `windows/386`, `windows/amd64`, and `windows/arm64`
- workflow YAML and patch whitespace validation

## Native Windows validation

[Windows run 32052116512](https://github.com/xgo-dev/llgo/actions/runs/32052116512) passed on `windows-amd64` at the current head with Go 1.26.5 and LLVM 19.1.7 in 2m55s. The workflow pins the matching Clang, LLVM, LLD, compiler-rt, libc++, libunwind, and runtime dependency closure so MSYS2 rolling updates cannot silently change the compiler version. It:

- ran the package-metadata mapping and boundary-validation tests
- ran Windows cache locking, mutual exclusion, and failed-lock cleanup tests
- checked helper/SSA MSVC triples and GOARM 5/6 target features
- built `llgo-windows-smoke.exe`
- executed `llgo-windows-smoke.exe version`

The same current head also passed on a real Windows 11 ARM64 VM using Go 1.26.5, LLVM 19.1.7, and the Visual Studio ARM64 SDK/toolchain. The VM built directly from the macOS Home share at `\\Mac\Home\source\goplus\llgo-wt-windows-toolchain-20260815` (without copying source), ran the affected tests, built the compiler, and reported `llgo (devel) windows/arm64`.

The COFF regression was also reproduced and verified on a real Windows 11 ARM64 VM with LLVM 19.1.7 and Go 1.26.5. Before the fix, the lowered `io/fs` object contained a generic `slices.SortFunc` fallback in a `NoDuplicates` COMDAT and lld-link rejected duplicate definitions. After the fix, the same section uses `Any`; the stacked runtime, standard-library, and callback/FFI smoke binaries all linked and ran successfully.

## Final CI and coverage

All 43 checks passed on `ce04acdd7`, including Linux and macOS Go 1.26.5 tests, Go 1.24 compatibility, Windows AMD64 host smoke, release-artifact smoke, benchmarks, and the development LTO jobs. Codecov reports that every modified and coverable line is covered by tests (100% patch coverage); both Linux and macOS coverage uploads completed successfully.

The PR is ready for review.
