### PR TITLE
[Superseded by #2327] meta: map package metadata on Windows

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 	"unsafe"
 )
 
@@ -170,16 +169,19 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
+	if fi.Size() <= 0 || fi.Size() > int64(^uint(0)>>1) {
+		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
+	}
 	size := int(fi.Size())
 
-	raw, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+	raw, err := mapFile(f, size)
 	if err != nil {
 		return nil, fmt.Errorf("meta: mmap %s: %w", path, err)
 	}
 
 	pm, err := newPackageMeta(raw)
 	if err != nil {
-		_ = syscall.Munmap(raw)
+		_ = unmapFile(raw)
 		return nil, err
 	}
 	pm.mmap = true
@@ -199,8 +201,9 @@ func (pm *PackageMeta) WriteTo(w io.Writer) (int64, error) {
 // It is a no-op for PackageMeta values returned from Builder.Build.
 func (pm *PackageMeta) Close() error {
 	if pm.mmap && pm.raw != nil {
-		err := syscall.Munmap(pm.raw)
+		err := unmapFile(pm.raw)
 		pm.raw = nil
+		pm.mmap = false
 		return err
 	}
 	return nil

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -260,7 +260,6 @@ func TestRoundTripFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer pm2.Close()
 
 	if got := pm2.symbolName(fn); got != "pkg.Fn" {
 		t.Errorf("SymbolName after file round-trip = %q, want \"pkg.Fn\"", got)
@@ -268,6 +267,12 @@ func TestRoundTripFile(t *testing.T) {
 	edges := pm2.ordinaryEdges(fn)
 	if len(edges) != 1 || edges[0] != dep {
 		t.Errorf("OrdinaryEdges after file round-trip = %v", edges)
+	}
+	if err := pm2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := pm2.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
 	}
 }
 

--- a/internal/meta/mmap_unix.go
+++ b/internal/meta/mmap_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package meta
+
+import (
+	"os"
+	"syscall"
+)
+
+func mapFile(f *os.File, size int) ([]byte, error) {
+	return syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func unmapFile(raw []byte) error {
+	return syscall.Munmap(raw)
+}

--- a/internal/meta/mmap_windows.go
+++ b/internal/meta/mmap_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package meta
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func mapFile(f *os.File, size int) ([]byte, error) {
+	mapping, err := windows.CreateFileMapping(
+		windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, 0, 0, nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(mapping)
+
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_READ, 0, 0, uintptr(size))
+	if err != nil {
+		return nil, err
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
+}
+
+func unmapFile(raw []byte) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return windows.UnmapViewOfFile(uintptr(unsafe.Pointer(&raw[0])))
+}


### PR DESCRIPTION
> Superseded by #2327.

The Windows package-metadata mapping from this PR has been replayed as its own commit on the latest `main` in #2327, together with the related target identity, cache locking, and native Windows smoke coverage.

This PR remains Draft only as historical review context. New Windows work should depend on #2327 rather than this PR.

