### PR TITLE
ssa: honor saturating uint32 conversion on amd64

### DIFF
--- a/cl/float_int_conversion_compile_test.go
+++ b/cl/float_int_conversion_compile_test.go
@@ -3,7 +3,6 @@
 package cl
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -27,8 +26,8 @@ func Convert(x float32) uint32 { return uint32(x) }
 		t.Run(tt.name, func(t *testing.T) {
 			ssaPkg, _, files := buildGoSSAPkg(t, src)
 			prog := newLLSSAProgForTarget(t, &llssa.Target{
-				GOOS:                    runtime.GOOS,
-				GOARCH:                  runtime.GOARCH,
+				GOOS:                    "linux",
+				GOARCH:                  "amd64",
 				SaturatingFloatToUint32: tt.saturating,
 			})
 			pkg, err := NewPackage(prog, ssaPkg, files)

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1090,6 +1090,8 @@ func castFloatToInt(b Builder, x llvm.Value, typ Type) llvm.Value {
 	dstSize := b.Prog.td.TypeAllocSize(typ.ll)
 	target := b.Prog.Target()
 	saturatingUint32 := target.SaturatingFloatToUint32 && typ.kind == vkUnsigned && dstSize == 4
+	// The amd64 lowering only models legacy CVTT semantics. Saturating uint32
+	// conversions must use the guarded unsigned conversion below.
 	if target.effectiveGOARCH() == "amd64" && !saturatingUint32 {
 		return castFloatToIntAMD64(b, x, typ, dstSize)
 	}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1088,7 +1088,9 @@ func castInt(b Builder, x llvm.Value, xtyp Type, typ Type) llvm.Value {
 
 func castFloatToInt(b Builder, x llvm.Value, typ Type) llvm.Value {
 	dstSize := b.Prog.td.TypeAllocSize(typ.ll)
-	if b.Prog.Target().effectiveGOARCH() == "amd64" {
+	target := b.Prog.Target()
+	saturatingUint32 := target.SaturatingFloatToUint32 && typ.kind == vkUnsigned && dstSize == 4
+	if target.effectiveGOARCH() == "amd64" && !saturatingUint32 {
 		return castFloatToIntAMD64(b, x, typ, dstSize)
 	}
 	if typ.kind == vkUnsigned {
@@ -1098,7 +1100,7 @@ func castFloatToInt(b Builder, x llvm.Value, typ Type) llvm.Value {
 			tmp := castFloatToSignedInt(b, x, b.Prog.Int32(), 32)
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}
-		if dstSize == 4 && !b.Prog.Target().SaturatingFloatToUint32 {
+		if dstSize == 4 && !saturatingUint32 {
 			tmp := castFloatToSignedInt(b, x, b.Prog.Int64(), 64)
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}


### PR DESCRIPTION
## Summary

- let explicit SaturatingFloatToUint32 mode bypass the amd64 legacy CVTT lowering and use the guarded unsigned saturating path
- pin the conversion-mode regression test to linux/amd64 so this integration is covered on every test host

## Root cause

The amd64-specific float-to-integer lowering merged before #2253 returns before the new SaturatingFloatToUint32 check. After #2253 was merged, the saturating test therefore still emitted fptosi-to-i64 plus truncation on amd64 instead of the guarded fptoui path.

Fixes the failure in https://github.com/xgo-dev/llgo/actions/runs/31864805928/job/94964075408.

## Validation

- go test ./cl -run '^(TestFloatToUint32ConversionMode|TestAMD64FloatToIntegerConversionIR)$' -count=1
- go test ./ssa -count=1
- go test ./internal/goflags ./internal/build -count=1
- git diff --check

A full go test ./cl -count=1 was also attempted locally. It reached unrelated existing LTO output failures because the local LLVM prints unsupported +zcm/+zcz feature warnings, then hit the package's default 10-minute timeout; the focused cl tests above pass.
