### PR TITLE
[depends on #2327] target: add COFF linking and Go architecture tuning

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,6 @@ jobs:
     env:
       LLVM_VERSION: "19.1.7"
       MSYS2_LLVM_PACKAGE_VERSION: "19.1.7-1"
-      MSYS2_LIBXML2_PACKAGE_VERSION: "2.13.8-3"
     steps:
       - uses: actions/checkout@v7
 
@@ -42,13 +41,37 @@ jobs:
 
           repo=https://repo.msys2.org/mingw/clang64
           prefix=mingw-w64-clang-x86_64
-          packages=(clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind)
+          packages=(
+            "clang-$MSYS2_LLVM_PACKAGE_VERSION"
+            "clang-libs-$MSYS2_LLVM_PACKAGE_VERSION"
+            "compiler-rt-$MSYS2_LLVM_PACKAGE_VERSION"
+            "llvm-$MSYS2_LLVM_PACKAGE_VERSION"
+            "llvm-libs-$MSYS2_LLVM_PACKAGE_VERSION"
+            "lld-$MSYS2_LLVM_PACKAGE_VERSION"
+            "libc++-$MSYS2_LLVM_PACKAGE_VERSION"
+            "libunwind-$MSYS2_LLVM_PACKAGE_VERSION"
+            "gettext-runtime-0.22.5-2"
+            "libffi-3.4.6-1"
+            "libiconv-1.17-4"
+            "libxml2-2.12.9-2"
+            "xz-5.6.3-3"
+            "zlib-1.3.1-1"
+            "zstd-1.5.6-2"
+          )
           urls=()
           for package in "${packages[@]}"; do
-            urls+=("$repo/$prefix-$package-$MSYS2_LLVM_PACKAGE_VERSION-any.pkg.tar.zst")
+            urls+=("$repo/$prefix-$package-any.pkg.tar.zst")
           done
-          urls+=("$repo/$prefix-libxml2-$MSYS2_LIBXML2_PACKAGE_VERSION-any.pkg.tar.zst")
           pacman --noconfirm -U "${urls[@]}"
+
+          for package in clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind; do
+            installed="$(pacman -Q "$prefix-$package" | awk '{print $2}')"
+            if [[ "$installed" != "$MSYS2_LLVM_PACKAGE_VERSION" ]]; then
+              echo "expected $package $MSYS2_LLVM_PACKAGE_VERSION, got $installed" >&2
+              exit 1
+            fi
+          done
+          clang --version
 
       - name: Build and test the Windows host compiler
         shell: msys2 {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,10 +101,10 @@ jobs:
             ./internal/meta \
             ./internal/xtool/llvm
           go test -tags="$build_tags" \
-            -run '^TestAcquire(AndReleaseLock|LockConcurrency)$' \
+            -run '^TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)$' \
             ./internal/crosscompile
           go test -tags="$build_tags" \
-            -run '^TestWindowsTargetTriple$' \
+            -run '^Test(WindowsTargetTriple|ARMTargetSpec)$' \
             ./ssa
 
           go build -tags="$build_tags" -o llgo-windows-smoke.exe ./cmd/llgo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: CLANG64
+          path-type: inherit
           update: true
           install: >-
             mingw-w64-clang-x86_64-clang

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,7 +105,7 @@ jobs:
             -run '^Test(ResolveGOARCHConfig|ResolveBuildConfigInvalidGOARCHValueIsAtomic|GOARCHEnv|GOARCHConfigSeparatesCacheFingerprints)$' \
             ./internal/build
           go test -tags="$build_tags" \
-            -run '^(TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)|TestNativeWindows.*|TestCOFFLTOLevel)$' \
+            -run '^(TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)|TestNativeWindows.*|TestCOFFLTOLevel|TestConfigureNativeClangRootFlags)$' \
             ./internal/crosscompile
           go test -tags="$build_tags" \
             -run '^Test(WindowsTargetTriple|ARMTargetSpec)$' \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,8 @@ jobs:
           go-version: "1.26.5"
 
       - name: Set up LLVM
+        # CLANG64 supplies Windows-hosted LLVM libraries used to build llgo.
+        # LLGo-generated Windows code independently selects the MSVC target ABI.
         uses: msys2/setup-msys2@v2
         with:
           msystem: CLANG64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,7 +99,11 @@ jobs:
           llvm-config --version
           go test -tags="$build_tags" \
             ./internal/meta \
+            ./internal/goarch \
             ./internal/xtool/llvm
+          go test -tags="$build_tags" \
+            -run '^Test(ResolveGOARCHConfig|ResolveBuildConfigInvalidGOARCHValueIsAtomic|GOARCHEnv|GOARCHConfigSeparatesCacheFingerprints)$' \
+            ./internal/build
           go test -tags="$build_tags" \
             -run '^(TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)|TestNativeWindows.*|TestCOFFLTOLevel)$' \
             ./internal/crosscompile

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,9 +13,13 @@ concurrency:
 
 jobs:
   host-smoke:
-    name: host smoke (windows-amd64, LLVM 22, Go 1.26.5)
+    name: host smoke (windows-amd64, LLVM 19, Go 1.26.5)
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      LLVM_VERSION: "19.1.7"
+      MSYS2_LLVM_PACKAGE_VERSION: "19.1.7-1"
+      MSYS2_LIBXML2_PACKAGE_VERSION: "2.13.8-3"
     steps:
       - uses: actions/checkout@v7
 
@@ -30,9 +34,21 @@ jobs:
           msystem: CLANG64
           path-type: inherit
           update: true
-          install: >-
-            mingw-w64-clang-x86_64-clang
-            mingw-w64-clang-x86_64-llvm
+
+      - name: Install LLVM 19
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+
+          repo=https://repo.msys2.org/mingw/clang64
+          prefix=mingw-w64-clang-x86_64
+          packages=(clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind)
+          urls=()
+          for package in "${packages[@]}"; do
+            urls+=("$repo/$prefix-$package-$MSYS2_LLVM_PACKAGE_VERSION-any.pkg.tar.zst")
+          done
+          urls+=("$repo/$prefix-libxml2-$MSYS2_LIBXML2_PACKAGE_VERSION-any.pkg.tar.zst")
+          pacman --noconfirm -U "${urls[@]}"
 
       - name: Build and test the Windows host compiler
         shell: msys2 {0}
@@ -48,13 +64,11 @@ jobs:
           export CGO_LDFLAGS="$(llvm-config --ldflags --libs all --system-libs)"
 
           llvm_version="$(llvm-config --version)"
-          case "$llvm_version" in
-            22.*) build_tags=byollvm,llvm22 ;;
-            *)
-              echo "unsupported MSYS2 LLVM version: $llvm_version" >&2
-              exit 1
-              ;;
-          esac
+          if [[ "$llvm_version" != "$LLVM_VERSION" ]]; then
+            echo "expected LLVM $LLVM_VERSION, got $llvm_version" >&2
+            exit 1
+          fi
+          build_tags=byollvm,llvm19
 
           go version
           llvm-config --version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,62 @@
+name: Windows
+
+on:
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  host-smoke:
+    name: host smoke (windows-amd64, LLVM 22, Go 1.26.5)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.5"
+
+      - name: Set up LLVM
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: true
+          install: >-
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-llvm
+
+      - name: Build and test the Windows host compiler
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+
+          export CC=clang
+          export CXX=clang++
+          export CGO_ENABLED=1
+          export CGO_CFLAGS="$(llvm-config --cflags)"
+          export CGO_CXXFLAGS="$(llvm-config --cxxflags)"
+          export CGO_LDFLAGS="$(llvm-config --ldflags --libs all --system-libs)"
+
+          llvm_version="$(llvm-config --version)"
+          case "$llvm_version" in
+            22.*) build_tags=byollvm,llvm22 ;;
+            *)
+              echo "unsupported MSYS2 LLVM version: $llvm_version" >&2
+              exit 1
+              ;;
+          esac
+
+          go version
+          llvm-config --version
+          go test -tags="$build_tags" \
+            ./internal/meta \
+            ./internal/crosscompile \
+            ./internal/xtool/llvm
+
+          go build -tags="$build_tags" -o llgo-windows-smoke.exe ./cmd/llgo
+          LLGO_ROOT="$PWD" ./llgo-windows-smoke.exe version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,6 +39,7 @@ jobs:
           export CC=clang
           export CXX=clang++
           export CGO_ENABLED=1
+          export LLGO_ROOT="$PWD"
           export CGO_CFLAGS="$(llvm-config --cflags)"
           export CGO_CXXFLAGS="$(llvm-config --cxxflags)"
           export CGO_LDFLAGS="$(llvm-config --ldflags --libs all --system-libs)"
@@ -56,8 +57,13 @@ jobs:
           llvm-config --version
           go test -tags="$build_tags" \
             ./internal/meta \
-            ./internal/crosscompile \
             ./internal/xtool/llvm
+          go test -tags="$build_tags" \
+            -run '^TestAcquire(AndReleaseLock|LockConcurrency)$' \
+            ./internal/crosscompile
+          go test -tags="$build_tags" \
+            -run '^TestWindowsTargetTriple$' \
+            ./ssa
 
           go build -tags="$build_tags" -o llgo-windows-smoke.exe ./cmd/llgo
-          LLGO_ROOT="$PWD" ./llgo-windows-smoke.exe version
+          ./llgo-windows-smoke.exe version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,7 +101,7 @@ jobs:
             ./internal/meta \
             ./internal/xtool/llvm
           go test -tags="$build_tags" \
-            -run '^TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)$' \
+            -run '^(TestAcquire(AndReleaseLock(Errors)?|LockConcurrency)|TestNativeWindows.*|TestCOFFLTOLevel)$' \
             ./internal/crosscompile
           go test -tags="$build_tags" \
             -run '^Test(WindowsTargetTriple|ARMTargetSpec)$' \

--- a/cl/_testdata/method/in.go
+++ b/cl/_testdata/method/in.go
@@ -25,7 +25,7 @@ func main() {
 
 // CHECK-LABEL: define i64 @"main.(*T).Add"(ptr %0, i64 %1){{.*}} {
 // CHECK: [[NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK-NEXT: call void @"{{.*}}PanicWrapNilPointer"(i1 [[NIL]], %"{{.*}}String" { ptr @{{[0-9]+}}, i64 44 }, %"{{.*}}String" { ptr @{{[0-9]+}}, i64 3 })
+// CHECK-NEXT: call void @"{{.*}}PanicWrapNilPointer"(i1 [[NIL]], %"{{.*}}String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} }, %"{{.*}}String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} })
 // CHECK-NEXT: [[RECEIVER:%[0-9]+]] = load i64, ptr %0
 // CHECK-NEXT: [[WRAPPED_SUM:%[0-9]+]] = call i64 @main.T.Add(i64 [[RECEIVER]], i64 %1)
 // CHECK-NEXT: ret i64 [[WRAPPED_SUM]]

--- a/cl/_testmeta/reflect_named/meta-expect.txt
+++ b/cl/_testmeta/reflect_named/meta-expect.txt
@@ -44,8 +44,8 @@ main.main:
 
 [UseIfaceMethod]
 main.main:
-    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
-    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$bReUJH2_12QVkFcde1SpCUgXqmhRT8DRulK5lXtpIkY MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+    github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$bReUJH2_12QVkFcde1SpCUgXqmhRT8DRulK5lXtpIkY MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
 
 [UseNamedMethod]
 main.main:
@@ -61,7 +61,7 @@ _llgo_main.T:
     1 main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).m main.T.m
 
 [InterfaceInfo]
-github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw:
+github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$bReUJH2_12QVkFcde1SpCUgXqmhRT8DRulK5lXtpIkY:
     Align _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
     AssignableTo _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
     Bits _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
@@ -101,6 +101,6 @@ github.com/xgo-dev/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFp
     PkgPath _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
     Size _llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s
     String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
-    reflect.common _llgo_func$w6XuV-1SmW103DbauPseXBpW50HpxXAEsUsGFibl0Uw
-    reflect.uncommon _llgo_func$iG49bujiXjI2lVflYdE0hPXlCAABL-XKRANSNJEKOio
+    reflect.common _llgo_func$_FtQJl7A5s1VI_ob-KR67FLMXbIG5TjcVaEFuqM5Lo4
+    reflect.uncommon _llgo_func$tpkXXN4h9pcUPRsL9rq-8-w7qAx06dW7DgXtepA0U1E
 

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -36,7 +36,7 @@ func main() {
 
 // CHECK-LABEL: define void @"main.(*Foo).Print"(ptr %0){{.*}} {
 // CHECK: [[WRAPPER_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[WRAPPER_NIL]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 5 })
+// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[WRAPPER_NIL]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} }, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 {{[0-9]+}} })
 // CHECK-NEXT: [[WRAPPER_VALUE:%[0-9]+]] = load %main.Foo, ptr %0
 // CHECK-NEXT: call void @main.Foo.Print(%main.Foo [[WRAPPER_VALUE]])
 

--- a/internal/abi/large.go
+++ b/internal/abi/large.go
@@ -114,6 +114,7 @@ func (l largeAggregateLowerer) transformFunc(m llvm.Module, fn llvm.Value) {
 	fn.SetName("")
 	nfn := llvm.AddFunction(m, name, newType)
 	nfn.SetLinkage(fn.Linkage())
+	nfn.SetComdat(fn.Comdat())
 	nfn.SetFunctionCallConv(fn.FunctionCallConv())
 	nfn.AddAttributeAtIndex(1, sretAttribute(ctx, retType))
 	for _, attr := range fn.GetFunctionAttributes() {

--- a/internal/abi/large_test.go
+++ b/internal/abi/large_test.go
@@ -33,8 +33,9 @@ func TestLowerLargeAggregates(t *testing.T) {
 	const testIR = `
 %Large = type [65537 x i8]
 %Small = type [65536 x i8]
+$callee = comdat any
 
-define %Large @callee(ptr nonnull %src) #1 {
+define linkonce_odr %Large @callee(ptr nonnull %src) #1 comdat {
 entry:
   %value = load %Large, ptr %src, align 1
   %first = getelementptr inbounds %Large, ptr %src, i64 0, i64 0
@@ -103,8 +104,14 @@ attributes #1 = { noinline }
 	LowerLargeAggregates(td, mod)
 
 	callee := mod.NamedFunction("callee").String()
-	if !strings.Contains(callee, "define void @callee(ptr sret([65537 x i8])") {
+	if !strings.Contains(callee, "define linkonce_odr void @callee(ptr sret([65537 x i8])") {
 		t.Fatalf("large return was not lowered to sret:\n%s", callee)
+	}
+	if !strings.Contains(callee, "comdat") {
+		t.Fatalf("large return lowering lost COMDAT metadata:\n%s", callee)
+	}
+	if kind := mod.NamedFunction("callee").Comdat().SelectionKind(); kind != llvm.AnyComdatSelectionKind {
+		t.Fatalf("large return COMDAT selection = %v, want any", kind)
 	}
 	if !strings.Contains(callee, "ptr nonnull %") || !strings.Contains(callee, "noinline") {
 		t.Fatalf("callee attributes were not preserved:\n%s", callee)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -50,6 +50,7 @@ import (
 	"github.com/xgo-dev/llgo/internal/env"
 	"github.com/xgo-dev/llgo/internal/firmware"
 	"github.com/xgo-dev/llgo/internal/flash"
+	"github.com/xgo-dev/llgo/internal/goarch"
 	"github.com/xgo-dev/llgo/internal/goembed"
 	"github.com/xgo-dev/llgo/internal/header"
 	"github.com/xgo-dev/llgo/internal/lto"
@@ -134,6 +135,9 @@ type ModuleHook func(pkg Package)
 type Config struct {
 	Goos               string
 	Goarch             string
+	GO386              string // 386 floating-point implementation: sse2 or softfloat
+	GOAMD64            string // amd64 microarchitecture level: v1 through v4
+	GOARM64            string // arm64 ISA version and optional lse/crypto extensions
 	Target             string // target name (e.g., "rp2040", "wasi") - takes precedence over Goos/Goarch
 	OptLevel           optlevel.Level
 	LTO                lto.Mode
@@ -257,6 +261,9 @@ func resolveBuildConfig(input *Config) (*Config, error) {
 	if conf.Goarch == "" {
 		conf.Goarch = runtime.GOARCH
 	}
+	if err := resolveGOARCHConfig(conf, os.Getenv); err != nil {
+		return nil, err
+	}
 	if conf.AppExt == "" {
 		conf.AppExt = defaultAppExt(conf)
 	}
@@ -285,6 +292,55 @@ func resolveBuildConfig(input *Config) (*Config, error) {
 	}
 	conf.OptLevel = effectiveOptLevel(conf)
 	return conf, nil
+}
+
+func resolveGOARCHConfig(conf *Config, getenv func(string) string) error {
+	if conf.Target != "" {
+		conf.GO386, conf.GOAMD64, conf.GOARM64 = "", "", ""
+		return nil
+	}
+	go386, goamd64, goarm64 := conf.GO386, conf.GOAMD64, conf.GOARM64
+	conf.GO386, conf.GOAMD64, conf.GOARM64 = "", "", ""
+	switch conf.Goarch {
+	case "386":
+		if go386 == "" {
+			go386 = getenv("GO386")
+		}
+		value, err := goarch.Resolve386(go386)
+		conf.GO386 = value
+		return err
+	case "amd64":
+		if goamd64 == "" {
+			goamd64 = getenv("GOAMD64")
+		}
+		value, err := goarch.ResolveAMD64(goamd64)
+		conf.GOAMD64 = value
+		return err
+	case "arm64":
+		if goarm64 == "" {
+			goarm64 = getenv("GOARM64")
+		}
+		value, err := goarch.ParseARM64(goarm64)
+		conf.GOARM64 = value.String()
+		return err
+	}
+	return nil
+}
+
+func goarchEnv(conf *Config) []string {
+	if conf == nil || conf.Target != "" {
+		return nil
+	}
+	values := []string{"GO386=", "GOAMD64=", "GOARM64="}
+	switch conf.Goarch {
+	case "386":
+		values[0] += conf.GO386
+	case "amd64":
+		values[1] += conf.GOAMD64
+	case "arm64":
+		values[2] += conf.GOARM64
+	}
+	return values
 }
 
 func NewDefaultConf(mode Mode) *Config {
@@ -386,11 +442,14 @@ func Build(inv Invocation) ([]Package, error) {
 		}
 	}
 	environ := os.Environ()
-	commands := commandEnv{dir: dir, environ: environ}
 	conf, err := resolveBuildConfig(inv.Config)
 	if err != nil {
 		return nil, err
 	}
+	// Keep child Go invocations (notably cmptest's baseline) on the same
+	// architecture level as the LLVM build. GOOS/GOARCH retain their existing
+	// per-command handling.
+	commands := commandEnv{dir: dir, environ: withEnv(environ, goarchEnv(conf)...)}
 	buildTrace, err := startBuildTrace(conf.BuildTrace, dir, conf.parallelism())
 	if err != nil {
 		return nil, fmt.Errorf("start build trace: %w", err)
@@ -427,6 +486,9 @@ func Build(inv Invocation) ([]Package, error) {
 	target := &llssa.Target{
 		GOOS:                    conf.Goos,
 		GOARCH:                  conf.Goarch,
+		GO386:                   conf.GO386,
+		GOAMD64:                 conf.GOAMD64,
+		GOARM64:                 conf.GOARM64,
 		Target:                  conf.Target,
 		LLVMTarget:              export.LLVMTarget,
 		OptLevel:                conf.OptLevel,
@@ -456,7 +518,7 @@ func Build(inv Invocation) ([]Package, error) {
 		Dir:        dir,
 		Fset:       token.NewFileSet(),
 		Tests:      conf.Mode == ModeTest,
-		Env:        withEnv(environ, "GOOS="+conf.Goos, "GOARCH="+conf.Goarch),
+		Env:        withEnv(commands.environ, "GOOS="+conf.Goos, "GOARCH="+conf.Goarch),
 	}
 	if conf.Mode == ModeTest {
 		cfg.Mode |= packages.NeedForTest

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1751,7 +1751,7 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	}
 	defer cleanupSiteLayout()
 	buildArgs = append(buildArgs, siteLayoutArgs...)
-	buildArgs = append(buildArgs, dwarfLinkerArgs(ctx.buildConf, &ctx.crossCompile)...)
+	buildArgs = append(buildArgs, debugInfoLinkerArgs(ctx.buildConf, &ctx.crossCompile)...)
 	ltoPluginFlags, err := ctx.buildConf.LTOPlugin.LinkerFlags(ctx.buildConf.Goos)
 	if err != nil {
 		return err

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -476,7 +476,7 @@ func Build(inv Invocation) ([]Package, error) {
 	}()
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
-	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel, conf.ltoMode(), conf.goGlobalDCEEnabled())
+	export, err := crosscompile.UseWithGOARM(conf.Goos, conf.Goarch, conf.GOARM, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel, conf.ltoMode(), conf.goGlobalDCEEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup crosscompile: %w", err)
 	}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -137,6 +137,7 @@ type Config struct {
 	Goarch             string
 	GO386              string // 386 floating-point implementation: sse2 or softfloat
 	GOAMD64            string // amd64 microarchitecture level: v1 through v4
+	GOARM              string // arm architecture and floating-point implementation
 	GOARM64            string // arm64 ISA version and optional lse/crypto extensions
 	Target             string // target name (e.g., "rp2040", "wasi") - takes precedence over Goos/Goarch
 	OptLevel           optlevel.Level
@@ -296,11 +297,11 @@ func resolveBuildConfig(input *Config) (*Config, error) {
 
 func resolveGOARCHConfig(conf *Config, getenv func(string) string) error {
 	if conf.Target != "" {
-		conf.GO386, conf.GOAMD64, conf.GOARM64 = "", "", ""
+		conf.GO386, conf.GOAMD64, conf.GOARM, conf.GOARM64 = "", "", "", ""
 		return nil
 	}
-	go386, goamd64, goarm64 := conf.GO386, conf.GOAMD64, conf.GOARM64
-	conf.GO386, conf.GOAMD64, conf.GOARM64 = "", "", ""
+	go386, goamd64, goarm, goarm64 := conf.GO386, conf.GOAMD64, conf.GOARM, conf.GOARM64
+	conf.GO386, conf.GOAMD64, conf.GOARM, conf.GOARM64 = "", "", "", ""
 	switch conf.Goarch {
 	case "386":
 		if go386 == "" {
@@ -315,6 +316,13 @@ func resolveGOARCHConfig(conf *Config, getenv func(string) string) error {
 		}
 		value, err := goarch.ResolveAMD64(goamd64)
 		conf.GOAMD64 = value
+		return err
+	case "arm":
+		if goarm == "" {
+			goarm = getenv("GOARM")
+		}
+		value, err := goarch.ParseARM(goarm)
+		conf.GOARM = value.String()
 		return err
 	case "arm64":
 		if goarm64 == "" {
@@ -331,14 +339,16 @@ func goarchEnv(conf *Config) []string {
 	if conf == nil || conf.Target != "" {
 		return nil
 	}
-	values := []string{"GO386=", "GOAMD64=", "GOARM64="}
+	values := []string{"GO386=", "GOAMD64=", "GOARM=", "GOARM64="}
 	switch conf.Goarch {
 	case "386":
 		values[0] += conf.GO386
 	case "amd64":
 		values[1] += conf.GOAMD64
+	case "arm":
+		values[2] += conf.GOARM
 	case "arm64":
-		values[2] += conf.GOARM64
+		values[3] += conf.GOARM64
 	}
 	return values
 }
@@ -488,6 +498,7 @@ func Build(inv Invocation) ([]Package, error) {
 		GOARCH:                  conf.Goarch,
 		GO386:                   conf.GO386,
 		GOAMD64:                 conf.GOAMD64,
+		GOARM:                   conf.GOARM,
 		GOARM64:                 conf.GOARM64,
 		Target:                  conf.Target,
 		LLVMTarget:              export.LLVMTarget,

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -91,6 +91,9 @@ func (c *context) packageCacheDisabled(id string) bool {
 func (c *context) collectEnvInputs(m *manifestBuilder) {
 	m.env.Goos = c.buildConf.Goos
 	m.env.Goarch = c.buildConf.Goarch
+	m.env.Go386 = c.buildConf.GO386
+	m.env.Goamd64 = c.buildConf.GOAMD64
+	m.env.Goarm64 = c.buildConf.GOARM64
 	m.env.LlvmTriple = c.crossCompile.LLVMTarget
 	m.env.LlgoVersion = env.Version()
 	m.env.LlgoCompilerHash = c.buildConf.CompilerHash

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -93,6 +93,7 @@ func (c *context) collectEnvInputs(m *manifestBuilder) {
 	m.env.Goarch = c.buildConf.Goarch
 	m.env.Go386 = c.buildConf.GO386
 	m.env.Goamd64 = c.buildConf.GOAMD64
+	m.env.Goarm = c.buildConf.GOARM
 	m.env.Goarm64 = c.buildConf.GOARM64
 	m.env.LlvmTriple = c.crossCompile.LLVMTarget
 	m.env.LlgoVersion = env.Version()

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -101,6 +101,7 @@ type envSection struct {
 	Goarch           string           `yaml:"GOARCH,omitempty"`
 	Go386            string           `yaml:"GO386,omitempty"`
 	Goamd64          string           `yaml:"GOAMD64,omitempty"`
+	Goarm            string           `yaml:"GOARM,omitempty"`
 	Goarm64          string           `yaml:"GOARM64,omitempty"`
 	GoVersion        string           `yaml:"GO_VERSION,omitempty"`
 	LlgoVersion      string           `yaml:"LLGO_VERSION,omitempty"`
@@ -111,7 +112,7 @@ type envSection struct {
 }
 
 func (s *envSection) empty() bool {
-	return s.Goos == "" && s.Goarch == "" && s.Go386 == "" && s.Goamd64 == "" && s.Goarm64 == "" && s.LlvmTriple == "" && s.LlgoVersion == "" && s.LlgoCompilerHash == "" && s.GoVersion == "" && s.LlvmVersion == "" && len(s.Vars) == 0
+	return s.Goos == "" && s.Goarch == "" && s.Go386 == "" && s.Goamd64 == "" && s.Goarm == "" && s.Goarm64 == "" && s.LlvmTriple == "" && s.LlgoVersion == "" && s.LlgoCompilerHash == "" && s.GoVersion == "" && s.LlvmVersion == "" && len(s.Vars) == 0
 }
 
 type commonSection struct {

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -99,6 +99,9 @@ func (m orderedStringMap) MarshalYAML() (interface{}, error) {
 type envSection struct {
 	Goos             string           `yaml:"GOOS,omitempty"`
 	Goarch           string           `yaml:"GOARCH,omitempty"`
+	Go386            string           `yaml:"GO386,omitempty"`
+	Goamd64          string           `yaml:"GOAMD64,omitempty"`
+	Goarm64          string           `yaml:"GOARM64,omitempty"`
 	GoVersion        string           `yaml:"GO_VERSION,omitempty"`
 	LlgoVersion      string           `yaml:"LLGO_VERSION,omitempty"`
 	LlgoCompilerHash string           `yaml:"LLGO_COMPILER_HASH,omitempty"`
@@ -108,7 +111,7 @@ type envSection struct {
 }
 
 func (s *envSection) empty() bool {
-	return s.Goos == "" && s.Goarch == "" && s.LlvmTriple == "" && s.LlgoVersion == "" && s.LlgoCompilerHash == "" && s.GoVersion == "" && s.LlvmVersion == "" && len(s.Vars) == 0
+	return s.Goos == "" && s.Goarch == "" && s.Go386 == "" && s.Goamd64 == "" && s.Goarm64 == "" && s.LlvmTriple == "" && s.LlgoVersion == "" && s.LlgoCompilerHash == "" && s.GoVersion == "" && s.LlvmVersion == "" && len(s.Vars) == 0
 }
 
 type commonSection struct {

--- a/internal/build/goarch_test.go
+++ b/internal/build/goarch_test.go
@@ -61,13 +61,23 @@ func TestResolveGOARCHConfig(t *testing.T) {
 		{
 			name: "arm default",
 			conf: Config{Goarch: "arm"},
-			want: Config{Goarch: "arm", GOARM: "7"},
+			want: Config{Goarch: "arm", GOARM: "7,hardfloat"},
 		},
 		{
 			name: "arm environment",
 			conf: Config{Goarch: "arm"},
 			env:  map[string]string{"GOARM": "6,softfloat"},
 			want: Config{Goarch: "arm", GOARM: "6,softfloat"},
+		},
+		{
+			name: "arm5 canonical default float mode",
+			conf: Config{Goarch: "arm", GOARM: "5"},
+			want: Config{Goarch: "arm", GOARM: "5,softfloat"},
+		},
+		{
+			name: "arm6 canonical default float mode",
+			conf: Config{Goarch: "arm", GOARM: "6"},
+			want: Config{Goarch: "arm", GOARM: "6,hardfloat"},
 		},
 		{
 			name: "arm explicit wins",
@@ -174,9 +184,9 @@ func TestGOARCHConfigSeparatesCacheFingerprints(t *testing.T) {
 		},
 		{
 			name:       "GOARM",
-			left:       &Config{Goos: "linux", Goarch: "arm", GOARM: "7"},
+			left:       &Config{Goos: "linux", Goarch: "arm", GOARM: "7,hardfloat"},
 			right:      &Config{Goos: "linux", Goarch: "arm", GOARM: "6,softfloat"},
-			leftEntry:  "GOARM: \"7\"",
+			leftEntry:  "GOARM: 7,hardfloat",
 			rightEntry: "GOARM: 6,softfloat",
 		},
 		{

--- a/internal/build/goarch_test.go
+++ b/internal/build/goarch_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveGOARCHConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		conf Config
+		env  map[string]string
+		want Config
+	}{
+		{
+			name: "386 default",
+			conf: Config{Goarch: "386"},
+			want: Config{Goarch: "386", GO386: "sse2"},
+		},
+		{
+			name: "386 environment",
+			conf: Config{Goarch: "386", GOAMD64: "v4"},
+			env:  map[string]string{"GO386": "softfloat"},
+			want: Config{Goarch: "386", GO386: "softfloat"},
+		},
+		{
+			name: "386 explicit wins",
+			conf: Config{Goarch: "386", GO386: "softfloat"},
+			env:  map[string]string{"GO386": "sse2"},
+			want: Config{Goarch: "386", GO386: "softfloat"},
+		},
+		{
+			name: "amd64 explicit wins",
+			conf: Config{Goarch: "amd64", GOAMD64: "v3"},
+			env:  map[string]string{"GOAMD64": "v4"},
+			want: Config{Goarch: "amd64", GOAMD64: "v3"},
+		},
+		{
+			name: "amd64 environment",
+			conf: Config{Goarch: "amd64"},
+			env:  map[string]string{"GOAMD64": "v4"},
+			want: Config{Goarch: "amd64", GOAMD64: "v4"},
+		},
+		{
+			name: "arm64 canonical extensions",
+			conf: Config{Goarch: "arm64", GOARM64: "v8.2,crypto"},
+			want: Config{Goarch: "arm64", GOARM64: "v8.2,lse,crypto"},
+		},
+		{
+			name: "arm64 environment",
+			conf: Config{Goarch: "arm64"},
+			env:  map[string]string{"GOARM64": "v9.1"},
+			want: Config{Goarch: "arm64", GOARM64: "v9.1,lse"},
+		},
+		{
+			name: "unrelated architecture",
+			conf: Config{Goarch: "wasm", GO386: "softfloat", GOAMD64: "v4", GOARM64: "v9.5"},
+			want: Config{Goarch: "wasm"},
+		},
+		{
+			name: "named target ignores architecture environment",
+			conf: Config{Goarch: "amd64", GOAMD64: "v4", Target: "wasi"},
+			want: Config{Goarch: "amd64", Target: "wasi"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			getenv := func(name string) string { return test.env[name] }
+			if err := resolveGOARCHConfig(&test.conf, getenv); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(test.conf, test.want) {
+				t.Fatalf("config = %+v, want %+v", test.conf, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveBuildConfigInvalidGOARCHValueIsAtomic(t *testing.T) {
+	input := &Config{Goarch: "amd64", GOAMD64: "v5", GoBuildFlags: []string{"-tags=keep"}}
+	want := input.clone()
+	if _, err := resolveBuildConfig(input); err == nil {
+		t.Fatal("resolveBuildConfig succeeded with GOAMD64=v5")
+	}
+	if !reflect.DeepEqual(input, want) {
+		t.Fatalf("input changed on error:\n got %+v\nwant %+v", input, want)
+	}
+}
+
+func TestGOARCHEnv(t *testing.T) {
+	tests := []struct {
+		conf *Config
+		want []string
+	}{
+		{},
+		{conf: &Config{Goarch: "386", GO386: "softfloat"}, want: []string{"GO386=softfloat", "GOAMD64=", "GOARM64="}},
+		{conf: &Config{Goarch: "amd64", GOAMD64: "v4"}, want: []string{"GO386=", "GOAMD64=v4", "GOARM64="}},
+		{conf: &Config{Goarch: "arm64", GOARM64: "v9.5,lse,crypto"}, want: []string{"GO386=", "GOAMD64=", "GOARM64=v9.5,lse,crypto"}},
+		{conf: &Config{Goarch: "amd64", Target: "wasi"}},
+	}
+	for _, test := range tests {
+		if got := goarchEnv(test.conf); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("goarchEnv(%+v) = %q, want %q", test.conf, got, test.want)
+		}
+	}
+}
+
+func TestGOARCHConfigSeparatesCacheFingerprints(t *testing.T) {
+	manifest := func(conf *Config) (string, string) {
+		m := newManifestBuilder()
+		ctx := &context{buildConf: conf, llvmVersion: "test"}
+		ctx.collectEnvInputs(m)
+		return m.Build(), m.Fingerprint()
+	}
+	for _, test := range []struct {
+		name       string
+		left       *Config
+		right      *Config
+		leftEntry  string
+		rightEntry string
+	}{
+		{
+			name:       "GO386",
+			left:       &Config{Goos: "windows", Goarch: "386", GO386: "sse2"},
+			right:      &Config{Goos: "windows", Goarch: "386", GO386: "softfloat"},
+			leftEntry:  "GO386: sse2",
+			rightEntry: "GO386: softfloat",
+		},
+		{
+			name:       "GOAMD64",
+			left:       &Config{Goos: "windows", Goarch: "amd64", GOAMD64: "v1"},
+			right:      &Config{Goos: "windows", Goarch: "amd64", GOAMD64: "v4"},
+			leftEntry:  "GOAMD64: v1",
+			rightEntry: "GOAMD64: v4",
+		},
+		{
+			name:       "GOARM64",
+			left:       &Config{Goos: "windows", Goarch: "arm64", GOARM64: "v8.0"},
+			right:      &Config{Goos: "windows", Goarch: "arm64", GOARM64: "v9.5,lse,crypto"},
+			leftEntry:  "GOARM64: v8.0",
+			rightEntry: "GOARM64: v9.5,lse,crypto",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			leftManifest, leftFingerprint := manifest(test.left)
+			rightManifest, rightFingerprint := manifest(test.right)
+			if leftFingerprint == rightFingerprint {
+				t.Fatalf("%s configurations share a cache fingerprint", test.name)
+			}
+			if !strings.Contains(leftManifest, test.leftEntry) || !strings.Contains(rightManifest, test.rightEntry) {
+				t.Fatalf("architecture settings missing from manifests:\n%s\n%s", leftManifest, rightManifest)
+			}
+		})
+	}
+}

--- a/internal/build/goarch_test.go
+++ b/internal/build/goarch_test.go
@@ -59,6 +59,23 @@ func TestResolveGOARCHConfig(t *testing.T) {
 			want: Config{Goarch: "amd64", GOAMD64: "v4"},
 		},
 		{
+			name: "arm default",
+			conf: Config{Goarch: "arm"},
+			want: Config{Goarch: "arm", GOARM: "7"},
+		},
+		{
+			name: "arm environment",
+			conf: Config{Goarch: "arm"},
+			env:  map[string]string{"GOARM": "6,softfloat"},
+			want: Config{Goarch: "arm", GOARM: "6,softfloat"},
+		},
+		{
+			name: "arm explicit wins",
+			conf: Config{Goarch: "arm", GOARM: "5,hardfloat"},
+			env:  map[string]string{"GOARM": "7"},
+			want: Config{Goarch: "arm", GOARM: "5,hardfloat"},
+		},
+		{
 			name: "arm64 canonical extensions",
 			conf: Config{Goarch: "arm64", GOARM64: "v8.2,crypto"},
 			want: Config{Goarch: "arm64", GOARM64: "v8.2,lse,crypto"},
@@ -71,12 +88,12 @@ func TestResolveGOARCHConfig(t *testing.T) {
 		},
 		{
 			name: "unrelated architecture",
-			conf: Config{Goarch: "wasm", GO386: "softfloat", GOAMD64: "v4", GOARM64: "v9.5"},
+			conf: Config{Goarch: "wasm", GO386: "softfloat", GOAMD64: "v4", GOARM: "5", GOARM64: "v9.5"},
 			want: Config{Goarch: "wasm"},
 		},
 		{
 			name: "named target ignores architecture environment",
-			conf: Config{Goarch: "amd64", GOAMD64: "v4", Target: "wasi"},
+			conf: Config{Goarch: "amd64", GOAMD64: "v4", GOARM: "5", Target: "wasi"},
 			want: Config{Goarch: "amd64", Target: "wasi"},
 		},
 	}
@@ -94,13 +111,17 @@ func TestResolveGOARCHConfig(t *testing.T) {
 }
 
 func TestResolveBuildConfigInvalidGOARCHValueIsAtomic(t *testing.T) {
-	input := &Config{Goarch: "amd64", GOAMD64: "v5", GoBuildFlags: []string{"-tags=keep"}}
-	want := input.clone()
-	if _, err := resolveBuildConfig(input); err == nil {
-		t.Fatal("resolveBuildConfig succeeded with GOAMD64=v5")
-	}
-	if !reflect.DeepEqual(input, want) {
-		t.Fatalf("input changed on error:\n got %+v\nwant %+v", input, want)
+	for _, input := range []*Config{
+		{Goarch: "amd64", GOAMD64: "v5", GoBuildFlags: []string{"-tags=keep"}},
+		{Goarch: "arm", GOARM: "8", GoBuildFlags: []string{"-tags=keep"}},
+	} {
+		want := input.clone()
+		if _, err := resolveBuildConfig(input); err == nil {
+			t.Fatalf("resolveBuildConfig succeeded with %+v", input)
+		}
+		if !reflect.DeepEqual(input, want) {
+			t.Fatalf("input changed on error:\n got %+v\nwant %+v", input, want)
+		}
 	}
 }
 
@@ -110,9 +131,10 @@ func TestGOARCHEnv(t *testing.T) {
 		want []string
 	}{
 		{},
-		{conf: &Config{Goarch: "386", GO386: "softfloat"}, want: []string{"GO386=softfloat", "GOAMD64=", "GOARM64="}},
-		{conf: &Config{Goarch: "amd64", GOAMD64: "v4"}, want: []string{"GO386=", "GOAMD64=v4", "GOARM64="}},
-		{conf: &Config{Goarch: "arm64", GOARM64: "v9.5,lse,crypto"}, want: []string{"GO386=", "GOAMD64=", "GOARM64=v9.5,lse,crypto"}},
+		{conf: &Config{Goarch: "386", GO386: "softfloat"}, want: []string{"GO386=softfloat", "GOAMD64=", "GOARM=", "GOARM64="}},
+		{conf: &Config{Goarch: "amd64", GOAMD64: "v4"}, want: []string{"GO386=", "GOAMD64=v4", "GOARM=", "GOARM64="}},
+		{conf: &Config{Goarch: "arm", GOARM: "6,softfloat"}, want: []string{"GO386=", "GOAMD64=", "GOARM=6,softfloat", "GOARM64="}},
+		{conf: &Config{Goarch: "arm64", GOARM64: "v9.5,lse,crypto"}, want: []string{"GO386=", "GOAMD64=", "GOARM=", "GOARM64=v9.5,lse,crypto"}},
 		{conf: &Config{Goarch: "amd64", Target: "wasi"}},
 	}
 	for _, test := range tests {
@@ -149,6 +171,13 @@ func TestGOARCHConfigSeparatesCacheFingerprints(t *testing.T) {
 			right:      &Config{Goos: "windows", Goarch: "amd64", GOAMD64: "v4"},
 			leftEntry:  "GOAMD64: v1",
 			rightEntry: "GOAMD64: v4",
+		},
+		{
+			name:       "GOARM",
+			left:       &Config{Goos: "linux", Goarch: "arm", GOARM: "7"},
+			right:      &Config{Goos: "linux", Goarch: "arm", GOARM: "6,softfloat"},
+			leftEntry:  "GOARM: \"7\"",
+			rightEntry: "GOARM: 6,softfloat",
 		},
 		{
 			name:       "GOARM64",

--- a/internal/build/link_options.go
+++ b/internal/build/link_options.go
@@ -115,18 +115,20 @@ func validateLinkOptions(conf *Config, target *crosscompile.Export) error {
 	return nil
 }
 
-// dwarfLinkerArgs asks the native linker not to copy debug information from
-// input objects into the final artifact. LLGo-generated DWARF is disabled
-// earlier; this handles debug sections in native and prebuilt inputs without
-// rewriting the linked binary afterward.
-func dwarfLinkerArgs(conf *Config, target *crosscompile.Export) []string {
-	if target.DebugInfo.AlwaysOmit || !effectiveOmitDWARF(conf, target) {
+// debugInfoLinkerArgs asks the native linker to preserve or omit debug
+// information consistently with the compile-time policy. Some linkers, such
+// as lld-link, discard DWARF unless preservation is requested explicitly.
+func debugInfoLinkerArgs(conf *Config, target *crosscompile.Export) []string {
+	if target.DebugInfo.AlwaysOmit {
 		return nil
 	}
-	// c-archive has no final native link step. Omitting generated DWARF is
-	// sufficient; consumers decide how to link the archive later.
+	// c-archive has no final native link step. Consumers decide how to link
+	// debug information from archive members later.
 	if conf.BuildMode == BuildModeCArchive {
 		return nil
 	}
-	return slices.Clone(target.DebugInfo.OmitLinkFlags)
+	if effectiveOmitDWARF(conf, target) {
+		return slices.Clone(target.DebugInfo.OmitLinkFlags)
+	}
+	return slices.Clone(target.DebugInfo.PreserveLinkFlags)
 }

--- a/internal/build/link_options_test.go
+++ b/internal/build/link_options_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/xgo-dev/llgo/xtool/env/llvm"
 )
 
-func TestDwarfLinkerArgs(t *testing.T) {
+func TestDebugInfoLinkerArgs(t *testing.T) {
 	tests := []struct {
 		name   string
 		conf   Config
@@ -48,12 +48,16 @@ func TestDwarfLinkerArgs(t *testing.T) {
 		{name: "w", conf: Config{LinkOptions: LinkOptions{DWARF: DWARFOmit}}, target: configurableDebugInfo(), want: []string{"-Wl,-S"}},
 		{name: "s implies w", conf: Config{LinkOptions: LinkOptions{OmitSymbolTable: true}}, target: configurableDebugInfo(), want: []string{"-Wl,-S"}},
 		{name: "explicit w false", conf: Config{LinkOptions: LinkOptions{OmitSymbolTable: true, DWARF: DWARFPreserve}}},
+		{name: "windows safe default", conf: Config{BuildMode: BuildModeExe, OmitDWARFByDefault: true}, target: windowsDebugInfo(), want: []string{"-Wl,/debug:none"}},
+		{name: "windows explicit w", conf: Config{BuildMode: BuildModeExe, LinkOptions: LinkOptions{DWARF: DWARFOmit}}, target: windowsDebugInfo(), want: []string{"-Wl,/debug:none"}},
+		{name: "windows explicit w false", conf: Config{BuildMode: BuildModeExe, LinkOptions: LinkOptions{DWARF: DWARFPreserve}}, target: windowsDebugInfo(), want: []string{"-Wl,/debug:dwarf"}},
+		{name: "windows c-archive", conf: Config{BuildMode: BuildModeCArchive, LinkOptions: LinkOptions{DWARF: DWARFPreserve}}, target: windowsDebugInfo()},
 		{name: "target linker already suppresses DWARF", conf: Config{Target: "rp2040", LinkOptions: LinkOptions{DWARF: DWARFOmit}}, target: alwaysOmitDebugInfo()},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := dwarfLinkerArgs(&tt.conf, &tt.target); !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("dwarfLinkerArgs(%+v) = %v, want %v", tt.conf.LinkOptions, got, tt.want)
+			if got := debugInfoLinkerArgs(&tt.conf, &tt.target); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("debugInfoLinkerArgs(%+v) = %v, want %v", tt.conf.LinkOptions, got, tt.want)
 			}
 		})
 	}
@@ -126,6 +130,9 @@ func TestValidateLinkOptions(t *testing.T) {
 		{name: "c-shared safe default", conf: Config{Goos: "linux", BuildMode: BuildModeCShared, OmitDWARFByDefault: true}, target: configurableDebugInfo()},
 		{name: "c-archive safe default", conf: Config{Goos: "linux", BuildMode: BuildModeCArchive, OmitDWARFByDefault: true}, target: configurableDebugInfo()},
 		{name: "unsupported native OS", conf: Config{Goos: "windows", BuildMode: BuildModeExe, LinkOptions: w}, wantErr: true},
+		{name: "windows safe default", conf: Config{Goos: "windows", BuildMode: BuildModeExe, OmitDWARFByDefault: true}, target: windowsDebugInfo()},
+		{name: "windows omit", conf: Config{Goos: "windows", BuildMode: BuildModeExe, LinkOptions: w}, target: windowsDebugInfo()},
+		{name: "windows preserve", conf: Config{Goos: "windows", BuildMode: BuildModeExe, LinkOptions: wFalse}, target: windowsDebugInfo()},
 		{name: "c-shared omit", conf: Config{Goos: "linux", BuildMode: BuildModeCShared, LinkOptions: w}, target: configurableDebugInfo()},
 		{name: "c-archive omit", conf: Config{Goos: "linux", BuildMode: BuildModeCArchive, LinkOptions: w}, target: configurableDebugInfo()},
 		{name: "c-shared preserve", conf: Config{Goos: "linux", BuildMode: BuildModeCShared, LinkOptions: wFalse}, target: configurableDebugInfo()},
@@ -170,7 +177,7 @@ func TestDwarfLinkerArgsSuppressNativeInputDWARF(t *testing.T) {
 
 	conf := &Config{Goos: "linux", BuildMode: BuildModeExe, LinkOptions: LinkOptions{DWARF: DWARFOmit}}
 	target := configurableDebugInfo()
-	args := append(dwarfLinkerArgs(conf, &target), "-o", bin, object)
+	args := append(debugInfoLinkerArgs(conf, &target), "-o", bin, object)
 	if out, err := exec.Command(clang, args...).CombinedOutput(); err != nil {
 		t.Fatalf("link native fixture with DWARF omission: %v\n%s", err, out)
 	}
@@ -184,6 +191,13 @@ func TestDwarfLinkerArgsSuppressNativeInputDWARF(t *testing.T) {
 
 func configurableDebugInfo() crosscompile.Export {
 	return crosscompile.Export{DebugInfo: crosscompile.DebugInfoPolicy{OmitLinkFlags: []string{"-Wl,-S"}}}
+}
+
+func windowsDebugInfo() crosscompile.Export {
+	return crosscompile.Export{DebugInfo: crosscompile.DebugInfoPolicy{
+		OmitLinkFlags:     []string{"-Wl,/debug:none"},
+		PreserveLinkFlags: []string{"-Wl,/debug:dwarf"},
+	}}
 }
 
 func alwaysOmitDebugInfo() crosscompile.Export {

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -67,7 +67,7 @@ func compilePkgSFiles(ctx *context, aPkg *aPackage, pkg *packages.Package, verbo
 		if shouldSkipDarwinDynimportTrampolineAsm(skipDarwinDynimportTrampolines, sfile, src) {
 			continue
 		}
-		tr, err := llplan9asm.TranslateSourceModuleForPkg(pkg, sfile, src, ctx.buildConf.Goos, ctx.buildConf.Goarch)
+		tr, err := llplan9asm.TranslateSourceModuleForPkgWithOptions(pkg, sfile, src, ctx.buildConf.Goos, ctx.buildConf.Goarch, llplan9asm.TranslateOptions{GOARM: ctx.buildConf.GOARM})
 		if err != nil {
 			// Some stdlib .s files are comment-only placeholders (e.g. internal/cpu/cpu.s).
 			// Skip those silently.
@@ -261,7 +261,7 @@ func plan9asmSigsForPkg(ctx *context, pkgPath string) (map[string]struct{}, erro
 		if err != nil {
 			return nil, fmt.Errorf("%s: read %s: %w", pkg.PkgPath, sfile, err)
 		}
-		tr, err := llplan9asm.TranslateSourceForPkg(pkg, sfile, src, ctx.buildConf.Goos, ctx.buildConf.Goarch)
+		tr, err := llplan9asm.TranslateSourceForPkgWithOptions(pkg, sfile, src, ctx.buildConf.Goos, ctx.buildConf.Goarch, llplan9asm.TranslateOptions{GOARM: ctx.buildConf.GOARM})
 		if err != nil {
 			if strings.Contains(err.Error(), "no TEXT directive found") {
 				continue

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -4,6 +4,8 @@
 package build
 
 import (
+	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -148,6 +150,38 @@ func TestPlan9AsmEnabledInitializesSelectedPackages(t *testing.T) {
 	}
 	if !ctx.plan9asmReady || ctx.plan9asmMode != plan9asmEnvSelected || !ctx.plan9asmPkgs["example.com/second"] {
 		t.Fatalf("prepared Plan 9 assembly policy = mode %v, packages %v", ctx.plan9asmMode, ctx.plan9asmPkgs)
+	}
+}
+
+func TestPlan9AsmSigsForConfiguredARMTarget(t *testing.T) {
+	const pkgPath = "example.com/armasm"
+	typesPkg := types.NewPackage(pkgPath, "armasm")
+	sig := types.NewSignatureType(nil, nil, nil, types.NewTuple(), types.NewTuple(), false)
+	if old := typesPkg.Scope().Insert(types.NewFunc(token.NoPos, typesPkg, "Foo", sig)); old != nil {
+		t.Fatalf("insert Foo: replaced %v", old)
+	}
+	pkg := &packages.Package{ID: pkgPath, PkgPath: pkgPath, Types: typesPkg}
+	asmPath := filepath.Join(t.TempDir(), "foo_arm.s")
+	ctx := &context{
+		buildConf: &Config{
+			Goos:    "linux",
+			Goarch:  "arm",
+			GOARM:   "6,softfloat",
+			Overlay: map[string][]byte{asmPath: []byte("TEXT ·Foo(SB),NOSPLIT,$0-0\n\tRET\n")},
+		},
+		pkgs:          map[*packages.Package]Package{pkg: nil},
+		sfilesCache:   map[string][]string{pkg.ID: {asmPath}},
+		sfilesFrozen:  true,
+		plan9asmReady: true,
+		plan9asmMode:  plan9asmEnvAll,
+	}
+
+	sigs, err := plan9asmSigsForPkg(ctx, pkgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := sigs[pkgPath+".Foo"]; !ok {
+		t.Fatalf("signatures = %v, want %s.Foo", sigs, pkgPath)
 	}
 }
 

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -387,6 +387,7 @@ func (p *Transformer) transformFunc(m llvm.Module, fn llvm.Value) bool {
 		nfn.AddAttributeAtIndex(1, preloweredSRet)
 	}
 	nfn.SetLinkage(fn.Linkage())
+	nfn.SetComdat(fn.Comdat())
 	nfn.SetFunctionCallConv(fn.FunctionCallConv())
 	for _, attr := range fn.GetFunctionAttributes() {
 		nfn.AddAttributeAtIndex(-1, attr)
@@ -696,7 +697,7 @@ func (p *Transformer) transformCallbackFunc(m llvm.Module, fn llvm.Value) (wrap 
 		return wrapFunc, true
 	}
 	wrapFunc := llvm.AddFunction(m, wrapName, nft)
-	wrapFunc.SetLinkage(llvm.LinkOnceAnyLinkage)
+	p.setODRLinkage(m, wrapFunc, llvm.LinkOnceAnyLinkage)
 	wrapFunc.AddFunctionAttr(funcInlineHint(ctx))
 
 	for i, attr := range attrs {
@@ -772,6 +773,20 @@ func (p *Transformer) transformCallbackFunc(m llvm.Module, fn llvm.Value) (wrap 
 		b.CreateRet(ret)
 	}
 	return wrapFunc, true
+}
+
+// setODRLinkage gives multiply emitted definitions the COMDAT metadata that
+// COFF linkers require. LLVM weak/linkonce linkage alone becomes a weak
+// external fallback in COFF, which lld-link cannot coalesce across objects.
+func (p *Transformer) setODRLinkage(m llvm.Module, value llvm.Value, linkage llvm.Linkage) {
+	value.SetLinkage(linkage)
+	target := p.prog.Target()
+	if target == nil || target.GOOS != "windows" {
+		return
+	}
+	comdat := m.Comdat(value.Name())
+	comdat.SetSelectionKind(llvm.AnyComdatSelectionKind)
+	value.SetComdat(comdat)
 }
 
 var closureEnvAttributeKinds = []uint{

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -235,6 +235,90 @@ entry:
 	}
 }
 
+func TestCABILoweringPreservesWindowsCOMDAT(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := ctx.NewModule("windows-comdat")
+	defer mod.Dispose()
+	aggregate := ctx.StructType([]llvm.Type{
+		ctx.Int64Type(), ctx.Int64Type(), ctx.Int64Type(),
+	}, false)
+	fn := llvm.AddFunction(mod, "shared", llvm.FunctionType(
+		ctx.VoidType(), []llvm.Type{aggregate}, false,
+	))
+	fn.SetLinkage(llvm.LinkOnceODRLinkage)
+	comdat := mod.Comdat(fn.Name())
+	comdat.SetSelectionKind(llvm.AnyComdatSelectionKind)
+	fn.SetComdat(comdat)
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	b.SetInsertPointAtEnd(ctx.AddBasicBlock(fn, "entry"))
+	b.CreateRetVoid()
+
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "windows", GOARCH: "amd64"})
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "amd64-unknown-linux-gnu", "", ModeAllFunc, true)
+	tr.TransformModule("test", mod)
+
+	got := mod.NamedFunction("shared")
+	ir := got.String()
+	if !strings.Contains(ir, "ptr") {
+		t.Fatalf("C ABI did not lower the aggregate parameter:\n%s", ir)
+	}
+	if !strings.Contains(ir, "comdat") {
+		t.Fatalf("C ABI lowering lost Windows COMDAT metadata:\n%s", ir)
+	}
+	if kind := got.Comdat().SelectionKind(); kind != llvm.AnyComdatSelectionKind {
+		t.Fatalf("C ABI COMDAT selection = %v, want any", kind)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("transformed Windows COMDAT module is invalid: %v\n%s", err, mod.String())
+	}
+}
+
+func TestWindowsCallbackWrapperUsesCOMDAT(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := ctx.NewModule("windows-callback-comdat")
+	defer mod.Dispose()
+	aggregate := ctx.StructType([]llvm.Type{
+		ctx.Int64Type(), ctx.Int64Type(), ctx.Int64Type(),
+	}, false)
+	callback := llvm.AddFunction(mod, "callback", llvm.FunctionType(
+		ctx.VoidType(), []llvm.Type{aggregate}, false,
+	))
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	b.SetInsertPointAtEnd(ctx.AddBasicBlock(callback, "entry"))
+	b.CreateRetVoid()
+
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "windows", GOARCH: "amd64"})
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "amd64-unknown-linux-gnu", "", ModeAllFunc, true)
+	wrapper, ok := tr.transformCallbackFunc(mod, callback)
+	if !ok {
+		t.Fatalf("callback wrapper was not required:\n%s", mod.String())
+	}
+	ir := wrapper.String()
+	if !strings.Contains(ir, "comdat") {
+		t.Fatalf("Windows callback wrapper lacks COMDAT metadata:\n%s", ir)
+	}
+	if kind := wrapper.Comdat().SelectionKind(); kind != llvm.AnyComdatSelectionKind {
+		t.Fatalf("Windows callback COMDAT selection = %v, want any", kind)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("Windows callback COMDAT module is invalid: %v\n%s", err, mod.String())
+	}
+}
+
 func TestSetSkipFuncsAndShouldSkipCall(t *testing.T) {
 	tr := &Transformer{}
 	tr.SetSkipFuncs([]string{" foo ", "", "bar"})

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -272,8 +272,8 @@ func nativeWindowsSectionFlags() (ccflags, ldflags []string) {
 	return
 }
 
-func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
-	targetTriple := llvm.GetTargetTriple(goos, goarch)
+func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
+	targetTriple := llvm.GetTargetTripleWithGOARM(goos, goarch, goarm)
 	llgoRoot := env.LLGoROOT()
 
 	// Check for ESP Clang support for target-based builds
@@ -766,8 +766,15 @@ func UseTarget(targetName string, level optlevel.Level, ltoMode lto.Mode) (expor
 // Use extends the original Use function to support target-based configuration
 // If targetName is provided, it takes precedence over goos/goarch
 func Use(goos, goarch, targetName string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
+	return UseWithGOARM(goos, goarch, "", targetName, wasiThreads, forceEspClang, level, ltoMode, goGlobalDCE)
+}
+
+// UseWithGOARM is Use with an explicit Go ARM architecture setting. The
+// setting affects native GOARCH=arm clang and linker triples; named targets
+// retain their target configuration's LLVM triple.
+func UseWithGOARM(goos, goarch, goarm, targetName string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
 	if targetName != "" && !strings.HasPrefix(targetName, "wasm") && !strings.HasPrefix(targetName, "wasi") {
 		return UseTarget(targetName, level, ltoMode)
 	}
-	return use(goos, goarch, wasiThreads, forceEspClang, level, ltoMode, goGlobalDCE)
+	return use(goos, goarch, goarm, wasiThreads, forceEspClang, level, ltoMode, goGlobalDCE)
 }

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -295,6 +295,36 @@ func nativeSectionFlags(goos string) (ccflags, ldflags []string) {
 	}
 }
 
+// configureNativeTargetFlags configures clang and the native-format linker for
+// a Go operating-system target. The target may differ from the host; SDK and
+// host-library discovery remain the caller's responsibility.
+func configureNativeTargetFlags(export *Export, goos, targetTriple string, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) {
+	export.DebugInfo = nativeDebugInfoPolicy(goos)
+	export.LDFLAGS = []string{
+		"-target", targetTriple,
+		"-Qunused-arguments",
+		"-Wno-unused-command-line-argument",
+	}
+	export.LDFLAGS = append(export.LDFLAGS, nativeLLDFlags(goos, level, ltoMode)...)
+	export.CCFLAGS = []string{
+		level.Flag(),
+		"-target", targetTriple,
+		"-Qunused-arguments",
+		"-Wno-unused-command-line-argument",
+		// Keep frame pointers in C code too: the runtime's physical
+		// unwinder walks fault-site chains through C frames (Go keeps
+		// them via the "frame-pointer"="non-leaf" attribute; x86-64 C
+		// would omit them at -O by default).
+		"-fno-omit-frame-pointer",
+	}
+	if ltoMode.Enabled() {
+		export.CCFLAGS = append(export.CCFLAGS, ltoMode.ClangFlag())
+	}
+	if ltoMode == lto.Full && goGlobalDCE {
+		export.CCFLAGS = append(export.CCFLAGS, "-fvirtual-function-elimination", "-fwhole-program-vtables")
+	}
+}
+
 func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
 	targetTriple := llvm.GetTargetTripleWithGOARM(goos, goarch, goarm)
 	llgoRoot := env.LLGoROOT()
@@ -313,61 +343,41 @@ func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optl
 		export.CC = "clang++"
 	}
 
-	if runtime.GOOS == goos && runtime.GOARCH == goarch {
-		export.DebugInfo = nativeDebugInfoPolicy(goos)
-		// not cross compile
-		// Set up basic flags for non-cross-compile
-		export.LDFLAGS = []string{
-			"-target", targetTriple,
-			"-Qunused-arguments",
-			"-Wno-unused-command-line-argument",
-		}
-		export.LDFLAGS = append(export.LDFLAGS, nativeLLDFlags(goos, level, ltoMode)...)
-		if clangRoot != "" {
-			clangLib := filepath.Join(clangRoot, "lib")
-			clangInc := filepath.Join(clangRoot, "include")
-			export.CFLAGS = append(export.CFLAGS, "-I"+clangInc)
-			export.LDFLAGS = append(export.LDFLAGS, "-L"+clangLib)
-			// Add platform-specific rpath flags
-			switch goos {
-			case "darwin":
-				export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
-			case "linux":
-				export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
-			case "windows":
-				// Windows doesn't support rpath, DLLs should be in PATH or same directory
-			default:
-				// For other Unix-like systems, try the generic rpath
-				export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
+	nativeHost := runtime.GOOS == goos && runtime.GOARCH == goarch
+	if nativeHost || goos == "windows" {
+		// Windows uses the same explicit MSVC/COFF target configuration for
+		// native and cross builds. Other native GOOS targets retain their
+		// existing host-only support.
+		configureNativeTargetFlags(&export, goos, targetTriple, level, ltoMode, goGlobalDCE)
+		if nativeHost {
+			if clangRoot != "" {
+				clangLib := filepath.Join(clangRoot, "lib")
+				clangInc := filepath.Join(clangRoot, "include")
+				export.CFLAGS = append(export.CFLAGS, "-I"+clangInc)
+				export.LDFLAGS = append(export.LDFLAGS, "-L"+clangLib)
+				// Add platform-specific rpath flags
+				switch goos {
+				case "darwin":
+					export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
+				case "linux":
+					export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
+				case "windows":
+					// Windows doesn't support rpath, DLLs should be in PATH or same directory
+				default:
+					// For other Unix-like systems, try the generic rpath
+					export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
+				}
 			}
-		}
-		export.CCFLAGS = []string{
-			level.Flag(),
-			"-target", targetTriple,
-			"-Qunused-arguments",
-			"-Wno-unused-command-line-argument",
-			// Keep frame pointers in C code too: the runtime's physical
-			// unwinder walks fault-site chains through C frames (Go keeps
-			// them via the "frame-pointer"="non-leaf" attribute; x86-64 C
-			// would omit them at -O by default).
-			"-fno-omit-frame-pointer",
-		}
-		if ltoMode.Enabled() {
-			export.CCFLAGS = append(export.CCFLAGS, ltoMode.ClangFlag())
-		}
-		if ltoMode == lto.Full && goGlobalDCE {
-			export.CCFLAGS = append(export.CCFLAGS, "-fvirtual-function-elimination", "-fwhole-program-vtables")
-		}
-
-		// Add sysroot for macOS only
-		if goos == "darwin" {
-			sysrootPath, sysrootErr := getMacOSSysroot()
-			if sysrootErr != nil {
-				err = fmt.Errorf("failed to get macOS SDK path: %w", sysrootErr)
-				return
+			// Add sysroot for macOS only.
+			if goos == "darwin" {
+				sysrootPath, sysrootErr := getMacOSSysroot()
+				if sysrootErr != nil {
+					err = fmt.Errorf("failed to get macOS SDK path: %w", sysrootErr)
+					return
+				}
+				export.CCFLAGS = append(export.CCFLAGS, "--sysroot="+sysrootPath)
+				export.LDFLAGS = append(export.LDFLAGS, "--sysroot="+sysrootPath)
 			}
-			export.CCFLAGS = append(export.CCFLAGS, []string{"--sysroot=" + sysrootPath}...)
-			export.LDFLAGS = append(export.LDFLAGS, []string{"--sysroot=" + sysrootPath}...)
 		}
 
 		ccflags, ldflags := nativeSectionFlags(goos)

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -51,14 +51,20 @@ type Export struct {
 // Build orchestration consumes this typed capability instead of inferring it
 // from a target name or linker executable.
 type DebugInfoPolicy struct {
-	AlwaysOmit    bool
-	OmitLinkFlags []string
+	AlwaysOmit        bool
+	OmitLinkFlags     []string
+	PreserveLinkFlags []string
 }
 
 func nativeDebugInfoPolicy(goos string) DebugInfoPolicy {
 	switch goos {
 	case "darwin", "linux":
 		return DebugInfoPolicy{OmitLinkFlags: []string{"-Wl,-S"}}
+	case "windows":
+		return DebugInfoPolicy{
+			OmitLinkFlags:     []string{"-Wl,/debug:none"},
+			PreserveLinkFlags: []string{"-Wl,/debug:dwarf"},
+		}
 	default:
 		return DebugInfoPolicy{}
 	}

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -268,10 +268,25 @@ func coffLTOLevel(level optlevel.Level) string {
 	}
 }
 
-func nativeWindowsSectionFlags() (ccflags, ldflags []string) {
-	ccflags = []string{"-fdata-sections", "-ffunction-sections"}
-	ldflags = []string{"-fdata-sections", "-ffunction-sections", "-Wl,/opt:ref"}
-	return
+func nativeSectionFlags(goos string) (ccflags, ldflags []string) {
+	switch goos {
+	case "darwin":
+		return nil, []string{"-Xlinker", "-dead_strip"}
+	case "windows":
+		return []string{"-fdata-sections", "-ffunction-sections"},
+			[]string{"-fdata-sections", "-ffunction-sections", "-Wl,/opt:ref"}
+	default:
+		return []string{"-fdata-sections", "-ffunction-sections"}, []string{
+			"-fdata-sections",
+			"-ffunction-sections",
+			"-Xlinker",
+			"--gc-sections",
+			"-latomic",
+			// libpthread & libdl is built-in since glibc 2.34 (2021-08-01); we need to support earlier versions.
+			"-lpthread",
+			"-ldl",
+		}
+	}
 }
 
 func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
@@ -349,35 +364,9 @@ func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optl
 			export.LDFLAGS = append(export.LDFLAGS, []string{"--sysroot=" + sysrootPath}...)
 		}
 
-		// Add OS-specific flags
-		switch goos {
-		case "darwin": // ld64.lld (macOS)
-			export.LDFLAGS = append(
-				export.LDFLAGS,
-				"-Xlinker", "-dead_strip",
-			)
-		case "windows": // lld-link (Windows)
-			ccflags, ldflags := nativeWindowsSectionFlags()
-			export.CCFLAGS = append(export.CCFLAGS, ccflags...)
-			export.LDFLAGS = append(export.LDFLAGS, ldflags...)
-		default: // ld.lld (Unix)
-			export.CCFLAGS = append(
-				export.CCFLAGS,
-				"-fdata-sections",
-				"-ffunction-sections",
-			)
-			export.LDFLAGS = append(
-				export.LDFLAGS,
-				"-fdata-sections",
-				"-ffunction-sections",
-				"-Xlinker",
-				"--gc-sections",
-				"-latomic",
-				// libpthread & libdl is built-in since glibc 2.34 (2021-08-01); we need to support earlier versions.
-				"-lpthread",
-				"-ldl",
-			)
-		}
+		ccflags, ldflags := nativeSectionFlags(goos)
+		export.CCFLAGS = append(export.CCFLAGS, ccflags...)
+		export.LDFLAGS = append(export.LDFLAGS, ldflags...)
 		return
 	}
 	if goarch != "wasm" {

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -142,7 +142,7 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 	}
 
 	// Try to download ESP Clang if platform is supported
-	platformSuffix := getESPClangPlatform(runtime.GOOS, runtime.GOARCH)
+	platformSuffix := getESPClangHostPlatform(runtime.GOOS, runtime.GOARCH)
 	if platformSuffix != "" {
 		cacheClangDir := filepath.Join(cacheRoot(), "crosscompile", "esp-clang-"+espClangVersion)
 		if _, err = os.Stat(cacheClangDir); err != nil {
@@ -162,8 +162,11 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 	return
 }
 
-// getESPClangPlatform returns the platform suffix for ESP Clang downloads
-func getESPClangPlatform(goos, goarch string) string {
+// getESPClangHostPlatform returns the host-platform suffix of an ESP Clang
+// distribution. For example, x86_64-w64-mingw32 describes the ABI of the
+// downloaded compiler executable; it does not select the ABI of code that
+// compiler emits for LLGo's target triple.
+func getESPClangHostPlatform(goos, goarch string) string {
 	switch goos {
 	case "darwin":
 		switch goarch {

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -220,6 +220,58 @@ func compileWithConfig(
 	return
 }
 
+func nativeLLDFlags(goos string, level optlevel.Level, ltoMode lto.Mode) []string {
+	flags := []string{"-fuse-ld=lld"}
+	if goos == "windows" {
+		flags = append(flags,
+			"-Wl,/errorlimit:0",
+			// Go requires distinct functions to have distinct PCs. lld-link
+			// enables identical COMDAT folding through /opt:icf, so keep it
+			// disabled even when other dead-code elimination is enabled.
+			"-Wl,/opt:noicf",
+		)
+	} else {
+		flags = append(flags,
+			"-Wl,--error-limit=0",
+			// lld's safe mode still folds llgo-emitted same-body functions.
+			"-Wl,--icf=none",
+		)
+	}
+	if !ltoMode.Enabled() {
+		return flags
+	}
+
+	flags = append(flags, ltoMode.ClangFlag())
+	if goos == "windows" {
+		flags = append(flags, "-Wl,/opt:lldlto="+coffLTOLevel(level))
+	} else {
+		flags = append(flags, "-Wl,--lto"+level.Flag())
+	}
+	return flags
+}
+
+func coffLTOLevel(level optlevel.Level) string {
+	switch level {
+	case optlevel.O0:
+		return "0"
+	case optlevel.O1:
+		return "1"
+	case optlevel.O3:
+		return "3"
+	default:
+		// lld-link accepts only 0 through 3. -Os and -Oz are preserved in
+		// the input IR through optsize/minsize attributes; use its normal
+		// optimization pipeline for the link-wide setting.
+		return "2"
+	}
+}
+
+func nativeWindowsSectionFlags() (ccflags, ldflags []string) {
+	ccflags = []string{"-fdata-sections", "-ffunction-sections"}
+	ldflags = []string{"-fdata-sections", "-ffunction-sections", "-Wl,/opt:ref"}
+	return
+}
+
 func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
 	targetTriple := llvm.GetTargetTriple(goos, goarch)
 	llgoRoot := env.LLGoROOT()
@@ -246,17 +298,8 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 			"-target", targetTriple,
 			"-Qunused-arguments",
 			"-Wno-unused-command-line-argument",
-			"-Wl,--error-limit=0",
-			"-fuse-ld=lld",
-			// ICF stays off: Go semantics require distinct functions to
-			// have distinct pcs (FuncForPC names, function-value identity —
-			// goroot fixedbugs/issue58300). lld's safe mode still folds
-			// llgo-emitted same-body functions, and gc never folds.
-			"-Wl,--icf=none",
 		}
-		if ltoMode.Enabled() {
-			export.LDFLAGS = append(export.LDFLAGS, ltoMode.ClangFlag(), "-Wl,--lto"+level.Flag())
-		}
+		export.LDFLAGS = append(export.LDFLAGS, nativeLLDFlags(goos, level, ltoMode)...)
 		if clangRoot != "" {
 			clangLib := filepath.Join(clangRoot, "lib")
 			clangInc := filepath.Join(clangRoot, "include")
@@ -312,7 +355,9 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 				"-Xlinker", "-dead_strip",
 			)
 		case "windows": // lld-link (Windows)
-			// TODO(lijie): Add options for Windows.
+			ccflags, ldflags := nativeWindowsSectionFlags()
+			export.CCFLAGS = append(export.CCFLAGS, ccflags...)
+			export.LDFLAGS = append(export.LDFLAGS, ldflags...)
 		default: // ld.lld (Unix)
 			export.CCFLAGS = append(
 				export.CCFLAGS,

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -325,6 +325,19 @@ func configureNativeTargetFlags(export *Export, goos, targetTriple string, level
 	}
 }
 
+func configureNativeClangRootFlags(export *Export, goos, clangRoot string) {
+	if clangRoot == "" {
+		return
+	}
+	clangLib := filepath.Join(clangRoot, "lib")
+	clangInc := filepath.Join(clangRoot, "include")
+	export.CFLAGS = append(export.CFLAGS, "-I"+clangInc)
+	export.LDFLAGS = append(export.LDFLAGS, "-L"+clangLib)
+	if goos != "windows" {
+		export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
+	}
+}
+
 func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
 	targetTriple := llvm.GetTargetTripleWithGOARM(goos, goarch, goarm)
 	llgoRoot := env.LLGoROOT()
@@ -350,24 +363,7 @@ func use(goos, goarch, goarm string, wasiThreads, forceEspClang bool, level optl
 		// existing host-only support.
 		configureNativeTargetFlags(&export, goos, targetTriple, level, ltoMode, goGlobalDCE)
 		if nativeHost {
-			if clangRoot != "" {
-				clangLib := filepath.Join(clangRoot, "lib")
-				clangInc := filepath.Join(clangRoot, "include")
-				export.CFLAGS = append(export.CFLAGS, "-I"+clangInc)
-				export.LDFLAGS = append(export.LDFLAGS, "-L"+clangLib)
-				// Add platform-specific rpath flags
-				switch goos {
-				case "darwin":
-					export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
-				case "linux":
-					export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
-				case "windows":
-					// Windows doesn't support rpath, DLLs should be in PATH or same directory
-				default:
-					// For other Unix-like systems, try the generic rpath
-					export.LDFLAGS = append(export.LDFLAGS, "-Wl,-rpath,"+clangLib)
-				}
-			}
+			configureNativeClangRootFlags(&export, goos, clangRoot)
 			// Add sysroot for macOS only.
 			if goos == "darwin" {
 				sysrootPath, sysrootErr := getMacOSSysroot()

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -245,6 +245,8 @@ func nativeLLDFlags(goos string, level optlevel.Level, ltoMode lto.Mode) []strin
 	if goos == "windows" {
 		flags = append(flags, "-Wl,/opt:lldlto="+coffLTOLevel(level))
 	} else {
+		// ld.lld accepts the size-oriented --lto-Os/--lto-Oz spellings;
+		// lld-link accepts only the numeric levels mapped above.
 		flags = append(flags, "-Wl,--lto"+level.Flag())
 	}
 	return flags

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -394,6 +394,105 @@ func TestOptimizationFlagPlacement(t *testing.T) {
 	}
 }
 
+func TestNativeWindowsLLDFlags(t *testing.T) {
+	flags := nativeLLDFlags("windows", optlevel.O2, lto.Off)
+	for _, want := range []string{
+		"-fuse-ld=lld",
+		"-Wl,/errorlimit:0",
+		"-Wl,/opt:noicf",
+	} {
+		if !slices.Contains(flags, want) {
+			t.Errorf("native Windows LLD flags = %v, want %q", flags, want)
+		}
+	}
+	for _, unwanted := range []string{"-Wl,--error-limit=0", "-Wl,--icf=none"} {
+		if slices.Contains(flags, unwanted) {
+			t.Errorf("native Windows LLD flags = %v, do not want %q", flags, unwanted)
+		}
+	}
+
+	thin := nativeLLDFlags("windows", optlevel.O3, lto.Thin)
+	for _, want := range []string{"-flto=thin", "-Wl,/opt:lldlto=3"} {
+		if !slices.Contains(thin, want) {
+			t.Errorf("native Windows ThinLTO flags = %v, want %q", thin, want)
+		}
+	}
+	if slices.Contains(thin, "-Wl,--lto-O3") {
+		t.Errorf("native Windows ThinLTO flags = %v, contain ELF LTO syntax", thin)
+	}
+}
+
+func TestCOFFLTOLevel(t *testing.T) {
+	for _, tt := range []struct {
+		level optlevel.Level
+		want  string
+	}{
+		{optlevel.O0, "0"},
+		{optlevel.O1, "1"},
+		{optlevel.O2, "2"},
+		{optlevel.O3, "3"},
+		{optlevel.Os, "2"},
+		{optlevel.Oz, "2"},
+	} {
+		if got := coffLTOLevel(tt.level); got != tt.want {
+			t.Errorf("coffLTOLevel(%s) = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}
+
+func TestNativeWindowsOSFlags(t *testing.T) {
+	ccflags, ldflags := nativeWindowsSectionFlags()
+
+	for _, want := range []string{"-fdata-sections", "-ffunction-sections"} {
+		if !slices.Contains(ccflags, want) {
+			t.Errorf("native Windows CCFLAGS = %v, want %q", ccflags, want)
+		}
+	}
+	for _, want := range []string{"-fdata-sections", "-ffunction-sections", "-Wl,/opt:ref"} {
+		if !slices.Contains(ldflags, want) {
+			t.Errorf("native Windows LDFLAGS = %v, want %q", ldflags, want)
+		}
+	}
+	for _, unwanted := range []string{"--gc-sections", "-latomic", "-lpthread", "-ldl"} {
+		if slices.Contains(ldflags, unwanted) {
+			t.Errorf("native Windows LDFLAGS = %v, do not want %q", ldflags, unwanted)
+		}
+	}
+}
+
+func TestNativeWindowsExportFlags(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("requires a native Windows host")
+	}
+
+	export, err := use("windows", runtime.GOARCH, false, false, optlevel.O2, lto.Thin, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"-Wl,/errorlimit:0",
+		"-Wl,/opt:noicf",
+		"-Wl,/opt:ref",
+		"-Wl,/opt:lldlto=2",
+	} {
+		if !slices.Contains(export.LDFLAGS, want) {
+			t.Errorf("native Windows LDFLAGS = %v, want %q", export.LDFLAGS, want)
+		}
+	}
+	for _, unwanted := range []string{
+		"-Wl,--error-limit=0",
+		"-Wl,--icf=none",
+		"--gc-sections",
+		"-latomic",
+		"-lpthread",
+		"-ldl",
+	} {
+		if slices.Contains(export.LDFLAGS, unwanted) {
+			t.Errorf("native Windows LDFLAGS = %v, do not want %q", export.LDFLAGS, unwanted)
+		}
+	}
+}
+
 func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 	export, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Off, false)
 	if err != nil {

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -81,7 +81,7 @@ func TestUseCrossCompileSDK(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := use(tc.goos, tc.goarch, false, false, optlevel.O2, lto.Off, false)
+			export, err := use(tc.goos, tc.goarch, "", false, false, optlevel.O2, lto.Off, false)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -465,7 +465,7 @@ func TestNativeWindowsExportFlags(t *testing.T) {
 		t.Skip("requires a native Windows host")
 	}
 
-	export, err := use("windows", runtime.GOARCH, false, false, optlevel.O2, lto.Thin, false)
+	export, err := use("windows", runtime.GOARCH, "", false, false, optlevel.O2, lto.Thin, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func TestNativeWindowsExportFlags(t *testing.T) {
 }
 
 func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
-	export, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Off, false)
+	export, err := use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2, lto.Off, false)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -509,7 +509,7 @@ func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 		}
 	}
 
-	thin, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Thin, false)
+	thin, err := use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2, lto.Thin, false)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -529,7 +529,7 @@ func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 		t.Fatalf("missing thin LTO linker opt flag: %v", thin.LDFLAGS)
 	}
 
-	full, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Full, false)
+	full, err := use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2, lto.Full, false)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -546,7 +546,7 @@ func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 		t.Fatalf("missing full LTO link driver flag: %v", full.LDFLAGS)
 	}
 
-	fullGlobalDCE, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Full, true)
+	fullGlobalDCE, err := use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2, lto.Full, true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -440,8 +440,36 @@ func TestCOFFLTOLevel(t *testing.T) {
 	}
 }
 
-func TestNativeWindowsOSFlags(t *testing.T) {
-	ccflags, ldflags := nativeWindowsSectionFlags()
+func TestNativeOSFlags(t *testing.T) {
+	for _, test := range []struct {
+		goos        string
+		wantCCFlags []string
+		wantLDFlags []string
+	}{
+		{goos: "darwin", wantLDFlags: []string{"-Xlinker", "-dead_strip"}},
+		{
+			goos:        "windows",
+			wantCCFlags: []string{"-fdata-sections", "-ffunction-sections"},
+			wantLDFlags: []string{"-fdata-sections", "-ffunction-sections", "-Wl,/opt:ref"},
+		},
+		{
+			goos:        "linux",
+			wantCCFlags: []string{"-fdata-sections", "-ffunction-sections"},
+			wantLDFlags: []string{"-fdata-sections", "-ffunction-sections", "-Xlinker", "--gc-sections", "-latomic", "-lpthread", "-ldl"},
+		},
+	} {
+		t.Run(test.goos, func(t *testing.T) {
+			ccflags, ldflags := nativeSectionFlags(test.goos)
+			if !slices.Equal(ccflags, test.wantCCFlags) {
+				t.Errorf("native %s CCFLAGS = %v, want %v", test.goos, ccflags, test.wantCCFlags)
+			}
+			if !slices.Equal(ldflags, test.wantLDFlags) {
+				t.Errorf("native %s LDFLAGS = %v, want %v", test.goos, ldflags, test.wantLDFlags)
+			}
+		})
+	}
+
+	ccflags, ldflags := nativeSectionFlags("windows")
 
 	for _, want := range []string{"-fdata-sections", "-ffunction-sections"} {
 		if !slices.Contains(ccflags, want) {

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -344,27 +344,29 @@ func TestUseWithTarget(t *testing.T) {
 		t.Error("Expected LDFLAGS to be set for native build")
 	}
 	wantDebugInfo := nativeDebugInfoPolicy(runtime.GOOS)
-	if export.DebugInfo.AlwaysOmit != wantDebugInfo.AlwaysOmit || !slices.Equal(export.DebugInfo.OmitLinkFlags, wantDebugInfo.OmitLinkFlags) {
+	if export.DebugInfo.AlwaysOmit != wantDebugInfo.AlwaysOmit ||
+		!slices.Equal(export.DebugInfo.OmitLinkFlags, wantDebugInfo.OmitLinkFlags) ||
+		!slices.Equal(export.DebugInfo.PreserveLinkFlags, wantDebugInfo.PreserveLinkFlags) {
 		t.Fatalf("native debug-info policy = %+v, want %+v", export.DebugInfo, wantDebugInfo)
 	}
 }
 
 func TestNativeDebugInfoPolicy(t *testing.T) {
 	tests := []struct {
-		goos      string
-		supported bool
+		goos     string
+		omit     []string
+		preserve []string
 	}{
-		{goos: "darwin", supported: true},
-		{goos: "linux", supported: true},
-		{goos: "windows"},
+		{goos: "darwin", omit: []string{"-Wl,-S"}},
+		{goos: "linux", omit: []string{"-Wl,-S"}},
+		{goos: "windows", omit: []string{"-Wl,/debug:none"}, preserve: []string{"-Wl,/debug:dwarf"}},
 		{goos: "freebsd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.goos, func(t *testing.T) {
 			policy := nativeDebugInfoPolicy(tt.goos)
-			got := !policy.AlwaysOmit && slices.Equal(policy.OmitLinkFlags, []string{"-Wl,-S"})
-			if got != tt.supported {
-				t.Fatalf("nativeDebugInfoPolicy(%q) = %+v, supported = %v", tt.goos, policy, got)
+			if policy.AlwaysOmit || !slices.Equal(policy.OmitLinkFlags, tt.omit) || !slices.Equal(policy.PreserveLinkFlags, tt.preserve) {
+				t.Fatalf("nativeDebugInfoPolicy(%q) = %+v, want omit=%v preserve=%v", tt.goos, policy, tt.omit, tt.preserve)
 			}
 		})
 	}

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -5,6 +5,7 @@ package crosscompile
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -487,6 +488,38 @@ func TestNativeOSFlags(t *testing.T) {
 		if slices.Contains(ldflags, unwanted) {
 			t.Errorf("native Windows LDFLAGS = %v, do not want %q", ldflags, unwanted)
 		}
+	}
+}
+
+func TestConfigureNativeClangRootFlags(t *testing.T) {
+	clangRoot := filepath.Join("toolchains", "clang")
+	clangLib := filepath.Join(clangRoot, "lib")
+	clangInc := filepath.Join(clangRoot, "include")
+	for _, test := range []struct {
+		goos        string
+		wantLDFlags []string
+	}{
+		{goos: "darwin", wantLDFlags: []string{"-L" + clangLib, "-Wl,-rpath," + clangLib}},
+		{goos: "linux", wantLDFlags: []string{"-L" + clangLib, "-Wl,-rpath," + clangLib}},
+		{goos: "freebsd", wantLDFlags: []string{"-L" + clangLib, "-Wl,-rpath," + clangLib}},
+		{goos: "windows", wantLDFlags: []string{"-L" + clangLib}},
+	} {
+		t.Run(test.goos, func(t *testing.T) {
+			export := Export{}
+			configureNativeClangRootFlags(&export, test.goos, clangRoot)
+			if want := []string{"-I" + clangInc}; !slices.Equal(export.CFLAGS, want) {
+				t.Errorf("native %s CFLAGS = %v, want %v", test.goos, export.CFLAGS, want)
+			}
+			if !slices.Equal(export.LDFLAGS, test.wantLDFlags) {
+				t.Errorf("native %s LDFLAGS = %v, want %v", test.goos, export.LDFLAGS, test.wantLDFlags)
+			}
+		})
+	}
+
+	export := Export{CFLAGS: []string{"existing-cflag"}, LDFLAGS: []string{"existing-ldflag"}}
+	configureNativeClangRootFlags(&export, "windows", "")
+	if !slices.Equal(export.CFLAGS, []string{"existing-cflag"}) || !slices.Equal(export.LDFLAGS, []string{"existing-ldflag"}) {
+		t.Fatalf("empty clang root changed flags: %+v", export)
 	}
 }
 

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -58,7 +58,7 @@ func TestUseCrossCompileSDK(t *testing.T) {
 		},
 		{
 			name:          "Unsupported Target",
-			goos:          "windows",
+			goos:          "plan9",
 			goarch:        "amd64",
 			expectSDK:     false, // Still false as it won't set up specific SDK
 			expectCCFlags: false, // No cross-compile specific flags
@@ -520,6 +520,53 @@ func TestNativeWindowsExportFlags(t *testing.T) {
 		if slices.Contains(export.LDFLAGS, unwanted) {
 			t.Errorf("native Windows LDFLAGS = %v, do not want %q", export.LDFLAGS, unwanted)
 		}
+	}
+}
+
+func TestCrossWindowsExportFlags(t *testing.T) {
+	goarch := "amd64"
+	if runtime.GOOS == "windows" && runtime.GOARCH == goarch {
+		goarch = "arm64"
+	}
+	targetTriple := llvm.GetTargetTriple("windows", goarch)
+	export, err := use("windows", goarch, "", false, false, optlevel.O2, lto.Thin, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !hasFlagValue(export.CCFLAGS, "-target", targetTriple) {
+		t.Errorf("cross-Windows CCFLAGS = %v, want -target %s", export.CCFLAGS, targetTriple)
+	}
+	if !hasFlagValue(export.LDFLAGS, "-target", targetTriple) {
+		t.Errorf("cross-Windows LDFLAGS = %v, want -target %s", export.LDFLAGS, targetTriple)
+	}
+	for _, want := range []string{
+		"-flto=thin",
+		"-Wl,/errorlimit:0",
+		"-Wl,/opt:noicf",
+		"-Wl,/opt:ref",
+		"-Wl,/opt:lldlto=2",
+	} {
+		if !slices.Contains(export.LDFLAGS, want) {
+			t.Errorf("cross-Windows LDFLAGS = %v, want %q", export.LDFLAGS, want)
+		}
+	}
+	for _, unwanted := range []string{
+		"-Wl,--error-limit=0",
+		"-Wl,--icf=none",
+		"--gc-sections",
+		"-latomic",
+		"-lpthread",
+		"-ldl",
+	} {
+		if slices.Contains(export.LDFLAGS, unwanted) {
+			t.Errorf("cross-Windows LDFLAGS = %v, do not want %q", export.LDFLAGS, unwanted)
+		}
+	}
+	wantDebugInfo := nativeDebugInfoPolicy("windows")
+	if !slices.Equal(export.DebugInfo.OmitLinkFlags, wantDebugInfo.OmitLinkFlags) ||
+		!slices.Equal(export.DebugInfo.PreserveLinkFlags, wantDebugInfo.PreserveLinkFlags) {
+		t.Errorf("cross-Windows debug-info policy = %+v, want %+v", export.DebugInfo, wantDebugInfo)
 	}
 }
 

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 // checkDownloadAndExtractWasiSDK downloads and extracts WASI SDK
@@ -133,22 +132,28 @@ func acquireLock(lockPath string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lock file: %w", err)
 	}
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+	if err := lockFileHandle(lockFile); err != nil {
 		lockFile.Close()
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
 	return lockFile, nil
 }
 
-// releaseLock unlocks and removes the lock file
+// releaseLock unlocks and closes the lock file. The file must remain in place:
+// removing it could let a new caller lock a different file while another caller
+// still holds the original one.
 func releaseLock(lockFile *os.File) error {
 	if lockFile == nil {
 		return nil
 	}
-	lockPath := lockFile.Name()
-	syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
-	lockFile.Close()
-	os.Remove(lockPath)
+	unlockErr := unlockFileHandle(lockFile)
+	closeErr := lockFile.Close()
+	if unlockErr != nil {
+		return fmt.Errorf("failed to release lock: %w", unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("failed to close lock file: %w", closeErr)
+	}
 	return nil
 }
 

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -123,6 +123,10 @@ func checkDownloadAndExtractLib(url, dstDir, internalArchiveSrcDir string) error
 
 // acquireLock creates and locks a file to prevent concurrent operations
 func acquireLock(lockPath string) (*os.File, error) {
+	return acquireLockWith(lockPath, lockFileHandle)
+}
+
+func acquireLockWith(lockPath string, lock func(*os.File) error) (*os.File, error) {
 	// Ensure the parent directory exists
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
 		return nil, fmt.Errorf("failed to create lock directory: %w", err)
@@ -132,7 +136,7 @@ func acquireLock(lockPath string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lock file: %w", err)
 	}
-	if err := lockFileHandle(lockFile); err != nil {
+	if err := lock(lockFile); err != nil {
 		lockFile.Close()
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
@@ -148,6 +152,10 @@ func releaseLock(lockFile *os.File) error {
 	}
 	unlockErr := unlockFileHandle(lockFile)
 	closeErr := lockFile.Close()
+	return lockReleaseError(unlockErr, closeErr)
+}
+
+func lockReleaseError(unlockErr, closeErr error) error {
 	if unlockErr != nil {
 		return fmt.Errorf("failed to release lock: %w", unlockErr)
 	}

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -133,8 +133,8 @@ func TestAcquireAndReleaseLockErrors(t *testing.T) {
 		if opened == nil {
 			t.Fatal("lock callback did not receive the opened file")
 		}
-		if _, err := opened.Stat(); !errors.Is(err, os.ErrClosed) {
-			t.Fatalf("failed lock file remained open: Stat error = %v", err)
+		if err := opened.Close(); err == nil {
+			t.Fatal("failed lock file remained open")
 		}
 	})
 

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -65,6 +65,10 @@ func createTestServer(t *testing.T, files map[string]string) *httptest.Server {
 }
 
 func TestAcquireAndReleaseLock(t *testing.T) {
+	if err := releaseLock(nil); err != nil {
+		t.Fatalf("releaseLock(nil) = %v, want nil", err)
+	}
+
 	tempDir := t.TempDir()
 	lockPath := filepath.Join(tempDir, "test.lock")
 

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -137,13 +137,35 @@ func TestAcquireAndReleaseLockErrors(t *testing.T) {
 			t.Fatal("failed lock file remained open")
 		}
 	})
+}
 
-	t.Run("close", func(t *testing.T) {
-		wantErr := errors.New("injected close failure")
-		if err := lockReleaseError(nil, wantErr); !errors.Is(err, wantErr) {
-			t.Fatalf("lockReleaseError = %v, want wrapped %v", err, wantErr)
-		}
-	})
+func TestLockReleaseError(t *testing.T) {
+	unlockErr := errors.New("unlock")
+	closeErr := errors.New("close")
+	for _, test := range []struct {
+		name      string
+		unlockErr error
+		closeErr  error
+		want      string
+	}{
+		{name: "success"},
+		{name: "unlock", unlockErr: unlockErr, want: "failed to release lock: unlock"},
+		{name: "close", closeErr: closeErr, want: "failed to close lock file: close"},
+		{name: "unlock takes precedence", unlockErr: unlockErr, closeErr: closeErr, want: "failed to release lock: unlock"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := lockReleaseError(test.unlockErr, test.closeErr)
+			if test.want == "" {
+				if err != nil {
+					t.Fatalf("lockReleaseError() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("lockReleaseError() = %v, want %q", err, test.want)
+			}
+		})
+	}
 }
 
 func TestAcquireLockConcurrency(t *testing.T) {

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -116,6 +117,33 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "failed to release lock") {
 		t.Fatalf("Unexpected closed lock release error: %v", err)
 	}
+}
+
+func TestAcquireAndReleaseLockErrors(t *testing.T) {
+	t.Run("acquire", func(t *testing.T) {
+		wantErr := errors.New("injected lock failure")
+		var opened *os.File
+		got, err := acquireLockWith(filepath.Join(t.TempDir(), "failed.lock"), func(file *os.File) error {
+			opened = file
+			return wantErr
+		})
+		if got != nil || !errors.Is(err, wantErr) {
+			t.Fatalf("acquireLockWith = (%v, %v), want (nil, %v)", got, err, wantErr)
+		}
+		if opened == nil {
+			t.Fatal("lock callback did not receive the opened file")
+		}
+		if _, err := opened.Stat(); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("failed lock file remained open: Stat error = %v", err)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		wantErr := errors.New("injected close failure")
+		if err := lockReleaseError(nil, wantErr); !errors.Is(err, wantErr) {
+			t.Fatalf("lockReleaseError = %v, want wrapped %v", err, wantErr)
+		}
+	})
 }
 
 func TestAcquireLockConcurrency(t *testing.T) {

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -83,9 +84,18 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 		t.Errorf("Failed to release lock: %v", err)
 	}
 
-	// Check lock file is removed
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Error("Lock file should be removed after release")
+	// The lock file remains so every caller continues to lock the same file.
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("Lock file should remain after release: %v", err)
+	}
+
+	// A retained lock file can be acquired again.
+	lockFile, err = acquireLock(lockPath)
+	if err != nil {
+		t.Fatalf("Failed to reacquire lock: %v", err)
+	}
+	if err := releaseLock(lockFile); err != nil {
+		t.Errorf("Failed to release reacquired lock: %v", err)
 	}
 }
 
@@ -96,6 +106,7 @@ func TestAcquireLockConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	var results []int
 	var resultsMu sync.Mutex
+	var active atomic.Int32
 
 	// Start multiple goroutines trying to acquire the same lock
 	for i := 0; i < 5; i++ {
@@ -109,12 +120,17 @@ func TestAcquireLockConcurrency(t *testing.T) {
 				return
 			}
 
+			if n := active.Add(1); n != 1 {
+				t.Errorf("Goroutine %d entered an occupied critical section (%d active)", id, n)
+			}
+
 			// Hold the lock for a short time
 			resultsMu.Lock()
 			results = append(results, id)
 			resultsMu.Unlock()
 
 			time.Sleep(10 * time.Millisecond)
+			active.Add(-1)
 
 			if err := releaseLock(lockFile); err != nil {
 				t.Errorf("Goroutine %d failed to release lock: %v", id, err)

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -97,6 +97,21 @@ func TestAcquireAndReleaseLock(t *testing.T) {
 	if err := releaseLock(lockFile); err != nil {
 		t.Errorf("Failed to release reacquired lock: %v", err)
 	}
+
+	// A closed handle exercises the platform unlock failure path and verifies
+	// that releaseLock preserves enough context for callers to diagnose it.
+	closedLock, err := acquireLock(filepath.Join(tempDir, "closed.lock"))
+	if err != nil {
+		t.Fatalf("Failed to acquire lock for error test: %v", err)
+	}
+	if err := closedLock.Close(); err != nil {
+		t.Fatalf("Failed to close lock for error test: %v", err)
+	}
+	if err := releaseLock(closedLock); err == nil {
+		t.Fatal("Expected release of a closed lock to fail")
+	} else if !strings.Contains(err.Error(), "failed to release lock") {
+		t.Fatalf("Unexpected closed lock release error: %v", err)
+	}
 }
 
 func TestAcquireLockConcurrency(t *testing.T) {

--- a/internal/crosscompile/filelock_unix.go
+++ b/internal/crosscompile/filelock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package crosscompile
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFileHandle(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFileHandle(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/crosscompile/filelock_windows.go
+++ b/internal/crosscompile/filelock_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package crosscompile
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFileHandle(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+}
+
+func unlockFileHandle(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/internal/goarch/config.go
+++ b/internal/goarch/config.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package goarch parses the Go toolchain's architecture-specific build
+// configuration. It deliberately contains Go semantics only; LLVM mappings
+// belong to the backend.
+package goarch
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	Default386   = "sse2"
+	DefaultAMD64 = "v1"
+	DefaultARM64 = "v8.0"
+)
+
+// Resolve386 validates and normalizes GO386. An empty value selects the Go
+// toolchain default.
+func Resolve386(value string) (string, error) {
+	if value == "" {
+		return Default386, nil
+	}
+	switch value {
+	case "sse2", "softfloat":
+		return value, nil
+	case "387":
+		return Default386, fmt.Errorf("unsupported setting GO386=387. Consider using GO386=softfloat instead")
+	default:
+		return Default386, fmt.Errorf("unsupported setting GO386=%s", value)
+	}
+}
+
+// ResolveAMD64 validates and normalizes GOAMD64. An empty value selects the Go
+// toolchain default.
+func ResolveAMD64(value string) (string, error) {
+	if value == "" {
+		return DefaultAMD64, nil
+	}
+	switch value {
+	case "v1", "v2", "v3", "v4":
+		return value, nil
+	default:
+		return DefaultAMD64, fmt.Errorf("invalid GOAMD64: must be v1, v2, v3, v4")
+	}
+}
+
+// ARM64 describes a normalized GOARM64 value.
+type ARM64 struct {
+	Version string
+	LSE     bool
+	Crypto  bool
+}
+
+func (f ARM64) String() string {
+	value := f.Version
+	if f.LSE {
+		value += ",lse"
+	}
+	if f.Crypto {
+		value += ",crypto"
+	}
+	return value
+}
+
+// ParseARM64 validates and normalizes GOARM64. Extension suffixes may occur in
+// either order, matching the Go toolchain. LSE is mandatory from ARMv8.1.
+func ParseARM64(value string) (ARM64, error) {
+	if value == "" {
+		value = DefaultARM64
+	}
+	var ret ARM64
+	for {
+		switch {
+		case strings.HasSuffix(value, ",lse"):
+			ret.LSE = true
+			value = strings.TrimSuffix(value, ",lse")
+		case strings.HasSuffix(value, ",crypto"):
+			ret.Crypto = true
+			value = strings.TrimSuffix(value, ",crypto")
+		default:
+			goto parsedExtensions
+		}
+	}
+
+parsedExtensions:
+	switch value {
+	case "v8.0":
+		ret.Version = value
+	case "v8.1", "v8.2", "v8.3", "v8.4", "v8.5", "v8.6", "v8.7", "v8.8", "v8.9",
+		"v9.0", "v9.1", "v9.2", "v9.3", "v9.4", "v9.5":
+		ret.Version = value
+		ret.LSE = true
+	default:
+		ret.Version = DefaultARM64
+		return ret, fmt.Errorf("invalid GOARM64: must start with v8.{0-9} or v9.{0-5} and may optionally end in %q and/or %q", ",lse", ",crypto")
+	}
+	return ret, nil
+}

--- a/internal/goarch/config.go
+++ b/internal/goarch/config.go
@@ -67,19 +67,13 @@ func ResolveAMD64(value string) (string, error) {
 type ARM struct {
 	Version   string
 	SoftFloat bool
-	floatSet  bool
 }
 
 func (f ARM) String() string {
-	value := f.Version
-	if f.floatSet {
-		if f.SoftFloat {
-			value += ",softfloat"
-		} else {
-			value += ",hardfloat"
-		}
+	if f.SoftFloat {
+		return f.Version + ",softfloat"
 	}
-	return value
+	return f.Version + ",hardfloat"
 }
 
 // ParseARM validates and normalizes GOARM. ARMv5 defaults to software floating
@@ -95,12 +89,13 @@ func ParseARM(value string) (ARM, error) {
 		hardFloat = ",hardfloat"
 	)
 	var ret ARM
+	floatSet := false
 	if strings.HasSuffix(value, softFloat) {
 		ret.SoftFloat = true
-		ret.floatSet = true
+		floatSet = true
 		value = strings.TrimSuffix(value, softFloat)
 	} else if strings.HasSuffix(value, hardFloat) {
-		ret.floatSet = true
+		floatSet = true
 		value = strings.TrimSuffix(value, hardFloat)
 	}
 	switch value {
@@ -110,7 +105,7 @@ func ParseARM(value string) (ARM, error) {
 		ret.Version = DefaultARM
 		return ret, fmt.Errorf("invalid GOARM: must start with 5, 6, or 7, and may optionally end in either %q or %q", hardFloat, softFloat)
 	}
-	if !ret.floatSet && ret.Version == "5" {
+	if !floatSet && ret.Version == "5" {
 		ret.SoftFloat = true
 	}
 	return ret, nil

--- a/internal/goarch/config.go
+++ b/internal/goarch/config.go
@@ -144,19 +144,19 @@ func ParseARM64(value string) (ARM64, error) {
 	}
 	var ret ARM64
 	for {
-		switch {
-		case strings.HasSuffix(value, ",lse"):
+		if strings.HasSuffix(value, ",lse") {
 			ret.LSE = true
 			value = strings.TrimSuffix(value, ",lse")
-		case strings.HasSuffix(value, ",crypto"):
+			continue
+		}
+		if strings.HasSuffix(value, ",crypto") {
 			ret.Crypto = true
 			value = strings.TrimSuffix(value, ",crypto")
-		default:
-			goto parsedExtensions
+			continue
 		}
+		break
 	}
 
-parsedExtensions:
 	switch value {
 	case "v8.0":
 		ret.Version = value

--- a/internal/goarch/config.go
+++ b/internal/goarch/config.go
@@ -32,7 +32,8 @@ const (
 )
 
 // Resolve386 validates and normalizes GO386. An empty value selects the Go
-// toolchain default.
+// toolchain default. Invalid input returns that default together with an error;
+// callers must check the error unless fallback behavior is intentional.
 func Resolve386(value string) (string, error) {
 	if value == "" {
 		return Default386, nil
@@ -48,7 +49,8 @@ func Resolve386(value string) (string, error) {
 }
 
 // ResolveAMD64 validates and normalizes GOAMD64. An empty value selects the Go
-// toolchain default.
+// toolchain default. Invalid input returns that default together with an error;
+// callers must check the error unless fallback behavior is intentional.
 func ResolveAMD64(value string) (string, error) {
 	if value == "" {
 		return DefaultAMD64, nil
@@ -82,6 +84,8 @@ func (f ARM) String() string {
 
 // ParseARM validates and normalizes GOARM. ARMv5 defaults to software floating
 // point; ARMv6 and ARMv7 default to hardware floating point, matching Go.
+// Invalid input returns a default-based value together with an error; callers
+// must check the error unless fallback behavior is intentional.
 func ParseARM(value string) (ARM, error) {
 	if value == "" {
 		value = DefaultARM
@@ -132,6 +136,8 @@ func (f ARM64) String() string {
 
 // ParseARM64 validates and normalizes GOARM64. Extension suffixes may occur in
 // either order, matching the Go toolchain. LSE is mandatory from ARMv8.1.
+// Invalid input returns a default-based value together with an error; callers
+// must check the error unless fallback behavior is intentional.
 func ParseARM64(value string) (ARM64, error) {
 	if value == "" {
 		value = DefaultARM64

--- a/internal/goarch/config.go
+++ b/internal/goarch/config.go
@@ -27,6 +27,7 @@ import (
 const (
 	Default386   = "sse2"
 	DefaultAMD64 = "v1"
+	DefaultARM   = "7"
 	DefaultARM64 = "v8.0"
 )
 
@@ -58,6 +59,57 @@ func ResolveAMD64(value string) (string, error) {
 	default:
 		return DefaultAMD64, fmt.Errorf("invalid GOAMD64: must be v1, v2, v3, v4")
 	}
+}
+
+// ARM describes a normalized GOARM value.
+type ARM struct {
+	Version   string
+	SoftFloat bool
+	floatSet  bool
+}
+
+func (f ARM) String() string {
+	value := f.Version
+	if f.floatSet {
+		if f.SoftFloat {
+			value += ",softfloat"
+		} else {
+			value += ",hardfloat"
+		}
+	}
+	return value
+}
+
+// ParseARM validates and normalizes GOARM. ARMv5 defaults to software floating
+// point; ARMv6 and ARMv7 default to hardware floating point, matching Go.
+func ParseARM(value string) (ARM, error) {
+	if value == "" {
+		value = DefaultARM
+	}
+	const (
+		softFloat = ",softfloat"
+		hardFloat = ",hardfloat"
+	)
+	var ret ARM
+	if strings.HasSuffix(value, softFloat) {
+		ret.SoftFloat = true
+		ret.floatSet = true
+		value = strings.TrimSuffix(value, softFloat)
+	} else if strings.HasSuffix(value, hardFloat) {
+		ret.floatSet = true
+		value = strings.TrimSuffix(value, hardFloat)
+	}
+	switch value {
+	case "5", "6", "7":
+		ret.Version = value
+	default:
+		ret.Version = DefaultARM
+		return ret, fmt.Errorf("invalid GOARM: must start with 5, 6, or 7, and may optionally end in either %q or %q", hardFloat, softFloat)
+	}
+	if !ret.floatSet && ret.Version == "5" {
+		ret.SoftFloat = true
+	}
+	return ret, nil
 }
 
 // ARM64 describes a normalized GOARM64 value.

--- a/internal/goarch/config_test.go
+++ b/internal/goarch/config_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package goarch
+
+import "testing"
+
+func TestResolve386(t *testing.T) {
+	for _, test := range []struct {
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{value: "", want: "sse2"},
+		{value: "sse2", want: "sse2"},
+		{value: "softfloat", want: "softfloat"},
+		{value: "387", want: "sse2", wantErr: true},
+		{value: "invalid", want: "sse2", wantErr: true},
+	} {
+		got, err := Resolve386(test.value)
+		if got != test.want || (err != nil) != test.wantErr {
+			t.Errorf("Resolve386(%q) = %q, %v; want %q, error=%v", test.value, got, err, test.want, test.wantErr)
+		}
+	}
+}
+
+func TestResolveAMD64(t *testing.T) {
+	for _, test := range []struct {
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{value: "", want: "v1"},
+		{value: "v1", want: "v1"},
+		{value: "v2", want: "v2"},
+		{value: "v3", want: "v3"},
+		{value: "v4", want: "v4"},
+		{value: "v5", want: "v1", wantErr: true},
+	} {
+		got, err := ResolveAMD64(test.value)
+		if got != test.want || (err != nil) != test.wantErr {
+			t.Errorf("ResolveAMD64(%q) = %q, %v; want %q, error=%v", test.value, got, err, test.want, test.wantErr)
+		}
+	}
+}
+
+func TestParseARM64(t *testing.T) {
+	for _, test := range []struct {
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{value: "", want: "v8.0"},
+		{value: "v8.0", want: "v8.0"},
+		{value: "v8.0,lse", want: "v8.0,lse"},
+		{value: "v8.0,crypto", want: "v8.0,crypto"},
+		{value: "v8.0,crypto,lse", want: "v8.0,lse,crypto"},
+		{value: "v8.0,lse,crypto", want: "v8.0,lse,crypto"},
+		{value: "v8.0,lse,lse,crypto", want: "v8.0,lse,crypto"},
+		{value: "v8.1", want: "v8.1,lse"},
+		{value: "v8.9", want: "v8.9,lse"},
+		{value: "v9.0", want: "v9.0,lse"},
+		{value: "v9.5,crypto", want: "v9.5,lse,crypto"},
+		{value: "v9.6", want: "v8.0", wantErr: true},
+		{value: "8.0", want: "v8.0", wantErr: true},
+	} {
+		got, err := ParseARM64(test.value)
+		if got.String() != test.want || (err != nil) != test.wantErr {
+			t.Errorf("ParseARM64(%q) = %q, %v; want %q, error=%v", test.value, got.String(), err, test.want, test.wantErr)
+		}
+	}
+}

--- a/internal/goarch/config_test.go
+++ b/internal/goarch/config_test.go
@@ -64,14 +64,14 @@ func TestParseARM(t *testing.T) {
 		wantSoft bool
 		wantErr  bool
 	}{
-		{value: "", want: "7"},
-		{value: "5", want: "5", wantSoft: true},
+		{value: "", want: "7,hardfloat"},
+		{value: "5", want: "5,softfloat", wantSoft: true},
 		{value: "5,softfloat", want: "5,softfloat", wantSoft: true},
 		{value: "5,hardfloat", want: "5,hardfloat"},
-		{value: "6", want: "6"},
+		{value: "6", want: "6,hardfloat"},
 		{value: "6,softfloat", want: "6,softfloat", wantSoft: true},
 		{value: "7,hardfloat", want: "7,hardfloat"},
-		{value: "4", want: "7", wantErr: true},
+		{value: "4", want: "7,hardfloat", wantErr: true},
 		{value: "7,softfloat,hardfloat", want: "7,hardfloat", wantErr: true},
 	} {
 		got, err := ParseARM(test.value)

--- a/internal/goarch/config_test.go
+++ b/internal/goarch/config_test.go
@@ -57,6 +57,30 @@ func TestResolveAMD64(t *testing.T) {
 	}
 }
 
+func TestParseARM(t *testing.T) {
+	for _, test := range []struct {
+		value    string
+		want     string
+		wantSoft bool
+		wantErr  bool
+	}{
+		{value: "", want: "7"},
+		{value: "5", want: "5", wantSoft: true},
+		{value: "5,softfloat", want: "5,softfloat", wantSoft: true},
+		{value: "5,hardfloat", want: "5,hardfloat"},
+		{value: "6", want: "6"},
+		{value: "6,softfloat", want: "6,softfloat", wantSoft: true},
+		{value: "7,hardfloat", want: "7,hardfloat"},
+		{value: "4", want: "7", wantErr: true},
+		{value: "7,softfloat,hardfloat", want: "7,hardfloat", wantErr: true},
+	} {
+		got, err := ParseARM(test.value)
+		if got.String() != test.want || got.SoftFloat != test.wantSoft || (err != nil) != test.wantErr {
+			t.Errorf("ParseARM(%q) = %q (soft=%v), %v; want %q (soft=%v), error=%v", test.value, got.String(), got.SoftFloat, err, test.want, test.wantSoft, test.wantErr)
+		}
+	}
+}
+
 func TestParseARM64(t *testing.T) {
 	for _, test := range []struct {
 		value   string

--- a/internal/meta/builder.go
+++ b/internal/meta/builder.go
@@ -282,7 +282,7 @@ func (b *Builder) Build() (*PackageMeta, error) {
 	writeMethodInfo(raw[offsets[secMethodInfo]:], b, nsyms)
 	writeIfaceInfo(raw[offsets[secIfaceInfo]:], b, nsyms)
 
-	return newPackageMeta(raw)
+	return packageMetaView(raw, offsets, nsyms), nil
 }
 
 // ── section writers ───────────────────────────────────────────────────────────

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -169,7 +169,7 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	if fi.Size() <= 0 || fi.Size() > int64(^uint(0)>>1) {
+	if fi.Size() < headerSize || fi.Size() > int64(^uint(0)>>1) {
 		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
 	}
 	size := int(fi.Size())
@@ -303,6 +303,9 @@ func (pm *PackageMeta) hasFuncDemand(sym Symbol) bool {
 // newPackageMeta checks the magic and version, then decodes the section offsets
 // from the fixed header.
 func newPackageMeta(raw []byte) (*PackageMeta, error) {
+	if len(raw) < headerSize {
+		return nil, fmt.Errorf("meta: file too small: %d bytes", len(raw))
+	}
 	if string(raw[0:4]) != magic {
 		return nil, fmt.Errorf("meta: bad magic %q", raw[0:4])
 	}
@@ -311,14 +314,30 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 		return nil, fmt.Errorf("meta: unsupported version %d", ver)
 	}
 
-	pm := &PackageMeta{raw: raw}
-	pm.strOff = binary.LittleEndian.Uint32(raw[8+secStringTable*4:])
-	pm.symOff = binary.LittleEndian.Uint32(raw[8+secSymbols*4:])
-	pm.ordinaryOff = binary.LittleEndian.Uint32(raw[8+secOrdinaryEdges*4:])
-	pm.demandOff = binary.LittleEndian.Uint32(raw[8+secFuncDemand*4:])
-	pm.childOff = binary.LittleEndian.Uint32(raw[8+secTypeChildren*4:])
-	pm.methodOff = binary.LittleEndian.Uint32(raw[8+secMethodInfo*4:])
-	pm.ifaceOff = binary.LittleEndian.Uint32(raw[8+secIfaceInfo*4:])
+	var offsets [numSections]uint32
+	prev := uint32(headerSize)
+	for sec := range offsets {
+		off := binary.LittleEndian.Uint32(raw[8+sec*4:])
+		if off < prev || uint64(off) > uint64(len(raw)) || off%4 != 0 {
+			return nil, fmt.Errorf("meta: invalid section %d offset %d", sec, off)
+		}
+		offsets[sec] = off
+		prev = off
+	}
+	if offsets[secOrdinaryEdges]-offsets[secSymbols] < 4 {
+		return nil, fmt.Errorf("meta: truncated symbols section")
+	}
+
+	pm := &PackageMeta{
+		raw:         raw,
+		strOff:      offsets[secStringTable],
+		symOff:      offsets[secSymbols],
+		ordinaryOff: offsets[secOrdinaryEdges],
+		demandOff:   offsets[secFuncDemand],
+		childOff:    offsets[secTypeChildren],
+		methodOff:   offsets[secMethodInfo],
+		ifaceOff:    offsets[secIfaceInfo],
+	}
 
 	// read nsyms from Symbols section header
 	pm.nsyms = binary.LittleEndian.Uint32(raw[pm.symOff:])

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -169,7 +169,7 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	if fi.Size() < headerSize || fi.Size() > int64(^uint(0)>>1) {
+	if fi.Size() < headerSize || uint64(fi.Size()) > uint64(^uint32(0)) || fi.Size() > int64(^uint(0)>>1) {
 		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
 	}
 	size := int(fi.Size())
@@ -306,6 +306,9 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 	if len(raw) < headerSize {
 		return nil, fmt.Errorf("meta: file too small: %d bytes", len(raw))
 	}
+	if uint64(len(raw)) > uint64(^uint32(0)) {
+		return nil, fmt.Errorf("meta: file too large: %d bytes", len(raw))
+	}
 	if string(raw[0:4]) != magic {
 		return nil, fmt.Errorf("meta: bad magic %q", raw[0:4])
 	}
@@ -327,9 +330,21 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 	if offsets[secOrdinaryEdges]-offsets[secSymbols] < 4 {
 		return nil, fmt.Errorf("meta: truncated symbols section")
 	}
+	nsyms := binary.LittleEndian.Uint32(raw[offsets[secSymbols]:])
+	pm := packageMetaView(raw, offsets, nsyms)
+	if err := pm.validate(); err != nil {
+		return nil, err
+	}
+	return pm, nil
+}
 
-	pm := &PackageMeta{
+// packageMetaView constructs a view over a layout whose header has already
+// been decoded. Builder uses it for bytes it just wrote; Open validates the
+// returned view before exposing mapped, file-controlled bytes.
+func packageMetaView(raw []byte, offsets [numSections]uint32, nsyms uint32) *PackageMeta {
+	return &PackageMeta{
 		raw:         raw,
+		nsyms:       nsyms,
 		strOff:      offsets[secStringTable],
 		symOff:      offsets[secSymbols],
 		ordinaryOff: offsets[secOrdinaryEdges],
@@ -338,10 +353,120 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 		methodOff:   offsets[secMethodInfo],
 		ifaceOff:    offsets[secIfaceInfo],
 	}
+}
 
-	// read nsyms from Symbols section header
-	pm.nsyms = binary.LittleEndian.Uint32(raw[pm.symOff:])
-	return pm, nil
+type csrLayout struct {
+	dataOff  uint32
+	nrecords uint32
+}
+
+func (pm *PackageMeta) validate() error {
+	symSize := uint64(pm.ordinaryOff - pm.symOff)
+	wantSymSize := uint64(4) + uint64(pm.nsyms)*12
+	if symSize != wantSymSize {
+		return fmt.Errorf("meta: invalid symbols section size %d for %d symbols", symSize, pm.nsyms)
+	}
+
+	sections := [...]struct {
+		name       string
+		start      uint32
+		end        uint32
+		recordSize uint32
+	}{
+		{name: "OrdinaryEdges", start: pm.ordinaryOff, end: pm.demandOff, recordSize: 4},
+		{name: "FuncDemand", start: pm.demandOff, end: pm.childOff, recordSize: 12},
+		{name: "TypeChildren", start: pm.childOff, end: pm.methodOff, recordSize: 4},
+		{name: "MethodInfo", start: pm.methodOff, end: pm.ifaceOff, recordSize: 20},
+		{name: "InterfaceInfo", start: pm.ifaceOff, end: uint32(len(pm.raw)), recordSize: 12},
+	}
+	var layouts [len(sections)]csrLayout
+	for i, section := range sections {
+		layout, err := validateCSRSection(pm.raw, section.name, section.start, section.end, pm.nsyms, section.recordSize)
+		if err != nil {
+			return err
+		}
+		layouts[i] = layout
+	}
+
+	strSize := pm.symOff - pm.strOff
+	if err := pm.validateNameRecords("Symbols", pm.symOff+4, pm.nsyms, 12, strSize); err != nil {
+		return err
+	}
+	if err := pm.validateFuncDemandNames(layouts[1], strSize); err != nil {
+		return err
+	}
+	if err := pm.validateNameRecords(sections[3].name, layouts[3].dataOff, layouts[3].nrecords, 20, strSize); err != nil {
+		return err
+	}
+	return pm.validateNameRecords(sections[4].name, layouts[4].dataOff, layouts[4].nrecords, 12, strSize)
+}
+
+func validNameRef(ref nameRef, strSize uint32) bool {
+	return uint64(ref.Off)+uint64(ref.Len) <= uint64(strSize)
+}
+
+func validateCSRSection(raw []byte, name string, start, end, nsyms, recordSize uint32) (csrLayout, error) {
+	sectionSize := uint64(end - start)
+	headerSize := uint64(4) + (uint64(nsyms)+1)*4
+	if sectionSize < headerSize {
+		return csrLayout{}, fmt.Errorf("meta: truncated %s CSR header", name)
+	}
+	if got := binary.LittleEndian.Uint32(raw[start:]); got != nsyms {
+		return csrLayout{}, fmt.Errorf("meta: %s has %d symbols, want %d", name, got, nsyms)
+	}
+	dataSize := sectionSize - headerSize
+	if dataSize%uint64(recordSize) != 0 {
+		return csrLayout{}, fmt.Errorf("meta: invalid %s data size %d", name, dataSize)
+	}
+	nrecords := dataSize / uint64(recordSize)
+	offsetsBase := start + 4
+	prev := binary.LittleEndian.Uint32(raw[offsetsBase:])
+	if prev != 0 {
+		return csrLayout{}, fmt.Errorf("meta: %s CSR first offset is %d, want 0", name, prev)
+	}
+	for sym := uint32(0); sym < nsyms; sym++ {
+		cur := binary.LittleEndian.Uint32(raw[offsetsBase+(sym+1)*4:])
+		if cur < prev || uint64(cur) > nrecords {
+			return csrLayout{}, fmt.Errorf("meta: invalid %s CSR offset %d at symbol %d", name, cur, sym)
+		}
+		prev = cur
+	}
+	if uint64(prev) != nrecords {
+		return csrLayout{}, fmt.Errorf("meta: %s CSR covers %d records, section contains %d", name, prev, nrecords)
+	}
+	return csrLayout{dataOff: uint32(uint64(start) + headerSize), nrecords: uint32(nrecords)}, nil
+}
+
+func (pm *PackageMeta) validateFuncDemandNames(layout csrLayout, strSize uint32) error {
+	for i := uint32(0); i < layout.nrecords; i++ {
+		base := layout.dataOff + i*12
+		kind := DemandKind(binary.LittleEndian.Uint32(pm.raw[base:]))
+		if kind != DemandNamedMethod {
+			continue
+		}
+		ref := nameRef{
+			Off: binary.LittleEndian.Uint32(pm.raw[base+4:]),
+			Len: binary.LittleEndian.Uint32(pm.raw[base+8:]),
+		}
+		if !validNameRef(ref, strSize) {
+			return fmt.Errorf("meta: FuncDemand record %d has invalid name range [%d,%d)", i, ref.Off, uint64(ref.Off)+uint64(ref.Len))
+		}
+	}
+	return nil
+}
+
+func (pm *PackageMeta) validateNameRecords(section string, dataOff, nrecords, recordSize, strSize uint32) error {
+	for i := uint32(0); i < nrecords; i++ {
+		base := dataOff + i*recordSize
+		ref := nameRef{
+			Off: binary.LittleEndian.Uint32(pm.raw[base:]),
+			Len: binary.LittleEndian.Uint32(pm.raw[base+4:]),
+		}
+		if !validNameRef(ref, strSize) {
+			return fmt.Errorf("meta: %s record %d has invalid name range [%d,%d)", section, i, ref.Off, uint64(ref.Off)+uint64(ref.Len))
+		}
+	}
+	return nil
 }
 
 // csrSlice returns the records for package-local sym from a CSR section, or nil

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -303,11 +303,8 @@ func (pm *PackageMeta) hasFuncDemand(sym Symbol) bool {
 // newPackageMeta checks the magic and version, then decodes the section offsets
 // from the fixed header.
 func newPackageMeta(raw []byte) (*PackageMeta, error) {
-	if len(raw) < headerSize {
-		return nil, fmt.Errorf("meta: file too small: %d bytes", len(raw))
-	}
-	if uint64(len(raw)) > uint64(^uint32(0)) {
-		return nil, fmt.Errorf("meta: file too large: %d bytes", len(raw))
+	if err := validateMetaSize(uint64(len(raw))); err != nil {
+		return nil, err
 	}
 	if string(raw[0:4]) != magic {
 		return nil, fmt.Errorf("meta: bad magic %q", raw[0:4])
@@ -336,6 +333,16 @@ func newPackageMeta(raw []byte) (*PackageMeta, error) {
 		return nil, err
 	}
 	return pm, nil
+}
+
+func validateMetaSize(size uint64) error {
+	if size < headerSize {
+		return fmt.Errorf("meta: file too small: %d bytes", size)
+	}
+	if size > uint64(^uint32(0)) {
+		return fmt.Errorf("meta: file too large: %d bytes", size)
+	}
+	return nil
 }
 
 // packageMetaView constructs a view over a layout whose header has already

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 	"unsafe"
 )
 
@@ -170,16 +169,19 @@ func Open(path string) (*PackageMeta, error) {
 	if err != nil {
 		return nil, err
 	}
+	if fi.Size() <= 0 || fi.Size() > int64(^uint(0)>>1) {
+		return nil, fmt.Errorf("meta: mmap %s: invalid file size %d", path, fi.Size())
+	}
 	size := int(fi.Size())
 
-	raw, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+	raw, err := mapFile(f, size)
 	if err != nil {
 		return nil, fmt.Errorf("meta: mmap %s: %w", path, err)
 	}
 
 	pm, err := newPackageMeta(raw)
 	if err != nil {
-		_ = syscall.Munmap(raw)
+		_ = unmapFile(raw)
 		return nil, err
 	}
 	pm.mmap = true
@@ -199,8 +201,9 @@ func (pm *PackageMeta) WriteTo(w io.Writer) (int64, error) {
 // It is a no-op for PackageMeta values returned from Builder.Build.
 func (pm *PackageMeta) Close() error {
 	if pm.mmap && pm.raw != nil {
-		err := syscall.Munmap(pm.raw)
+		err := unmapFile(pm.raw)
 		pm.raw = nil
+		pm.mmap = false
 		return err
 	}
 	return nil

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -237,6 +237,7 @@ func TestRoundTripFile(t *testing.T) {
 	fn := b.Sym("pkg.Fn")
 	dep := b.Sym("runtime.X")
 	b.AddOrdinaryEdge(fn, dep)
+	b.AddIfaceUse(fn, dep)
 
 	pm, err := b.Build()
 	if err != nil {
@@ -268,6 +269,10 @@ func TestRoundTripFile(t *testing.T) {
 	if len(edges) != 1 || edges[0] != dep {
 		t.Errorf("OrdinaryEdges after file round-trip = %v", edges)
 	}
+	demands := pm2.funcDemands(fn)
+	if len(demands) != 1 || demands[0].Kind != DemandUseIface || Symbol(demands[0].Target) != dep {
+		t.Errorf("FuncDemand after file round-trip = %v", demands)
+	}
 	if err := pm2.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -280,6 +285,13 @@ func TestOpenErrors(t *testing.T) {
 	t.Run("short in-memory header", func(t *testing.T) {
 		if _, err := newPackageMeta(make([]byte, headerSize-1)); err == nil || !strings.Contains(err.Error(), "meta: file too small") {
 			t.Fatalf("newPackageMeta error = %v, want short-file error", err)
+		}
+	})
+
+	t.Run("oversized in-memory metadata", func(t *testing.T) {
+		size := uint64(^uint32(0)) + 1
+		if err := validateMetaSize(size); err == nil || !strings.Contains(err.Error(), "meta: file too large") {
+			t.Fatalf("validateMetaSize error = %v, want large-file error", err)
 		}
 	})
 

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -299,6 +299,8 @@ func TestOpenErrors(t *testing.T) {
 		}
 	})
 
+	validRaw := validationMetaBytes(t)
+	cloneValid := func() []byte { return append([]byte(nil), validRaw...) }
 	tests := []struct {
 		name string
 		raw  func() []byte
@@ -365,6 +367,111 @@ func TestOpenErrors(t *testing.T) {
 			},
 			want: "meta: truncated symbols section",
 		},
+		{
+			name: "symbol count exceeds section",
+			raw: func() []byte {
+				raw := cloneValid()
+				symOff := metaSectionOffset(raw, secSymbols)
+				nsyms := binary.LittleEndian.Uint32(raw[symOff:])
+				binary.LittleEndian.PutUint32(raw[symOff:], nsyms+1)
+				return raw
+			},
+			want: "meta: invalid symbols section size",
+		},
+		{
+			name: "truncated csr offsets",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				binary.LittleEndian.PutUint32(raw[8+secFuncDemand*4:], ordinaryOff+4)
+				return raw
+			},
+			want: "meta: truncated OrdinaryEdges CSR header",
+		},
+		{
+			name: "csr symbol count mismatch",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				nsyms := binary.LittleEndian.Uint32(raw[ordinaryOff:])
+				binary.LittleEndian.PutUint32(raw[ordinaryOff:], nsyms+1)
+				return raw
+			},
+			want: "meta: OrdinaryEdges has",
+		},
+		{
+			name: "descending csr offsets",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				offsetsBase := ordinaryOff + 4
+				binary.LittleEndian.PutUint32(raw[offsetsBase+4:], 1)
+				binary.LittleEndian.PutUint32(raw[offsetsBase+8:], 0)
+				return raw
+			},
+			want: "meta: invalid OrdinaryEdges CSR offset",
+		},
+		{
+			name: "csr offset past data",
+			raw: func() []byte {
+				raw := cloneValid()
+				ordinaryOff := metaSectionOffset(raw, secOrdinaryEdges)
+				nsyms := binary.LittleEndian.Uint32(raw[ordinaryOff:])
+				offsetsBase := ordinaryOff + 4
+				last := offsetsBase + nsyms*4
+				nrecords := binary.LittleEndian.Uint32(raw[last:])
+				binary.LittleEndian.PutUint32(raw[last:], nrecords+1)
+				return raw
+			},
+			want: "meta: invalid OrdinaryEdges CSR offset",
+		},
+		{
+			name: "symbol name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				binary.LittleEndian.PutUint32(raw[symOff+4:], symOff-strOff)
+				return raw
+			},
+			want: "meta: Symbols record 0 has invalid name range",
+		},
+		{
+			name: "demand name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				dataOff := metaCSRDataOffset(raw, secFuncDemand)
+				binary.LittleEndian.PutUint32(raw[dataOff+4:], symOff-strOff)
+				return raw
+			},
+			want: "meta: FuncDemand record 0 has invalid name range",
+		},
+		{
+			name: "method name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				dataOff := metaCSRDataOffset(raw, secMethodInfo)
+				binary.LittleEndian.PutUint32(raw[dataOff:], symOff-strOff)
+				return raw
+			},
+			want: "meta: MethodInfo record 0 has invalid name range",
+		},
+		{
+			name: "interface name past string table",
+			raw: func() []byte {
+				raw := cloneValid()
+				strOff := metaSectionOffset(raw, secStringTable)
+				symOff := metaSectionOffset(raw, secSymbols)
+				dataOff := metaCSRDataOffset(raw, secIfaceInfo)
+				binary.LittleEndian.PutUint32(raw[dataOff:], symOff-strOff)
+				return raw
+			},
+			want: "meta: InterfaceInfo record 0 has invalid name range",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -377,6 +484,37 @@ func TestOpenErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validationMetaBytes(t *testing.T) []byte {
+	t.Helper()
+	b := NewBuilder()
+	src := b.Sym("pkg.src")
+	dst := b.Sym("pkg.dst")
+	iface := b.Sym("pkg.iface")
+	mtype := b.Sym("pkg.mtype")
+	ifn := b.Sym("pkg.ifn")
+	tfn := b.Sym("pkg.tfn")
+	b.AddOrdinaryEdge(src, dst)
+	b.AddNamedMethodUse(src, "Method")
+	b.AddTypeChild(src, dst)
+	b.AddMethodSlot(src, "Method", mtype, ifn, tfn)
+	b.AddIfaceMethod(iface, "Method", mtype)
+	pm, err := b.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append([]byte(nil), pm.raw...)
+}
+
+func metaSectionOffset(raw []byte, section int) uint32 {
+	return binary.LittleEndian.Uint32(raw[8+section*4:])
+}
+
+func metaCSRDataOffset(raw []byte, section int) uint32 {
+	sectionOff := metaSectionOffset(raw, section)
+	nsyms := binary.LittleEndian.Uint32(raw[sectionOff:])
+	return sectionOff + 4 + (nsyms+1)*4
 }
 
 func validEmptyMetaHeader(size int) []byte {

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -277,6 +277,12 @@ func TestRoundTripFile(t *testing.T) {
 }
 
 func TestOpenErrors(t *testing.T) {
+	t.Run("short in-memory header", func(t *testing.T) {
+		if _, err := newPackageMeta(make([]byte, headerSize-1)); err == nil || !strings.Contains(err.Error(), "meta: file too small") {
+			t.Fatalf("newPackageMeta error = %v, want short-file error", err)
+		}
+	})
+
 	t.Run("open", func(t *testing.T) {
 		if _, err := Open(filepath.Join(t.TempDir(), "missing.meta")); err == nil {
 			t.Fatal("Open succeeded for a missing file")
@@ -299,6 +305,13 @@ func TestOpenErrors(t *testing.T) {
 		want string
 	}{
 		{
+			name: "short header",
+			raw: func() []byte {
+				return make([]byte, headerSize-1)
+			},
+			want: "meta: mmap",
+		},
+		{
 			name: "magic",
 			raw: func() []byte {
 				raw := make([]byte, headerSize)
@@ -317,6 +330,41 @@ func TestOpenErrors(t *testing.T) {
 			},
 			want: "meta: unsupported version 2",
 		},
+		{
+			name: "section offset past end",
+			raw: func() []byte {
+				raw := validEmptyMetaHeader(headerSize)
+				binary.LittleEndian.PutUint32(raw[8+secIfaceInfo*4:], headerSize+4)
+				return raw
+			},
+			want: "meta: invalid section 6 offset 40",
+		},
+		{
+			name: "section offsets out of order",
+			raw: func() []byte {
+				raw := validEmptyMetaHeader(headerSize + 4)
+				binary.LittleEndian.PutUint32(raw[8+secSymbols*4:], headerSize+4)
+				binary.LittleEndian.PutUint32(raw[8+secOrdinaryEdges*4:], headerSize)
+				return raw
+			},
+			want: "meta: invalid section 2 offset 36",
+		},
+		{
+			name: "unaligned section offset",
+			raw: func() []byte {
+				raw := validEmptyMetaHeader(headerSize + 4)
+				binary.LittleEndian.PutUint32(raw[8+secSymbols*4:], headerSize+1)
+				return raw
+			},
+			want: "meta: invalid section 1 offset 37",
+		},
+		{
+			name: "truncated symbols section",
+			raw: func() []byte {
+				return validEmptyMetaHeader(headerSize)
+			},
+			want: "meta: truncated symbols section",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -329,4 +377,14 @@ func TestOpenErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validEmptyMetaHeader(size int) []byte {
+	raw := make([]byte, size)
+	copy(raw, magic)
+	binary.LittleEndian.PutUint32(raw[4:8], version)
+	for sec := range numSections {
+		binary.LittleEndian.PutUint32(raw[8+sec*4:], headerSize)
+	}
+	return raw
 }

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -486,6 +486,48 @@ func TestOpenErrors(t *testing.T) {
 	}
 }
 
+func TestValidateCSRSectionErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   []byte
+		nsyms uint32
+		want  string
+	}{
+		{
+			name: "misaligned data size",
+			raw:  make([]byte, 9),
+			want: "invalid Test data size",
+		},
+		{
+			name: "nonzero first offset",
+			raw: func() []byte {
+				raw := make([]byte, 8)
+				binary.LittleEndian.PutUint32(raw[4:], 1)
+				return raw
+			}(),
+			want: "Test CSR first offset is 1, want 0",
+		},
+		{
+			name: "terminal offset before data end",
+			raw: func() []byte {
+				raw := make([]byte, 16)
+				binary.LittleEndian.PutUint32(raw, 1)
+				return raw
+			}(),
+			nsyms: 1,
+			want:  "Test CSR covers 0 records, section contains 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateCSRSection(tt.raw, "Test", 0, uint32(len(tt.raw)), tt.nsyms, 4)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateCSRSection error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func validationMetaBytes(t *testing.T) []byte {
 	t.Helper()
 	b := NewBuilder()

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -260,7 +260,6 @@ func TestRoundTripFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer pm2.Close()
 
 	if got := pm2.symbolName(fn); got != "pkg.Fn" {
 		t.Errorf("SymbolName after file round-trip = %q, want \"pkg.Fn\"", got)
@@ -268,6 +267,12 @@ func TestRoundTripFile(t *testing.T) {
 	edges := pm2.ordinaryEdges(fn)
 	if len(edges) != 1 || edges[0] != dep {
 		t.Errorf("OrdinaryEdges after file round-trip = %v", edges)
+	}
+	if err := pm2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := pm2.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
 	}
 }
 

--- a/internal/meta/mmap_unix.go
+++ b/internal/meta/mmap_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package meta
+
+import (
+	"os"
+	"syscall"
+)
+
+func mapFile(f *os.File, size int) ([]byte, error) {
+	return syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func unmapFile(raw []byte) error {
+	return syscall.Munmap(raw)
+}

--- a/internal/meta/mmap_windows.go
+++ b/internal/meta/mmap_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package meta
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func mapFile(f *os.File, size int) ([]byte, error) {
+	mapping, err := windows.CreateFileMapping(
+		windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, 0, 0, nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(mapping)
+
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_READ, 0, 0, uintptr(size))
+	if err != nil {
+		return nil, err
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
+}
+
+func unmapFile(raw []byte) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return windows.UnmapViewOfFile(uintptr(unsafe.Pointer(&raw[0])))
+}

--- a/internal/plan9asm/translate.go
+++ b/internal/plan9asm/translate.go
@@ -32,6 +32,7 @@ type ModuleTranslation struct {
 
 type TranslateOptions struct {
 	AnnotateSource bool
+	GOARM          string
 }
 
 func TranslateFileForPkg(pkg *packages.Package, sfile string, goos string, goarch string, overlay map[string][]byte) (*FileTranslation, error) {
@@ -105,7 +106,7 @@ func TranslateSourceModuleForPkgWithOptions(pkg *packages.Package, sfile string,
 		FileName:       sfile,
 		GOOS:           goos,
 		GOARCH:         goarch,
-		TargetTriple:   intllvm.GetTargetTriple(goos, goarch),
+		TargetTriple:   intllvm.GetTargetTripleWithGOARM(goos, goarch, opt.GOARM),
 		AnnotateSource: opt.AnnotateSource,
 		ResolveSym:     resolve,
 		KeepFunc:       keep,

--- a/internal/plan9asm/translate_helpers_test.go
+++ b/internal/plan9asm/translate_helpers_test.go
@@ -109,7 +109,7 @@ func Foo()
 		t.Fatal(err)
 	}
 	defer tr.Module.Dispose()
-	if got, want := tr.Module.Target(), "armv6-unknown-linux-gnueabihf"; got != want {
+	if got, want := tr.Module.Target(), "armv6-unknown-linux-gnueabi"; got != want {
 		t.Fatalf("module target = %q, want %q", got, want)
 	}
 }

--- a/internal/plan9asm/translate_helpers_test.go
+++ b/internal/plan9asm/translate_helpers_test.go
@@ -98,6 +98,22 @@ func Foo()
 	}
 }
 
+func TestTranslateGOARMTargetTriple(t *testing.T) {
+	pkg := mustTestPackage(t, "example.com/arm", `package arm
+func Foo()
+`)
+	asmPath := filepath.Join(t.TempDir(), "foo_arm.s")
+	asm := []byte("TEXT ·Foo(SB),NOSPLIT,$0-0\n\tRET\n")
+	tr, err := TranslateSourceModuleForPkgWithOptions(pkg, asmPath, asm, "linux", "arm", TranslateOptions{GOARM: "6,softfloat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Module.Dispose()
+	if got, want := tr.Module.Target(), "armv6-unknown-linux-gnueabihf"; got != want {
+		t.Fatalf("module target = %q, want %q", got, want)
+	}
+}
+
 func TestTranslateHelperFunctions(t *testing.T) {
 	if got := StripABISuffix("runtime·cmpstring<ABIInternal>"); got != "runtime·cmpstring" {
 		t.Fatalf("StripABISuffix runtime = %q", got)

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -3,6 +3,12 @@ package llvm
 import "runtime"
 
 func GetTargetTriple(goos, goarch string) string {
+	return GetTargetTripleWithGOARM(goos, goarch, "")
+}
+
+// GetTargetTripleWithGOARM returns the LLVM target triple for a Go target.
+// goarm selects the ARM version for GOARCH=arm and defaults to ARMv7.
+func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	var llvmarch string
 	if goarch == "" {
 		goarch = runtime.GOARCH
@@ -22,9 +28,14 @@ func GetTargetTriple(goos, goarch string) string {
 	case "arm64":
 		llvmarch = "aarch64"
 	case "arm":
-		// Keep the default in sync with ssa.Target.Spec when GOARM is not
-		// explicitly modeled by this helper.
-		llvmarch = "armv7"
+		switch goarm {
+		case "5":
+			llvmarch = "armv5"
+		case "6":
+			llvmarch = "armv6"
+		default:
+			llvmarch = "armv7"
+		}
 	case "wasm":
 		llvmarch = "wasm32"
 	default:
@@ -41,7 +52,6 @@ func GetTargetTriple(goos, goarch string) string {
 			// Looks like Apple prefers to call this architecture ARM64
 			// instead of AArch64.
 			llvmarch = "arm64"
-			llvmos = "macosx"
 		}
 		llvmvendor = "apple"
 	case "wasip1":

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -3,7 +3,7 @@ package llvm
 import (
 	"runtime"
 
-	archcfg "github.com/goplus/llgo/internal/goarch"
+	archcfg "github.com/xgo-dev/llgo/internal/goarch"
 )
 
 func GetTargetTriple(goos, goarch string) string {

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -12,7 +12,11 @@ func GetTargetTriple(goos, goarch string) string {
 	}
 	switch goarch {
 	case "386":
-		llvmarch = "i386"
+		if goos == "windows" {
+			llvmarch = "i686"
+		} else {
+			llvmarch = "i386"
+		}
 	case "amd64":
 		llvmarch = "x86_64"
 	case "arm64":
@@ -42,13 +46,18 @@ func GetTargetTriple(goos, goarch string) string {
 		llvmvendor = "apple"
 	case "wasip1":
 		llvmos = "wasip1"
+	case "windows":
+		// GOOS=windows defaults to the native Microsoft ABI. MinGW is a
+		// separate target toolchain and must not be inferred from the host
+		// shell.
+		llvmvendor = "pc"
 	}
 	// Target triples (which actually have four components, but are called
 	// triples for historical reasons) have the form:
 	//   arch-vendor-os-environment
 	triple := llvmarch + "-" + llvmvendor + "-" + llvmos
 	if llvmos == "windows" {
-		triple += "-gnu"
+		triple += "-msvc"
 	} else if goarch == "arm" {
 		triple += "-gnueabihf"
 	}

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -1,6 +1,10 @@
 package llvm
 
-import "runtime"
+import (
+	"runtime"
+
+	archcfg "github.com/goplus/llgo/internal/goarch"
+)
 
 func GetTargetTriple(goos, goarch string) string {
 	return GetTargetTripleWithGOARM(goos, goarch, "")
@@ -29,7 +33,8 @@ func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	case "arm64":
 		llvmarch = "aarch64"
 	case "arm":
-		switch goarm {
+		arm, _ := archcfg.ParseARM(goarm)
+		switch arm.Version {
 		case "5":
 			llvmarch = "armv5"
 		case "6":
@@ -70,10 +75,9 @@ func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	if llvmos == "windows" {
 		triple += "-msvc"
 	} else if goarch == "arm" {
-		// Match Go's defaults: GOARM=5 uses software floating point, while
-		// GOARM=6 and GOARM=7 use hardware floating point.
+		arm, _ := archcfg.ParseARM(goarm)
 		triple += "-gnueabi"
-		if goarm != "5" {
+		if !arm.SoftFloat {
 			triple += "hf"
 		}
 	}

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -19,6 +19,7 @@ func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	switch goarch {
 	case "386":
 		if goos == "windows" {
+			// LLVM's 32-bit MSVC target spelling uses i686.
 			llvmarch = "i686"
 		} else {
 			llvmarch = "i386"

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -70,7 +70,12 @@ func GetTargetTripleWithGOARM(goos, goarch, goarm string) string {
 	if llvmos == "windows" {
 		triple += "-msvc"
 	} else if goarch == "arm" {
-		triple += "-gnueabihf"
+		// Match Go's defaults: GOARM=5 uses software floating point, while
+		// GOARM=6 and GOARM=7 use hardware floating point.
+		triple += "-gnueabi"
+		if goarm != "5" {
+			triple += "hf"
+		}
 	}
 	return triple
 }

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -42,6 +42,7 @@ func TestGetTargetTriple(t *testing.T) {
 	clangArchMap := map[string][]string{
 		"x86_64":  {"x86-64", "x86_64"},
 		"i386":    {"x86", "i386"},
+		"i686":    {"x86", "i386"},
 		"aarch64": {"aarch64", "arm64"},
 		"arm64":   {"arm64", "aarch64"},
 		"armv7":   {"arm", "thumb"},
@@ -144,7 +145,8 @@ func TestGetTargetTriple(t *testing.T) {
 	checkTriple(t, "linux/arm", "linux", "arm", "armv7-unknown-linux-gnueabihf")
 	checkTriple(t, "darwin/amd64", "darwin", "amd64", "x86_64-apple-macosx")
 	checkTriple(t, "darwin/arm64", "darwin", "arm64", "arm64-apple-macosx")
-	checkTriple(t, "windows/amd64", "windows", "amd64", "x86_64-unknown-windows-gnu")
-	checkTriple(t, "windows/386", "windows", "386", "i386-unknown-windows-gnu")
+	checkTriple(t, "windows/amd64", "windows", "amd64", "x86_64-pc-windows-msvc")
+	checkTriple(t, "windows/386", "windows", "386", "i686-pc-windows-msvc")
+	checkTriple(t, "windows/arm64", "windows", "arm64", "aarch64-pc-windows-msvc")
 	checkTriple(t, "js/wasm", "js", "wasm", "wasm32-unknown-js")
 }

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -157,7 +157,9 @@ func TestGetTargetTripleWithGOARM(t *testing.T) {
 		want  string
 	}{
 		{"5", "armv5-unknown-linux-gnueabi"},
+		{"5,hardfloat", "armv5-unknown-linux-gnueabihf"},
 		{"6", "armv6-unknown-linux-gnueabihf"},
+		{"6,softfloat", "armv6-unknown-linux-gnueabi"},
 		{"7", "armv7-unknown-linux-gnueabihf"},
 		{"", "armv7-unknown-linux-gnueabihf"},
 	} {

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -156,7 +156,7 @@ func TestGetTargetTripleWithGOARM(t *testing.T) {
 		goarm string
 		want  string
 	}{
-		{"5", "armv5-unknown-linux-gnueabihf"},
+		{"5", "armv5-unknown-linux-gnueabi"},
 		{"6", "armv6-unknown-linux-gnueabihf"},
 		{"7", "armv7-unknown-linux-gnueabihf"},
 		{"", "armv7-unknown-linux-gnueabihf"},

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -150,3 +150,19 @@ func TestGetTargetTriple(t *testing.T) {
 	checkTriple(t, "windows/arm64", "windows", "arm64", "aarch64-pc-windows-msvc")
 	checkTriple(t, "js/wasm", "js", "wasm", "wasm32-unknown-js")
 }
+
+func TestGetTargetTripleWithGOARM(t *testing.T) {
+	for _, test := range []struct {
+		goarm string
+		want  string
+	}{
+		{"5", "armv5-unknown-linux-gnueabihf"},
+		{"6", "armv6-unknown-linux-gnueabihf"},
+		{"7", "armv7-unknown-linux-gnueabihf"},
+		{"", "armv7-unknown-linux-gnueabihf"},
+	} {
+		if got := GetTargetTripleWithGOARM("linux", "arm", test.goarm); got != test.want {
+			t.Errorf("GetTargetTripleWithGOARM(linux, arm, %q) = %q, want %q", test.goarm, got, test.want)
+		}
+	}
+}

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -176,7 +176,7 @@ func (b Builder) abiStructFields(t *types.Struct, name string) llvm.Value {
 		g = b.Pkg.doNewVar(name, prog.Pointer(atyp))
 		g.Init(data)
 		g.impl.SetGlobalConstant(true)
-		g.impl.SetLinkage(llvm.WeakODRLinkage)
+		b.Pkg.setODRLinkage(g.impl, llvm.WeakODRLinkage)
 	}
 	size := uint64(n)
 	return llvm.ConstNamedStruct(prog.rtType("Slice").ll, []llvm.Value{
@@ -226,7 +226,7 @@ func (b Builder) abiInterfaceImethods(t *types.Interface, name string) llvm.Valu
 		g = b.Pkg.doNewVar(name, prog.Pointer(atyp))
 		g.Init(data)
 		g.impl.SetGlobalConstant(true)
-		g.impl.SetLinkage(llvm.WeakODRLinkage)
+		b.Pkg.setODRLinkage(g.impl, llvm.WeakODRLinkage)
 	}
 	size := uint64(n)
 	return llvm.ConstNamedStruct(prog.rtType("Slice").ll, []llvm.Value{
@@ -254,7 +254,7 @@ func (b Builder) abiTuples(t *types.Tuple, name string) llvm.Value {
 		g = b.Pkg.doNewVar(name, prog.Pointer(atyp))
 		g.Init(data)
 		g.impl.SetGlobalConstant(true)
-		g.impl.SetLinkage(llvm.WeakODRLinkage)
+		b.Pkg.setODRLinkage(g.impl, llvm.WeakODRLinkage)
 	}
 	size := uint64(n)
 	return llvm.ConstNamedStruct(prog.rtType("Slice").ll, []llvm.Value{
@@ -683,7 +683,7 @@ func (b Builder) abiType(t types.Type) Expr {
 		}
 		g.impl.SetInitializer(llvm.ConstNamedStruct(g.impl.GlobalValueType(), fields))
 		g.impl.SetGlobalConstant(true)
-		g.impl.SetLinkage(llvm.WeakODRLinkage)
+		b.Pkg.setODRLinkage(g.impl, llvm.WeakODRLinkage)
 		if prog.enableGoGlobalDCE {
 			prog.addMethodTypeMetadata(g.impl, prog.Type(typ, InGo), methods)
 		}

--- a/ssa/coff_comdat_test.go
+++ b/ssa/coff_comdat_test.go
@@ -1,0 +1,51 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestWindowsODRDefinitionsUseCOMDAT(t *testing.T) {
+	prog := NewProgram(&Target{GOOS: "windows", GOARCH: "amd64"})
+	defer prog.Dispose()
+	pkg := prog.NewPackage("example.com/p", "example.com/p")
+
+	global := pkg.NewVar("shared.global", types.NewPointer(types.Typ[types.Int]), InGo)
+	global.Init(prog.IntVal(0, prog.Int()))
+	pkg.setODRLinkage(global.impl, llvm.WeakODRLinkage)
+	fn := pkg.NewFuncEx("shared.func", NoArgsNoRet, InGo, false, true)
+	body := fn.MakeBody(1)
+	body.Return()
+	body.EndBuild()
+
+	ir := pkg.String()
+	for _, want := range []string{
+		`$shared.global = comdat any`,
+		`$shared.func = comdat any`,
+		`@shared.global = weak_odr global i64 0, comdat`,
+		`define linkonce void @shared.func() #0 comdat`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("Windows ODR IR does not contain %q:\n%s", want, ir)
+		}
+	}
+}
+
+func TestUnixODRDefinitionsDoNotGainCOMDAT(t *testing.T) {
+	prog := NewProgram(&Target{GOOS: "linux", GOARCH: "amd64"})
+	defer prog.Dispose()
+	pkg := prog.NewPackage("example.com/p", "example.com/p")
+
+	global := pkg.NewVar("shared.global", types.NewPointer(types.Typ[types.Int]), InGo)
+	global.Init(prog.IntVal(0, prog.Int()))
+	pkg.setODRLinkage(global.impl, llvm.WeakODRLinkage)
+
+	if ir := pkg.String(); strings.Contains(ir, "comdat") {
+		t.Fatalf("non-Windows ODR IR unexpectedly contains COMDAT:\n%s", ir)
+	}
+}

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -87,10 +87,24 @@ func (p Package) moduleZeroSizedAlloc(elem Type) Expr {
 		byteTy := p.Prog.Byte()
 		zerobase = llvm.AddGlobal(p.mod, byteTy.ll, moduleZeroName)
 		zerobase.SetInitializer(llvm.ConstNull(byteTy.ll))
-		zerobase.SetLinkage(llvm.LinkOnceODRLinkage)
+		p.setODRLinkage(zerobase, llvm.LinkOnceODRLinkage)
 		zerobase.SetUnnamedAddr(true)
 	}
 	return Expr{zerobase, p.Prog.Pointer(elem)}
+}
+
+// setODRLinkage gives multiply emitted definitions the section-group metadata
+// required by COFF. On ELF and Mach-O, LLVM's weak/linkonce linkage is enough;
+// on COFF, omitting COMDAT leaves every object with a separately named weak
+// fallback and lld-link rejects the otherwise identical definitions.
+func (p Package) setODRLinkage(value llvm.Value, linkage llvm.Linkage) {
+	value.SetLinkage(linkage)
+	if p.Prog.target.effectiveGOOS() != "windows" {
+		return
+	}
+	comdat := p.mod.Comdat(value.Name())
+	comdat.SetSelectionKind(llvm.AnyComdatSelectionKind)
+	value.SetComdat(comdat)
 }
 
 func (p Package) ownsGlobal(name string) bool {
@@ -319,7 +333,7 @@ func (p Package) newFunc(
 		}
 	}
 	if instantiated {
-		fn.SetLinkage(llvm.LinkOnceAnyLinkage)
+		p.setODRLinkage(fn, llvm.LinkOnceAnyLinkage)
 	}
 	if p.isPreservedName(name) {
 		p.markLLVMUsed(fn)

--- a/ssa/python.go
+++ b/ssa/python.go
@@ -310,7 +310,7 @@ func (p Package) PyNewModVar(name string, doInit bool) Global {
 	g := p.NewVar(name, objPtr, InC)
 	if doInit {
 		g.InitNil()
-		g.impl.SetLinkage(llvm.LinkOnceAnyLinkage)
+		p.setODRLinkage(g.impl, llvm.LinkOnceAnyLinkage)
 	}
 	p.pymods[name] = g
 	return g
@@ -591,7 +591,7 @@ func (p Package) PyNewFunc(name string, sig *types.Signature, doInit bool) PyObj
 	if doInit {
 		p.NeedPyInit = true
 		obj.InitNil()
-		obj.impl.SetLinkage(llvm.LinkOnceAnyLinkage)
+		p.setODRLinkage(obj.impl, llvm.LinkOnceAnyLinkage)
 	}
 	ty := &aType{obj.ll, rawType{types.NewPointer(sig)}, vkPyFuncRef}
 	expr := Expr{obj.impl, ty}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2700,6 +2700,26 @@ func TestWindowsTargetTriple(t *testing.T) {
 	}
 }
 
+func TestARMTargetSpec(t *testing.T) {
+	for _, test := range []struct {
+		goarm       string
+		wantTriple  string
+		wantFeature string
+	}{
+		{"5", "armv5-unknown-linux-gnueabi", "+armv5t"},
+		{"6", "armv6-unknown-linux-gnueabihf", "+armv6"},
+		{"7", "armv7-unknown-linux-gnueabihf", "+armv7-a"},
+	} {
+		spec := (&Target{GOOS: "linux", GOARCH: "arm", GOARM: test.goarm}).Spec()
+		if spec.Triple != test.wantTriple {
+			t.Errorf("linux/arm GOARM=%s triple = %q, want %q", test.goarm, spec.Triple, test.wantTriple)
+		}
+		if !strings.Contains(spec.Features, test.wantFeature) {
+			t.Errorf("linux/arm GOARM=%s features = %q, want %q", test.goarm, spec.Features, test.wantFeature)
+		}
+	}
+}
+
 func TestAbiTables(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2684,6 +2684,22 @@ func TestTargetMachineAndDataLayout(t *testing.T) {
 	}
 }
 
+func TestWindowsTargetTriple(t *testing.T) {
+	for _, test := range []struct {
+		goarch string
+		want   string
+	}{
+		{"386", "i686-pc-windows-msvc"},
+		{"amd64", "x86_64-pc-windows-msvc"},
+		{"arm64", "aarch64-pc-windows-msvc"},
+	} {
+		target := &Target{GOOS: "windows", GOARCH: test.goarch}
+		if got := target.Spec().Triple; got != test.want {
+			t.Errorf("windows/%s target triple = %q, want %q", test.goarch, got, test.want)
+		}
+	}
+}
+
 func TestAbiTables(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strings"
 
+	archcfg "github.com/xgo-dev/llgo/internal/goarch"
 	"github.com/xgo-dev/llgo/internal/optlevel"
 	intllvm "github.com/xgo-dev/llgo/internal/xtool/llvm"
 	"github.com/xgo-dev/llvm"
@@ -30,7 +31,10 @@ import (
 type Target struct {
 	GOOS                    string
 	GOARCH                  string
+	GO386                   string // "sse2" (default) or "softfloat"
+	GOAMD64                 string // "v1" (default), "v2", "v3", or "v4"
 	GOARM                   string // "5", "6", "7" (default)
+	GOARM64                 string // "v8.0" (default) through "v9.5", with optional extensions
 	Target                  string // target name from -target flag (e.g., "esp32", "arm7tdmi", "wasi")
 	LLVMTarget              string // physical LLVM target selected by a target configuration
 	OptLevel                optlevel.Level
@@ -136,9 +140,26 @@ func (p *Target) Spec() (spec TargetSpec) {
 	switch goarch {
 	case "386":
 		spec.CPU = "pentium4"
-		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
+		go386 := p.GO386
+		if p.Target != "" {
+			go386 = ""
+		}
+		go386, _ = archcfg.Resolve386(go386)
+		if go386 == "softfloat" {
+			spec.Features = "+cx8,+fxsr,+mmx,+soft-float,-sse,-sse2,-x87"
+		} else {
+			spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
+		}
 	case "amd64":
+		goamd64 := p.GOAMD64
+		if p.Target != "" {
+			goamd64 = ""
+		}
+		goamd64, _ = archcfg.ResolveAMD64(goamd64)
 		spec.CPU = "x86-64"
+		if goamd64 != "v1" {
+			spec.CPU += "-" + goamd64
+		}
 		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
@@ -152,11 +173,30 @@ func (p *Target) Spec() (spec TargetSpec) {
 		}
 	case "arm64":
 		spec.CPU = "generic"
-		if goos == "darwin" {
-			spec.Features = "+neon"
-		} else { // windows, linux
-			spec.Features = "+neon,-fmv"
+		goarm64 := p.GOARM64
+		if p.Target != "" {
+			goarm64 = ""
 		}
+		arm64, _ := archcfg.ParseARM64(goarm64)
+		archFeature := arm64.Version + "a"
+		if arm64.Version == "v9.0" {
+			archFeature = "v9a"
+		}
+		features := make([]string, 0, 5)
+		if arm64.Version != "v8.0" {
+			features = append(features, "+"+archFeature)
+		}
+		features = append(features, "+neon")
+		if arm64.LSE {
+			features = append(features, "+lse")
+		}
+		if arm64.Crypto {
+			features = append(features, "+crypto")
+		}
+		if goos != "darwin" { // windows, linux
+			features = append(features, "-fmv")
+		}
+		spec.Features = strings.Join(features, ",")
 	case "wasm":
 		spec.CPU = "generic"
 		spec.Features = "+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext"

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -130,30 +130,8 @@ type TargetSpec struct {
 func (p *Target) Spec() (spec TargetSpec) {
 	// Configure based on GOOS/GOARCH environment variables (falling back to
 	// runtime.GOOS/runtime.GOARCH), and generate a LLVM target based on it.
-	var llvmarch string
 	goarch := p.effectiveGOARCH()
 	goos := p.effectiveGOOS()
-	switch goarch {
-	case "386":
-		llvmarch = "i386"
-	case "amd64":
-		llvmarch = "x86_64"
-	case "arm64":
-		llvmarch = "aarch64"
-	case "arm":
-		switch p.GOARM {
-		case "5":
-			llvmarch = "armv5"
-		case "6":
-			llvmarch = "armv6"
-		default:
-			llvmarch = "armv7"
-		}
-	case "wasm":
-		llvmarch = "wasm32"
-	default:
-		llvmarch = goarch
-	}
 	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, p.GOARM)
 	switch goarch {
 	case "386":
@@ -164,12 +142,12 @@ func (p *Target) Spec() (spec TargetSpec) {
 		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
-		switch llvmarch {
-		case "armv5":
+		switch p.GOARM {
+		case "5":
 			spec.Features = "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
-		case "armv6":
+		case "6":
 			spec.Features = "+armv6,+dsp,+fp64,+strict-align,+vfp2,+vfp2sp,-aes,-d32,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-neon,-sha2,-thumb-mode,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
-		case "armv7":
+		default:
 			spec.Features = "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-aes,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-sha2,-thumb-mode,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 		}
 	case "arm64":

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -131,35 +131,34 @@ type TargetSpec struct {
 	Features string
 }
 
+func (p *Target) goArchitectureSetting(value string) string {
+	if p.Target != "" {
+		return ""
+	}
+	return value
+}
+
 func (p *Target) Spec() (spec TargetSpec) {
 	// Configure based on GOOS/GOARCH environment variables (falling back to
 	// runtime.GOOS/runtime.GOARCH), and generate a LLVM target based on it.
 	goarch := p.effectiveGOARCH()
 	goos := p.effectiveGOOS()
-	goarm := p.GOARM
-	if p.Target != "" {
-		goarm = ""
-	}
+	goarm := p.goArchitectureSetting(p.GOARM)
 	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, goarm)
+	// Build validates these settings before constructing Target. Spec also
+	// accepts hand-built Targets, so it intentionally uses each resolver's
+	// documented Go-default fallback when its error cannot be returned here.
 	switch goarch {
 	case "386":
 		spec.CPU = "pentium4"
-		go386 := p.GO386
-		if p.Target != "" {
-			go386 = ""
-		}
-		go386, _ = archcfg.Resolve386(go386)
+		go386, _ := archcfg.Resolve386(p.goArchitectureSetting(p.GO386))
 		if go386 == "softfloat" {
 			spec.Features = "+cx8,+fxsr,+mmx,+soft-float,-sse,-sse2,-x87"
 		} else {
 			spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 		}
 	case "amd64":
-		goamd64 := p.GOAMD64
-		if p.Target != "" {
-			goamd64 = ""
-		}
-		goamd64, _ = archcfg.ResolveAMD64(goamd64)
+		goamd64, _ := archcfg.ResolveAMD64(p.goArchitectureSetting(p.GOAMD64))
 		spec.CPU = "x86-64"
 		if goamd64 != "v1" {
 			spec.CPU += "-" + goamd64
@@ -185,11 +184,7 @@ func (p *Target) Spec() (spec TargetSpec) {
 		}
 	case "arm64":
 		spec.CPU = "generic"
-		goarm64 := p.GOARM64
-		if p.Target != "" {
-			goarm64 = ""
-		}
-		arm64, _ := archcfg.ParseARM64(goarm64)
+		arm64, _ := archcfg.ParseARM64(p.goArchitectureSetting(p.GOARM64))
 		archFeature := arm64.Version + "a"
 		if arm64.Version == "v9.0" {
 			archFeature = "v9a"

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -136,7 +136,11 @@ func (p *Target) Spec() (spec TargetSpec) {
 	// runtime.GOOS/runtime.GOARCH), and generate a LLVM target based on it.
 	goarch := p.effectiveGOARCH()
 	goos := p.effectiveGOOS()
-	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, p.GOARM)
+	goarm := p.GOARM
+	if p.Target != "" {
+		goarm = ""
+	}
+	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, goarm)
 	switch goarch {
 	case "386":
 		spec.CPU = "pentium4"
@@ -163,13 +167,21 @@ func (p *Target) Spec() (spec TargetSpec) {
 		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
-		switch p.GOARM {
+		arm, _ := archcfg.ParseARM(goarm)
+		switch arm.Version {
 		case "5":
 			spec.Features = "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 		case "6":
 			spec.Features = "+armv6,+dsp,+fp64,+strict-align,+vfp2,+vfp2sp,-aes,-d32,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-neon,-sha2,-thumb-mode,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
-		default:
+		case "7":
 			spec.Features = "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-aes,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-sha2,-thumb-mode,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
+		}
+		if arm.SoftFloat {
+			spec.Features += ",+soft-float"
+		} else if arm.Version == "5" {
+			// GOARM=5,hardfloat uses VFPv2 even though ARMv5 defaults to
+			// software floating point.
+			spec.Features += ",+fp64,+fpregs,+vfp2,+vfp2sp"
 		}
 	case "arm64":
 		spec.CPU = "generic"

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/xgo-dev/llgo/internal/optlevel"
+	intllvm "github.com/xgo-dev/llgo/internal/xtool/llvm"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -153,32 +154,7 @@ func (p *Target) Spec() (spec TargetSpec) {
 	default:
 		llvmarch = goarch
 	}
-	llvmvendor := "unknown"
-	llvmos := goos
-	switch goos {
-	case "darwin":
-		// Use macosx* instead of darwin, otherwise darwin/arm64 will refer
-		// to iOS!
-		llvmos = "macosx"
-		if llvmarch == "aarch64" {
-			// Looks like Apple prefers to call this architecture ARM64
-			// instead of AArch64.
-			llvmarch = "arm64"
-			llvmos = "macosx"
-		}
-		llvmvendor = "apple"
-	case "wasip1":
-		llvmos = "wasip1"
-	}
-	// Target triples (which actually have four components, but are called
-	// triples for historical reasons) have the form:
-	//   arch-vendor-os-environment
-	spec.Triple = llvmarch + "-" + llvmvendor + "-" + llvmos
-	if llvmos == "windows" {
-		spec.Triple += "-gnu"
-	} else if goarch == "arm" {
-		spec.Triple += "-gnueabihf"
-	}
+	spec.Triple = intllvm.GetTargetTripleWithGOARM(goos, goarch, p.GOARM)
 	switch goarch {
 	case "386":
 		spec.CPU = "pentium4"

--- a/ssa/target_features_test.go
+++ b/ssa/target_features_test.go
@@ -35,12 +35,16 @@ func TestTargetArchitectureFeatures(t *testing.T) {
 		{name: "amd64 v2", target: Target{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v2"}, wantCPU: "x86-64-v2", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
 		{name: "amd64 v3", target: Target{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v3"}, wantCPU: "x86-64-v3", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
 		{name: "amd64 v4", target: Target{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v4"}, wantCPU: "x86-64-v4", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "arm default", target: Target{GOOS: "linux", GOARCH: "arm"}, wantCPU: "generic", wantFeat: "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-aes,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-sha2,-thumb-mode,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"},
+		{name: "arm6 softfloat", target: Target{GOOS: "linux", GOARCH: "arm", GOARM: "6,softfloat"}, wantCPU: "generic", wantFeat: "+armv6,+dsp,+fp64,+strict-align,+vfp2,+vfp2sp,-aes,-d32,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-neon,-sha2,-thumb-mode,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp,+soft-float"},
+		{name: "arm5 hardfloat", target: Target{GOOS: "linux", GOARCH: "arm", GOARM: "5,hardfloat"}, wantCPU: "generic", wantFeat: "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp,+fp64,+fpregs,+vfp2,+vfp2sp"},
 		{name: "arm64 default", target: Target{GOOS: "windows", GOARCH: "arm64"}, wantCPU: "generic", wantFeat: "+neon,-fmv"},
 		{name: "arm64 v8.1", target: Target{GOOS: "windows", GOARCH: "arm64", GOARM64: "v8.1"}, wantCPU: "generic", wantFeat: "+v8.1a,+neon,+lse,-fmv"},
 		{name: "arm64 v9 crypto", target: Target{GOOS: "windows", GOARCH: "arm64", GOARM64: "v9.0,crypto"}, wantCPU: "generic", wantFeat: "+v9a,+neon,+lse,+crypto,-fmv"},
 		{name: "darwin arm64", target: Target{GOOS: "darwin", GOARCH: "arm64", GOARM64: "v8.2"}, wantCPU: "generic", wantFeat: "+v8.2a,+neon,+lse"},
 		{name: "named 386 target unchanged", target: Target{GOOS: "linux", GOARCH: "386", GO386: "softfloat", Target: "custom"}, wantCPU: "pentium4", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
 		{name: "named amd64 target unchanged", target: Target{GOOS: "linux", GOARCH: "amd64", GOAMD64: "v4", Target: "custom"}, wantCPU: "x86-64", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "named arm target unchanged", target: Target{GOOS: "linux", GOARCH: "arm", GOARM: "5,hardfloat", Target: "custom"}, wantCPU: "generic", wantFeat: "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-aes,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-sha2,-thumb-mode,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"},
 		{name: "named arm64 target unchanged", target: Target{GOOS: "linux", GOARCH: "arm64", GOARM64: "v9.5,crypto", Target: "custom"}, wantCPU: "generic", wantFeat: "+neon,-fmv"},
 	}
 	for _, test := range tests {
@@ -57,6 +61,8 @@ func TestArchitectureFeatureTargetMachines(t *testing.T) {
 	for _, target := range []*Target{
 		{GOOS: "windows", GOARCH: "386", GO386: "softfloat"},
 		{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v4"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "6,softfloat"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "5,hardfloat"},
 		{GOOS: "windows", GOARCH: "arm64", GOARM64: "v9.5,crypto"},
 	} {
 		prog := NewProgram(target)

--- a/ssa/target_features_test.go
+++ b/ssa/target_features_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssa
+
+import (
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestTargetArchitectureFeatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   Target
+		wantCPU  string
+		wantFeat string
+	}{
+		{name: "386 default", target: Target{GOOS: "windows", GOARCH: "386"}, wantCPU: "pentium4", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "386 softfloat", target: Target{GOOS: "windows", GOARCH: "386", GO386: "softfloat"}, wantCPU: "pentium4", wantFeat: "+cx8,+fxsr,+mmx,+soft-float,-sse,-sse2,-x87"},
+		{name: "amd64 v1", target: Target{GOOS: "windows", GOARCH: "amd64"}, wantCPU: "x86-64", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "amd64 v2", target: Target{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v2"}, wantCPU: "x86-64-v2", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "amd64 v3", target: Target{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v3"}, wantCPU: "x86-64-v3", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "amd64 v4", target: Target{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v4"}, wantCPU: "x86-64-v4", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "arm64 default", target: Target{GOOS: "windows", GOARCH: "arm64"}, wantCPU: "generic", wantFeat: "+neon,-fmv"},
+		{name: "arm64 v8.1", target: Target{GOOS: "windows", GOARCH: "arm64", GOARM64: "v8.1"}, wantCPU: "generic", wantFeat: "+v8.1a,+neon,+lse,-fmv"},
+		{name: "arm64 v9 crypto", target: Target{GOOS: "windows", GOARCH: "arm64", GOARM64: "v9.0,crypto"}, wantCPU: "generic", wantFeat: "+v9a,+neon,+lse,+crypto,-fmv"},
+		{name: "darwin arm64", target: Target{GOOS: "darwin", GOARCH: "arm64", GOARM64: "v8.2"}, wantCPU: "generic", wantFeat: "+v8.2a,+neon,+lse"},
+		{name: "named 386 target unchanged", target: Target{GOOS: "linux", GOARCH: "386", GO386: "softfloat", Target: "custom"}, wantCPU: "pentium4", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "named amd64 target unchanged", target: Target{GOOS: "linux", GOARCH: "amd64", GOAMD64: "v4", Target: "custom"}, wantCPU: "x86-64", wantFeat: "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"},
+		{name: "named arm64 target unchanged", target: Target{GOOS: "linux", GOARCH: "arm64", GOARM64: "v9.5,crypto", Target: "custom"}, wantCPU: "generic", wantFeat: "+neon,-fmv"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := test.target.Spec()
+			if spec.CPU != test.wantCPU || spec.Features != test.wantFeat {
+				t.Fatalf("target spec = CPU %q, features %q; want CPU %q, features %q", spec.CPU, spec.Features, test.wantCPU, test.wantFeat)
+			}
+		})
+	}
+}
+
+func TestArchitectureFeatureTargetMachines(t *testing.T) {
+	for _, target := range []*Target{
+		{GOOS: "windows", GOARCH: "386", GO386: "softfloat"},
+		{GOOS: "windows", GOARCH: "amd64", GOAMD64: "v4"},
+		{GOOS: "windows", GOARCH: "arm64", GOARM64: "v9.5,crypto"},
+	} {
+		prog := NewProgram(target)
+		pkg := prog.NewPackage("p", "example.com/p")
+		pkg.NewFunc("example.com/p.f", NoArgsNoRet, InGo).MakeBody(1).Return()
+		buf, err := prog.TargetMachine().EmitToMemoryBuffer(pkg.Module(), llvm.ObjectFile)
+		if err != nil {
+			prog.Dispose()
+			t.Fatalf("emit %s/%s with CPU/features %q/%q: %v", target.GOOS, target.GOARCH, target.Spec().CPU, target.Spec().Features, err)
+		}
+		buf.Dispose()
+		prog.Dispose()
+	}
+}


### PR DESCRIPTION
Part of #2325, the MSVC-first Windows support proposal.

Depends on #2327, which establishes MSVC target triples and the native Windows host-smoke foundation.

## Summary

- translate native Windows linker diagnostics, ICF, dead-code elimination, debug-info, and ThinLTO controls to COFF/lld-link syntax
- configure the Windows MSVC/COFF target consistently for native and cross builds without overloading LLGo's named `-target` system
- parse and normalize `GO386`, `GOAMD64`, `GOARM`, and `GOARM64` with Go 1.26-compatible defaults, accepted values, diagnostics, and canonical forms
- carry the normalized architecture setting through package selection, child Go commands, cache fingerprints, clang/linker triples, Plan 9 assembly, and LLVM CPU/features
- attach COFF COMDAT metadata to LLGo's multiply emitted weak/linkonce definitions while keeping ICF disabled for distinct Go functions
- keep named `-target` configurations independent of host GOARCH tuning

## Go architecture compatibility

- `GO386=sse2|softfloat` preserves the Go defaults and selects the corresponding LLVM floating-point behavior
- `GOAMD64=v1..v4` maps to LLVM `x86-64`, `x86-64-v2`, `x86-64-v3`, and `x86-64-v4`
- `GOARM=5/6/7[,softfloat|hardfloat]` selects the matching ISA and float ABI; normalized values explicitly include the effective float mode, matching `buildcfg.GoarmFeatures.String()`
- `GOARM64=v8.0..v9.5[,lse][,crypto]` maps to the corresponding AArch64 feature set, with mandatory LSE from v8.1 onward

The architecture parser contains Go semantics only. LLVM mapping remains in the backend, and Windows-specific COFF translation remains in crosscompile configuration.

## Scope

This PR covers native target configuration, architecture tuning, clang/lld flag generation, and COFF definition grouping. It does not add the Windows runtime, SDK discovery, FFI/C ABI implementation, GC, goroutines, panic/recover, or debugger backends.

Because this is stacked on #2327, GitHub includes the foundation commits in the PR until #2327 merges.

## Validation

- macOS: `go test ./internal/build ./internal/crosscompile ./internal/goarch ./internal/xtool/llvm ./internal/plan9asm ./ssa`
- macOS: `actionlint .github/workflows/windows.yml`
- Win11 ARM64 + LLVM 19.1.7: metadata, architecture parser, build-config, Windows linker/lock, SSA target, and full `internal/cabi` tests
- Win11 ARM64: built and ran `llgo-windows-smoke.exe version` successfully
- the Windows source was used directly at `\\Mac\Home\source\goplus\llgo-wt-windows-coff-linker-20260815`; only caches and output stayed on the VM
- LLVM 19 `lld-link` accepts `/debug:none`, `/debug:dwarf`, `/opt:noicf`, `/opt:ref`, and `/opt:lldlto=2`

## Final CI and coverage

- all 43 check runs completed without failure: 42 passed and 1 was conditionally skipped
- Linux and macOS full test/coverage jobs passed; the macOS job completed in 31m52s
- the LLVM 19 Windows AMD64 host-smoke job passed in 1m59s
- Codecov patch coverage is 99.35% (target 49.24%)
- same-runner benchmarks report no file-size change and no consistent performance regression
