### PR TITLE
ssa: isolate index range panic path

### DIFF
--- a/cl/_testdata/print/in.go
+++ b/cl/_testdata/print/in.go
@@ -71,8 +71,10 @@ func bytes(s string) (ret []byte) {
 // CHECK-NEXT: [[GWRITE_MORE:%[0-9]+]] = icmp slt i64 [[GWRITE_INDEX]], [[GWRITE_RANGE_LEN]]
 // CHECK: [[GWRITE_DATA:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK: [[GWRITE_BOUND:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 [[GWRITE_INDEX]], i1 true, i64 [[GWRITE_BOUND]])
-// CHECK-NEXT: [[GWRITE_BYTE_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[GWRITE_DATA]], i64 [[GWRITE_INDEX]]
+// CHECK: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 [[GWRITE_INDEX]], i64 [[GWRITE_BOUND]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
+// CHECK: [[GWRITE_BYTE_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[GWRITE_DATA]], i64 [[GWRITE_INDEX]]
 // CHECK-NEXT: [[GWRITE_BYTE:%[0-9]+]] = load i8, ptr [[GWRITE_BYTE_PTR]]
 // CHECK-NEXT: {{%[0-9]+}} = call i32 (ptr, ...) @printf(ptr [[FMT_CHAR]], i8 [[GWRITE_BYTE]])
 
@@ -296,45 +298,44 @@ func printbool(v bool) {
 }
 
 // CHECK-LABEL: define void @main.printfloat(double %0){{.*}} {
-// CHECK: [[PF_NAN:%[0-9]+]] = fcmp une double %0, %0
-// CHECK-NEXT: br i1 [[PF_NAN]], label %{{.*}}, label %{{.*}}
-// CHECK: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_NAN]], i64 3 })
-// CHECK: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_PINF]], i64 4 })
-// CHECK: [[PF_INF_SUM:%[0-9]+]] = fadd double %0, %0
-// CHECK-NEXT: [[PF_IS_INF:%[0-9]+]] = fcmp oeq double [[PF_INF_SUM]], %0
-// CHECK: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_NINF]], i64 4 })
-// CHECK: [[PF_NINF_SUM:%[0-9]+]] = fadd double %0, %0
-// CHECK-NEXT: [[PF_IS_NINF:%[0-9]+]] = fcmp oeq double [[PF_NINF_SUM]], %0
-// CHECK: [[PF_BUFFER:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 14)
-// CHECK: [[PF_IS_ZERO:%[0-9]+]] = fcmp oeq double %0, 0.000000e+00
-// CHECK: [[PF_ZERO_SIGN:%[0-9]+]] = fdiv double 1.000000e+00, %0
-// CHECK-NEXT: {{%[0-9]+}} = fcmp olt double [[PF_ZERO_SIGN]], 0.000000e+00
-// CHECK: [[PF_NEGATED:%[0-9]+]] = fneg double %0
-// CHECK: [[PF_SCALE_DOWN:%[0-9]+]] = fdiv double [[PF_NORMAL:%[0-9]+]], 1.000000e+01
-// CHECK: [[PF_NORMAL]] = phi double [ %0, %{{.*}} ], [ [[PF_SCALE_DOWN]], %{{.*}} ], [ [[PF_NEGATED]], %{{.*}} ]
-// CHECK: [[PF_TOO_LARGE:%[0-9]+]] = fcmp oge double [[PF_NORMAL]], 1.000000e+01
-// CHECK: [[PF_SCALE_UP:%[0-9]+]] = fmul double [[PF_SMALL_VALUE:%[0-9]+]], 1.000000e+01
-// CHECK: [[PF_SMALL_VALUE]] = phi double [ [[PF_NORMAL]], %{{.*}} ], [ [[PF_SCALE_UP]], %{{.*}} ]
-// CHECK: [[PF_TOO_SMALL:%[0-9]+]] = fcmp olt double [[PF_SMALL_VALUE]], 1.000000e+00
-// CHECK: [[PF_ROUND_COUNT:%[0-9]+]] = phi i64 [ 0, %{{.*}} ], [ %{{[0-9]+}}, %{{.*}} ]
-// CHECK-NEXT: [[PF_ROUND_MORE:%[0-9]+]] = icmp slt i64 [[PF_ROUND_COUNT]], 7
-// CHECK: [[PF_ROUNDED:%[0-9]+]] = fadd double %{{[0-9]+}}, %{{[0-9]+}}
-// CHECK-NEXT: [[PF_ROUND_OVERFLOW:%[0-9]+]] = fcmp oge double [[PF_ROUNDED]], 1.000000e+01
-// CHECK: [[PF_DIGIT_INDEX:%[0-9]+]] = phi i64 [ 0, %{{.*}} ], [ %{{[0-9]+}}, %{{.*}} ]
-// CHECK-NEXT: [[PF_MORE_DIGITS:%[0-9]+]] = icmp slt i64 [[PF_DIGIT_INDEX]], 7
-// CHECK: [[PF_DIGIT:%[0-9]+]] = fptosi double %{{[0-9]+}} to i64
-// CHECK: [[PF_DIGIT_CHAR:%[0-9]+]] = trunc i64 %{{[0-9]+}} to i8
-// CHECK: store i8 [[PF_DIGIT_CHAR]], ptr %{{[0-9]+}}
-// CHECK: [[PF_REMAINDER:%[0-9]+]] = fsub double %{{[0-9]+}}, %{{[0-9]+}}
-// CHECK-NEXT: [[PF_NEXT_DIGIT:%[0-9]+]] = fmul double [[PF_REMAINDER]], 1.000000e+01
-// CHECK: store i8 46, ptr %{{[0-9]+}}
-// CHECK: store i8 101, ptr %{{[0-9]+}}
-// CHECK: [[PF_EXP_NEG:%[0-9]+]] = icmp slt i64 [[PF_EXP:%[0-9]+]], 0
-// CHECK: [[PF_EXP_ABS:%[0-9]+]] = phi i64 [ [[PF_EXP]], %{{.*}} ], [ %{{[0-9]+}}, %{{.*}} ]
-// CHECK: [[PF_SLICE0:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr [[PF_BUFFER]], 0
-// CHECK-NEXT: [[PF_SLICE1:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" [[PF_SLICE0]], i64 14, 1
-// CHECK-NEXT: [[PF_SLICE:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" [[PF_SLICE1]], i64 14, 2
-// CHECK-NEXT: call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" [[PF_SLICE]])
+// CHECK-DAG: [[PF_NAN:%[0-9]+]] = fcmp une double %0, %0
+// CHECK-DAG: br i1 [[PF_NAN]], label %{{.*}}, label %{{.*}}
+// CHECK-DAG: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_NAN]], i64 3 })
+// CHECK-DAG: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_PINF]], i64 4 })
+// CHECK-DAG: [[PF_INF_SUM:%[0-9]+]] = fadd double %0, %0
+// CHECK-DAG: [[PF_IS_INF:%[0-9]+]] = fcmp oeq double [[PF_INF_SUM]], %0
+// CHECK-DAG: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_NINF]], i64 4 })
+// CHECK-DAG: [[PF_NINF_SUM:%[0-9]+]] = fadd double %0, %0
+// CHECK-DAG: [[PF_IS_NINF:%[0-9]+]] = fcmp oeq double [[PF_NINF_SUM]], %0
+// CHECK-DAG: [[PF_BUFFER:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 14)
+// CHECK-DAG: [[PF_IS_ZERO:%[0-9]+]] = fcmp oeq double %0, 0.000000e+00
+// CHECK-DAG: [[PF_ZERO_SIGN:%[0-9]+]] = fdiv double 1.000000e+00, %0
+// CHECK-DAG: {{%[0-9]+}} = fcmp olt double [[PF_ZERO_SIGN]], 0.000000e+00
+// CHECK-DAG: [[PF_NEGATED:%[0-9]+]] = fneg double %0
+// CHECK-DAG: [[PF_SCALE_DOWN:%[0-9]+]] = fdiv double [[PF_NORMAL:%[0-9]+]], 1.000000e+01
+// CHECK-DAG: [[PF_NORMAL]] = phi double [ %0, %{{.*}} ], [ [[PF_SCALE_DOWN]], %{{.*}} ], [ [[PF_NEGATED]], %{{.*}} ]
+// CHECK-DAG: [[PF_TOO_LARGE:%[0-9]+]] = fcmp oge double [[PF_NORMAL]], 1.000000e+01
+// CHECK-DAG: [[PF_SCALE_UP:%[0-9]+]] = fmul double [[PF_SMALL_VALUE:%[0-9]+]], 1.000000e+01
+// CHECK-DAG: [[PF_SMALL_VALUE]] = phi double [ [[PF_NORMAL]], %{{.*}} ], [ [[PF_SCALE_UP]], %{{.*}} ]
+// CHECK-DAG: [[PF_TOO_SMALL:%[0-9]+]] = fcmp olt double [[PF_SMALL_VALUE]], 1.000000e+00
+// CHECK-DAG: [[PF_ROUND_MORE:%[0-9]+]] = icmp slt i64 %{{[0-9]+}}, 7
+// CHECK-DAG: [[PF_ROUNDED:%[0-9]+]] = fadd double %{{[0-9]+}}, %{{[0-9]+}}
+// CHECK-DAG: [[PF_ROUND_OVERFLOW:%[0-9]+]] = fcmp oge double [[PF_ROUNDED]], 1.000000e+01
+// CHECK-DAG: [[PF_MORE_DIGITS:%[0-9]+]] = icmp slt i64 %{{[0-9]+}}, 7
+// CHECK-DAG: [[PF_DIGIT:%[0-9]+]] = fptosi double %{{[0-9]+}} to i64
+// CHECK-DAG: [[PF_DIGIT_CHAR:%[0-9]+]] = trunc i64 %{{[0-9]+}} to i8
+// CHECK-DAG: store i8 [[PF_DIGIT_CHAR]], ptr %{{[0-9]+}}
+// CHECK-DAG: [[PF_REMAINDER:%[0-9]+]] = fsub double %{{[0-9]+}}, %{{[0-9]+}}
+// CHECK-DAG: [[PF_NEXT_DIGIT:%[0-9]+]] = fmul double [[PF_REMAINDER]], 1.000000e+01
+// CHECK-DAG: store i8 46, ptr %{{[0-9]+}}
+// CHECK-DAG: store i8 101, ptr %{{[0-9]+}}
+// CHECK-DAG: [[PF_EXP:%[0-9]+]] = phi i64 [ 0, %{{.*}} ], [ %{{[0-9]+}}, %{{.*}} ], [ 0, %{{.*}} ], [ %{{[0-9]+}}, %{{.*}} ]
+// CHECK-DAG: [[PF_EXP_NEG:%[0-9]+]] = icmp slt i64 [[PF_EXP]], 0
+// CHECK-DAG: [[PF_EXP_ABS:%[0-9]+]] = phi i64 [ [[PF_EXP]], %{{.*}} ], [ %{{[0-9]+}}, %{{.*}} ]
+// CHECK-DAG: [[PF_SLICE0:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr [[PF_BUFFER]], 0
+// CHECK-DAG: [[PF_SLICE1:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" [[PF_SLICE0]], i64 14, 1
+// CHECK-DAG: [[PF_SLICE:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" [[PF_SLICE1]], i64 14, 2
+// CHECK-DAG: call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" [[PF_SLICE]])
 
 func printfloat(v float64) {
 	switch {
@@ -409,24 +410,24 @@ func printfloat(v float64) {
 }
 
 // CHECK-LABEL: define void @main.printhex(i64 %0){{.*}} {
-// CHECK: [[PH_BUFFER:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 100)
-// CHECK: [[PH_DIGIT:%[0-9]+]] = urem i64 [[PH_VALUE:%[0-9]+]], 16
-// CHECK: [[PH_DIGIT_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[HEX_DIGITS]], i64 [[PH_DIGIT]]
-// CHECK-NEXT: [[PH_DIGIT_CHAR:%[0-9]+]] = load i8, ptr [[PH_DIGIT_PTR]]
-// CHECK: [[PH_BUFFER_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[PH_BUFFER]], i64 [[PH_INDEX:%[0-9]+]]
-// CHECK-NEXT: store i8 [[PH_DIGIT_CHAR]], ptr [[PH_BUFFER_PTR]]
-// CHECK: [[PH_LAST_DIGIT:%[0-9]+]] = icmp ult i64 [[PH_VALUE]], 16
-// CHECK: store i8 120, ptr %{{[0-9]+}}
-// CHECK: store i8 48, ptr %{{[0-9]+}}
-// CHECK: [[PH_SLICE:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[PH_BUFFER]], i64 1, i64 100, i64 %{{[0-9]+}}, i64 100, i1 true, i1 true, i1 true)
-// CHECK-NEXT: call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" [[PH_SLICE]])
-// CHECK: [[PH_VALUE]] = phi i64 [ %0, %{{.*}} ], [ [[PH_QUOTIENT:%[0-9]+]], %{{.*}} ]
-// CHECK-NEXT: [[PH_INDEX]] = phi i64 [ 99, %{{.*}} ], [ [[PH_PREV_INDEX:%[0-9]+]], %{{.*}} ]
-// CHECK: [[PH_QUOTIENT]] = udiv i64 [[PH_VALUE]], 16
-// CHECK-NEXT: [[PH_PREV_INDEX]] = sub i64 [[PH_INDEX]], 1
-// CHECK: [[PH_WIDTH:%[0-9]+]] = sub i64 100, [[PH_INDEX]]
-// CHECK-NEXT: [[PH_MIN_WIDTH:%[0-9]+]] = load i64, ptr @main.minhexdigits
-// CHECK-NEXT: [[PH_WIDE_ENOUGH:%[0-9]+]] = icmp sge i64 [[PH_WIDTH]], [[PH_MIN_WIDTH]]
+// CHECK-DAG: [[PH_BUFFER:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 100)
+// CHECK-DAG: [[PH_DIGIT:%[0-9]+]] = urem i64 [[PH_VALUE:%[0-9]+]], 16
+// CHECK-DAG: [[PH_DIGIT_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[HEX_DIGITS]], i64 [[PH_DIGIT]]
+// CHECK-DAG: [[PH_DIGIT_CHAR:%[0-9]+]] = load i8, ptr [[PH_DIGIT_PTR]]
+// CHECK-DAG: [[PH_BUFFER_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[PH_BUFFER]], i64 [[PH_INDEX:%[0-9]+]]
+// CHECK-DAG: store i8 [[PH_DIGIT_CHAR]], ptr [[PH_BUFFER_PTR]]
+// CHECK-DAG: [[PH_LAST_DIGIT:%[0-9]+]] = icmp ult i64 [[PH_VALUE]], 16
+// CHECK-DAG: store i8 120, ptr %{{[0-9]+}}
+// CHECK-DAG: store i8 48, ptr %{{[0-9]+}}
+// CHECK-DAG: [[PH_SLICE:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[PH_BUFFER]], i64 1, i64 100, i64 %{{[0-9]+}}, i64 100, i1 true, i1 true, i1 true)
+// CHECK-DAG: call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" [[PH_SLICE]])
+// CHECK-DAG: [[PH_VALUE]] = phi i64 [ %0, %{{.*}} ], [ [[PH_QUOTIENT:%[0-9]+]], %{{.*}} ]
+// CHECK-DAG: [[PH_INDEX]] = phi i64 [ 99, %{{.*}} ], [ [[PH_PREV_INDEX:%[0-9]+]], %{{.*}} ]
+// CHECK-DAG: [[PH_QUOTIENT]] = udiv i64 [[PH_VALUE]], 16
+// CHECK-DAG: [[PH_PREV_INDEX]] = sub i64 [[PH_INDEX]], 1
+// CHECK-DAG: [[PH_WIDTH:%[0-9]+]] = sub i64 100, [[PH_INDEX]]
+// CHECK-DAG: [[PH_MIN_WIDTH:%[0-9]+]] = load i64, ptr @main.minhexdigits
+// CHECK-DAG: [[PH_WIDE_ENOUGH:%[0-9]+]] = icmp sge i64 [[PH_WIDTH]], [[PH_MIN_WIDTH]]
 
 func printhex(v uint64) {
 	const dig = "0123456789abcdef"
@@ -463,18 +464,20 @@ func printint(v int64) {
 }
 
 // CHECK-LABEL: define void @main.println(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
-// CHECK: [[PL_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK: [[PL_INDEX:%[0-9]+]] = add i64 %{{[0-9]+}}, 1
-// CHECK-NEXT: [[PL_MORE:%[0-9]+]] = icmp slt i64 [[PL_INDEX]], [[PL_LEN]]
-// CHECK: [[PL_DATA:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 0
-// CHECK: [[PL_BOUND:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 [[PL_INDEX]], i1 true, i64 [[PL_BOUND]])
-// CHECK-NEXT: [[PL_ITEM_PTR:%[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr [[PL_DATA]], i64 [[PL_INDEX]]
-// CHECK-NEXT: [[PL_ITEM:%[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.eface", ptr [[PL_ITEM_PTR]]
-// CHECK: [[PL_NEEDS_SPACE:%[0-9]+]] = icmp ne i64 [[PL_INDEX]], 0
-// CHECK: call void @main.printnl()
-// CHECK: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_SPACE]], i64 1 })
-// CHECK: call void @main.printany(%"{{.*}}/runtime/internal/runtime.eface" [[PL_ITEM]])
+// CHECK-DAG: [[PL_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
+// CHECK-DAG: [[PL_INDEX:%[0-9]+]] = add i64 %{{[0-9]+}}, 1
+// CHECK-DAG: [[PL_MORE:%[0-9]+]] = icmp slt i64 [[PL_INDEX]], [[PL_LEN]]
+// CHECK-DAG: [[PL_DATA:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 0
+// CHECK-DAG: [[PL_BOUND:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
+// CHECK-DAG: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 [[PL_INDEX]], i64 [[PL_BOUND]])
+// CHECK-DAG: br label %{{_llgo_[0-9]+}}
+// CHECK-DAG: [[PL_ITEM_PTR:%[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr [[PL_DATA]], i64 [[PL_INDEX]]
+// CHECK-DAG: [[PL_ITEM:%[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.eface", ptr [[PL_ITEM_PTR]]
+// CHECK-DAG: [[PL_NEEDS_SPACE:%[0-9]+]] = icmp ne i64 [[PL_INDEX]], 0
+// CHECK-DAG: call void @main.printnl()
+// CHECK-DAG: call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr [[STR_SPACE]], i64 1 })
+// CHECK-DAG: call void @main.printany(%"{{.*}}/runtime/internal/runtime.eface" [[PL_ITEM]])
 
 func println(args ...any) {
 	for i, v := range args {
@@ -509,19 +512,19 @@ func printstring(s string) {
 }
 
 // CHECK-LABEL: define void @main.printuint(i64 %0){{.*}} {
-// CHECK: [[PU_BUFFER:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 100)
-// CHECK: [[PU_DIGIT:%[0-9]+]] = urem i64 [[PU_VALUE:%[0-9]+]], 10
-// CHECK-NEXT: [[PU_ASCII:%[0-9]+]] = add i64 [[PU_DIGIT]], 48
-// CHECK-NEXT: [[PU_CHAR:%[0-9]+]] = trunc i64 [[PU_ASCII]] to i8
-// CHECK: [[PU_CHAR_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[PU_BUFFER]], i64 [[PU_INDEX:%[0-9]+]]
-// CHECK-NEXT: store i8 [[PU_CHAR]], ptr [[PU_CHAR_PTR]]
-// CHECK-NEXT: [[PU_LAST_DIGIT:%[0-9]+]] = icmp ult i64 [[PU_VALUE]], 10
-// CHECK: [[PU_SLICE:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[PU_BUFFER]], i64 1, i64 100, i64 [[PU_INDEX]], i64 100, i1 true, i1 true, i1 true)
-// CHECK-NEXT: call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" [[PU_SLICE]])
-// CHECK: [[PU_VALUE]] = phi i64 [ %0, %{{.*}} ], [ [[PU_QUOTIENT:%[0-9]+]], %{{.*}} ]
-// CHECK-NEXT: [[PU_INDEX]] = phi i64 [ 99, %{{.*}} ], [ [[PU_PREV_INDEX:%[0-9]+]], %{{.*}} ]
-// CHECK: [[PU_QUOTIENT]] = udiv i64 [[PU_VALUE]], 10
-// CHECK-NEXT: [[PU_PREV_INDEX]] = sub i64 [[PU_INDEX]], 1
+// CHECK-DAG: [[PU_BUFFER:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 100)
+// CHECK-DAG: [[PU_DIGIT:%[0-9]+]] = urem i64 [[PU_VALUE:%[0-9]+]], 10
+// CHECK-DAG: [[PU_ASCII:%[0-9]+]] = add i64 [[PU_DIGIT]], 48
+// CHECK-DAG: [[PU_CHAR:%[0-9]+]] = trunc i64 [[PU_ASCII]] to i8
+// CHECK-DAG: [[PU_CHAR_PTR:%[0-9]+]] = getelementptr inbounds i8, ptr [[PU_BUFFER]], i64 [[PU_INDEX:%[0-9]+]]
+// CHECK-DAG: store i8 [[PU_CHAR]], ptr [[PU_CHAR_PTR]]
+// CHECK-DAG: [[PU_LAST_DIGIT:%[0-9]+]] = icmp ult i64 [[PU_VALUE]], 10
+// CHECK-DAG: [[PU_SLICE:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[PU_BUFFER]], i64 1, i64 100, i64 [[PU_INDEX]], i64 100, i1 true, i1 true, i1 true)
+// CHECK-DAG: call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" [[PU_SLICE]])
+// CHECK-DAG: [[PU_VALUE]] = phi i64 [ %0, %{{.*}} ], [ [[PU_QUOTIENT:%[0-9]+]], %{{.*}} ]
+// CHECK-DAG: [[PU_INDEX]] = phi i64 [ 99, %{{.*}} ], [ [[PU_PREV_INDEX:%[0-9]+]], %{{.*}} ]
+// CHECK-DAG: [[PU_QUOTIENT]] = udiv i64 [[PU_VALUE]], 10
+// CHECK-DAG: [[PU_PREV_INDEX]] = sub i64 [[PU_INDEX]], 1
 
 func printuint(v uint64) {
 	var buf [100]byte

--- a/cl/_testdata/utf8/in.go
+++ b/cl/_testdata/utf8/in.go
@@ -33,7 +33,13 @@ func main() {
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = icmp slt i64 %[[TMP1]], 0
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = icmp uge i64 %[[TMP1]], 8
 // CHECK-NEXT:   %[[TMP4:[0-9]+]] = or i1 %[[TMP3]], %[[TMP2]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP4]], i64 %[[TMP1]], i1 true, i64 8)
+// CHECK-NEXT:   br i1 %[[TMP4]], label %_llgo_[[BB1:[0-9]+]], label %_llgo_[[BB2:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB1]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP1]], i64 8)
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP5:[0-9]+]] = getelementptr inbounds i8, ptr @main.array, i64 %[[TMP1]]
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = load i8, ptr %[[TMP5]], align 1
 // CHECK-NEXT:   ret i8 %[[TMP6]]

--- a/cl/_testdata/vargs/in.go
+++ b/cl/_testdata/vargs/in.go
@@ -48,7 +48,7 @@ func test(a ...any) {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP3:[0-9]+]], %_llgo_[[BB4:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP3:[0-9]+]], %_llgo_[[BB6:[0-9]+]] ]
 // CHECK-NEXT:   %[[TMP3]] = add i64 %[[TMP2]], 1
 // CHECK-NEXT:   %[[TMP4:[0-9]+]] = icmp slt i64 %[[TMP3]], %[[TMP1]]
 // CHECK-NEXT:   br i1 %[[TMP4]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
@@ -59,23 +59,29 @@ func test(a ...any) {
 // CHECK-NEXT:   %[[TMP7:[0-9]+]] = icmp slt i64 %[[TMP3]], 0
 // CHECK-NEXT:   %[[TMP8:[0-9]+]] = icmp uge i64 %[[TMP3]], %[[TMP6]]
 // CHECK-NEXT:   %[[TMP9:[0-9]+]] = or i1 %[[TMP8]], %[[TMP7]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP9]], i64 %[[TMP3]], i1 true, i64 %[[TMP6]])
-// CHECK-NEXT:   %[[TMP10:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %[[TMP5]], i64 %[[TMP3]]
-// CHECK-NEXT:   %[[TMP11:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.eface", ptr %[[TMP10]], align 8
-// CHECK-NEXT:   %[[TMP12:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %[[TMP11]], 0
-// CHECK-NEXT:   %[[TMP13:[0-9]+]] = icmp eq ptr %[[TMP12]], @_llgo_int
-// CHECK-NEXT:   br i1 %[[TMP13]], label %_llgo_[[BB4]], label %_llgo_[[BB5:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP9]], label %_llgo_[[BB4:[0-9]+]], label %_llgo_[[BB5:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB3]]:
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB4]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP3]], i64 %[[TMP6]])
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB5]]:
+// CHECK-NEXT:   %[[TMP10:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %[[TMP5]], i64 %[[TMP3]]
+// CHECK-NEXT:   %[[TMP11:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.eface", ptr %[[TMP10]], align 8
+// CHECK-NEXT:   %[[TMP12:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %[[TMP11]], 0
+// CHECK-NEXT:   %[[TMP13:[0-9]+]] = icmp eq ptr %[[TMP12]], @_llgo_int
+// CHECK-NEXT:   br i1 %[[TMP13]], label %_llgo_[[BB6]], label %_llgo_[[BB7:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB6]]:
 // CHECK-NEXT:   %[[TMP14:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %[[TMP11]], 1
 // CHECK-NEXT:   %[[TMP15:[0-9]+]] = load i64, ptr %[[TMP14]], align 8
 // CHECK-NEXT:   %[[TMP16:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB1]], i64 %[[TMP15]])
 // CHECK-NEXT:   br label %_llgo_[[BB1]]
 // CHECK-EMPTY:
-// CHECK-NEXT: _llgo_[[BB5]]:
+// CHECK-NEXT: _llgo_[[BB7]]:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicTypeAssert"(ptr null, ptr %[[TMP12]], ptr @_llgo_int)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -36,20 +36,20 @@ func (c Cursor) Node() ast.Node {
 // CHECK: [[FN_LIMIT:%[0-9]+]] = extractvalue { i32, i32 } [[FN_RANGE]], 1
 // CHECK: [[FN_I:%[0-9]+]] = phi i32 [ [[FN_START]],
 // CHECK: [[FN_MORE:%[0-9]+]] = icmp slt i32 [[FN_I]], [[FN_LIMIT]]
-// CHECK: [[FN_EVENT_PTR:%[0-9]+]] = getelementptr inbounds %main.event, ptr %{{[0-9]+}}, i64 %{{[0-9]+}}
-// CHECK: [[FN_EVENT:%[0-9]+]] = load %main.event, ptr [[FN_EVENT_PTR]]
-// CHECK: [[FN_PAIR_INDEX:%[0-9]+]] = load i32, ptr %{{[0-9]+}}
-// CHECK: [[FN_PUSH:%[0-9]+]] = icmp sgt i32 [[FN_PAIR_INDEX]], [[FN_I]]
 // CHECK: [[FN_EVENT_TYPE:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
 // CHECK: [[FN_TYPE_MATCH:%[0-9]+]] = and i64 [[FN_EVENT_TYPE]], [[FN_MASK]]
 // CHECK: [[FN_MAY_MATCH:%[0-9]+]] = icmp ne i64 [[FN_TYPE_MATCH]], 0
 // CHECK: store i32 [[FN_I]], ptr %{{[0-9]+}}
 // CHECK: store i1 true, ptr %{{[0-9]+}}
 // CHECK: [[FN_POP:%[0-9]+]] = load i32, ptr %{{[0-9]+}}
+// CHECK: [[FN_NODE_EQUAL:%[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK: [[FN_EVENT_PTR:%[0-9]+]] = getelementptr inbounds %main.event, ptr %{{[0-9]+}}, i64 %{{[0-9]+}}
+// CHECK: [[FN_EVENT:%[0-9]+]] = load %main.event, ptr [[FN_EVENT_PTR]]
+// CHECK: [[FN_PAIR_INDEX:%[0-9]+]] = load i32, ptr %{{[0-9]+}}
+// CHECK: [[FN_PUSH:%[0-9]+]] = icmp sgt i32 [[FN_PAIR_INDEX]], [[FN_I]]
 // CHECK: [[FN_POP_TYPE:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
 // CHECK: [[FN_POP_MASK:%[0-9]+]] = and i64 [[FN_POP_TYPE]], [[FN_MASK]]
 // CHECK: [[FN_SKIP:%[0-9]+]] = icmp eq i64 [[FN_POP_MASK]], 0
-// CHECK: [[FN_NODE_EQUAL:%[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
 
 func (c Cursor) FindNode(n ast.Node) (Cursor, bool) {
 
@@ -345,17 +345,10 @@ const (
 // CHECK: [[PRE_LIMIT:%[0-9]+]] = extractvalue { i32, i32 } [[PRE_RANGE]], 1
 // CHECK: [[PRE_I:%[0-9]+]] = phi i32 [ [[PRE_START]],
 // CHECK: [[PRE_MORE:%[0-9]+]] = icmp slt i32 [[PRE_I]], [[PRE_LIMIT]]
-// CHECK: [[PRE_EVENT:%[0-9]+]] = load %main.event, ptr %{{[0-9]+}}
-// CHECK: [[PRE_POP:%[0-9]+]] = load i32, ptr %{{[0-9]+}}
-// CHECK: [[PRE_PUSH:%[0-9]+]] = icmp sgt i32 [[PRE_POP]], [[PRE_I]]
 // CHECK: [[PRE_EVENT_TYPE:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
 // CHECK: [[PRE_SAVED_MASK:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
 // CHECK: [[PRE_MATCH_BITS:%[0-9]+]] = and i64 [[PRE_EVENT_TYPE]], [[PRE_SAVED_MASK]]
 // CHECK: [[PRE_MATCH:%[0-9]+]] = icmp ne i64 [[PRE_MATCH_BITS]], 0
-// CHECK: [[PRE_SUBTREE_TYPE:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
-// CHECK: [[PRE_SUBTREE_MASK:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
-// CHECK: [[PRE_SUBTREE_BITS:%[0-9]+]] = and i64 [[PRE_SUBTREE_TYPE]], [[PRE_SUBTREE_MASK]]
-// CHECK: [[PRE_SKIP:%[0-9]+]] = icmp eq i64 [[PRE_SUBTREE_BITS]], 0
 // CHECK: store i32 [[PRE_I]], ptr %{{[0-9]+}}
 // CHECK: [[PRE_YIELD_ENV:%[0-9]+]] = extractvalue { ptr, ptr } %1, 1
 // CHECK-NEXT: [[PRE_YIELD_CODE:%[0-9]+]] = extractvalue { ptr, ptr } %1, 0
@@ -363,6 +356,13 @@ const (
 // LINUX-AMD64: [[PRE_YIELD:%[0-9]+]] = call i1 %{{[^ ]+}}(ptr nest [[PRE_YIELD_ENV]], %main.Cursor %{{[0-9]+}})
 // CHECK: br i1 [[PRE_YIELD]],
 // CHECK: [[PRE_AFTER_POP:%[0-9]+]] = add i32 [[PRE_SKIP_POP:%[0-9]+]], 1
+// CHECK: [[PRE_EVENT:%[0-9]+]] = load %main.event, ptr %{{[0-9]+}}
+// CHECK: [[PRE_POP:%[0-9]+]] = load i32, ptr %{{[0-9]+}}
+// CHECK: [[PRE_PUSH:%[0-9]+]] = icmp sgt i32 [[PRE_POP]], [[PRE_I]]
+// CHECK: [[PRE_SUBTREE_TYPE:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
+// CHECK: [[PRE_SUBTREE_MASK:%[0-9]+]] = load i64, ptr %{{[0-9]+}}
+// CHECK: [[PRE_SUBTREE_BITS:%[0-9]+]] = and i64 [[PRE_SUBTREE_TYPE]], [[PRE_SUBTREE_MASK]]
+// CHECK: [[PRE_SKIP:%[0-9]+]] = icmp eq i64 [[PRE_SUBTREE_BITS]], 0
 
 // A virtual-root Cursor exposes all events; a real Cursor exposes its push/pop subtree.
 // CHECK-LABEL: define { i32, i32 } @main.Cursor.indices(%main.Cursor %0){{.*}} {
@@ -386,10 +386,10 @@ const (
 // CHECK: [[MASK_ALL:%[0-9]+]] = icmp eq i64 [[MASK_LEN]], 0
 // CHECK: ret i64 -1
 // CHECK: [[MASK_ACC:%[0-9]+]] = phi i64 [ 0,
+// CHECK: ret i64 [[MASK_ACC]]
 // CHECK: [[MASK_NODE:%[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.iface", ptr %{{[0-9]+}}
 // CHECK: [[MASK_ONE:%[0-9]+]] = call i64 @main.typeOf(%"{{.*}}/runtime/internal/runtime.iface" [[MASK_NODE]])
 // CHECK: [[MASK_NEXT:%[0-9]+]] = or i64 [[MASK_ACC]], [[MASK_ONE]]
-// CHECK: ret i64 [[MASK_ACC]]
 
 // CHECK-LABEL: define i64 @main.typeOf(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // Ident has the dedicated fast path; the switch covers every declared node type

--- a/cl/_testgo/indexerr/in.go
+++ b/cl/_testgo/indexerr/in.go
@@ -2,18 +2,23 @@
 package main
 
 // The fixture covers a matrix of fixed array/slice and signed/unsigned index
-// lowering. Follow each predicate and index into CheckIndexRange; helper names
-// alone would not prove that the right condition is being checked.
+// lowering. Follow each predicate into the panic branch and each index into
+// PanicIndex/PanicIndexU; helper names alone would not prove that the right condition
+// is being checked.
 // CHECK-LABEL: define void @main.array(i64 %0){{.*}} {
 // CHECK: %[[ARRAY_NEG:[0-9]+]] = icmp slt i64 %0, 0
 // CHECK: %[[ARRAY_UPPER:[0-9]+]] = icmp uge i64 %0, 2
 // CHECK: %[[ARRAY_OOB:[0-9]+]] = or i1 %[[ARRAY_UPPER]], %[[ARRAY_NEG]]
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %[[ARRAY_OOB]], i64 %0, i1 true, i64 2)
+// CHECK: br i1 %[[ARRAY_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndex"(i64 %0, i64 2)
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // CHECK-LABEL: define void @main.array2(i64 %0){{.*}} {
 // CHECK-NOT: icmp slt
 // CHECK: %[[UARRAY_OOB:[0-9]+]] = icmp uge i64 %0, 2
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %[[UARRAY_OOB]], i64 %0, i1 false, i64 2)
+// CHECK: br i1 %[[UARRAY_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndexU"(i64 %0, i64 2)
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // The literal-index cases keep the signedness bit correct after constant
 // folding. They are intentionally representative; defer/recover mechanics are
@@ -22,20 +27,28 @@ package main
 // CHECK: %[[SLICE10_LEN:[0-9]+]] = extractvalue %"{{.*}}Slice" %{{[0-9]+}}, 1
 // CHECK: %[[SLICE10_UPPER:[0-9]+]] = icmp uge i64 -1, %[[SLICE10_LEN]]
 // CHECK: %[[SLICE10_OOB:[0-9]+]] = or i1 %[[SLICE10_UPPER]], true
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %[[SLICE10_OOB]], i64 -1, i1 true, i64 %[[SLICE10_LEN]])
+// CHECK: br i1 %[[SLICE10_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndex"(i64 -1, i64 %[[SLICE10_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // CHECK-LABEL: define void @"main.init#12"(){{.*}} {
 // CHECK-NOT: icmp slt
 // CHECK: %[[SLICE12_LEN:[0-9]+]] = extractvalue %"{{.*}}Slice" %{{[0-9]+}}, 1
 // CHECK: %[[SLICE12_OOB:[0-9]+]] = icmp uge i64 2, %[[SLICE12_LEN]]
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %[[SLICE12_OOB]], i64 2, i1 false, i64 %[[SLICE12_LEN]])
+// CHECK: br i1 %[[SLICE12_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndexU"(i64 2, i64 %[[SLICE12_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // CHECK-LABEL: define void @"main.init#7"(){{.*}} {
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 true, i64 -1, i1 true, i64 2)
+// CHECK: br i1 true, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndex"(i64 -1, i64 2)
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // CHECK-LABEL: define void @"main.init#9"(){{.*}} {
 // CHECK-NOT: icmp slt
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 true, i64 2, i1 false, i64 2)
+// CHECK: br i1 true, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndexU"(i64 2, i64 2)
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // Slice bounds use the extracted dynamic length. Both helpers are checked so
 // one source scenario cannot silently lose its range check.
@@ -44,14 +57,18 @@ package main
 // CHECK: %[[SLICE_NEG:[0-9]+]] = icmp slt i64 %0, 0
 // CHECK: %[[SLICE_UPPER:[0-9]+]] = icmp uge i64 %0, %[[SLICE_LEN]]
 // CHECK: %[[SLICE_OOB:[0-9]+]] = or i1 %[[SLICE_UPPER]], %[[SLICE_NEG]]
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %[[SLICE_OOB]], i64 %0, i1 true, i64 %[[SLICE_LEN]])
+// CHECK: br i1 %[[SLICE_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndex"(i64 %0, i64 %[[SLICE_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // CHECK-LABEL: define void @main.slice2(i64 %0){{.*}} {
 // CHECK: %[[SLICE2_LEN:[0-9]+]] = extractvalue %"{{.*}}Slice" %{{[0-9]+}}, 1
 // CHECK: %[[SLICE2_NEG:[0-9]+]] = icmp slt i64 %0, 0
 // CHECK: %[[SLICE2_UPPER:[0-9]+]] = icmp uge i64 %0, %[[SLICE2_LEN]]
 // CHECK: %[[SLICE2_OOB:[0-9]+]] = or i1 %[[SLICE2_UPPER]], %[[SLICE2_NEG]]
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %[[SLICE2_OOB]], i64 %0, i1 true, i64 %[[SLICE2_LEN]])
+// CHECK: br i1 %[[SLICE2_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}PanicIndex"(i64 %0, i64 %[[SLICE2_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 func main() {
 }

--- a/cl/_testgo/reader/in.go
+++ b/cl/_testgo/reader/in.go
@@ -439,14 +439,14 @@ func main() {
 // CHECK: [[RR_LEN:%[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.String" %{{[0-9]+}}, 1
 // CHECK: [[RR_EOF:%[0-9]+]] = icmp sge i64 [[RR_I]], [[RR_LEN]]
 // CHECK: store i64 [[RR_PREV_I:%[0-9]+]], ptr %{{[0-9]+}}
-// CHECK: [[RR_BYTE:%[0-9]+]] = load i8, ptr %{{[0-9]+}}
-// CHECK: [[RR_ASCII:%[0-9]+]] = icmp ult i8 [[RR_BYTE]], -128
 // CHECK: [[RR_ASCII_NEXT:%[0-9]+]] = add i64 %{{[0-9]+}}, 1
-// CHECK: [[RR_RUNE:%[0-9]+]] = zext i8 [[RR_BYTE]] to i32
+// CHECK: [[RR_RUNE:%[0-9]+]] = zext i8 %{{[0-9]+}} to i32
 // CHECK: [[RR_DECODE:%[0-9]+]] = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"
 // CHECK: [[RR_WIDTH:%[0-9]+]] = extractvalue { i32, i64 } [[RR_DECODE]], 1
 // CHECK: [[RR_NEXT:%[0-9]+]] = add i64 %{{[0-9]+}}, [[RR_WIDTH]]
 // CHECK: store i64 [[RR_NEXT]], ptr %{{[0-9]+}}
+// CHECK: [[RR_BYTE:%[0-9]+]] = load i8, ptr %{{[0-9]+}}
+// CHECK: [[RR_ASCII:%[0-9]+]] = icmp ult i8 [[RR_BYTE]], -128
 
 // Seek handles start/current/end, rejects invalid/negative results, and stores abs.
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2){{.*}} {

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -185,14 +185,15 @@ func mapDemo2() {
 // CHECK: %[[CLOSURE_VALUE:[0-9]+]] = call %reflect.Value @reflect.ValueOf
 // CHECK: %[[CLOSURE_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[CLOSURE_VALUE]], %"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}})
 // CHECK: %[[CLOSURE_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[CLOSURE_RESULTS]], 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 0, i1 true, i64 %[[CLOSURE_LEN]])
+// CHECK: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// DARWIN-ARM64: call i64 %__llgo_funcval_code(ptr swiftself %{{[0-9]+}}, i64 100)
+// LINUX-AMD64: call i64 %__llgo_funcval_code(ptr nest %{{[0-9]+}}, i64 100)
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[CLOSURE_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 // CHECK: %[[CLOSURE_IFACE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %[[CLOSURE_VALUE]])
 // CHECK: %[[CLOSURE_TYPE:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %[[CLOSURE_IFACE]], 0
 // CHECK: %[[CLOSURE_MATCH:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %[[CLOSURE_TYPE]])
 // CHECK: br i1 %[[CLOSURE_MATCH]]
-// DARWIN-ARM64: call i64 %__llgo_funcval_code(ptr swiftself %{{[0-9]+}}, i64 100)
-// LINUX-AMD64: call i64 %__llgo_funcval_code(ptr nest %{{[0-9]+}}, i64 100)
-
 // DARWIN-ARM64-LABEL: define i64 @"main.callClosure$1"(ptr swiftself %0, i64 %1){{.*}} {
 // LINUX-AMD64-LABEL: define i64 @"main.callClosure$1"(ptr nest %0, i64 %1){{.*}} {
 // CHECK: [[CC_ENV:%[0-9]+]] = load { ptr }, ptr %0
@@ -206,16 +207,18 @@ func mapDemo2() {
 // CHECK: %[[FUNC_VALUE:[0-9]+]] = call %reflect.Value @reflect.ValueOf
 // CHECK: %[[FUNC_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[FUNC_VALUE]], %"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}})
 // CHECK: %[[FUNC_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[FUNC_RESULTS]], 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 0, i1 true, i64 %[[FUNC_LEN]])
+// CHECK: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[FUNC_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 // CHECK: call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %[[FUNC_VALUE]])
 
 // CHECK-LABEL: define void @main.callIMethod(){{.*}} {
 // CHECK: %[[IFACE_VALUE:[0-9]+]] = call %reflect.Value @reflect.ValueOf
 // CHECK: %[[IFACE_METHOD:[0-9]+]] = call %reflect.Value @reflect.Value.Method(%reflect.Value %[[IFACE_VALUE]], i64 0)
 // CHECK: %[[IFACE_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[IFACE_METHOD]],{{.*}})
-// CHECK: call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %[[IFACE_METHOD]])
 // DARWIN-ARM64: call i64 %__llgo_funcval_code(ptr swiftself %{{[0-9]+}}, i64 1)
 // LINUX-AMD64: call i64 %__llgo_funcval_code(ptr nest %{{[0-9]+}}, i64 1)
+// CHECK: call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %[[IFACE_METHOD]])
 
 // CHECK-LABEL: define void @main.callMethod(){{.*}} {
 // CHECK: %[[RECV_VALUE:[0-9]+]] = call %reflect.Value @reflect.ValueOf
@@ -227,7 +230,9 @@ func mapDemo2() {
 // CHECK: %[[SLICE_FUNC:[0-9]+]] = call %reflect.Value @reflect.ValueOf
 // CHECK: %[[SLICE_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value %[[SLICE_FUNC]], %"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}})
 // CHECK: %[[SLICE_RESULT_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE_RESULTS]], 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 0, i1 true, i64 %[[SLICE_RESULT_LEN]])
+// CHECK: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[SLICE_RESULT_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: call void @main.callSlice()

--- a/cl/_testgo/reflectconv/in.go
+++ b/cl/_testgo/reflectconv/in.go
@@ -78,12 +78,7 @@ import (
 // CHECK: [[CAN_MAP:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map{{\[\[2\]}}_llgo_reflect.Type]_llgo_bool", i64 0)
 // CHECK: [[ALL_MAP:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_reflect.Type]_llgo_bool", i64 0)
 // CHECK: [[CONVERT_TABLE:%[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @main.convertTests
-// CHECK: [[ENTRY_PTR:%[0-9]+]] = getelementptr inbounds { %reflect.Value, %reflect.Value }, ptr %{{[0-9]+}}, i64 %{{[0-9]+}}
-// CHECK: [[ENTRY:%[0-9]+]] = load { %reflect.Value, %reflect.Value }, ptr [[ENTRY_PTR]]
-// CHECK: [[IN_VALUE:%[0-9]+]] = load %reflect.Value, ptr %{{[0-9]+}}
-// CHECK: [[T1:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value [[IN_VALUE]])
-// CHECK: [[SELF_CONVERTIBLE:%[0-9]+]] = call i1 %{{[0-9]+}}(ptr %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.iface" [[T1]])
-// CHECK: br i1 [[SELF_CONVERTIBLE]],
+// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" [[T1:%[0-9]+]])
 // CHECK: [[OUT_VALUE:%[0-9]+]] = load %reflect.Value, ptr %{{[0-9]+}}
 // CHECK: [[T2:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value [[OUT_VALUE]])
 // CHECK: [[PAIR_CONVERTIBLE:%[0-9]+]] = call i1 %{{[0-9]+}}(ptr %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.iface" [[T2]])
@@ -132,6 +127,12 @@ import (
 // CHECK: [[BAD_MATRIX:%[0-9]+]] = icmp ne i1 [[MATRIX_OK]], %{{[0-9]+}}
 // CHECK: [[KNOWN_PAIR_PTR:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map{{\[\[2\]}}_llgo_reflect.Type]_llgo_bool", ptr [[CAN_MAP]],
 // CHECK: [[KNOWN_PAIR:%[0-9]+]] = load i1, ptr [[KNOWN_PAIR_PTR]]
+// CHECK: [[ENTRY_PTR:%[0-9]+]] = getelementptr inbounds { %reflect.Value, %reflect.Value }, ptr %{{[0-9]+}}, i64 %{{[0-9]+}}
+// CHECK: [[ENTRY:%[0-9]+]] = load { %reflect.Value, %reflect.Value }, ptr [[ENTRY_PTR]]
+// CHECK: [[IN_VALUE:%[0-9]+]] = load %reflect.Value, ptr %{{[0-9]+}}
+// CHECK: [[T1]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value [[IN_VALUE]])
+// CHECK: [[SELF_CONVERTIBLE:%[0-9]+]] = call i1 %{{[0-9]+}}(ptr %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.iface" [[T1]])
+// CHECK: br i1 [[SELF_CONVERTIBLE]],
 
 // sNaN must survive both an ordinary store/load and a reflective named-float conversion.
 // CHECK-LABEL: define void @main.TestConvertNaNs(ptr %0){{.*}} {

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -79,67 +79,71 @@ func methodByName(name string) {
 // CHECK-LABEL: define void @main.main(){{.*}} {
 // Recover the element Type from *Point and reuse that exact interface for all
 // constructor inputs.
-// CHECK: %[[PTR_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Point", ptr null })
-// CHECK: %[[PTR_DATA:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[PTR_TYPE]])
-// CHECK: %[[RT:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" %{{[0-9]+}}(ptr %{{[0-9]+}})
+// CHECK-DAG: %[[PTR_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Point", ptr null })
+// CHECK-DAG: %[[PTR_DATA:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[PTR_TYPE]])
+// CHECK-DAG: %[[RT:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" %{{[0-9]+}}(ptr %{{[0-9]+}})
 
 // Each constructed type must be queried and compared back to RT. This proves
 // more than the presence of seven reflect helper calls.
-// CHECK: %[[ARRAY_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.ArrayOf(i64 1, %"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[ARRAY_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: %[[CHAN_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.ChanOf(i64 2, %"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[CHAN_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: store %"{{.*}}/runtime/internal/runtime.iface" %[[RT]], ptr %{{[0-9]+}}
-// CHECK: store %"{{.*}}/runtime/internal/runtime.iface" %[[RT]], ptr %{{[0-9]+}}
-// CHECK: %[[FUNC_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf(%"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}}, i1 false)
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[FUNC_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: %[[MAP_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.MapOf(%"{{.*}}/runtime/internal/runtime.iface" %[[RT]], %"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[MAP_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: %[[PTR_TO_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.PointerTo(%"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[PTR_TO_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: %[[SLICE_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.SliceOf(%"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[SLICE_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: store %"{{.*}}/runtime/internal/runtime.iface" %[[RT]], ptr %{{[0-9]+}}
-// CHECK: %[[STRUCT_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.StructOf(%"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}})
-// CHECK: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[STRUCT_TYPE]])
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: %[[ARRAY_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.ArrayOf(i64 1, %"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[ARRAY_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: %[[CHAN_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.ChanOf(i64 2, %"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[CHAN_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: store %"{{.*}}/runtime/internal/runtime.iface" %[[RT]], ptr %{{[0-9]+}}
+// CHECK-DAG: store %"{{.*}}/runtime/internal/runtime.iface" %[[RT]], ptr %{{[0-9]+}}
+// CHECK-DAG: %[[FUNC_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf(%"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}}, i1 false)
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[FUNC_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: %[[MAP_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.MapOf(%"{{.*}}/runtime/internal/runtime.iface" %[[RT]], %"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[MAP_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: %[[PTR_TO_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.PointerTo(%"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[PTR_TO_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: %[[SLICE_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.SliceOf(%"{{.*}}/runtime/internal/runtime.iface" %[[RT]])
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[SLICE_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK-DAG: store %"{{.*}}/runtime/internal/runtime.iface" %[[RT]], ptr %{{[0-9]+}}
+// CHECK-DAG: %[[STRUCT_TYPE:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.StructOf(%"{{.*}}/runtime/internal/runtime.Slice" %{{[0-9]+}})
+// CHECK-DAG: call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %[[STRUCT_TYPE]])
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
 
 // Type.Method's returned Method is stored and its Name field is what reaches
 // StringEqual. MethodByName additionally carries the tuple's ok bit to a branch.
-// CHECK: %[[METHOD_SLOT:[0-9]+]] = alloca %reflect.Method
-// CHECK: %[[METHOD:[0-9]+]] = call %reflect.Method %{{[0-9]+}}(ptr %{{[0-9]+}}, i64 0)
-// CHECK: store %reflect.Method %[[METHOD]], ptr %[[METHOD_SLOT]]
-// CHECK: %[[METHOD_NAME_PTR:[0-9]+]] = getelementptr inbounds %reflect.Method, ptr %[[METHOD_SLOT]], i32 0, i32 0
-// CHECK: %[[METHOD_NAME:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr %[[METHOD_NAME_PTR]]
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[METHOD_NAME]],{{.*}})
-// CHECK: %[[NAMED_METHOD:[0-9]+]] = call { %reflect.Method, i1 } %{{[0-9]+}}(ptr %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 6 })
-// CHECK: extractvalue { %reflect.Method, i1 } %[[NAMED_METHOD]], 0
-// CHECK: %[[METHOD_OK:[0-9]+]] = extractvalue { %reflect.Method, i1 } %[[NAMED_METHOD]], 1
-// CHECK: br i1 %[[METHOD_OK]]
+// CHECK-DAG: %[[METHOD_SLOT:[0-9]+]] = alloca %reflect.Method
+// CHECK-DAG: %[[METHOD:[0-9]+]] = call %reflect.Method %{{[0-9]+}}(ptr %{{[0-9]+}}, i64 0)
+// CHECK-DAG: store %reflect.Method %[[METHOD]], ptr %[[METHOD_SLOT]]
+// CHECK-DAG: %[[METHOD_NAME_PTR:[0-9]+]] = getelementptr inbounds %reflect.Method, ptr %[[METHOD_SLOT]], i32 0, i32 0
+// CHECK-DAG: %[[METHOD_NAME:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr %[[METHOD_NAME_PTR]]
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[METHOD_NAME]],{{.*}})
+// CHECK-DAG: %[[NAMED_METHOD:[0-9]+]] = call { %reflect.Method, i1 } %{{[0-9]+}}(ptr %{{[0-9]+}}, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 6 })
+// CHECK-DAG: extractvalue { %reflect.Method, i1 } %[[NAMED_METHOD]], 0
+// CHECK-DAG: %[[METHOD_OK:[0-9]+]] = extractvalue { %reflect.Method, i1 } %[[NAMED_METHOD]], 1
+// CHECK-DAG: br i1 %[[METHOD_OK]]
 
 // Value.Method and MethodByName must invoke the Value they return, range-check
 // the returned slice, and compare the first result's string.
-// CHECK: %[[VALUE:[0-9]+]] = call %reflect.Value @reflect.ValueOf
-// CHECK: %[[INDEX_METHOD:[0-9]+]] = call %reflect.Value @reflect.Value.Method(%reflect.Value %[[VALUE]], i64 1)
-// CHECK: %[[INDEX_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[INDEX_METHOD]], %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
-// CHECK: %[[INDEX_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[INDEX_RESULTS]], 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 0, i1 true, i64 %[[INDEX_LEN]])
-// CHECK: %[[INDEX_STRING:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[INDEX_STRING]],{{.*}})
-// CHECK: %[[NAME_METHOD:[0-9]+]] = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %[[VALUE]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 6 })
-// CHECK: %[[NAME_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[NAME_METHOD]], %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
-// CHECK: %[[NAME_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[NAME_RESULTS]], 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{[0-9]+}}, i64 0, i1 true, i64 %[[NAME_LEN]])
-// CHECK: %[[NAME_STRING:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String
-// CHECK: call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[NAME_STRING]],{{.*}})
-// CHECK:   call void @main.method(i64 1)
-// CHECK:   call void @main.methodByName(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 6 })
+// CHECK-DAG: %[[VALUE:[0-9]+]] = call %reflect.Value @reflect.ValueOf
+// CHECK-DAG: %[[INDEX_METHOD:[0-9]+]] = call %reflect.Value @reflect.Value.Method(%reflect.Value %[[VALUE]], i64 1)
+// CHECK-DAG: %[[INDEX_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[INDEX_METHOD]], %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
+// CHECK-DAG: %[[INDEX_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[INDEX_RESULTS]], 1
+// CHECK-DAG: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[INDEX_LEN]])
+// CHECK-DAG: br label %{{_llgo_[0-9]+}}
+// CHECK-DAG: %[[INDEX_STRING:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[INDEX_STRING]],{{.*}})
+// CHECK-DAG: %[[NAME_METHOD:[0-9]+]] = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %[[VALUE]], %"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 6 })
+// CHECK-DAG: %[[NAME_RESULTS:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %[[NAME_METHOD]], %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
+// CHECK-DAG: %[[NAME_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[NAME_RESULTS]], 1
+// CHECK-DAG: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[NAME_LEN]])
+// CHECK-DAG: br label %{{_llgo_[0-9]+}}
+// CHECK-DAG: %[[NAME_STRING:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String
+// CHECK-DAG: call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[NAME_STRING]],{{.*}})
+// CHECK-DAG:   call void @main.method(i64 1)
+// CHECK-DAG:   call void @main.methodByName(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{[0-9]+}}, i64 6 })
 
 // CHECK-LABEL: define void @main.method(i64 %0){{.*}} {
 // CHECK: %[[DYNAMIC_INDEX:[0-9]+]] = call %reflect.Value @reflect.Value.Method(%reflect.Value %{{[0-9]+}}, i64 %0)

--- a/cl/_testgo/reflectmkfn/in.go
+++ b/cl/_testgo/reflectmkfn/in.go
@@ -38,14 +38,14 @@ func main() {
 // CHECK-LABEL: define %"g{{.*}}/runtime/internal/runtime.Slice" @"main.main$1"(%"g{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK: [[ARG0_DATA:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK: [[ARG0_LEN:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK: call void @"g{{.*}}/runtime/internal/runtime.CheckIndexRange"({{.*}}i64 0,{{.*}}i64 [[ARG0_LEN]])
+// CHECK: call void @"g{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 [[ARG0_LEN]])
 // CHECK: [[ARG0_PTR:%[0-9]+]] = getelementptr inbounds %reflect.Value, ptr [[ARG0_DATA]], i64 0
 // CHECK: [[ARG0_SAFE:%[0-9]+]] = call ptr @"g{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[ARG0_PTR]])
 // CHECK-NEXT: [[ARG0:%[0-9]+]] = load %reflect.Value, ptr [[ARG0_SAFE]]
 // CHECK-NEXT: [[TEXT:%[0-9]+]] = call %"g{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value [[ARG0]])
 // CHECK: [[ARG1_DATA:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK: [[ARG1_LEN:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK: call void @"g{{.*}}/runtime/internal/runtime.CheckIndexRange"({{.*}}i64 1,{{.*}}i64 [[ARG1_LEN]])
+// CHECK: call void @"g{{.*}}/runtime/internal/runtime.PanicIndex"(i64 1, i64 [[ARG1_LEN]])
 // CHECK: [[ARG1_PTR:%[0-9]+]] = getelementptr inbounds %reflect.Value, ptr [[ARG1_DATA]], i64 1
 // CHECK: [[ARG1_SAFE:%[0-9]+]] = call ptr @"g{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[ARG1_PTR]])
 // CHECK-NEXT: [[ARG1:%[0-9]+]] = load %reflect.Value, ptr [[ARG1_SAFE]]

--- a/cl/_testgo/tpindex/in.go
+++ b/cl/_testgo/tpindex/in.go
@@ -18,12 +18,14 @@ func main() {
 // CHECK: [[INDEX_POS:%[0-9]+]] = add i64 %{{[0-9]+}}, 1
 // CHECK: [[INDEX_DATA:%[0-9]+]] = extractvalue %"{{.*}}Slice" %0, 0
 // CHECK: [[INDEX_LEN:%[0-9]+]] = extractvalue %"{{.*}}Slice" %0, 1
-// CHECK: call void @"{{.*}}CheckIndexRange"(i1 %{{[0-9]+}}, i64 [[INDEX_POS]], i1 true, i64 [[INDEX_LEN]])
-// CHECK-NEXT: [[INDEX_ITEM_PTR:%[0-9]+]] = getelementptr inbounds i64, ptr [[INDEX_DATA]], i64 [[INDEX_POS]]
-// CHECK-NEXT: [[INDEX_ITEM:%[0-9]+]] = load i64, ptr [[INDEX_ITEM_PTR]]
-// CHECK-NEXT: [[INDEX_MATCH:%[0-9]+]] = icmp eq i64 %1, [[INDEX_ITEM]]
+// CHECK: br i1 %{{[0-9]+}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
 // CHECK: ret i64 -1
 // CHECK: ret i64 [[INDEX_POS]]
+// CHECK: call void @"{{.*}}PanicIndex"(i64 [[INDEX_POS]], i64 [[INDEX_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
+// CHECK: [[INDEX_ITEM_PTR:%[0-9]+]] = getelementptr inbounds i64, ptr [[INDEX_DATA]], i64 [[INDEX_POS]]
+// CHECK-NEXT: [[INDEX_ITEM:%[0-9]+]] = load i64, ptr [[INDEX_ITEM_PTR]]
+// CHECK-NEXT: [[INDEX_MATCH:%[0-9]+]] = icmp eq i64 %1, [[INDEX_ITEM]]
 func index[E comparable](s []E, v E) int {
 	for i, vs := range s {
 		if v == vs {

--- a/cl/_testgo/tprecur/in.go
+++ b/cl/_testgo/tprecur/in.go
@@ -94,10 +94,10 @@ func recur2[T Integer](n T) T {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP3:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP4:[0-9]+]], %_llgo_[[BB2:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP3:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP4:[0-9]+]], %_llgo_[[BB8:[0-9]+]] ]
 // CHECK-NEXT:   %[[TMP4]] = add i64 %[[TMP3]], 1
 // CHECK-NEXT:   %[[TMP5:[0-9]+]] = icmp slt i64 %[[TMP4]], %[[TMP2]]
-// CHECK-NEXT:   br i1 %[[TMP5]], label %_llgo_[[BB2]], label %_llgo_[[BB3:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP5]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = add i64 %[[TMP4]], 1
@@ -106,37 +106,49 @@ func recur2[T Integer](n T) T {
 // CHECK-NEXT:   %[[TMP9:[0-9]+]] = icmp slt i64 %[[TMP4]], 0
 // CHECK-NEXT:   %[[TMP10:[0-9]+]] = icmp uge i64 %[[TMP4]], %[[TMP8]]
 // CHECK-NEXT:   %[[TMP11:[0-9]+]] = or i1 %[[TMP10]], %[[TMP9]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP11]], i64 %[[TMP4]], i1 true, i64 %[[TMP8]])
-// CHECK-NEXT:   %[[TMP12:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP7]], i64 %[[TMP4]]
-// CHECK-NEXT:   store i64 %[[TMP6]], ptr %[[TMP12]], align 8
-// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-NEXT:   br i1 %[[TMP11]], label %_llgo_[[BB7:[0-9]+]], label %_llgo_[[BB8]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB3]]:
-// CHECK-NEXT:   %[[TMP13:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP1]], 1
+// CHECK-NEXT:   %[[TMP12:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP1]], 1
 // CHECK-NEXT:   br label %_llgo_[[BB4:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB4]]:
-// CHECK-NEXT:   %[[TMP14:[0-9]+]] = phi i64 [ 0, %_llgo_[[BB3]] ], [ %[[TMP25:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
-// CHECK-NEXT:   %[[TMP15:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB3]] ], [ %[[TMP16:[0-9]+]], %_llgo_[[BB5]] ]
-// CHECK-NEXT:   %[[TMP16]] = add i64 %[[TMP15]], 1
-// CHECK-NEXT:   %[[TMP17:[0-9]+]] = icmp slt i64 %[[TMP16]], %[[TMP13]]
-// CHECK-NEXT:   br i1 %[[TMP17]], label %_llgo_[[BB5]], label %_llgo_[[BB6:[0-9]+]]
+// CHECK-NEXT:   %[[TMP13:[0-9]+]] = phi i64 [ 0, %_llgo_[[BB3]] ], [ %[[TMP28:[0-9]+]], %_llgo_[[BB10:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP14:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB3]] ], [ %[[TMP15:[0-9]+]], %_llgo_[[BB10]] ]
+// CHECK-NEXT:   %[[TMP15]] = add i64 %[[TMP14]], 1
+// CHECK-NEXT:   %[[TMP16:[0-9]+]] = icmp slt i64 %[[TMP15]], %[[TMP12]]
+// CHECK-NEXT:   br i1 %[[TMP16]], label %_llgo_[[BB5:[0-9]+]], label %_llgo_[[BB6:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB5]]:
-// CHECK-NEXT:   %[[TMP18:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP1]], 0
-// CHECK-NEXT:   %[[TMP19:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP1]], 1
-// CHECK-NEXT:   %[[TMP20:[0-9]+]] = icmp slt i64 %[[TMP16]], 0
-// CHECK-NEXT:   %[[TMP21:[0-9]+]] = icmp uge i64 %[[TMP16]], %[[TMP19]]
-// CHECK-NEXT:   %[[TMP22:[0-9]+]] = or i1 %[[TMP21]], %[[TMP20]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP22]], i64 %[[TMP16]], i1 true, i64 %[[TMP19]])
-// CHECK-NEXT:   %[[TMP23:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP18]], i64 %[[TMP16]]
-// CHECK-NEXT:   %[[TMP24:[0-9]+]] = load i64, ptr %[[TMP23]], align 8
-// CHECK-NEXT:   %[[TMP25]] = add i64 %[[TMP14]], %[[TMP24]]
-// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-NEXT:   %[[TMP17:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP1]], 0
+// CHECK-NEXT:   %[[TMP18:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP1]], 1
+// CHECK-NEXT:   %[[TMP19:[0-9]+]] = icmp slt i64 %[[TMP15]], 0
+// CHECK-NEXT:   %[[TMP20:[0-9]+]] = icmp uge i64 %[[TMP15]], %[[TMP18]]
+// CHECK-NEXT:   %[[TMP21:[0-9]+]] = or i1 %[[TMP20]], %[[TMP19]]
+// CHECK-NEXT:   br i1 %[[TMP21]], label %_llgo_[[BB9:[0-9]+]], label %_llgo_[[BB10]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB6]]:
-// CHECK-NEXT:   %[[TMP26:[0-9]+]] = sub i64 %[[TMP0]], 1
-// CHECK-NEXT:   %[[TMP27:[0-9]+]] = call i64 @"main.recur1[main.T.1.0]"(i64 %[[TMP26]])
-// CHECK-NEXT:   %[[TMP28:[0-9]+]] = add i64 %[[TMP14]], %[[TMP27]]
-// CHECK-NEXT:   ret i64 %[[TMP28]]
+// CHECK-NEXT:   %[[TMP22:[0-9]+]] = sub i64 %[[TMP0]], 1
+// CHECK-NEXT:   %[[TMP23:[0-9]+]] = call i64 @"main.recur1[main.T.1.0]"(i64 %[[TMP22]])
+// CHECK-NEXT:   %[[TMP24:[0-9]+]] = add i64 %[[TMP13]], %[[TMP23]]
+// CHECK-NEXT:   ret i64 %[[TMP24]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB7]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP4]], i64 %[[TMP8]])
+// CHECK-NEXT:   br label %_llgo_[[BB7]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB8]]:
+// CHECK-NEXT:   %[[TMP25:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP7]], i64 %[[TMP4]]
+// CHECK-NEXT:   store i64 %[[TMP6]], ptr %[[TMP25]], align 8
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB9]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP15]], i64 %[[TMP18]])
+// CHECK-NEXT:   br label %_llgo_[[BB9]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB10]]:
+// CHECK-NEXT:   %[[TMP26:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP17]], i64 %[[TMP15]]
+// CHECK-NEXT:   %[[TMP27:[0-9]+]] = load i64, ptr %[[TMP26]], align 8
+// CHECK-NEXT:   %[[TMP28]] = add i64 %[[TMP13]], %[[TMP27]]
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
 // CHECK-NEXT: }

--- a/cl/_testgo/tptypes/in.go
+++ b/cl/_testgo/tptypes/in.go
@@ -157,7 +157,13 @@ func main() {
 // CHECK-NEXT:   %[[TMP53:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP52]], 0
 // CHECK-NEXT:   %[[TMP54:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP52]], 1
 // CHECK-NEXT:   %[[TMP55:[0-9]+]] = icmp uge i64 0, %[[TMP54]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP55]], i64 0, i1 true, i64 %[[TMP54]])
+// CHECK-NEXT:   br i1 %[[TMP55]], label %_llgo_[[BB1:[0-9]+]], label %_llgo_[[BB2:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB1]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[TMP54]])
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP56:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP53]], i64 0
 // CHECK-NEXT:   %[[TMP57:[0-9]+]] = load i64, ptr %[[TMP56]], align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %[[TMP50]])
@@ -171,7 +177,13 @@ func main() {
 // CHECK-NEXT:   %[[TMP62:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP61]], 0
 // CHECK-NEXT:   %[[TMP63:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP61]], 1
 // CHECK-NEXT:   %[[TMP64:[0-9]+]] = icmp uge i64 0, %[[TMP63]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP64]], i64 0, i1 true, i64 %[[TMP63]])
+// CHECK-NEXT:   br i1 %[[TMP64]], label %_llgo_[[BB3:[0-9]+]], label %_llgo_[[BB4:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB3]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[TMP63]])
+// CHECK-NEXT:   br label %_llgo_[[BB3]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB4]]:
 // CHECK-NEXT:   %[[TMP65:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP62]], i64 0
 // CHECK-NEXT:   %[[TMP66:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP65]], align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %[[TMP59]])
@@ -185,7 +197,13 @@ func main() {
 // CHECK-NEXT:   %[[TMP71:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP70]], 0
 // CHECK-NEXT:   %[[TMP72:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP70]], 1
 // CHECK-NEXT:   %[[TMP73:[0-9]+]] = icmp uge i64 0, %[[TMP72]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP73]], i64 0, i1 true, i64 %[[TMP72]])
+// CHECK-NEXT:   br i1 %[[TMP73]], label %_llgo_[[BB5:[0-9]+]], label %_llgo_[[BB6:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB5]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[TMP72]])
+// CHECK-NEXT:   br label %_llgo_[[BB5]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB6]]:
 // CHECK-NEXT:   %[[TMP74:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP71]], i64 0
 // CHECK-NEXT:   %[[TMP75:[0-9]+]] = load i64, ptr %[[TMP74]], align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintSlice"(%"{{.*}}/runtime/internal/runtime.Slice" %[[TMP68]])

--- a/cl/_testlibc/allocacstrs/in.go
+++ b/cl/_testlibc/allocacstrs/in.go
@@ -58,9 +58,9 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_[[BB1]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB4]]:
-// CHECK-NEXT:   %[[TMP16:[0-9]+]] = phi i64 [ 0, %_llgo_[[BB0]] ], [ %[[TMP30:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP16:[0-9]+]] = phi i64 [ 0, %_llgo_[[BB0]] ], [ %[[TMP31:[0-9]+]], %_llgo_[[BB8:[0-9]+]] ]
 // CHECK-NEXT:   %[[TMP17:[0-9]+]] = icmp slt i64 %[[TMP16]], %[[TMP7]]
-// CHECK-NEXT:   br i1 %[[TMP17]], label %_llgo_[[BB5]], label %_llgo_[[BB6]]
+// CHECK-NEXT:   br i1 %[[TMP17]], label %_llgo_[[BB5:[0-9]+]], label %_llgo_[[BB6]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB5]]:
 // CHECK-NEXT:   %[[TMP18:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP6]], 0
@@ -68,20 +68,26 @@ func main() {
 // CHECK-NEXT:   %[[TMP20:[0-9]+]] = icmp slt i64 %[[TMP16]], 0
 // CHECK-NEXT:   %[[TMP21:[0-9]+]] = icmp uge i64 %[[TMP16]], %[[TMP19]]
 // CHECK-NEXT:   %[[TMP22:[0-9]+]] = or i1 %[[TMP21]], %[[TMP20]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP22]], i64 %[[TMP16]], i1 true, i64 %[[TMP19]])
-// CHECK-NEXT:   %[[TMP23:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP18]], i64 %[[TMP16]]
-// CHECK-NEXT:   %[[TMP24:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP23]], align 8
-// CHECK-NEXT:   %[[TMP25:[0-9]+]] = getelementptr ptr, ptr %[[TMP9]], i64 %[[TMP16]]
-// CHECK-NEXT:   %[[TMP26:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.String" %[[TMP24]], 1
-// CHECK-NEXT:   %[[TMP27:[0-9]+]] = add i64 %[[TMP26]], 1
-// CHECK-NEXT:   %[[TMP28:[0-9]+]] = alloca i8, i64 %[[TMP27]], align 1
-// CHECK-NEXT:   %[[TMP29:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.CStrCopy"(ptr %[[TMP28]], %"{{.*}}/runtime/internal/runtime.String" %[[TMP24]])
-// CHECK-NEXT:   store ptr %[[TMP29]], ptr %[[TMP25]], align 8
-// CHECK-NEXT:   %[[TMP30]] = add i64 %[[TMP16]], 1
-// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-NEXT:   br i1 %[[TMP22]], label %_llgo_[[BB7:[0-9]+]], label %_llgo_[[BB8]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB6]]:
-// CHECK-NEXT:   %[[TMP31:[0-9]+]] = getelementptr ptr, ptr %[[TMP9]], i64 %[[TMP7]]
-// CHECK-NEXT:   store ptr null, ptr %[[TMP31]], align 8
+// CHECK-NEXT:   %[[TMP23:[0-9]+]] = getelementptr ptr, ptr %[[TMP9]], i64 %[[TMP7]]
+// CHECK-NEXT:   store ptr null, ptr %[[TMP23]], align 8
 // CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB7]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP16]], i64 %[[TMP19]])
+// CHECK-NEXT:   br label %_llgo_[[BB7]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB8]]:
+// CHECK-NEXT:   %[[TMP24:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP18]], i64 %[[TMP16]]
+// CHECK-NEXT:   %[[TMP25:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP24]], align 8
+// CHECK-NEXT:   %[[TMP26:[0-9]+]] = getelementptr ptr, ptr %[[TMP9]], i64 %[[TMP16]]
+// CHECK-NEXT:   %[[TMP27:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.String" %[[TMP25]], 1
+// CHECK-NEXT:   %[[TMP28:[0-9]+]] = add i64 %[[TMP27]], 1
+// CHECK-NEXT:   %[[TMP29:[0-9]+]] = alloca i8, i64 %[[TMP28]], align 1
+// CHECK-NEXT:   %[[TMP30:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.CStrCopy"(ptr %[[TMP29]], %"{{.*}}/runtime/internal/runtime.String" %[[TMP25]])
+// CHECK-NEXT:   store ptr %[[TMP30]], ptr %[[TMP26]], align 8
+// CHECK-NEXT:   %[[TMP31]] = add i64 %[[TMP16]], 1
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
 // CHECK-NEXT: }

--- a/cl/_testlibgo/mapzero/in.go
+++ b/cl/_testlibgo/mapzero/in.go
@@ -55,7 +55,7 @@ func main() {
 // CHECK-NEXT:   %[[TMP16:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %[[TMP15]], 2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %[[TMP16]])
 // CHECK-NEXT:   %[[TMP17:[0-9]+]] = load ptr, ptr %[[TMP9]], align 8
-// CHECK-NEXT:   indirectbr ptr %[[TMP17]], [label %_llgo_[[BB3]], label %_llgo_[[BB6:[0-9]+]]]
+// CHECK-NEXT:   indirectbr ptr %[[TMP17]], [label %_llgo_[[BB3]], label %_llgo_[[BB8:[0-9]+]]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB3]]:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Rethrow"(ptr %[[TMP0]])
@@ -66,19 +66,25 @@ func main() {
 // CHECK-NEXT:   %[[TMP19:[0-9]+]] = icmp slt i64 %[[TMP18]], 0
 // CHECK-NEXT:   %[[TMP20:[0-9]+]] = icmp uge i64 %[[TMP18]], 0
 // CHECK-NEXT:   %[[TMP21:[0-9]+]] = or i1 %[[TMP20]], %[[TMP19]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP21]], i64 %[[TMP18]], i1 true, i64 0)
-// CHECK-NEXT:   %[[TMP22:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1Fast64"(ptr @"map[_llgo_int]_llgo_int", ptr null, i64 0)
-// CHECK-NEXT:   %[[TMP23:[0-9]+]] = load i64, ptr %[[TMP22]], align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %[[TMP23]])
-// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_[[BB6]]), ptr %[[TMP9]], align 8
-// CHECK-NEXT:   br label %_llgo_[[BB2]]
+// CHECK-NEXT:   br i1 %[[TMP21]], label %_llgo_[[BB6:[0-9]+]], label %_llgo_[[BB7:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB5]]:
 // CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_[[BB3]]), ptr %[[TMP9]], align 8
-// CHECK-NEXT:   %[[TMP24:[0-9]+]] = load ptr, ptr %[[TMP8]], align 8
-// CHECK-NEXT:   indirectbr ptr %[[TMP24]], [label %_llgo_[[BB3]], label %_llgo_[[BB2]]]
+// CHECK-NEXT:   %[[TMP22:[0-9]+]] = load ptr, ptr %[[TMP8]], align 8
+// CHECK-NEXT:   indirectbr ptr %[[TMP22]], [label %_llgo_[[BB3]], label %_llgo_[[BB2]]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB6]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP18]], i64 0)
+// CHECK-NEXT:   br label %_llgo_[[BB6]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB7]]:
+// CHECK-NEXT:   %[[TMP23:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1Fast64"(ptr @"map[_llgo_int]_llgo_int", ptr null, i64 0)
+// CHECK-NEXT:   %[[TMP24:[0-9]+]] = load i64, ptr %[[TMP23]], align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %[[TMP24]])
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_[[BB8]]), ptr %[[TMP9]], align 8
+// CHECK-NEXT:   br label %_llgo_[[BB2]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB8]]:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 

--- a/cl/_testrt/concat/in.go
+++ b/cl/_testrt/concat/in.go
@@ -32,11 +32,11 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi %"{{.*}}/runtime/internal/runtime.String" [ zeroinitializer, %_llgo_[[BB0]] ], [ %[[TMP13:[0-9]+]], %_llgo_[[BB2:[0-9]+]] ]
-// CHECK-NEXT:   %[[TMP3:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP4:[0-9]+]], %_llgo_[[BB2]] ]
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi %"{{.*}}/runtime/internal/runtime.String" [ zeroinitializer, %_llgo_[[BB0]] ], [ %[[TMP13:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP3:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP4:[0-9]+]], %_llgo_[[BB5]] ]
 // CHECK-NEXT:   %[[TMP4]] = add i64 %[[TMP3]], 1
 // CHECK-NEXT:   %[[TMP5:[0-9]+]] = icmp slt i64 %[[TMP4]], %[[TMP1]]
-// CHECK-NEXT:   br i1 %[[TMP5]], label %_llgo_[[BB2]], label %_llgo_[[BB3:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP5]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP0]], 0
@@ -44,14 +44,20 @@ func main() {
 // CHECK-NEXT:   %[[TMP8:[0-9]+]] = icmp slt i64 %[[TMP4]], 0
 // CHECK-NEXT:   %[[TMP9:[0-9]+]] = icmp uge i64 %[[TMP4]], %[[TMP7]]
 // CHECK-NEXT:   %[[TMP10:[0-9]+]] = or i1 %[[TMP9]], %[[TMP8]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP10]], i64 %[[TMP4]], i1 true, i64 %[[TMP7]])
+// CHECK-NEXT:   br i1 %[[TMP10]], label %_llgo_[[BB4:[0-9]+]], label %_llgo_[[BB5]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB3]]:
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %[[TMP2]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB4]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP4]], i64 %[[TMP7]])
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB5]]:
 // CHECK-NEXT:   %[[TMP11:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP6]], i64 %[[TMP4]]
 // CHECK-NEXT:   %[[TMP12:[0-9]+]] = load %"{{.*}}/runtime/internal/runtime.String", ptr %[[TMP11]], align 8
 // CHECK-NEXT:   %[[TMP13]] = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %[[TMP2]], %"{{.*}}/runtime/internal/runtime.String" %[[TMP12]])
 // CHECK-NEXT:   br label %_llgo_[[BB1]]
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_[[BB3]]:
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %[[TMP2]]
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.info(

--- a/cl/_testrt/gblarray/in.go
+++ b/cl/_testrt/gblarray/in.go
@@ -39,7 +39,13 @@ func main() {
 // CHECK-SAME: i64 %[[TMP0:[0-9]+]]){{.*}} {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP1:[0-9]+]] = icmp uge i64 %[[TMP0]], 25
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP1]], i64 %[[TMP0]], i1 false, i64 25)
+// CHECK-NEXT:   br i1 %[[TMP1]], label %_llgo_[[BB1:[0-9]+]], label %_llgo_[[BB2:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB1]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndexU"(i64 %[[TMP0]], i64 25)
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = getelementptr inbounds ptr, ptr @main.basicTypes, i64 %[[TMP0]]
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = load ptr, ptr %[[TMP2]], align 8
 // CHECK-NEXT:   ret ptr %[[TMP3]]
@@ -51,7 +57,13 @@ func main() {
 // CHECK-NEXT:   %[[TMP1:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 72)
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %[[TMP1]], i32 0, i32 0
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = icmp uge i64 %[[TMP0]], 25
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP3]], i64 %[[TMP0]], i1 false, i64 25)
+// CHECK-NEXT:   br i1 %[[TMP3]], label %_llgo_[[BB1:[0-9]+]], label %_llgo_[[BB2:[0-9]+]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB1]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndexU"(i64 %[[TMP0]], i64 25)
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP4:[0-9]+]] = getelementptr inbounds i64, ptr @main.sizeBasicTypes, i64 %[[TMP0]]
 // CHECK-NEXT:   %[[TMP5:[0-9]+]] = load i64, ptr %[[TMP4]], align 8
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %[[TMP1]], i32 0, i32 2

--- a/cl/_testrt/index/in.go
+++ b/cl/_testrt/index/in.go
@@ -75,7 +75,9 @@ type S []int
 // CHECK: %[[SLICE_DATA:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
 // CHECK: %[[SLICE_LEN:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 1
 // CHECK: %[[SLICE_OOB:[0-9]+]] = icmp uge i64 1, %[[SLICE_LEN]]
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[SLICE_OOB]], i64 1, i1 true, i64 %[[SLICE_LEN]])
+// CHECK: br i1 %[[SLICE_OOB]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 1, i64 %[[SLICE_LEN]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
 // CHECK: %[[SLICE_ELEM:[0-9]+]] = getelementptr inbounds i64, ptr %[[SLICE_DATA]], i64 1
 // CHECK: load i64, ptr %[[SLICE_ELEM]]
 

--- a/cl/_testrt/intgen/in.go
+++ b/cl/_testrt/intgen/in.go
@@ -59,10 +59,10 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP4:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP5:[0-9]+]], %_llgo_[[BB2:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP4:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP5:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
 // CHECK-NEXT:   %[[TMP5]] = add i64 %[[TMP4]], 1
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = icmp slt i64 %[[TMP5]], %[[TMP3]]
-// CHECK-NEXT:   br i1 %[[TMP6]], label %_llgo_[[BB2]], label %_llgo_[[BB3:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP6]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP7:[0-9]+]] = extractvalue { ptr, ptr } %[[TMP1]], 1
@@ -75,13 +75,19 @@ func main() {
 // CHECK-NEXT:   %[[TMP12:[0-9]+]] = icmp slt i64 %[[TMP5]], 0
 // CHECK-NEXT:   %[[TMP13:[0-9]+]] = icmp uge i64 %[[TMP5]], %[[TMP11]]
 // CHECK-NEXT:   %[[TMP14:[0-9]+]] = or i1 %[[TMP13]], %[[TMP12]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP14]], i64 %[[TMP5]], i1 true, i64 %[[TMP11]])
-// CHECK-NEXT:   %[[TMP15:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP10]], i64 %[[TMP5]]
-// CHECK-NEXT:   store i32 %[[TMP9]], ptr %[[TMP15]], align 4
-// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-NEXT:   br i1 %[[TMP14]], label %_llgo_[[BB4:[0-9]+]], label %_llgo_[[BB5]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB3]]:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP2]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB4]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP5]], i64 %[[TMP11]])
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB5]]:
+// CHECK-NEXT:   %[[TMP15:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP10]], i64 %[[TMP5]]
+// CHECK-NEXT:   store i32 %[[TMP9]], ptr %[[TMP15]], align 4
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i32 @"main.(*generator).next"(
@@ -104,10 +110,10 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP3:[0-9]+]], %_llgo_[[BB2:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP3:[0-9]+]], %_llgo_[[BB11:[0-9]+]] ]
 // CHECK-NEXT:   %[[TMP3]] = add i64 %[[TMP2]], 1
 // CHECK-NEXT:   %[[TMP4:[0-9]+]] = icmp slt i64 %[[TMP3]], %[[TMP1]]
-// CHECK-NEXT:   br i1 %[[TMP4]], label %_llgo_[[BB2]], label %_llgo_[[BB3:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP4]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP5:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP0]], 0
@@ -115,73 +121,91 @@ func main() {
 // CHECK-NEXT:   %[[TMP7:[0-9]+]] = icmp slt i64 %[[TMP3]], 0
 // CHECK-NEXT:   %[[TMP8:[0-9]+]] = icmp uge i64 %[[TMP3]], %[[TMP6]]
 // CHECK-NEXT:   %[[TMP9:[0-9]+]] = or i1 %[[TMP8]], %[[TMP7]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP9]], i64 %[[TMP3]], i1 true, i64 %[[TMP6]])
-// CHECK-NEXT:   %[[TMP10:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP5]], i64 %[[TMP3]]
-// CHECK-NEXT:   %[[TMP11:[0-9]+]] = load i32, ptr %[[TMP10]], align 4
-// CHECK-NEXT:   %[[TMP12:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB0]], i32 %[[TMP11]])
-// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-NEXT:   br i1 %[[TMP9]], label %_llgo_[[BB10:[0-9]+]], label %_llgo_[[BB11]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB3]]:
-// CHECK-NEXT:   %[[TMP13:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
-// CHECK-NEXT:   store i32 1, ptr %[[TMP13]], align 4
-// CHECK-NEXT:   %[[TMP14:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   %[[TMP15:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[TMP14]], i32 0, i32 0
-// CHECK-NEXT:   store ptr %[[TMP13]], ptr %[[TMP15]], align 8
-// CHECK-NEXT:   %[[TMP16:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %[[TMP14]], 1
-// CHECK-NEXT:   %[[TMP17:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %[[TMP16]])
-// CHECK-NEXT:   %[[TMP18:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP17]], 1
+// CHECK-NEXT:   %[[TMP10:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
+// CHECK-NEXT:   store i32 1, ptr %[[TMP10]], align 4
+// CHECK-NEXT:   %[[TMP11:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %[[TMP12:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[TMP11]], i32 0, i32 0
+// CHECK-NEXT:   store ptr %[[TMP10]], ptr %[[TMP12]], align 8
+// CHECK-NEXT:   %[[TMP13:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %[[TMP11]], 1
+// CHECK-NEXT:   %[[TMP14:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %[[TMP13]])
+// CHECK-NEXT:   %[[TMP15:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP14]], 1
 // CHECK-NEXT:   br label %_llgo_[[BB4:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB4]]:
-// CHECK-NEXT:   %[[TMP19:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB3]] ], [ %[[TMP20:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
-// CHECK-NEXT:   %[[TMP20]] = add i64 %[[TMP19]], 1
-// CHECK-NEXT:   %[[TMP21:[0-9]+]] = icmp slt i64 %[[TMP20]], %[[TMP18]]
-// CHECK-NEXT:   br i1 %[[TMP21]], label %_llgo_[[BB5]], label %_llgo_[[BB6:[0-9]+]]
+// CHECK-NEXT:   %[[TMP16:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB3]] ], [ %[[TMP17:[0-9]+]], %_llgo_[[BB13:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP17]] = add i64 %[[TMP16]], 1
+// CHECK-NEXT:   %[[TMP18:[0-9]+]] = icmp slt i64 %[[TMP17]], %[[TMP15]]
+// CHECK-NEXT:   br i1 %[[TMP18]], label %_llgo_[[BB5:[0-9]+]], label %_llgo_[[BB6:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB5]]:
-// CHECK-NEXT:   %[[TMP22:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP17]], 0
-// CHECK-NEXT:   %[[TMP23:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP17]], 1
-// CHECK-NEXT:   %[[TMP24:[0-9]+]] = icmp slt i64 %[[TMP20]], 0
-// CHECK-NEXT:   %[[TMP25:[0-9]+]] = icmp uge i64 %[[TMP20]], %[[TMP23]]
-// CHECK-NEXT:   %[[TMP26:[0-9]+]] = or i1 %[[TMP25]], %[[TMP24]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP26]], i64 %[[TMP20]], i1 true, i64 %[[TMP23]])
-// CHECK-NEXT:   %[[TMP27:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP22]], i64 %[[TMP20]]
-// CHECK-NEXT:   %[[TMP28:[0-9]+]] = load i32, ptr %[[TMP27]], align 4
-// CHECK-NEXT:   %[[TMP29:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB1]], i32 %[[TMP28]])
-// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-NEXT:   %[[TMP19:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP14]], 0
+// CHECK-NEXT:   %[[TMP20:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP14]], 1
+// CHECK-NEXT:   %[[TMP21:[0-9]+]] = icmp slt i64 %[[TMP17]], 0
+// CHECK-NEXT:   %[[TMP22:[0-9]+]] = icmp uge i64 %[[TMP17]], %[[TMP20]]
+// CHECK-NEXT:   %[[TMP23:[0-9]+]] = or i1 %[[TMP22]], %[[TMP21]]
+// CHECK-NEXT:   br i1 %[[TMP23]], label %_llgo_[[BB12:[0-9]+]], label %_llgo_[[BB13]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB6]]:
-// CHECK-NEXT:   %[[TMP30:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
-// CHECK-NEXT:   %[[TMP31:[0-9]+]] = getelementptr inbounds %main.generator, ptr %[[TMP30]], i32 0, i32 0
-// CHECK-NEXT:   store i32 1, ptr %[[TMP31]], align 4
-// CHECK-NEXT:   %[[TMP32:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   %[[TMP33:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[TMP32]], i32 0, i32 0
-// CHECK-NEXT:   store ptr %[[TMP30]], ptr %[[TMP33]], align 8
-// CHECK-NEXT:   %[[TMP34:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.(*generator).next$bound", ptr undef }, ptr %[[TMP32]], 1
-// CHECK-NEXT:   %[[TMP35:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %[[TMP34]])
-// CHECK-NEXT:   %[[TMP36:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP35]], 1
+// CHECK-NEXT:   %[[TMP24:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
+// CHECK-NEXT:   %[[TMP25:[0-9]+]] = getelementptr inbounds %main.generator, ptr %[[TMP24]], i32 0, i32 0
+// CHECK-NEXT:   store i32 1, ptr %[[TMP25]], align 4
+// CHECK-NEXT:   %[[TMP26:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %[[TMP27:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[TMP26]], i32 0, i32 0
+// CHECK-NEXT:   store ptr %[[TMP24]], ptr %[[TMP27]], align 8
+// CHECK-NEXT:   %[[TMP28:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.(*generator).next$bound", ptr undef }, ptr %[[TMP26]], 1
+// CHECK-NEXT:   %[[TMP29:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %[[TMP28]])
+// CHECK-NEXT:   %[[TMP30:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP29]], 1
 // CHECK-NEXT:   br label %_llgo_[[BB7:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB7]]:
-// CHECK-NEXT:   %[[TMP37:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB6]] ], [ %[[TMP38:[0-9]+]], %_llgo_[[BB8:[0-9]+]] ]
-// CHECK-NEXT:   %[[TMP38]] = add i64 %[[TMP37]], 1
-// CHECK-NEXT:   %[[TMP39:[0-9]+]] = icmp slt i64 %[[TMP38]], %[[TMP36]]
-// CHECK-NEXT:   br i1 %[[TMP39]], label %_llgo_[[BB8]], label %_llgo_[[BB9:[0-9]+]]
+// CHECK-NEXT:   %[[TMP31:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB6]] ], [ %[[TMP32:[0-9]+]], %_llgo_[[BB15:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP32]] = add i64 %[[TMP31]], 1
+// CHECK-NEXT:   %[[TMP33:[0-9]+]] = icmp slt i64 %[[TMP32]], %[[TMP30]]
+// CHECK-NEXT:   br i1 %[[TMP33]], label %_llgo_[[BB8:[0-9]+]], label %_llgo_[[BB9:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB8]]:
-// CHECK-NEXT:   %[[TMP40:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP35]], 0
-// CHECK-NEXT:   %[[TMP41:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP35]], 1
-// CHECK-NEXT:   %[[TMP42:[0-9]+]] = icmp slt i64 %[[TMP38]], 0
-// CHECK-NEXT:   %[[TMP43:[0-9]+]] = icmp uge i64 %[[TMP38]], %[[TMP41]]
-// CHECK-NEXT:   %[[TMP44:[0-9]+]] = or i1 %[[TMP43]], %[[TMP42]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP44]], i64 %[[TMP38]], i1 true, i64 %[[TMP41]])
-// CHECK-NEXT:   %[[TMP45:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP40]], i64 %[[TMP38]]
-// CHECK-NEXT:   %[[TMP46:[0-9]+]] = load i32, ptr %[[TMP45]], align 4
-// CHECK-NEXT:   %[[TMP47:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB2]], i32 %[[TMP46]])
-// CHECK-NEXT:   br label %_llgo_[[BB7]]
+// CHECK-NEXT:   %[[TMP34:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP29]], 0
+// CHECK-NEXT:   %[[TMP35:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP29]], 1
+// CHECK-NEXT:   %[[TMP36:[0-9]+]] = icmp slt i64 %[[TMP32]], 0
+// CHECK-NEXT:   %[[TMP37:[0-9]+]] = icmp uge i64 %[[TMP32]], %[[TMP35]]
+// CHECK-NEXT:   %[[TMP38:[0-9]+]] = or i1 %[[TMP37]], %[[TMP36]]
+// CHECK-NEXT:   br i1 %[[TMP38]], label %_llgo_[[BB14:[0-9]+]], label %_llgo_[[BB15]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB9]]:
 // CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB10]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP3]], i64 %[[TMP6]])
+// CHECK-NEXT:   br label %_llgo_[[BB10]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB11]]:
+// CHECK-NEXT:   %[[TMP39:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP5]], i64 %[[TMP3]]
+// CHECK-NEXT:   %[[TMP40:[0-9]+]] = load i32, ptr %[[TMP39]], align 4
+// CHECK-NEXT:   %[[TMP41:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB0]], i32 %[[TMP40]])
+// CHECK-NEXT:   br label %_llgo_[[BB1]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB12]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP17]], i64 %[[TMP20]])
+// CHECK-NEXT:   br label %_llgo_[[BB12]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB13]]:
+// CHECK-NEXT:   %[[TMP42:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP19]], i64 %[[TMP17]]
+// CHECK-NEXT:   %[[TMP43:[0-9]+]] = load i32, ptr %[[TMP42]], align 4
+// CHECK-NEXT:   %[[TMP44:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB1]], i32 %[[TMP43]])
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB14]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP32]], i64 %[[TMP35]])
+// CHECK-NEXT:   br label %_llgo_[[BB14]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB15]]:
+// CHECK-NEXT:   %[[TMP45:[0-9]+]] = getelementptr inbounds i32, ptr %[[TMP34]], i64 %[[TMP32]]
+// CHECK-NEXT:   %[[TMP46:[0-9]+]] = load i32, ptr %[[TMP45]], align 4
+// CHECK-NEXT:   %[[TMP47:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB2]], i32 %[[TMP46]])
+// CHECK-NEXT:   br label %_llgo_[[BB7]]
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i32 @"main.main$1"(

--- a/cl/_testrt/qsort/in.go
+++ b/cl/_testrt/qsort/in.go
@@ -42,23 +42,29 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP8:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP9:[0-9]+]], %_llgo_[[BB2:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP8:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP9:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
 // CHECK-NEXT:   %[[TMP9]] = add i64 %[[TMP8]], 1
 // CHECK-NEXT:   %[[TMP10:[0-9]+]] = icmp slt i64 %[[TMP9]], 5
-// CHECK-NEXT:   br i1 %[[TMP10]], label %_llgo_[[BB2]], label %_llgo_[[BB3:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP10]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP11:[0-9]+]] = icmp slt i64 %[[TMP9]], 0
 // CHECK-NEXT:   %[[TMP12:[0-9]+]] = icmp uge i64 %[[TMP9]], 5
 // CHECK-NEXT:   %[[TMP13:[0-9]+]] = or i1 %[[TMP12]], %[[TMP11]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP13]], i64 %[[TMP9]], i1 true, i64 5)
+// CHECK-NEXT:   br i1 %[[TMP13]], label %_llgo_[[BB4:[0-9]+]], label %_llgo_[[BB5]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB3]]:
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB4]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP9]], i64 5)
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB5]]:
 // CHECK-NEXT:   %[[TMP14:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP0]], i64 %[[TMP9]]
 // CHECK-NEXT:   %[[TMP15:[0-9]+]] = load i64, ptr %[[TMP14]], align 8
 // CHECK-NEXT:   %[[TMP16:[0-9]+]] = call i32 (ptr, ...) @printf(ptr @[[GLOB0]], i64 %[[TMP15]])
 // CHECK-NEXT:   br label %_llgo_[[BB1]]
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_[[BB3]]:
-// CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i32 @"main.main$1"(

--- a/cl/_testrt/reflectclosureenv/in.go
+++ b/cl/_testrt/reflectclosureenv/in.go
@@ -8,106 +8,108 @@ type receiver struct {
 }
 
 // CHECK-LABEL: define void @main.checkInt(%reflect.Value %0, %"{{.*}}Slice" %1){{.*}} {
-// CHECK: [[CHECK_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value %0, %"{{.*}}Slice" %1)
-// CHECK: [[CHECK_RESULTS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[CHECK_RESULTS]], 0
-// CHECK: [[CHECK_RESULTS_LEN:%.*]] = extractvalue %"{{.*}}Slice" [[CHECK_RESULTS]], 1
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %{{.*}}, i64 0, i1 true, i64 [[CHECK_RESULTS_LEN]])
-// CHECK: [[CHECK_FIRST_PTR:%.*]] = getelementptr inbounds %reflect.Value, ptr [[CHECK_RESULTS_PTR]], i64 0
-// CHECK: [[CHECK_FIRST_SAFE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[CHECK_FIRST_PTR]])
-// CHECK: [[CHECK_FIRST:%.*]] = load %reflect.Value, ptr [[CHECK_FIRST_SAFE]]
-// CHECK: [[CHECK_GOT:%.*]] = call i64 @reflect.Value.Int(%reflect.Value [[CHECK_FIRST]])
-// CHECK: [[CHECK_BAD:%.*]] = icmp ne i64 [[CHECK_GOT]], 55
-// CHECK: br i1 [[CHECK_BAD]], label %{{.*}}, label %{{.*}}
-// CHECK: store i64 [[CHECK_GOT]], ptr %{{.*}}
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.Panic"
+// CHECK-DAG: [[CHECK_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value %0, %"{{.*}}Slice" %1)
+// CHECK-DAG: [[CHECK_RESULTS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[CHECK_RESULTS]], 0
+// CHECK-DAG: [[CHECK_RESULTS_LEN:%.*]] = extractvalue %"{{.*}}Slice" [[CHECK_RESULTS]], 1
+// CHECK-DAG: br i1 %{{.*}}, label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
+// CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 [[CHECK_RESULTS_LEN]])
+// CHECK-DAG: br label %{{_llgo_[0-9]+}}
+// CHECK-DAG: [[CHECK_FIRST_PTR:%.*]] = getelementptr inbounds %reflect.Value, ptr [[CHECK_RESULTS_PTR]], i64 0
+// CHECK-DAG: [[CHECK_FIRST_SAFE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[CHECK_FIRST_PTR]])
+// CHECK-DAG: [[CHECK_FIRST:%.*]] = load %reflect.Value, ptr [[CHECK_FIRST_SAFE]]
+// CHECK-DAG: [[CHECK_GOT:%.*]] = call i64 @reflect.Value.Int(%reflect.Value [[CHECK_FIRST]])
+// CHECK-DAG: [[CHECK_BAD:%.*]] = icmp ne i64 [[CHECK_GOT]], 55
+// CHECK-DAG: br i1 [[CHECK_BAD]], label %{{.*}}, label %{{.*}}
+// CHECK-DAG: store i64 [[CHECK_GOT]], ptr %{{.*}}
+// CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.Panic"
 
 // CHECK-LABEL: define %"{{.*}}Slice" @main.floatArgs(){{.*}} {
-// CHECK: [[FLOAT_ARG_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
-// CHECK: [[FLOAT_ARGS:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[FLOAT_ARG_STORAGE]], i64 24, i64 9, i64 0, i64 9, i1 true, i1 true, i1 true)
-// CHECK: [[FLOAT_INDEX:%.*]] = add i64 %{{.*}}, 1
-// CHECK: [[FLOAT_ORDINAL:%.*]] = add i64 [[FLOAT_INDEX]], 1
-// CHECK: [[FLOAT_NUMBER:%.*]] = sitofp i64 [[FLOAT_ORDINAL]] to double
-// CHECK: store double [[FLOAT_NUMBER]], ptr [[FLOAT_BOX_ADDR:%[-A-Za-z0-9_.]+]]
-// CHECK: [[FLOAT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_float64, ptr undef }, ptr [[FLOAT_BOX_ADDR]], 1
-// CHECK: [[FLOAT_REFLECT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[FLOAT_BOX]])
-// CHECK: [[FLOAT_ARGS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[FLOAT_ARGS]], 0
-// CHECK: [[FLOAT_DEST:%.*]] = getelementptr inbounds %reflect.Value, ptr [[FLOAT_ARGS_PTR]], i64 [[FLOAT_INDEX]]
-// CHECK: store %reflect.Value [[FLOAT_REFLECT]], ptr [[FLOAT_DEST]]
-// CHECK: ret %"{{.*}}Slice" [[FLOAT_ARGS]]
+// CHECK-DAG: [[FLOAT_ARG_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
+// CHECK-DAG: [[FLOAT_ARGS:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[FLOAT_ARG_STORAGE]], i64 24, i64 9, i64 0, i64 9, i1 true, i1 true, i1 true)
+// CHECK-DAG: [[FLOAT_INDEX:%.*]] = add i64 %{{.*}}, 1
+// CHECK-DAG: [[FLOAT_ORDINAL:%.*]] = add i64 [[FLOAT_INDEX]], 1
+// CHECK-DAG: [[FLOAT_NUMBER:%.*]] = sitofp i64 [[FLOAT_ORDINAL]] to double
+// CHECK-DAG: store double [[FLOAT_NUMBER]], ptr [[FLOAT_BOX_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK-DAG: [[FLOAT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_float64, ptr undef }, ptr [[FLOAT_BOX_ADDR]], 1
+// CHECK-DAG: [[FLOAT_REFLECT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[FLOAT_BOX]])
+// CHECK-DAG: [[FLOAT_ARGS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[FLOAT_ARGS]], 0
+// CHECK-DAG: [[FLOAT_DEST:%.*]] = getelementptr inbounds %reflect.Value, ptr [[FLOAT_ARGS_PTR]], i64 [[FLOAT_INDEX]]
+// CHECK-DAG: store %reflect.Value [[FLOAT_REFLECT]], ptr [[FLOAT_DEST]]
+// CHECK-DAG: ret %"{{.*}}Slice" [[FLOAT_ARGS]]
 
 // CHECK-LABEL: define %"{{.*}}Slice" @main.intArgs(){{.*}} {
-// CHECK: [[INT_ARG_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
-// CHECK: [[INT_ARGS:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[INT_ARG_STORAGE]], i64 24, i64 9, i64 0, i64 9, i1 true, i1 true, i1 true)
-// CHECK: [[INT_INDEX:%.*]] = add i64 %{{.*}}, 1
-// CHECK: [[INT_ORDINAL:%.*]] = add i64 [[INT_INDEX]], 1
-// CHECK: store i64 [[INT_ORDINAL]], ptr [[INT_BOX_ADDR:%[-A-Za-z0-9_.]+]]
-// CHECK: [[INT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[INT_BOX_ADDR]], 1
-// CHECK: [[INT_REFLECT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[INT_BOX]])
-// CHECK: [[INT_ARGS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[INT_ARGS]], 0
-// CHECK: [[INT_DEST:%.*]] = getelementptr inbounds %reflect.Value, ptr [[INT_ARGS_PTR]], i64 [[INT_INDEX]]
-// CHECK: store %reflect.Value [[INT_REFLECT]], ptr [[INT_DEST]]
-// CHECK: ret %"{{.*}}Slice" [[INT_ARGS]]
+// CHECK-DAG: [[INT_ARG_STORAGE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 216)
+// CHECK-DAG: [[INT_ARGS:%.*]] = call %"{{.*}}Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr [[INT_ARG_STORAGE]], i64 24, i64 9, i64 0, i64 9, i1 true, i1 true, i1 true)
+// CHECK-DAG: [[INT_INDEX:%.*]] = add i64 %{{.*}}, 1
+// CHECK-DAG: [[INT_ORDINAL:%.*]] = add i64 [[INT_INDEX]], 1
+// CHECK-DAG: store i64 [[INT_ORDINAL]], ptr [[INT_BOX_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK-DAG: [[INT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[INT_BOX_ADDR]], 1
+// CHECK-DAG: [[INT_REFLECT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[INT_BOX]])
+// CHECK-DAG: [[INT_ARGS_PTR:%.*]] = extractvalue %"{{.*}}Slice" [[INT_ARGS]], 0
+// CHECK-DAG: [[INT_DEST:%.*]] = getelementptr inbounds %reflect.Value, ptr [[INT_ARGS_PTR]], i64 [[INT_INDEX]]
+// CHECK-DAG: store %reflect.Value [[INT_REFLECT]], ptr [[INT_DEST]]
+// CHECK-DAG: ret %"{{.*}}Slice" [[INT_ARGS]]
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
 // The direct and nested integer closures are boxed and called with the same nine arguments.
-// CHECK: [[MAIN_INTS:%.*]] = call %"{{.*}}Slice" @main.intArgs()
-// CHECK: [[MAIN_SUM_FN:%.*]] = call { ptr, ptr } @main.makeSum(i64 10)
-// CHECK: store { ptr, ptr } [[MAIN_SUM_FN]], ptr [[MAIN_SUM_ADDR:%[-A-Za-z0-9_.]+]]
-// CHECK: [[MAIN_SUM_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_SUM_ADDR]], 1
-// CHECK: [[MAIN_SUM_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_SUM_BOX]])
-// CHECK: call void @main.checkInt(%reflect.Value [[MAIN_SUM_VALUE]], %"{{.*}}Slice" [[MAIN_INTS]])
-// CHECK: [[MAIN_NESTED_FN:%.*]] = call { ptr, ptr } @main.makeNestedSum(i64 10)
-// CHECK: store { ptr, ptr } [[MAIN_NESTED_FN]], ptr [[MAIN_NESTED_ADDR:%[-A-Za-z0-9_.]+]]
-// CHECK: [[MAIN_NESTED_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_NESTED_ADDR]], 1
-// CHECK: [[MAIN_NESTED_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_NESTED_BOX]])
-// CHECK: call void @main.checkInt(%reflect.Value [[MAIN_NESTED_VALUE]], %"{{.*}}Slice" [[MAIN_INTS]])
+// CHECK-DAG: [[MAIN_INTS:%.*]] = call %"{{.*}}Slice" @main.intArgs()
+// CHECK-DAG: [[MAIN_SUM_FN:%.*]] = call { ptr, ptr } @main.makeSum(i64 10)
+// CHECK-DAG: store { ptr, ptr } [[MAIN_SUM_FN]], ptr [[MAIN_SUM_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK-DAG: [[MAIN_SUM_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_SUM_ADDR]], 1
+// CHECK-DAG: [[MAIN_SUM_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_SUM_BOX]])
+// CHECK-DAG: call void @main.checkInt(%reflect.Value [[MAIN_SUM_VALUE]], %"{{.*}}Slice" [[MAIN_INTS]])
+// CHECK-DAG: [[MAIN_NESTED_FN:%.*]] = call { ptr, ptr } @main.makeNestedSum(i64 10)
+// CHECK-DAG: store { ptr, ptr } [[MAIN_NESTED_FN]], ptr [[MAIN_NESTED_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK-DAG: [[MAIN_NESTED_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_NESTED_ADDR]], 1
+// CHECK-DAG: [[MAIN_NESTED_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_NESTED_BOX]])
+// CHECK-DAG: call void @main.checkInt(%reflect.Value [[MAIN_NESTED_VALUE]], %"{{.*}}Slice" [[MAIN_INTS]])
 // MakeFunc receives the type of the nine-argument literal and the slice callback main$2.
-// CHECK: [[FUNC_TYPE:%.*]] = call %"{{.*}}iface" @reflect.TypeOf(%"{{.*}}eface" %{{.*}})
-// CHECK: [[MADE:%.*]] = call %reflect.Value @reflect.MakeFunc(%"{{.*}}iface" [[FUNC_TYPE]], { ptr, ptr } { ptr @"main.main$2", ptr null })
-// CHECK: call void @main.checkInt(%reflect.Value [[MADE]], %"{{.*}}Slice" [[MAIN_INTS]])
+// CHECK-DAG: [[FUNC_TYPE:%.*]] = call %"{{.*}}iface" @reflect.TypeOf(%"{{.*}}eface" %{{.*}})
+// CHECK-DAG: [[MADE:%.*]] = call %reflect.Value @reflect.MakeFunc(%"{{.*}}iface" [[FUNC_TYPE]], { ptr, ptr } { ptr @"main.main$2", ptr null })
+// CHECK-DAG: call void @main.checkInt(%reflect.Value [[MADE]], %"{{.*}}Slice" [[MAIN_INTS]])
 // MethodByName is performed on receiver{base: 10} and checked with the same arguments.
-// CHECK: store i64 10, ptr %{{.*}}
-// CHECK: [[RECEIVER_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.receiver, ptr undef }, ptr %{{.*}}, 1
-// CHECK: [[RECEIVER_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[RECEIVER_BOX]])
-// CHECK: [[METHOD:%.*]] = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value [[RECEIVER_VALUE]], %"{{.*}}String" { ptr @{{.*}}, i64 3 })
-// CHECK: call void @main.checkInt(%reflect.Value [[METHOD]], %"{{.*}}Slice" [[MAIN_INTS]])
-// CHECK: [[METHOD_IFACE:%.*]] = call %"{{.*}}eface" @reflect.Value.Interface(%reflect.Value [[METHOD]])
-// CHECK: [[METHOD_TYPE:%.*]] = extractvalue %"{{.*}}eface" [[METHOD_IFACE]], 0
-// CHECK: [[METHOD_MATCH:%.*]] = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr [[METHOD_TYPE]])
-// CHECK: br i1 [[METHOD_MATCH]], label %{{.*}}, label %{{.*}}
+// CHECK-DAG: store i64 10, ptr %{{.*}}
+// CHECK-DAG: [[RECEIVER_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_main.receiver, ptr undef }, ptr %{{.*}}, 1
+// CHECK-DAG: [[RECEIVER_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[RECEIVER_BOX]])
+// CHECK-DAG: [[METHOD:%.*]] = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value [[RECEIVER_VALUE]], %"{{.*}}String" { ptr @{{.*}}, i64 3 })
+// CHECK-DAG: call void @main.checkInt(%reflect.Value [[METHOD]], %"{{.*}}Slice" [[MAIN_INTS]])
+// CHECK-DAG: [[METHOD_IFACE:%.*]] = call %"{{.*}}eface" @reflect.Value.Interface(%reflect.Value [[METHOD]])
+// CHECK-DAG: [[METHOD_TYPE:%.*]] = extractvalue %"{{.*}}eface" [[METHOD_IFACE]], 0
+// CHECK-DAG: [[METHOD_MATCH:%.*]] = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr [[METHOD_TYPE]])
+// CHECK-DAG: br i1 [[METHOD_MATCH]], label %{{.*}}, label %{{.*}}
 // The floating closure is reflect-called with floatArgs and compared with 55.
-// CHECK: [[MAIN_FLOAT_FN:%.*]] = call { ptr, ptr } @main.makeFloatSum(double 1.000000e+01)
-// CHECK: store { ptr, ptr } [[MAIN_FLOAT_FN]], ptr [[MAIN_FLOAT_ADDR:%[-A-Za-z0-9_.]+]]
-// CHECK: [[MAIN_FLOAT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_FLOAT_ADDR]], 1
-// CHECK: [[MAIN_FLOAT_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_FLOAT_BOX]])
-// CHECK: [[MAIN_FLOAT_ARGS:%.*]] = call %"{{.*}}Slice" @main.floatArgs()
-// CHECK: [[MAIN_FLOAT_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value [[MAIN_FLOAT_VALUE]], %"{{.*}}Slice" [[MAIN_FLOAT_ARGS]])
-// CHECK: [[MAIN_FLOAT_GOT:%.*]] = call double @reflect.Value.Float(%reflect.Value %{{.*}})
-// CHECK: [[MAIN_FLOAT_BAD:%.*]] = fcmp une double [[MAIN_FLOAT_GOT]], 5.500000e+01
-// CHECK: br i1 [[MAIN_FLOAT_BAD]], label %{{.*}}, label %{{.*}}
+// CHECK-DAG: [[MAIN_FLOAT_FN:%.*]] = call { ptr, ptr } @main.makeFloatSum(double 1.000000e+01)
+// CHECK-DAG: store { ptr, ptr } [[MAIN_FLOAT_FN]], ptr [[MAIN_FLOAT_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK-DAG: [[MAIN_FLOAT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr [[MAIN_FLOAT_ADDR]], 1
+// CHECK-DAG: [[MAIN_FLOAT_VALUE:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAIN_FLOAT_BOX]])
+// CHECK-DAG: [[MAIN_FLOAT_ARGS:%.*]] = call %"{{.*}}Slice" @main.floatArgs()
+// CHECK-DAG: [[MAIN_FLOAT_RESULTS:%.*]] = call %"{{.*}}Slice" @reflect.Value.Call(%reflect.Value [[MAIN_FLOAT_VALUE]], %"{{.*}}Slice" [[MAIN_FLOAT_ARGS]])
+// CHECK-DAG: [[MAIN_FLOAT_GOT:%.*]] = call double @reflect.Value.Float(%reflect.Value %{{.*}})
+// CHECK-DAG: [[MAIN_FLOAT_BAD:%.*]] = fcmp une double [[MAIN_FLOAT_GOT]], 5.500000e+01
+// CHECK-DAG: br i1 [[MAIN_FLOAT_BAD]], label %{{.*}}, label %{{.*}}
 // The asserted method closure keeps code and environment through the direct nine-argument call.
-// CHECK: [[METHOD_DATA:%.*]] = extractvalue %"{{.*}}eface" [[METHOD_IFACE]], 1
-// CHECK: [[METHOD_FN:%.*]] = load { ptr, ptr }, ptr [[METHOD_DATA]]
-// CHECK: [[METHOD_ENV:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 1
-// CHECK: [[METHOD_CODE_RAW:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 0
-// CHECK: [[METHOD_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[METHOD_CODE_RAW]])
+// CHECK-DAG: [[METHOD_DATA:%.*]] = extractvalue %"{{.*}}eface" [[METHOD_IFACE]], 1
+// CHECK-DAG: [[METHOD_FN:%.*]] = load { ptr, ptr }, ptr [[METHOD_DATA]]
+// CHECK-DAG: [[METHOD_ENV:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 1
+// CHECK-DAG: [[METHOD_CODE_RAW:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 0
+// CHECK-DAG: [[METHOD_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[METHOD_CODE_RAW]])
 // DARWIN-ARM64: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr swiftself [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
 // LINUX-AMD64: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr nest [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
-// CHECK: [[METHOD_BAD:%.*]] = icmp ne i64 [[METHOD_GOT]], 55
+// CHECK-DAG: [[METHOD_BAD:%.*]] = icmp ne i64 [[METHOD_GOT]], 55
 
 // CHECK-LABEL: define i64 @"main.main$1"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8){{.*}} {
 // CHECK: ret i64 0
 
 // CHECK-LABEL: define %"{{.*}}Slice" @"main.main$2"(%"{{.*}}Slice" %0){{.*}} {
-// CHECK: [[MAKEFUNC_ARGS_LEN:%.*]] = extractvalue %"{{.*}}Slice" %0, 1
-// CHECK: [[MAKEFUNC_SUM:%.*]] = phi i64 [ 10, %{{.*}} ], [ [[MAKEFUNC_NEXT:%.*]], %{{.*}} ]
-// CHECK: [[MAKEFUNC_ARG:%.*]] = call i64 @reflect.Value.Int(%reflect.Value %{{.*}})
-// CHECK: [[MAKEFUNC_NEXT]] = add i64 [[MAKEFUNC_SUM]], [[MAKEFUNC_ARG]]
-// CHECK: store i64 [[MAKEFUNC_SUM]], ptr [[MAKEFUNC_RESULT_ADDR:%[-A-Za-z0-9_.]+]]
-// CHECK: [[MAKEFUNC_RESULT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[MAKEFUNC_RESULT_ADDR]], 1
-// CHECK: [[MAKEFUNC_RESULT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAKEFUNC_RESULT_BOX]])
-// CHECK: store %reflect.Value [[MAKEFUNC_RESULT]], ptr %{{.*}}
-// CHECK: ret %"{{.*}}Slice" %{{.*}}
+// CHECK-DAG: [[MAKEFUNC_ARGS_LEN:%.*]] = extractvalue %"{{.*}}Slice" %0, 1
+// CHECK-DAG: [[MAKEFUNC_SUM:%.*]] = phi i64 [ 10, %{{.*}} ], [ [[MAKEFUNC_NEXT:%.*]], %{{.*}} ]
+// CHECK-DAG: [[MAKEFUNC_ARG:%.*]] = call i64 @reflect.Value.Int(%reflect.Value %{{.*}})
+// CHECK-DAG: [[MAKEFUNC_NEXT]] = add i64 [[MAKEFUNC_SUM]], [[MAKEFUNC_ARG]]
+// CHECK-DAG: store i64 [[MAKEFUNC_SUM]], ptr [[MAKEFUNC_RESULT_ADDR:%[-A-Za-z0-9_.]+]]
+// CHECK-DAG: [[MAKEFUNC_RESULT_BOX:%.*]] = insertvalue %"{{.*}}eface" { ptr @_llgo_int, ptr undef }, ptr [[MAKEFUNC_RESULT_ADDR]], 1
+// CHECK-DAG: [[MAKEFUNC_RESULT:%.*]] = call %reflect.Value @reflect.ValueOf(%"{{.*}}eface" [[MAKEFUNC_RESULT_BOX]])
+// CHECK-DAG: store %reflect.Value [[MAKEFUNC_RESULT]], ptr %{{.*}}
+// CHECK-DAG: ret %"{{.*}}Slice" %{{.*}}
 
 // CHECK-LABEL: define { ptr, ptr } @main.makeFloatSum(double %0){{.*}} {
 // CHECK: store double %0, ptr [[FLOAT_BASE_ADDR:%[-A-Za-z0-9_.]+]]

--- a/cl/_testrt/reflectclosureenv/in.go
+++ b/cl/_testrt/reflectclosureenv/in.go
@@ -93,8 +93,8 @@ type receiver struct {
 // CHECK-DAG: [[METHOD_ENV:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 1
 // CHECK-DAG: [[METHOD_CODE_RAW:%.*]] = extractvalue { ptr, ptr } [[METHOD_FN]], 0
 // CHECK-DAG: [[METHOD_CODE:%.*]] = call ptr asm "", "=r,0"(ptr [[METHOD_CODE_RAW]])
-// DARWIN-ARM64: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr swiftself [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
-// LINUX-AMD64: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr nest [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
+// DARWIN-ARM64-DAG: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr swiftself [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
+// LINUX-AMD64-DAG: [[METHOD_GOT:%.*]] = call i64 [[METHOD_CODE]](ptr nest [[METHOD_ENV]], i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9)
 // CHECK-DAG: [[METHOD_BAD:%.*]] = icmp ne i64 [[METHOD_GOT]], 55
 
 // CHECK-LABEL: define i64 @"main.main$1"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8){{.*}} {

--- a/cl/_testrt/sum/in.go
+++ b/cl/_testrt/sum/in.go
@@ -45,11 +45,11 @@ func sum(args ...int) (ret int) {
 // CHECK-NEXT:   br label %_llgo_[[BB1:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB1]]:
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi i64 [ 0, %_llgo_[[BB0]] ], [ %[[TMP13:[0-9]+]], %_llgo_[[BB2:[0-9]+]] ]
-// CHECK-NEXT:   %[[TMP3:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP4:[0-9]+]], %_llgo_[[BB2]] ]
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = phi i64 [ 0, %_llgo_[[BB0]] ], [ %[[TMP13:[0-9]+]], %_llgo_[[BB5:[0-9]+]] ]
+// CHECK-NEXT:   %[[TMP3:[0-9]+]] = phi i64 [ -1, %_llgo_[[BB0]] ], [ %[[TMP4:[0-9]+]], %_llgo_[[BB5]] ]
 // CHECK-NEXT:   %[[TMP4]] = add i64 %[[TMP3]], 1
 // CHECK-NEXT:   %[[TMP5:[0-9]+]] = icmp slt i64 %[[TMP4]], %[[TMP1]]
-// CHECK-NEXT:   br i1 %[[TMP5]], label %_llgo_[[BB2]], label %_llgo_[[BB3:[0-9]+]]
+// CHECK-NEXT:   br i1 %[[TMP5]], label %_llgo_[[BB2:[0-9]+]], label %_llgo_[[BB3:[0-9]+]]
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_[[BB2]]:
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[TMP0]], 0
@@ -57,12 +57,18 @@ func sum(args ...int) (ret int) {
 // CHECK-NEXT:   %[[TMP8:[0-9]+]] = icmp slt i64 %[[TMP4]], 0
 // CHECK-NEXT:   %[[TMP9:[0-9]+]] = icmp uge i64 %[[TMP4]], %[[TMP7]]
 // CHECK-NEXT:   %[[TMP10:[0-9]+]] = or i1 %[[TMP9]], %[[TMP8]]
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[TMP10]], i64 %[[TMP4]], i1 true, i64 %[[TMP7]])
+// CHECK-NEXT:   br i1 %[[TMP10]], label %_llgo_[[BB4:[0-9]+]], label %_llgo_[[BB5]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB3]]:
+// CHECK-NEXT:   ret i64 %[[TMP2]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB4]]:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 %[[TMP4]], i64 %[[TMP7]])
+// CHECK-NEXT:   br label %_llgo_[[BB4]]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_[[BB5]]:
 // CHECK-NEXT:   %[[TMP11:[0-9]+]] = getelementptr inbounds i64, ptr %[[TMP6]], i64 %[[TMP4]]
 // CHECK-NEXT:   %[[TMP12:[0-9]+]] = load i64, ptr %[[TMP11]], align 8
 // CHECK-NEXT:   %[[TMP13]] = add i64 %[[TMP2]], %[[TMP12]]
 // CHECK-NEXT:   br label %_llgo_[[BB1]]
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_[[BB3]]:
-// CHECK-NEXT:   ret i64 %[[TMP2]]
 // CHECK-NEXT: }

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -56,8 +56,7 @@ type N struct {
 // CHECK: %[[DATA0:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
 // CHECK: %[[LEN0:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 1
 // CHECK: %[[OOB0:[0-9]+]] = icmp uge i64 0, %[[LEN0]]
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[OOB0]], i64 0, i1 true, i64 %[[LEN0]])
-// CHECK: getelementptr inbounds i64, ptr %[[DATA0]], i64 0
+// CHECK: br i1 %[[OOB0]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
 // The remaining StringData loads may be printed in predecessor block order,
 // but must still use the captured string backing pointer.
 // CHECK: load i8, ptr getelementptr inbounds (i8, ptr @[[CSTR]], i64 2)
@@ -70,11 +69,17 @@ type N struct {
 // CHECK: %[[DATA1:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 0
 // CHECK: %[[LEN1:[0-9]+]] = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %[[SLICE]], 1
 // CHECK: %[[OOB1:[0-9]+]] = icmp uge i64 1, %[[LEN1]]
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %[[OOB1]], i64 1, i1 true, i64 %[[LEN1]])
-// CHECK: getelementptr inbounds i64, ptr %[[DATA1]], i64 1
+// CHECK: br i1 %[[OOB1]], label %{{_llgo_[0-9]+}}, label %{{_llgo_[0-9]+}}
 
 // unsafe.Add(nil, 1) remains a byte-wise pointer addition.
 // CHECK: icmp ne i64 ptrtoint (ptr getelementptr (i8, ptr null, i64 1) to i64), 1
+
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 %[[LEN0]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
+// CHECK: getelementptr inbounds i64, ptr %[[DATA0]], i64 0
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 1, i64 %[[LEN1]])
+// CHECK-NEXT: br label %{{_llgo_[0-9]+}}
+// CHECK: getelementptr inbounds i64, ptr %[[DATA1]], i64 1
 
 func main() {
 	if unsafe.Sizeof(*(*T)(nil)) != unsafe.Sizeof(0) {

--- a/internal/build/bounds_checks_test.go
+++ b/internal/build/bounds_checks_test.go
@@ -16,7 +16,7 @@ func TestDisableBoundsChecksIR(t *testing.T) {
 	checked := boundsChecksModuleIR(t, false)
 	unchecked := boundsChecksModuleIR(t, true)
 
-	for _, helper := range []string{"CheckIndexRange", "StringSlice2", "NewSlice2", "NewSlice3Bounds", "PanicSliceConvert"} {
+	for _, helper := range []string{"PanicIndex", "StringSlice2", "NewSlice2", "NewSlice3Bounds", "PanicSliceConvert"} {
 		if !strings.Contains(checked, helper) {
 			t.Errorf("default IR does not contain bounds helper %q", helper)
 		}
@@ -27,7 +27,7 @@ func TestDisableBoundsChecksIR(t *testing.T) {
 
 	for _, function := range []string{"indexString", "indexSlice", "indexArray", "indexArrayPointer"} {
 		body := llvmFunctionBody(t, unchecked, function)
-		if strings.Contains(body, "CheckIndexRange") {
+		if strings.Contains(body, "PanicIndex") {
 			t.Errorf("-B %s contains an index bounds check:\n%s", function, body)
 		}
 	}

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -1,5 +1,6 @@
 #include "LLGOLTOPasses.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ConstantFolding.h"
@@ -1219,6 +1220,11 @@ Value *getSRetArg(CallBase *CB) {
   return nullptr;
 }
 
+Value *getSRetStorage(CallBase *CB) {
+  Value *SRet = getSRetArg(CB);
+  return SRet ? SRet->stripPointerCasts() : nullptr;
+}
+
 void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
                                  SmallPtrSetImpl<CallBase *> &SeenLoads,
                                  SmallVectorImpl<CallBase *> &Loads) {
@@ -1288,7 +1294,20 @@ public:
 
     bool Changed = false;
     const DataLayout &DL = M.getDataLayout();
+    DenseMap<CallBase *, Value *> SRetStorageByCall;
+    DenseMap<Value *, SmallVector<CallBase *, 4>> CallsBySRetStorage;
     for (CallBase *ReflectCall : Calls) {
+      Value *SRetStorage = getSRetStorage(ReflectCall);
+      SRetStorageByCall.insert({ReflectCall, SRetStorage});
+      if (SRetStorage)
+        CallsBySRetStorage[SRetStorage].push_back(ReflectCall);
+    }
+
+    SmallPtrSet<CallBase *, 16> ProcessedCalls;
+    for (CallBase *ReflectCall : Calls) {
+      if (!ProcessedCalls.insert(ReflectCall).second)
+        continue;
+
       Attribute KindAttr = ReflectCall->getFnAttr(ReflectMethodByNameCallAttr);
       if (!KindAttr.isStringAttribute() || ReflectCall->arg_empty())
         continue;
@@ -1306,17 +1325,47 @@ public:
         continue;
       }
 
+      // Optimizations can leave several MethodByName calls sharing one sret
+      // slot. The checked-load walk starts from the slot and sees the loads for
+      // all of those calls. Refine them with the union of every provable name
+      // instead of letting the first call claim all of them. If any name is
+      // unknown, leave the generic markers intact so GlobalDCE remains
+      // conservative.
+      Value *SRetStorage = SRetStorageByCall.lookup(ReflectCall);
+      SmallVector<CallBase *, 4> SharedCalls{ReflectCall};
+      if (SRetStorage) {
+        for (CallBase *Candidate :
+             CallsBySRetStorage.find(SRetStorage)->second) {
+          if (Candidate == ReflectCall)
+            continue;
+          Attribute CandidateKind =
+              Candidate->getFnAttr(ReflectMethodByNameCallAttr);
+          if (!CandidateKind.isStringAttribute() ||
+              CandidateKind.getValueAsString() != Kind)
+            continue;
+          SharedCalls.push_back(Candidate);
+          ProcessedCalls.insert(Candidate);
+        }
+      }
+
       SmallVector<std::string, 4> Names;
-      bool KnownNames = collectStringSetFromCallArgs(ReflectCall, DL, Names);
+      bool KnownNames = true;
+      // The bounded name budget applies to the combined group. Exceeding it
+      // leaves every generic marker intact.
+      for (CallBase *SharedCall : SharedCalls) {
+        if (!collectStringSetFromCallArgs(SharedCall, DL, Names)) {
+          KnownNames = false;
+          break;
+        }
+      }
       if (!KnownNames || Names.empty())
         continue;
 
       SmallVector<CallBase *, 2> GenericLoads;
       SmallPtrSet<CallBase *, 4> SeenLoads;
       SmallPtrSet<Value *, 16> SeenValues;
-      collectSRetReflectMethodCheckedLoads(getSRetArg(ReflectCall),
-                                           GenericTypeID, SeenValues, SeenLoads,
-                                           GenericLoads);
+      collectSRetReflectMethodCheckedLoads(SRetStorage, GenericTypeID,
+                                           SeenValues, SeenLoads, GenericLoads);
       for (CallBase *GenericLoad : GenericLoads) {
         insertMethodNameChecks(GenericLoad, Names, Prefix);
         if (!eraseGenericCheckedLoad(GenericLoad))

--- a/runtime/internal/runtime/errors.go
+++ b/runtime/internal/runtime/errors.go
@@ -96,12 +96,6 @@ func boundsAbove(x int64, signed bool, y int64) bool {
 	return uint64(x) > uint64(y)
 }
 
-func CheckIndexRange(b bool, x int64, signed bool, y int) {
-	if b {
-		panicBounds(x, signed, y, boundsIndex)
-	}
-}
-
 func appendIntStr(b []byte, v int64, signed bool) []byte {
 	if signed && v < 0 {
 		b = append(b, '-')

--- a/ssa/bounds_checks_test.go
+++ b/ssa/bounds_checks_test.go
@@ -4,6 +4,7 @@ package ssa_test
 
 import (
 	"go/types"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestBoundsCheckModesIR(t *testing.T) {
 	unchecked := boundsCheckModeIR(t, true)
 
 	for _, helper := range []string{
-		"CheckIndexRange",
+		"PanicIndex",
 		"StringSlice2",
 		"NewSlice2",
 		"NewSlice3Bounds",
@@ -31,6 +32,11 @@ func TestBoundsCheckModesIR(t *testing.T) {
 	}
 	if !strings.Contains(unchecked, "AssertNilDeref") {
 		t.Error("unchecked *array slice lost its nil check")
+	}
+	panicPath := regexp.MustCompile(`(?m)^[ \t]+br i1 %[0-9]+, label %(_llgo_[0-9]+), label %_llgo_[0-9]+\n\n(_llgo_[0-9]+):.*\n[ \t]+call void @"[^"]*PanicIndex"\([^\n]*\)\n[ \t]+br label %(_llgo_[0-9]+)$`)
+	match := panicPath.FindStringSubmatch(checked)
+	if len(match) == 0 || match[1] != match[2] || match[2] != match[3] {
+		t.Error("checked IR does not isolate PanicIndex in a non-returning failure branch")
 	}
 	if got := strings.Count(unchecked, "select i1"); got < 4 {
 		t.Errorf("unchecked IR contains %d select operations, want at least 4", got)

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -284,8 +284,19 @@ func (b Builder) checkIndex(idx Expr, max Expr) Expr {
 		}
 	}
 	if !check.IsNil() {
-		boundsIdx, _ := b.boundsArg(idx)
-		b.InlineCall(b.Pkg.rtFunc("CheckIndexRange"), check, boundsIdx, prog.BoolVal(signed), max)
+		blks := b.Func.MakeBlocks(2)
+		b.If(check, blks[0], blks[1])
+		b.SetBlockEx(blks[0], AtEnd, false)
+		panicIndex := "PanicIndexU"
+		if signed {
+			panicIndex = "PanicIndex"
+		}
+		b.InlineCall(b.Pkg.rtFunc(panicIndex), idx, max)
+		// Keep the failure path disconnected from the successful continuation,
+		// while retaining a post-call instruction for return-address line info.
+		b.Jump(blks[0])
+		b.SetBlockEx(blks[1], AtEnd, false)
+		b.blk.last = blks[1].last
 	}
 	return idx
 }


### PR DESCRIPTION
## Summary

  Move index bounds panics off the normal execution path and lower them through dedicated signed and unsigned runtime
  helpers.

  Previously, every checked index operation called:

  ```go
  CheckIndexRange(outOfRange, index, signed, length)
```
  even when the index was valid. The helper carried a dynamic condition and a signedness flag into the runtime.

  This change branches on the bounds-check result in generated code and calls a runtime panic helper only from the
  failure path:

  func PanicIndex(x int, y int)
  func PanicIndexU(x uint, y int)

  This matches Go's runtime.panicIndex / runtime.panicIndexU lowering model.

  ## Motivation

  The previous lowering kept a runtime call on the successful index path:

  %out_of_range = ...
  call void @runtime.CheckIndexRange(
      i1 %out_of_range,
      i64 %index,
      i1 %signed,
      i64 %length
  )

  The runtime call received information that was already known by the compiler:

  - The bounds-check condition
  - Whether the index was signed
  - A constant true once the failure path was isolated

  This unnecessarily complicated the runtime interface and the generated fast path.

  ## Implementation

  Index lowering now:

  1. Computes the existing out-of-range condition.
  2. Branches to a dedicated failure block.
  3. Selects the panic helper at compile time based on index signedness.
  4. Calls PanicIndex or PanicIndexU only from the failure block.
  5. Continues directly to the index operation on the successful path.

  Signed indexes are lowered to:

  %out_of_range = ...
  br i1 %out_of_range, label %panic, label %continue

  panic:
    call void @runtime.PanicIndex(i64 %index, i64 %length)
    br label %continue

  Unsigned indexes use:

  call void @runtime.PanicIndexU(i64 %index, i64 %length)

  The actual argument width follows the target architecture through int and uint.

  ## Runtime Changes

  Remove the obsolete runtime helper:

  func CheckIndexRange(
      outOfRange bool,
      index int64,
      signed bool,
      length int,
  )

  Index bounds failures now use the existing interfaces:

  func PanicIndex(x int, y int)
  func PanicIndexU(x uint, y int)

  This removes the runtime condition and signedness parameters while preserving signed and unsigned bounds-error
  formatting.

  ## Source Line Information

  The panic block intentionally retains a continuation edge instead of ending immediately with unreachable.

  Although PanicIndex and PanicIndexU do not return at runtime, placing unreachable directly after the call caused
  LLVM's return-address line information to resolve to the following source line. This broke recovered bounds-panic
  stack traces and TestRuntimeStatementLineInfo.

  Keeping a branch after the panic call gives the return address an instruction with the correct debug location. Runtime
  behavior is unchanged because the panic helpers never return.

  ## Bounds-Check Modes

  The existing -B behavior is preserved:

  - Normal builds emit the conditional panic path.
  - Builds with bounds checks disabled emit neither PanicIndex nor PanicIndexU.
  - Mandatory checks unrelated to index bounds, such as nil dereference and unsafe builtin checks, remain unchanged.

  ## Test Coverage

  LLVM IR fixtures were updated to verify:

  - The bounds predicate branches to a dedicated failure block.
  - Signed indexes call PanicIndex.
  - Unsigned indexes call PanicIndexU.
  - Both helpers use the two-argument runtime interface.
  - The failure block retains the expected continuation branch.
  - Constant and dynamic indexes preserve the correct signedness.
  - Array, slice, string, generic, reflect, runtime, libc, and libgo indexing paths use the new lowering.
  - Disabled bounds checks do not emit either panic helper.
  - Recovered panic stacks report the original bounds-expression line.

```
 核心测试形式：

  for i := 0; i < b.N; i++ {
      sum += values[indexes[i&(datasetSize-1)]]
  }

  同时覆盖动态切片读、动态切片写和动态字符串读。输入在计时前构造，结果写入全局 sink，防止访问被删除。

  测试环境：

  - Apple M5，darwin/arm64
  - 基线：upstream/main (7f954d618)
  - PR：d3fa29e51
  - -benchtime=500ms -count=10
  - LLGO_BUILD_CACHE=off
  - 表中取 10 轮中位数，数值越低越好

   Benchmark            upstream/main             PR      变化     加速
  ━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━  
   DynamicSliceRead       0.938 ns/op    0.337 ns/op    -64.1%    2.79x
  ───────────────────  ───────────────  ─────────────  
   DynamicSliceWrite      0.926 ns/op    0.309 ns/op    -66.6%    3.00x
  ───────────────────  ───────────────  ─────────────  
   DynamicStringRead      0.927 ns/op    0.327 ns/op    -64.8%    2.84x

  这个 microbenchmark 是动态索引密集场景，每轮包含索引表访问和目标对象访问，因此反映的是边界检查热路径优化效果，不应直接等同于整个应用的性能提升。
```