### PR TITLE
fix(build): skip asm scan for synthetic test main

### DIFF
--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -391,6 +391,14 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	if v, ok := ctx.sfilesCache[pkg.ID]; ok {
 		return v, nil
 	}
+	// The synthetic test main shares the tested package's directory, so a
+	// directory scan may find assembly files that do not belong to testmain.
+	// Its generated import path (for example, example.com/p.test) is also not
+	// a package that can be queried directly with `go list`.
+	if ctx.mode == ModeTest && pkg.Name == "main" && strings.HasSuffix(pkg.ID, ".test") {
+		ctx.sfilesCache[pkg.ID] = nil
+		return nil, nil
+	}
 	// Some unit tests construct synthetic packages that are not loadable via
 	// `go list` (PkgPath not in any module, and Dir/Standard/Goroot unset).
 	// In that case, treat the package as having no selected .s files.

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -110,6 +110,33 @@ printf '{"Dir":"%s","SFiles":["asm_amd64.s"]}\n' "$PACKAGE_DIR"
 	}
 }
 
+func TestPkgSFilesSkipsSyntheticTestMain(t *testing.T) {
+	pkgDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pkgDir, "asm.s"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &context{
+		mode:      ModeTest,
+		buildConf: &Config{Goos: "linux", Goarch: "amd64"},
+	}
+	got, err := pkgSFiles(ctx, &packages.Package{
+		ID:      "example.com/p.test",
+		PkgPath: "example.com/p.test",
+		Name:    "main",
+		Dir:     pkgDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("pkgSFiles = %v, want nil", got)
+	}
+	if cached, ok := ctx.sfilesCache["example.com/p.test"]; !ok || cached != nil {
+		t.Fatalf("synthetic test main cache entry = %v, %v; want nil, true", cached, ok)
+	}
+}
+
 func TestPlan9AsmEnabledInitializesSelectedPackages(t *testing.T) {
 	t.Setenv(llgoPlan9ASMPkgs, "example.com/first, example.com/second")
 	ctx := &context{buildConf: &Config{}}


### PR DESCRIPTION
## Summary

  Fix `llgo test` for packages whose source directories contain assembly files.

  The synthetic test main package shares the tested package's directory, causing LLGo's assembly scan to find unrelated
  `.s` files and run `go list` with a generated package path such as `github.com/visualfc/gid.test`. That path is not
  directly loadable, so the build failed.

  Skip assembly discovery for synthetic test main packages and cache the empty result.

  ## Testing

  - `go test ./internal/build -count=1`
  - Built LLGo from this branch and ran `llgo test -v` in `github.com/visualfc/gid`
  - `git diff --check`

