### PR TITLE
build: inherit host args in c-shared libraries

### DIFF
--- a/dev/test_std_buildmodes.sh
+++ b/dev/test_std_buildmodes.sh
@@ -99,8 +99,12 @@ for mode in c-shared c-archive; do
 			test_main_pkg="${import_path}.test"
 			runner_base="${work_dir}/runner-${i}"
 			echo "==> ${test_pkgs[$i]}: run ${mode}"
+			runner_cflags=("-DGO_TEST_PACKAGE=\"${test_main_pkg}\"")
+			if [[ "${mode}" == c-shared ]]; then
+				runner_cflags+=("-DGO_C_SHARED=1")
+			fi
 			clang -x c -c "${runner_source}" \
-				"-DGO_TEST_PACKAGE=\"${test_main_pkg}\"" \
+				"${runner_cflags[@]}" \
 				-o "${runner_base}.o"
 
 			if [[ "${mode}" == c-shared ]]; then
@@ -113,7 +117,7 @@ for mode in c-shared c-archive; do
 					-L"${work_dir}" "-l${stem}" "${runtime_libs[@]}"
 				LD_LIBRARY_PATH="${work_dir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
 					DYLD_LIBRARY_PATH="${work_dir}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}" \
-					"${runner_base}"
+					"${runner_base}" llgo-cshared-arg-one "llgo c-shared arg two"
 			else
 				library="${work_dir}/lib${stem}.a"
 				clang++ "${runner_base}.o" -o "${runner_base}" \

--- a/dev/test_std_buildmodes/runner.c
+++ b/dev/test_std_buildmodes/runner.c
@@ -2,6 +2,8 @@
 #error GO_TEST_PACKAGE must name the generated Go test main package
 #endif
 
+#include <string.h>
+
 #ifdef __APPLE__
 #define GO_SYMBOL(name) __asm__("_" name)
 #else
@@ -14,8 +16,19 @@ extern int __llgo_argc;
 extern char **__llgo_argv;
 
 int main(int argc, char **argv) {
+#ifdef GO_C_SHARED
+    if (__llgo_argc != argc || __llgo_argv == NULL) {
+        return 101;
+    }
+    for (int i = 0; i < argc; i++) {
+        if (__llgo_argv[i] == NULL || strcmp(__llgo_argv[i], argv[i]) != 0) {
+            return 101;
+        }
+    }
+#else
     __llgo_argc = argc;
     __llgo_argv = argv;
+#endif
     llgo_test_init();
     llgo_test_run();
     return 0;

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -159,7 +159,11 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 			inits = append(inits, packageInits...)
 			inits = append(inits, mainInit)
 		}
-		defineLibraryRuntimeInit(mainPkg, initArraySection, inits...)
+		defineLibraryRuntimeInit(
+			mainPkg, initArraySection, argcVar, argvVar, argvValueType,
+			libraryConstructorReceivesProcessArgs(ctx.buildConf.Goos),
+			inits...,
+		)
 		return mainAPkg
 	}
 
@@ -182,17 +186,38 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	return mainAPkg
 }
 
+func libraryConstructorReceivesProcessArgs(goos string) bool {
+	return goos == "linux" || goos == "darwin"
+}
+
 // defineLibraryRuntimeInit arranges for the LLGo runtime to be initialized
-// before a C program calls an exported Go function. Linux shared libraries use
-// .init_array explicitly because the raw LLVM target machine lowers
-// llvm.global_ctors to legacy .ctors; other library formats use LLVM's
-// platform-specific constructor lowering.
-func defineLibraryRuntimeInit(pkg llssa.Package, initArraySection string, inits ...llssa.Function) {
+// before a C program calls an exported Go function. Linux and Darwin c-shared
+// and c-archive constructors receive the host process argc/argv; these values
+// must be stored before package initialization so os.Args sees them. Linux
+// c-shared libraries use .init_array explicitly because the raw LLVM target
+// machine lowers llvm.global_ctors to legacy .ctors. Linux c-archive and Darwin
+// library modes use LLVM's platform-specific global constructor lowering.
+func defineLibraryRuntimeInit(
+	pkg llssa.Package, initArraySection string,
+	argcVar, argvVar llssa.Global, argvType llssa.Type,
+	receivesProcessArgs bool, inits ...llssa.Function,
+) {
 	const ctorName = "__llgo_runtime_ctor"
-	ctor := pkg.NewFunc(ctorName, llssa.NoArgsNoRet, llssa.InC)
+	ctorSig := llssa.NoArgsNoRet
+	if receivesProcessArgs {
+		ctorSig = newSignature(
+			[]types.Type{types.Typ[types.Int32], argvType.RawType()},
+			nil,
+		)
+	}
+	ctor := pkg.NewFunc(ctorName, ctorSig, llssa.InC)
 	ctorValue := pkg.Module().NamedFunction(ctorName)
 	ctorValue.SetLinkage(llvm.InternalLinkage)
 	b := ctor.MakeBody(1)
+	if receivesProcessArgs {
+		b.Store(argcVar.Expr, ctor.Param(0))
+		b.Store(argvVar.Expr, ctor.Param(1))
+	}
 	for _, init := range inits {
 		if init != nil {
 			b.Call(init.Expr)

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -258,7 +258,9 @@ func TestGenMainModuleLibraryInitializesRuntime(t *testing.T) {
 			})
 			ir := mod.LPkg.String()
 			checks := []string{
-				"define internal void @__llgo_runtime_ctor()",
+				"define internal void @__llgo_runtime_ctor(i32 %0, ptr %1)",
+				"store i32 %0, ptr @__llgo_argc",
+				"store ptr %1, ptr @__llgo_argv",
 				"call void @\"github.com/xgo-dev/llgo/runtime/internal/runtime.init\"()",
 				"call void @\"example.com/dep.init\"()",
 				"call void @\"example.com/foo.init\"()",
@@ -273,8 +275,47 @@ func TestGenMainModuleLibraryInitializesRuntime(t *testing.T) {
 					t.Fatalf("library module IR missing %q:\n%s", want, ir)
 				}
 			}
+			assertInOrder(t, ir,
+				"store i32 %0, ptr @__llgo_argc",
+				"store ptr %1, ptr @__llgo_argv",
+				"call void @\"github.com/xgo-dev/llgo/runtime/internal/runtime.init\"()",
+				"call void @\"example.com/dep.init\"()",
+				"call void @\"example.com/foo.init\"()",
+			)
 			if strings.Contains(ir, "define i32 @main") {
 				t.Fatalf("library mode should not emit main function:\n%s", ir)
+			}
+		})
+	}
+}
+
+func TestGenMainModuleLibraryConstructorArgsByPlatform(t *testing.T) {
+	llvm.InitializeAllTargets()
+	t.Setenv(llgoStdioNobuf, "")
+	for _, test := range []struct {
+		goos     string
+		wantArgs bool
+	}{
+		{goos: "linux", wantArgs: true},
+		{goos: "darwin", wantArgs: true},
+		{goos: "windows", wantArgs: false},
+	} {
+		t.Run(test.goos, func(t *testing.T) {
+			ctx := &context{
+				prog: llssa.NewProgram(nil),
+				buildConf: &Config{
+					BuildMode: BuildModeCShared,
+					Goos:      test.goos,
+					Goarch:    "amd64",
+				},
+			}
+			pkg := &packages.Package{PkgPath: "example.com/foo", ExportFile: "foo.a"}
+			ir := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{}).LPkg.String()
+			hasArgSignature := strings.Contains(ir, "define internal void @__llgo_runtime_ctor(i32 %0, ptr %1)")
+			hasArgStores := strings.Contains(ir, "store i32 %0, ptr @__llgo_argc") &&
+				strings.Contains(ir, "store ptr %1, ptr @__llgo_argv")
+			if hasArgSignature != test.wantArgs || hasArgStores != test.wantArgs {
+				t.Fatalf("constructor argument capture = (%v, %v), want %v:\n%s", hasArgSignature, hasArgStores, test.wantArgs, ir)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

  - Capture the host process `argc` and `argv` in Linux and Darwin library constructors.
  - Store arguments before Go package initialization so `os.Args` is populated correctly in `c-shared` libraries.
  - Preserve the no-argument constructor behavior on platforms such as Windows.
  - Update buildmode tests to verify arguments are inherited automatically instead of injected by the C runner.
  - Add platform-specific IR coverage for Linux, Darwin, and Windows.

  ## Testing

  - `go test ./internal/build -run '^TestGenMainModule' -count=1`
  - Verified a C host linked against an LLGo `c-shared` library receives matching `os.Args`.
  - Verified delayed `dlopen` with arguments `alpha beta`.
  - Rebuilt SPX with the updated LLGo and ran demo 9 without panic, `SIGKILL`, or segmentation faults.


