### PR TITLE
runtime: bridge cgroup throw for Go 1.25

### DIFF
--- a/runtime/internal/lib/runtime/cgroup_linux_go125_llgo.go
+++ b/runtime/internal/lib/runtime/cgroup_linux_go125_llgo.go
@@ -1,4 +1,4 @@
-//go:build linux && go1.26
+//go:build linux && go1.25
 
 package runtime
 


### PR DESCRIPTION
## Summary

  - Enable the Linux internal/runtime/cgroup.throw bridge starting with Go 1.25.
  - Rename the bridge file to reflect its minimum supported Go version.
  - Fix undefined symbol errors when linking c-shared and c-archive outputs with Go 1.25.

  ## Testing

  - go test ./internal/lib/runtime from the runtime module.
  - Ran _demo/go/export/test.sh on Linux amd64 with LLVM 19 and Go 1.25.0.
  - Verified both c-shared and c-archive C consumers build and run successfully.
  - Verified Go 1.26.5 still selects the bridge file.
