### PR TITLE
runtime: fix trace stop deadlock on Go 1.25

### DIFF
--- a/runtime/internal/lib/runtime/trace_stub_llgo.go
+++ b/runtime/internal/lib/runtime/trace_stub_llgo.go
@@ -11,7 +11,7 @@ func traceAdvance(stopTrace bool) {}
 func traceClockNow() uint64 { return 0 }
 
 //go:linkname runtime_readTrace runtime/trace.runtime_readTrace
-func runtime_readTrace() []byte { return nil }
+func runtime_readTrace() []byte { return ReadTrace() }
 
 //go:linkname trace_userTaskCreate runtime/trace.userTaskCreate
 func trace_userTaskCreate(id, parentID uint64, taskType string) {}


### PR DESCRIPTION
## Summary

  - route the Go 1.25 `runtime/trace.runtime_readTrace` bridge to LLGo's existing `ReadTrace` implementation
  - prevent the trace reader from exiting before it drains and closes the trace channel
  - fix `runtime/trace.Stop` hanging indefinitely under `llgo test`

  ## Root cause

  Go 1.25 `runtime/trace` reads trace data through the private
  `runtime/trace.runtime_readTrace` symbol. LLGo's stub returned `nil`
  unconditionally, so the reader goroutine exited immediately. `StopTrace`
  then waited forever for that reader to signal completion.

  ## Testing

  - `env GOCACHE=/tmp/llgo-trace-gocache llgo test -v -count=1 -timeout=30s ./test/std/runtime/trace`
  - `env GOCACHE=/tmp/llgo-trace-go-gocache go test -v -count=1 -timeout=30s ./test/std/runtime/trace`