### PR TITLE
build: align alternate runtime Go toolchain

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -597,6 +597,8 @@ func Build(inv Invocation) ([]Package, error) {
 	altPkgPaths := altPkgs(initial, conf, llssa.PkgRuntime)
 	altCfg := *cfg
 	altCfg.Dir = env.LLGoRuntimeDir()
+	// The runtime submodule may otherwise select a different toolchain from its go.mod.
+	altCfg.Env = withResolvedGoToolchain(cfg.Env, sourcePatchGoVersion)
 	loadAltSpan := buildTrace.startCoordinator("load runtime packages", map[string]any{
 		"packages": slices.Clone(altPkgPaths),
 	})

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -419,6 +419,28 @@ func TestWithEnvLastValueWins(t *testing.T) {
 	}
 }
 
+func TestWithResolvedGoToolchain(t *testing.T) {
+	tests := []struct {
+		name      string
+		environ   []string
+		goversion string
+		want      []string
+	}{
+		{"replace existing", []string{"PATH=/bin", "GOTOOLCHAIN=auto"}, "go1.25.0", []string{"PATH=/bin", "GOTOOLCHAIN=go1.25.0"}},
+		{"append missing", []string{"PATH=/bin"}, "go1.25.0", []string{"PATH=/bin", "GOTOOLCHAIN=go1.25.0"}},
+		{"preserve development version", []string{"PATH=/bin"}, "devel go1.26-deadbeef", []string{"PATH=/bin"}},
+		{"preserve empty version", []string{"PATH=/bin"}, "", []string{"PATH=/bin"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := withResolvedGoToolchain(tt.environ, tt.goversion)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("withResolvedGoToolchain = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClosePackageMetas(t *testing.T) {
 	b := meta.NewBuilder()
 	b.Sym("pkg.main")

--- a/internal/build/invocation.go
+++ b/internal/build/invocation.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"go/version"
 	"os/exec"
 	"path/filepath"
 	"slices"
@@ -66,4 +67,11 @@ func withEnv(environ []string, values ...string) []string {
 		}
 	}
 	return append(ret, values...)
+}
+
+func withResolvedGoToolchain(environ []string, goversion string) []string {
+	if !version.IsValid(goversion) {
+		return environ
+	}
+	return withEnv(environ, "GOTOOLCHAIN="+goversion)
 }


### PR DESCRIPTION
 ## Summary

  Align the Go toolchain used to load llgo's alternate runtime packages with the toolchain already resolved for the main
  build.

  When `GOTOOLCHAIN` is not explicitly set, the root module and the `runtime` submodule can resolve different Go
  versions because their `go.mod` files have different `go` directives. This may compile the standard library with Go
  1.25 while excluding Go 1.25-specific runtime sources, resulting in missing symbols such as:

  ```text
  runtime/trace.runtime_traceClockUnitsPerSecond
```

  Pass the resolved sourcePatchGoVersion as GOTOOLCHAIN when loading alternate runtime packages, ensuring both package
  sets use the same Go version.

  ## Changes

  - Set GOTOOLCHAIN for alternate runtime package loading.
  - Add a test covering replacement of an existing GOTOOLCHAIN value.

  ## Testing

  go test ./internal/build -run '^(TestWithEnv|TestGenMainModule|TestBuildSourcePatch)' -count=1
  go test ./internal/env -count=1
  LLGO=./dev/llgo.sh dev/test_std_buildmodes.sh ./test/std/os

  Both c-shared and c-archive build-mode tests pass without manually setting GOTOOLCHAIN.