### PR TITLE
cl: deduplicate same-line panic PC anchors

### DIFF
--- a/cl/caller_frame_test.go
+++ b/cl/caller_frame_test.go
@@ -4,6 +4,7 @@
 package cl
 
 import (
+	"fmt"
 	"go/ast"
 	"go/importer"
 	"go/parser"
@@ -379,6 +380,8 @@ func owner() {
 	defer inspect()
 	defer deferredPanicLeaf()
 	panicLeaf()
+	repeatedPanicLeaf(nil, 0)
+	branchPanicLeaf(nil, 0, true)
 }
 
 func panicLeaf() {
@@ -391,6 +394,16 @@ func deferredPanicLeaf() {
 	var p *int
 //line deferred_panic_site.go:234
 	_ = *p
+}
+
+func repeatedPanicLeaf(p *[1]int, i int) int {
+//line repeated_panic_site.go:345
+	return p[i] + p[i]
+}
+
+func branchPanicLeaf(p *[1]int, i int, cond bool) int {
+//line branch_panic_site.go:456
+	if cond { return p[i] }; return p[i]
 }
 
 //go:noinline
@@ -415,6 +428,21 @@ func pinnedPanicSite() {
 		if !strings.Contains(ir, want) {
 			t.Fatalf("recover-visible nil dereference is missing panic-site metadata %q:\n%s", want, ir)
 		}
+	}
+	countPCLine := func(symbol, file string, line int) (count int) {
+		want := fmt.Sprintf(`!"%s", !"%s", i32 %d`, symbol, file, line)
+		for _, row := range strings.Split(ir, "\n") {
+			if strings.Contains(row, `!{i32 1, i64 `) && strings.Contains(row, want) {
+				count++
+			}
+		}
+		return count
+	}
+	if got := countPCLine("example.com/foo.repeatedPanicLeaf", "repeated_panic_site.go", 345); got != 1 {
+		t.Fatalf("same-line panic sites in one basic block produced %d metadata records, want 1:\n%s", got, ir)
+	}
+	if got := countPCLine("example.com/foo.branchPanicLeaf", "branch_panic_site.go", 456); got != 2 {
+		t.Fatalf("same-line panic sites in separate basic blocks produced %d metadata records, want 2:\n%s", got, ir)
 	}
 	if strings.Contains(ir, `!"non_recover_site.go"`) {
 		t.Fatalf("ordinary pinned function unexpectedly received implicit panic-site metadata:\n%s", ir)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -167,6 +167,11 @@ type context struct {
 	runtimeCallerFuncs   map[*ssa.Function]bool
 	panicSiteFuncs       map[*ssa.Function]bool
 	pcLineSeq            uint64
+	// The runtime PC-line table stores file and line, but not column. Keep the
+	// last emitted position within one SSA basic block so repeated checks for a
+	// single source line can share an anchor.
+	lastPCLineFile       string
+	lastPCLineLine       int
 	options              Options
 	recoverSlots         map[*ssa.Alloc]none
 	implicitDeferResults []llssa.Expr
@@ -893,6 +898,10 @@ func (p *context) debugParams(b llssa.Builder, f *ssa.Function) {
 }
 
 func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, doModInit bool) llssa.BasicBlock {
+	// A control-flow edge can enter this block without executing the preceding
+	// block's anchor, so deduplication must never cross a block boundary.
+	p.lastPCLineFile = ""
+	p.lastPCLineLine = 0
 	oldLocalBlock := p.locality.function.block
 	p.locality.function.block = block
 	defer func() { p.locality.function.block = oldLocalBlock }()

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1971,6 +1971,15 @@ func (p *context) emitPCLineLabel(b llssa.Builder, pos token.Pos) {
 	if position.Line <= 0 || position.Filename == "" {
 		return
 	}
+	// Lookup uses the nearest preceding PC anchor. Within one basic block,
+	// another anchor for the same runtime-visible file and line cannot change
+	// the result, even when several implicit panic checks came from one Go
+	// expression.
+	if position.Filename == p.lastPCLineFile && position.Line == p.lastPCLineLine {
+		return
+	}
+	p.lastPCLineFile = position.Filename
+	p.lastPCLineLine = position.Line
 	p.pcLineSeq++
 	id := pcLineID(p.fn.Name(), p.pcLineSeq)
 	label := pcLineLabelName(id)


### PR DESCRIPTION
## Summary

- deduplicate recover-visible PC-line anchors for repeated implicit panic checks on the same file and line within one SSA basic block
- reset deduplication at every basic-block boundary so control-flow paths keep a reachable anchor
- cover both same-block deduplication and cross-block preservation

## Motivation

PR #2293 made implicit panic locations visible to `runtime.Caller`, but expressions that lower to several checks on one source line emitted redundant `__llgo_pcl` records.

In an XGo Darwin A/B build:

- before #2293: 18,160,896 bytes; `__llgo_pcl` 317,920 bytes
- after #2293: 18,954,928 bytes; `__llgo_pcl` 643,344 bytes
- with this change: 18,249,008 bytes; `__llgo_pcl` 366,880 bytes

This recovers 705,920 bytes, or 88.9% of the observed binary-size regression, while retaining panic line information.

## Testing

- `go test ./cl -run "TestCompileRuntimeCallerPanicPCLineMetadata|TestRuntimeCallerFuncSetKeepsRecoverObservableCallees|TestRuntimeCallerAnalysisEdgeCases" -count=1`
- `go test -vet=off ./test/go -run "TestRuntimeStatementLineInfo|TestRuntimeDeferredPanicLine" -count=1`
- `go test -vet=off ./test/go` (full package, 244.486s)
- full main-module package run: all packages passed except four `internal/build` cache tests when the whole run was forced through `LLGO_BUILD_CACHE=off`; those four passed after rerunning with the normal cache setting
