### PR TITLE
ci: allow release job to publish artifacts

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -185,6 +185,8 @@ jobs:
           mod-version: ${{ matrix.go-mod-version }}
 
   release:
+    permissions:
+      contents: write
     needs: [setup, test-artifacts, populate-linux-sysroot]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary

- grant `contents: write` only to the tag-gated `release` job
- allow GoReleaser to create or update GitHub releases and upload artifacts
- keep build and artifact-test jobs on their existing read-only permissions

## Context

The v1.0.0-pre.2 release run completed all builds and artifact tests, then failed while publishing with:

`403 Resource not accessible by integration`

The release job reported `Contents: read`, while GoReleaser needs write access to update the GitHub release.

Failing job: https://github.com/xgo-dev/llgo/actions/runs/32128366552/job/95704529859

## Validation

- `git diff --check`
- parsed `.github/workflows/release-build.yml` with Ruby YAML parser