### PR TITLE
Trigger runtime benchmarks for released tags

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -215,3 +215,35 @@ jobs:
             -w /go/src/llgo \
             "${GORELEASER_CROSS_IMAGE}" \
             release --clean --verbose --skip nfpm,snapcraft
+
+  notify-runtime-benchmark:
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      BENCHMARKS_REPOSITORY: ${{ vars.BENCHMARKS_REPOSITORY || 'xgo-dev/benchmarks' }}
+      BENCHMARKS_DISPATCH_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
+    steps:
+      - name: Request a runtime benchmark for the released tag
+        run: |
+          set -euo pipefail
+          if [[ -z "$BENCHMARKS_DISPATCH_TOKEN" ]]; then
+            echo "BENCHMARKS_DISPATCH_TOKEN is not configured" >&2
+            exit 1
+          fi
+
+          payload="$(jq -cn \
+            --arg source_repository "$GITHUB_REPOSITORY" \
+            --arg llgo_repository "$GITHUB_REPOSITORY" \
+            --arg llgo_commit "$GITHUB_SHA" \
+            --arg llgo_tag "$GITHUB_REF_NAME" \
+            --arg source_run_url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{event_type: "llgo-tag-released", client_payload: {source_repository: $source_repository, llgo_repository: $llgo_repository, llgo_commit: $llgo_commit, llgo_tag: $llgo_tag, source_run_url: $source_run_url}}')"
+
+          curl --fail-with-body --location --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${BENCHMARKS_DISPATCH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${BENCHMARKS_REPOSITORY}/dispatches" \
+            --data "$payload"


### PR DESCRIPTION
Depends on xgo-dev/benchmarks#23 landing first.

After the tag-only release job publishes artifacts successfully, this adds a separate notification job that dispatches `llgo-tag-released` to xgo-dev/benchmarks with:
- the source/repository identity;
- the exact released tag;
- the exact commit;
- the source workflow URL.

It reuses the existing `BENCHMARKS_REPOSITORY` variable and `BENCHMARKS_DISPATCH_TOKEN` secret contract. Ordinary main pushes continue to use the existing binary-size notification and do not trigger runtime benchmarks.

Validation: workflow YAML parsed successfully and `git diff --check` passed.