### PR TITLE
ssa: canonicalize basic aliases in generic symbols

### DIFF
--- a/cl/_testgo/tpnamed/in.go
+++ b/cl/_testgo/tpnamed/in.go
@@ -25,11 +25,10 @@ func WriteFile(fileName string) IO[error] {
 }
 
 // CHECK-LABEL: define void @main.main(){{.*}} {
-// CHECK: call [0 x i8] @"main.RunIO{{\[\[0\]byte\]}}"(%"main.IO{{\[\[0\]byte\]}}" { ptr @"main.main$1", ptr null })
+// CHECK: call [0 x i8] @"main.RunIO{{\[\[0\]uint8\]}}"(%"main.IO{{\[\[0\]uint8\]}}" { ptr @"main.main$1", ptr null })
 // CHECK-NEXT: ret void
 
 func main() {
-
 	RunIO[Void](func() Future[Void] {
 
 		return func() (ret Void) {
@@ -42,13 +41,13 @@ func RunIO[T any](call IO[T]) T {
 	return call()()
 }
 
-// CHECK-LABEL: define linkonce [0 x i8] @"main.RunIO{{\[\[0\]byte\]}}"(%"main.IO{{\[\[0\]byte\]}}" %0){{.*}} {
-// CHECK: [[IO_ENV:%[0-9]+]] = extractvalue %"main.IO{{\[\[0\]byte\]}}" %0, 1
-// CHECK-NEXT: [[IO_CODE:%[0-9]+]] = extractvalue %"main.IO{{\[\[0\]byte\]}}" %0, 0
-// DARWIN-ARM64: [[FUTURE:%[0-9]+]] = call %"main.Future{{\[\[0\]byte\]}}" %__llgo_funcval_code(ptr swiftself [[IO_ENV]])
-// LINUX-AMD64: [[FUTURE:%[0-9]+]] = call %"main.Future{{\[\[0\]byte\]}}" %__llgo_funcval_code(ptr nest [[IO_ENV]])
-// CHECK-NEXT: [[FUTURE_ENV:%[0-9]+]] = extractvalue %"main.Future{{\[\[0\]byte\]}}" [[FUTURE]], 1
-// CHECK-NEXT: [[FUTURE_CODE:%[0-9]+]] = extractvalue %"main.Future{{\[\[0\]byte\]}}" [[FUTURE]], 0
+// CHECK-LABEL: define linkonce [0 x i8] @"main.RunIO{{\[\[0\]uint8\]}}"(%"main.IO{{\[\[0\]uint8\]}}" %0){{.*}} {
+// CHECK: [[IO_ENV:%[0-9]+]] = extractvalue %"main.IO{{\[\[0\]uint8\]}}" %0, 1
+// CHECK-NEXT: [[IO_CODE:%[0-9]+]] = extractvalue %"main.IO{{\[\[0\]uint8\]}}" %0, 0
+// DARWIN-ARM64: [[FUTURE:%[0-9]+]] = call %"main.Future{{\[\[0\]uint8\]}}" %__llgo_funcval_code(ptr swiftself [[IO_ENV]])
+// LINUX-AMD64: [[FUTURE:%[0-9]+]] = call %"main.Future{{\[\[0\]uint8\]}}" %__llgo_funcval_code(ptr nest [[IO_ENV]])
+// CHECK-NEXT: [[FUTURE_ENV:%[0-9]+]] = extractvalue %"main.Future{{\[\[0\]uint8\]}}" [[FUTURE]], 1
+// CHECK-NEXT: [[FUTURE_CODE:%[0-9]+]] = extractvalue %"main.Future{{\[\[0\]uint8\]}}" [[FUTURE]], 0
 // CHECK-NEXT: [[FUTURE_NIL:%[0-9]+]] = icmp eq ptr [[FUTURE_CODE]], null
 // CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[FUTURE_NIL]])
 // DARWIN-ARM64: [[IO_RESULT:%[0-9]+]] = call [0 x i8] %__llgo_funcval_code1(ptr swiftself [[FUTURE_ENV]])

--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -245,6 +245,15 @@ func typeArgString(t types.Type) string {
 	case *types.Alias:
 		return typeArgString(types.Unalias(t))
 	case *types.Basic:
+		// byte and rune are aliases for uint8 and int32. go/types may cache a
+		// generic instance using either spelling, so ABI symbols must not
+		// depend on which spelling was instantiated first.
+		switch t.Kind() {
+		case types.Byte:
+			return types.Typ[types.Uint8].String()
+		case types.Rune:
+			return types.Typ[types.Int32].String()
+		}
 		return t.String()
 	case *types.Named:
 		return namedLikeTypeArgString(t.Obj(), t.TypeArgs())

--- a/ssa/abi/abi_patch_test.go
+++ b/ssa/abi/abi_patch_test.go
@@ -46,9 +46,22 @@ func TestTypeArgs_FormatsCommonKinds(t *testing.T) {
 		local,
 		aliasInt,
 	})
-	const want = "[byte,*int,[]string,[2]int,map[string]int,chan int,chan<- int,<-chan int,chan (<-chan int),Local,int]"
+	const want = "[uint8,*int,[]string,[2]int,map[string]int,chan int,chan<- int,<-chan int,chan (<-chan int),Local,int]"
 	if got != want {
 		t.Fatalf("TypeArgs = %q, want %q", got, want)
+	}
+}
+
+func TestTypeArgs_CanonicalizesBasicAliases(t *testing.T) {
+	for _, pair := range [][2]*types.Basic{
+		{types.Typ[types.Byte], types.Typ[types.Uint8]},
+		{types.Typ[types.Rune], types.Typ[types.Int32]},
+	} {
+		alias := TypeArgs([]types.Type{pair[0]})
+		underlying := TypeArgs([]types.Type{pair[1]})
+		if alias != underlying {
+			t.Fatalf("TypeArgs(%v) = %q, TypeArgs(%v) = %q", pair[0], alias, pair[1], underlying)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Extracted from #2234.

Canonicalizes basic aliases `byte` (`uint8`) and `rune` (`int32`) in generic ABI symbols (`ssa/abi.typeArgString`).

`go/types` may cache a generic instance using either spelling depending on which spelling was instantiated first. Canonicalizing `byte` and `rune` to `uint8` and `int32` ensures that generic ABI symbols do not depend on type instantiation order.

## Validation

- `go test -v ./ssa/abi -count=1`
- `go test -v ./cl -run '^TestRunAndTestFromTestgo/tpnamed$' -count=1`
- `go test -v ./cl -run '^TestRunAndTestFromTestgo$' -count=1`