### PR TITLE
build: default pclntab to external

### DIFF
--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -187,13 +187,18 @@ func TestBuildLTOFlagInvalid(t *testing.T) {
 }
 
 func TestBuildPCLNFlags(t *testing.T) {
+	t.Setenv("GOBIN", t.TempDir())
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
+	t.Setenv("LLGO_FUNCINFO", "")
+	t.Setenv("LLGO_FUNCINFO_SITES", "")
 	tests := []struct {
 		name      string
 		args      []string
 		want      build.PCLNMode
 		specified bool
 	}{
-		{name: "default embedded", want: build.PCLNEmbedded},
+		{name: "default external", want: build.PCLNExternal},
 		{name: "embedded", args: []string{"-pclntab=embedded"}, want: build.PCLNEmbedded, specified: true},
 		{name: "external", args: []string{"-pclntab=external"}, want: build.PCLNExternal, specified: true},
 		{name: "none", args: []string{"-pclntab=none"}, want: build.PCLNNone, specified: true},
@@ -213,7 +218,7 @@ func TestBuildPCLNFlags(t *testing.T) {
 			if PCLN.Mode != tt.want {
 				t.Fatalf("PCLN.Mode = %v, want %v", PCLN.Mode, tt.want)
 			}
-			conf := &build.Config{}
+			conf := build.NewDefaultConf(build.ModeBuild)
 			if err := UpdateConfig(conf); err != nil {
 				t.Fatalf("UpdateConfig error: %v", err)
 			}

--- a/cmd/internal/flags/pclntab.go
+++ b/cmd/internal/flags/pclntab.go
@@ -52,6 +52,6 @@ func (f *pclnFlag) Set(value string) error {
 var PCLN pclnFlag
 
 func addPCLNFlag(fs *flag.FlagSet) {
-	PCLN = pclnFlag{Mode: build.PCLNEmbedded}
-	fs.Var(&PCLN, "pclntab", "PCLN metadata mode: embedded, external, or none (default: embedded)")
+	PCLN = pclnFlag{Mode: build.PCLNExternal}
+	fs.Var(&PCLN, "pclntab", "PCLN metadata mode: embedded, external, or none (external requires a supported native executable)")
 }

--- a/doc/design/pclntab-packaging.md
+++ b/doc/design/pclntab-packaging.md
@@ -10,18 +10,21 @@ and line metadata used by `runtime.Caller`, `runtime.Callers`,
 `runtime.FuncForPC`, and stack traces or pprof symbolization on the available
 unwinding paths:
 
-- `-pclntab=embedded` keeps the metadata in the executable. This is the
-  default and preserves existing behavior.
+- `-pclntab=embedded` keeps the metadata in the executable. It remains the
+  default fallback for build configurations that cannot emit a sidecar.
 - `-pclntab=external` writes `<executable>.pclntab`. The executable loads that
   optional file on the first safe symbolization request. A missing, stale, or
   corrupt file is a cached soft failure; the program continues with the
-  available native fallback.
+  available native fallback. This is the default for supported native
+  executable builds.
 - `-pclntab=none` does not generate the metadata and does not link the external
   loader or its path/probe code.
 
 `-pclntab=external` is initially supported only for native executable builds
-without `-target` on Darwin/Linux amd64/arm64. `ModeGen`, `c-archive`,
-`c-shared`, named targets, and other OS/architecture combinations reject it.
+without `-target` on Darwin/Linux amd64/arm64. Those builds select it by
+default. `ModeGen`, `c-archive`, `c-shared`, named targets, and other
+OS/architecture combinations default to `embedded`; an explicit external
+request still reports the existing capability error.
 
 The policy is deliberately separate from Go's `-ldflags=-s` and `-w`:
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -311,8 +311,8 @@ func NewDefaultConf(mode Mode) *Config {
 		BuildMode:          BuildModeExe,
 		AbiMode:            cabi.ModeAllFunc,
 		OmitDWARFByDefault: mode != ModeGen,
-		PCLNMode:           PCLNEmbedded,
 	}
+	conf.PCLNMode = defaultPCLNMode(conf)
 	return conf
 }
 

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -264,7 +264,7 @@ func TestCollectFingerprintIncludesPCLNMode(t *testing.T) {
 	newContext := func(mode PCLNMode) *context {
 		return &context{
 			conf:      &packages.Config{},
-			buildConf: &Config{Goos: "linux", Goarch: "amd64", BuildMode: BuildModeExe, PCLNMode: mode},
+			buildConf: &Config{Goos: "linux", Goarch: "amd64", BuildMode: BuildModeExe, PCLNMode: mode, PCLNModeSet: true},
 		}
 	}
 
@@ -277,7 +277,7 @@ func TestCollectFingerprintIncludesPCLNMode(t *testing.T) {
 		{mode: PCLNNone, want: "none"},
 	}
 	fingerprints := make(map[string]bool, len(tests))
-	var embeddedFingerprint string
+	var externalFingerprint string
 	for _, tt := range tests {
 		pkg := newPkg()
 		if err := newContext(tt.mode).collectFingerprint(pkg); err != nil {
@@ -294,8 +294,8 @@ func TestCollectFingerprintIncludesPCLNMode(t *testing.T) {
 			t.Fatalf("manifest does not contain PCLN_MODE=%s:\n%s", tt.want, pkg.Manifest)
 		}
 		fingerprints[pkg.Fingerprint] = true
-		if tt.mode == PCLNEmbedded {
-			embeddedFingerprint = pkg.Fingerprint
+		if tt.mode == PCLNExternal {
+			externalFingerprint = pkg.Fingerprint
 		}
 	}
 	if len(fingerprints) != len(tests) {
@@ -303,11 +303,13 @@ func TestCollectFingerprintIncludesPCLNMode(t *testing.T) {
 	}
 
 	defaultMode := newPkg()
-	if err := newContext(PCLNMode(0)).collectFingerprint(defaultMode); err != nil {
+	defaultContext := newContext(PCLNEmbedded)
+	defaultContext.buildConf.PCLNModeSet = false
+	if err := defaultContext.collectFingerprint(defaultMode); err != nil {
 		t.Fatal(err)
 	}
-	if defaultMode.Fingerprint != embeddedFingerprint {
-		t.Fatal("zero-value PCLN mode and embedded mode produced different fingerprints")
+	if defaultMode.Fingerprint != externalFingerprint {
+		t.Fatal("default PCLN mode and external mode produced different fingerprints")
 	}
 }
 
@@ -365,10 +367,9 @@ func TestCollectFingerprintCanonicalizesPCLNEnvironment(t *testing.T) {
 	embeddedDefault, embeddedDefaultData := collect(explicitEmbeddedConf, "0", "")
 	embeddedOne, embeddedOneData := collect(explicitEmbeddedConf, "1", "1")
 	embeddedTrue, _ := collect(explicitEmbeddedConf, "", "true")
-	legacyEmbedded, _ := collect(base, "on", "on")
+	defaultExternal, _ := collect(base, "on", "on")
 	if embeddedDefault.Fingerprint != embeddedOne.Fingerprint ||
-		embeddedDefault.Fingerprint != embeddedTrue.Fingerprint ||
-		embeddedDefault.Fingerprint != legacyEmbedded.Fingerprint {
+		embeddedDefault.Fingerprint != embeddedTrue.Fingerprint {
 		t.Fatal("equivalent enabled PCLN inputs produced different fingerprints")
 	}
 	for _, data := range []manifestData{embeddedDefaultData, embeddedOneData} {
@@ -398,6 +399,9 @@ func TestCollectFingerprintCanonicalizesPCLNEnvironment(t *testing.T) {
 	externalLegacyOn, _ := collect(explicitExternalConf, "1", "true")
 	if externalLegacyOff.Fingerprint != externalLegacyOn.Fingerprint {
 		t.Fatal("LLGO_FUNCINFO changed an explicit external fingerprint")
+	}
+	if defaultExternal.Fingerprint != externalLegacyOn.Fingerprint {
+		t.Fatal("default and explicit external modes produced different fingerprints")
 	}
 	if externalLegacyOffData.Common == nil || externalLegacyOffData.Common.PCLNMode != "external" {
 		t.Fatalf("explicit external mode = %+v, want external", externalLegacyOffData.Common)

--- a/internal/build/pcln_mode.go
+++ b/internal/build/pcln_mode.go
@@ -22,9 +22,11 @@ import "fmt"
 type PCLNMode uint8
 
 const (
-	// PCLNEmbedded keeps the metadata in the executable. It is the default.
+	// PCLNEmbedded keeps the metadata in the executable. It remains the
+	// fallback for configurations that cannot emit an external sidecar.
 	PCLNEmbedded PCLNMode = iota
-	// PCLNExternal writes the metadata to an optional sidecar file.
+	// PCLNExternal writes the metadata to an optional sidecar file. It is the
+	// default for supported native executable builds.
 	PCLNExternal
 	// PCLNNone omits the metadata and its loading support.
 	PCLNNone
@@ -60,13 +62,40 @@ func (m PCLNMode) validate() error {
 	return nil
 }
 
-// effectivePCLNMode translates the legacy environment escape hatch once at
-// the configuration boundary. An explicit -pclntab value always wins.
+// defaultPCLNMode selects external metadata where the build can emit a
+// sidecar. Other build configurations retain embedded metadata by default;
+// an explicit external request is still rejected by validatePCLNMode.
+func defaultPCLNMode(conf *Config) PCLNMode {
+	if conf == nil || conf.Mode == ModeGen || conf.Target != "" || !IsFuncInfoSitesEnabled() {
+		return PCLNEmbedded
+	}
+	if conf.BuildMode != "" && conf.BuildMode != BuildModeExe {
+		return PCLNEmbedded
+	}
+	switch conf.Goos {
+	case "darwin", "linux":
+	default:
+		return PCLNEmbedded
+	}
+	switch conf.Goarch {
+	case "amd64", "arm64":
+		return PCLNExternal
+	default:
+		return PCLNEmbedded
+	}
+}
+
+// effectivePCLNMode resolves the contextual default and translates the legacy
+// environment escape hatch once at the configuration boundary. An explicit
+// -pclntab value always wins.
 func effectivePCLNMode(conf *Config) PCLNMode {
-	if !conf.PCLNModeSet && conf.PCLNMode == PCLNEmbedded && !IsFuncInfoEnabled() {
+	if conf.PCLNModeSet || conf.PCLNMode == PCLNNone || !conf.PCLNMode.IsValid() {
+		return conf.PCLNMode
+	}
+	if !IsFuncInfoEnabled() {
 		return PCLNNone
 	}
-	return conf.PCLNMode
+	return defaultPCLNMode(conf)
 }
 
 // shouldEnablePCLNSites reports whether compiler-emitted PC anchor records are

--- a/internal/build/pcln_mode_test.go
+++ b/internal/build/pcln_mode_test.go
@@ -93,19 +93,23 @@ func TestValidatePCLNMode(t *testing.T) {
 }
 
 func TestEffectivePCLNModeLegacyPrecedence(t *testing.T) {
+	native := Config{Goos: "linux", Goarch: "amd64", BuildMode: BuildModeExe}
 	tests := []struct {
 		name     string
 		funcInfo string
 		conf     Config
 		want     PCLNMode
 	}{
-		{name: "default", conf: Config{}, want: PCLNEmbedded},
-		{name: "legacy enabled", funcInfo: "1", conf: Config{}, want: PCLNEmbedded},
-		{name: "legacy disabled", funcInfo: "0", conf: Config{}, want: PCLNNone},
+		{name: "default", conf: native, want: PCLNExternal},
+		{name: "legacy enabled", funcInfo: "1", conf: native, want: PCLNExternal},
+		{name: "legacy disabled", funcInfo: "0", conf: native, want: PCLNNone},
+		{name: "generation fallback", conf: Config{Goos: "linux", Goarch: "amd64", Mode: ModeGen, BuildMode: BuildModeExe}, want: PCLNEmbedded},
+		{name: "named target fallback", conf: Config{Goos: "wasip1", Goarch: "wasm", Target: "wasi", BuildMode: BuildModeExe}, want: PCLNEmbedded},
+		{name: "shared fallback", conf: Config{Goos: "linux", Goarch: "amd64", BuildMode: BuildModeCShared}, want: PCLNEmbedded},
+		{name: "unsupported platform fallback", conf: Config{Goos: "windows", Goarch: "amd64", BuildMode: BuildModeExe}, want: PCLNEmbedded},
 		{name: "explicit embedded wins", funcInfo: "0", conf: Config{PCLNMode: PCLNEmbedded, PCLNModeSet: true}, want: PCLNEmbedded},
 		{name: "explicit external wins", funcInfo: "0", conf: Config{PCLNMode: PCLNExternal, PCLNModeSet: true}, want: PCLNExternal},
 		{name: "explicit none wins", funcInfo: "1", conf: Config{PCLNMode: PCLNNone, PCLNModeSet: true}, want: PCLNNone},
-		{name: "typed external is authoritative", funcInfo: "0", conf: Config{PCLNMode: PCLNExternal}, want: PCLNExternal},
 		{name: "typed none is authoritative", funcInfo: "1", conf: Config{PCLNMode: PCLNNone}, want: PCLNNone},
 	}
 	for _, tt := range tests {
@@ -115,6 +119,11 @@ func TestEffectivePCLNModeLegacyPrecedence(t *testing.T) {
 				t.Fatalf("effectivePCLNMode() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+	t.Setenv(llgoFuncInfo, "")
+	t.Setenv(llgoFuncInfoSites, "0")
+	if got := effectivePCLNMode(&native); got != PCLNEmbedded {
+		t.Fatalf("effectivePCLNMode() with disabled sites = %v, want %v", got, PCLNEmbedded)
 	}
 }
 
@@ -148,10 +157,13 @@ func TestShouldEnablePCLNSites(t *testing.T) {
 
 func TestNewDefaultConfMetadataDefaults(t *testing.T) {
 	t.Setenv("GOBIN", t.TempDir())
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
 	t.Setenv(llgoFuncInfo, "")
+	t.Setenv(llgoFuncInfoSites, "")
 	conf := NewDefaultConf(ModeBuild)
-	if got := conf.PCLNMode; got != PCLNEmbedded {
-		t.Fatalf("NewDefaultConf().PCLNMode = %v, want %v", got, PCLNEmbedded)
+	if got := conf.PCLNMode; got != PCLNExternal {
+		t.Fatalf("NewDefaultConf().PCLNMode = %v, want %v", got, PCLNExternal)
 	}
 	if conf.PCLNModeSet {
 		t.Fatal("NewDefaultConf().PCLNModeSet = true, want unresolved legacy default")
@@ -160,6 +172,9 @@ func TestNewDefaultConfMetadataDefaults(t *testing.T) {
 		t.Fatal("NewDefaultConf().OmitDWARFByDefault = false, want safe provisional-DWARF default")
 	}
 	genConf := NewDefaultConf(ModeGen)
+	if got := genConf.PCLNMode; got != PCLNEmbedded {
+		t.Fatalf("NewDefaultConf(ModeGen).PCLNMode = %v, want %v", got, PCLNEmbedded)
+	}
 	if genConf.OmitDWARFByDefault {
 		t.Fatal("NewDefaultConf(ModeGen).OmitDWARFByDefault = true, want no linked-build policy")
 	}


### PR DESCRIPTION
## Summary

- default `-pclntab` to `external` for supported native executable builds
- retain `embedded` as the contextual default where external sidecars are unavailable
- preserve explicit-mode validation and update help, design documentation, and fingerprint/default-policy coverage

## Default behavior

| Build configuration | Default PCLN mode | Explicit `-pclntab=external` |
| --- | --- | --- |
| Native Darwin/Linux `amd64` or `arm64` executable, without `-target` | `external` | supported |
| `ModeGen` | `embedded` | capability error |
| `c-archive` or `c-shared` | `embedded` | capability error |
| Any named `-target`, including WASI/wasm and embedded targets | `embedded` | capability error |
| Windows or another unsupported OS | `embedded` | capability error |
| Darwin/Linux architectures other than `amd64` and `arm64` | `embedded` | capability error |
| Builds with `LLGO_FUNCINFO_SITES=0` | `embedded` | capability error |

Explicit `-pclntab=embedded` and `-pclntab=none` continue to win over the contextual default. The legacy `LLGO_FUNCINFO=0` escape hatch also continues to select `none` when no explicit PCLN mode was requested.

## Why the architecture scope is limited

The initial external format and post-link analyzer require a 64-bit, little-endian ELF or Mach-O executable. This directly excludes 32-bit Linux architectures such as `386` and `arm`, and big-endian targets such as `s390x` and `ppc64`.

Other 64-bit little-endian Linux architectures, such as `riscv64`, `loong64`, or `ppc64le`, are not fundamentally excluded by those two layout checks. They remain disabled because the sidecar target-code table, runtime loader build tags/architecture constants, and final-PC site/LTO behavior have only been implemented and validated for `amd64` and `arm64`. Enabling them should be a separate port with target codes and native integration coverage.

## Validation

- `go test ./cmd/internal/flags ./internal/build -count=1`
- `go vet ./cmd/internal/flags ./internal/build`
- built `benchmark/binary_size/println` with the default and verified the executable plus `.pclntab` sidecar were produced
- built the same fixture with `-pclntab=embedded` and verified no sidecar was produced
- `git diff --check`