### PR TITLE
build: guard and verify deadcode test-main roots

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -207,6 +207,9 @@ jobs:
       - name: Run Go method drop tests
         run: go test -tags=dev -timeout 30m -run '^TestBuildAndCheckSymbolsFromTestdrop$' ./cl
 
+      - name: Run test-main reachability regression
+        run: go test -tags=dev -timeout 10m -run '^TestDeadcodeTestMainIsReachable$' ./internal/build
+
       - name: Run Go deadcode-drop demos
         run: |
           LLGO_DEMO_LLGORUN_FLAGS="-deadcodedrop" \

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1603,10 +1603,27 @@ func applyDeadcodeDropOverrides(pkgs []Package, entryPkg Package, needRuntime bo
 		return err
 	}
 
+	// Global method analysis must start from the Go executable entry point. If
+	// its metadata is absent, continuing would treat every method reachable
+	// only from main as dead and can produce a smaller binary that crashes at
+	// startup. A generated test main must retain the "main" identity; the
+	// @ForTest marker instead disambiguates a real main package under test.
+	if !hasDCEExecutableRoot(summary) {
+		if verbose {
+			fmt.Fprintln(os.Stderr, "llgo: deadcode method pruning skipped: main.main is absent from package metadata")
+		}
+		return nil
+	}
+
 	roots := dceEntryRootCandidates(pkgs, needRuntime)
 	liveSlots := deadcode.Analyze(summary, roots)
 	dcepass.EmitStrongTypeOverrides(entryPkg.LPkg.Module(), dceSourceModules(pkgs), liveSlots, verbose)
 	return nil
+}
+
+func hasDCEExecutableRoot(summary *meta.GlobalSummary) bool {
+	root, ok := summary.LookupSymbol("main.main")
+	return ok && summary.HasFacts(root)
 }
 
 func dceSourceModules(pkgs []Package) []gllvm.Module {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -261,6 +261,28 @@ func TestConcurrentDeadcodeBuildsUseIndependentWorkerContexts(t *testing.T) {
 	}
 }
 
+func TestDeadcodeTestMainIsReachable(t *testing.T) {
+	if !buildenv.Dev {
+		t.Skip("deadcode drop requires a development build")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := filepath.Join(repoRoot, "internal", "build", "testdata", "deadcodetestmain")
+	t.Setenv("LLGO_ROOT", repoRoot)
+	t.Setenv(llgoBuildCache, "0")
+
+	conf := NewDefaultConf(ModeTest)
+	conf.DeadcodeDrop = true
+	conf.PCLNMode = PCLNNone
+	conf.OutFile = filepath.Join(t.TempDir(), "deadcodetestmain.test")
+	conf.RunArgs = []string{"-test.run=^TestReachable$"}
+	if _, err := Build(Invocation{Args: []string{"."}, Config: conf, Dir: fixture}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDeadcodeBuildColdAndHotPackageCache(t *testing.T) {
 	if !buildenv.Dev {
 		t.Skip("deadcode drop requires a development build")

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -281,6 +281,23 @@ func TestDeadcodeTestMainIsReachable(t *testing.T) {
 	if _, err := Build(Invocation{Args: []string{"."}, Config: conf, Dir: fixture}); err != nil {
 		t.Fatal(err)
 	}
+
+	nm, err := exec.Command("nm", "-a", conf.OutFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("read test binary symbols: %v\n%s", err, nm)
+	}
+	symbols := string(nm)
+	for _, live := range []string{
+		"deadcodetestmain.initOnlyAnswer.initAnswer",
+		"deadcodetestmain.liveAnswer.Answer",
+	} {
+		if !strings.Contains(symbols, live) {
+			t.Fatalf("live test method %q was dropped:\n%s", live, symbols)
+		}
+	}
+	if strings.Contains(symbols, "deadcodetestmain.deadAnswer.Drop") {
+		t.Fatalf("dead test method was retained:\n%s", symbols)
+	}
 }
 
 func TestDeadcodeBuildColdAndHotPackageCache(t *testing.T) {

--- a/internal/build/deadcode_test.go
+++ b/internal/build/deadcode_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -60,6 +61,61 @@ func TestApplyDeadcodeDropOverridesWritesStrongTypeOverride(t *testing.T) {
 	}
 }
 
+func TestApplyDeadcodeDropOverridesSkipsMissingGoEntryRoot(t *testing.T) {
+	llssa.Initialize(llssa.InitAll)
+	ctx := &context{
+		prog: llssa.NewProgram(nil),
+		buildConf: &Config{
+			BuildMode: BuildModeExe,
+			Goos:      "linux",
+			Goarch:    "amd64",
+		},
+	}
+	defer ctx.prog.Dispose()
+
+	srcProg := llssa.NewProgram(nil)
+	defer srcProg.Dispose()
+	srcPkg := srcProg.NewPackage("pkg", "pkg")
+	addMethodTypeGlobal(srcPkg.Module(), "_llgo_pkg.T")
+	pkgMeta := buildDeadcodeMetaForRoot(t, "example.com/p.test.main")
+	defer pkgMeta.Close()
+	srcAPkg := &aPackage{
+		Package: &packages.Package{PkgPath: "pkg"},
+		LPkg:    srcPkg,
+		Meta:    pkgMeta,
+	}
+	entryPkg := genMainModule(ctx, llssa.PkgRuntime, &packages.Package{
+		PkgPath:    "pkg",
+		ExportFile: "pkg.a",
+	}, &genConfig{})
+
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = oldStderr })
+	if err := applyDeadcodeDropOverrides([]Package{srcAPkg}, entryPkg, false, true); err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = oldStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	diagnostic, err := os.ReadFile(stderr.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(diagnostic), "deadcode method pruning skipped: main.main is absent") {
+		t.Fatalf("missing diagnostic in stderr: %q", diagnostic)
+	}
+
+	if out := entryPkg.LPkg.Module().String(); strings.Contains(out, `@_llgo_pkg.T = constant`) {
+		t.Fatalf("missing Go entry root unexpectedly emitted a type override:\n%s", out)
+	}
+}
+
 func TestDCEEntryRootCandidates(t *testing.T) {
 	want := []string{"main.init", "main.main"}
 	if got := dceEntryRootCandidates(nil, false); !reflect.DeepEqual(got, want) {
@@ -87,9 +143,16 @@ func TestDCEEntryRootCandidatesIncludesCExports(t *testing.T) {
 }
 
 func buildDeadcodeMeta(t *testing.T) *meta.PackageMeta {
+	return buildDeadcodeMetaForRoot(t, "main.main")
+}
+
+func buildDeadcodeMetaForRoot(t *testing.T, rootName string) *meta.PackageMeta {
 	t.Helper()
 	b := meta.NewBuilder()
-	main := b.Sym("main.main")
+	main := b.Sym(rootName)
+	// Keep an exact main.main reference in the negative fixture. A referenced-
+	// only symbol is not a usable analysis root because it owns no facts.
+	b.AddOrdinaryEdge(main, b.Sym("main.main"))
 	use := b.Sym("pkg.use")
 	typ := b.Sym("_llgo_pkg.T")
 	iface := b.Sym("_llgo_iface$I")

--- a/internal/build/testdata/deadcodetestmain/deadcodetestmain.go
+++ b/internal/build/testdata/deadcodetestmain/deadcodetestmain.go
@@ -1,0 +1,5 @@
+package deadcodetestmain
+
+func Answer() int {
+	return 42
+}

--- a/internal/build/testdata/deadcodetestmain/deadcodetestmain.go
+++ b/internal/build/testdata/deadcodetestmain/deadcodetestmain.go
@@ -1,5 +1,50 @@
 package deadcodetestmain
 
-func Answer() int {
+type answerer interface {
+	Answer() int
+}
+
+type liveAnswer struct{}
+
+func (liveAnswer) Answer() int {
 	return 42
+}
+
+type deadAnswer struct{}
+
+func (deadAnswer) Drop() int {
+	return -1
+}
+
+type initAnswerer interface {
+	initAnswer() int
+}
+
+type initOnlyAnswer struct{}
+
+func (initOnlyAnswer) initAnswer() int {
+	return 7
+}
+
+var initializedAnswer int
+
+func init() {
+	initializedAnswer = callInitAnswer(initOnlyAnswer{})
+}
+
+func callInitAnswer(answer initAnswerer) int {
+	return answer.initAnswer()
+}
+
+func Answer() int {
+	var answer answerer = liveAnswer{}
+	return answer.Answer()
+}
+
+func DeadType() any {
+	return deadAnswer{}
+}
+
+func InitializedAnswer() int {
+	return initializedAnswer
 }

--- a/internal/build/testdata/deadcodetestmain/deadcodetestmain_test.go
+++ b/internal/build/testdata/deadcodetestmain/deadcodetestmain_test.go
@@ -3,7 +3,13 @@ package deadcodetestmain
 import "testing"
 
 func TestReachable(t *testing.T) {
+	if got := InitializedAnswer(); got != 7 {
+		t.Fatalf("InitializedAnswer() = %d, want 7", got)
+	}
 	if got := Answer(); got != 42 {
 		t.Fatalf("Answer() = %d, want 42", got)
+	}
+	if DeadType() == nil {
+		t.Fatal("DeadType() returned nil")
 	}
 }

--- a/internal/build/testdata/deadcodetestmain/deadcodetestmain_test.go
+++ b/internal/build/testdata/deadcodetestmain/deadcodetestmain_test.go
@@ -1,0 +1,9 @@
+package deadcodetestmain
+
+import "testing"
+
+func TestReachable(t *testing.T) {
+	if got := Answer(); got != 42 {
+		t.Fatalf("Answer() = %d, want 42", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Skip global method-table pruning when `main.main` is absent from package metadata.
- Retain weak method tables and print a verbose diagnostic on that fail-safe path.
- Add an end-to-end generated test-main regression covering both `main.init` and `main.main` roots.
- Verify that live interface methods remain callable while an unrelated dead method is removed from the linked test binary.

## Motivation

#2370 restored the generated test main to the `main` ABI identity. Before that fix, whole-program method analysis could not resolve the executable roots and could remove methods required by `testing.M.Run`. The resulting binary was smaller but invalid; the reproduced `Dustin_humanize` binary crashed at startup with `unreachable method called`.

This PR makes the metadata invariant fail-safe. It also prevents the opposite regression: merely disabling method pruning would retain the dead method and fail the new symbol assertion.

The normal post-#2370 path is unchanged, so this PR is a correctness guard and regression test rather than a size optimization.

## Size validation

Published Linux Bent results for `Dustin_humanize`:

| Build | Size | Result |
| --- | ---: | --- |
| Pre-#2370, missing roots | 3,586,976 B | Crashes during `testing.M.Run` |
| #2370, correct roots with deadcode drop | 3,803,824 B | Passes |
| #2370, deadcode drop disabled | 5,244,456 B | Passes |

Correct test-main deadcode drop removes 1,440,632 B, or 27.5%, relative to disabling deadcode drop. The old result was another 216,848 B smaller only because it removed live code.

For the new regression fixture on macOS arm64:

| Build | Size |
| --- | ---: |
| Deadcode drop disabled | 4,659,632 B |
| Deadcode drop enabled | 3,466,784 B |

That is a reduction of 1,192,848 B, or 25.6%. The optimized binary passes, retains the init-only and test-only live methods, and does not contain `deadAnswer.Drop`.

## Testing

- `go test -tags=dev ./internal/build ./internal/deadcode ./internal/meta -count=1`
- Targeted coverage: `applyDeadcodeDropOverrides` 91.7%, `hasDCEExecutableRoot` 100%
- Pre-#2370 reproduction: the new fixture fails during `testing.M.Run`
- CI: 41 checks passed, with one expected release check skipped
- Codecov: all modified and coverable lines are covered
