### PR TITLE
ci: limit benchmark notifications to compiler changes

### DIFF
--- a/.github/scripts/classify_benchmark_changes.py
+++ b/.github/scripts/classify_benchmark_changes.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Classify LLGo repository changes for benchmark workflow decisions.
+
+Each changed path has one primary category.  A commit can therefore contain
+multiple categories, while workflows can make decisions from stable boolean
+outputs such as ``compiler=true``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+import subprocess
+import sys
+from typing import Iterable, Sequence
+
+
+CATEGORIES = (
+    "compiler",
+    "runtime",
+    "stdlib",
+    "test",
+    "benchmark",
+    "example",
+    "docs",
+    "ci",
+    "tooling",
+    "other",
+)
+
+TEST_DIRS = {
+    "_cmptest",
+    "test",
+    "cl/cltest",
+    "cmd/llgo/lldbtest",
+    "internal/filecheck",
+    "internal/littest",
+    "internal/llgen",
+    "runtime/_test",
+    "runtime/_patch/_test",
+    "runtime/internal/test",
+    "ssa/ssatest",
+}
+
+COMPILER_DIRS = {
+    "cl",
+    "cmd/internal/base",
+    "cmd/internal/build",
+    "cmd/internal/clean",
+    "cmd/internal/compile",
+    "cmd/internal/compilerhash",
+    "cmd/internal/flags",
+    "cmd/internal/get",
+    "cmd/internal/help",
+    "cmd/internal/install",
+    "cmd/internal/lldb",
+    "cmd/internal/monitor",
+    "cmd/internal/run",
+    "cmd/internal/test",
+    "cmd/internal/version",
+    "internal",
+    "ltoplugin",
+    "ssa",
+    "targets",
+    "xtool",
+}
+
+
+@dataclass(frozen=True)
+class Change:
+    status: str
+    paths: tuple[str, ...]
+
+
+def _under(path: str, directory: str) -> bool:
+    return path == directory or path.startswith(directory + "/")
+
+
+def _under_any(path: str, directories: Iterable[str]) -> bool:
+    return any(_under(path, directory) for directory in directories)
+
+
+def classify_path(raw_path: str) -> str:
+    """Return the primary category for a repository-relative path."""
+    path = PurePosixPath(raw_path.replace("\\", "/")).as_posix()
+    if path.startswith("./"):
+        path = path[2:]
+    name = PurePosixPath(path).name
+
+    # Put purpose-specific files before their containing source tree.  For
+    # example, runtime/foo_test.go is a test rather than a runtime change.
+    if _under(path, ".github") or name in {".goreleaser.yml", ".goreleaser.yaml"}:
+        return "ci"
+    if (
+        _under_any(path, {"doc", "docs", "LICENSES"})
+        or name.lower().endswith((".md", ".markdown", ".rst"))
+        or name in {"LICENSE", "THIRD_PARTY_NOTICES.md"}
+    ):
+        return "docs"
+    if (
+        name.endswith("_test.go")
+        or "testdata" in PurePosixPath(path).parts
+        or _under_any(path, TEST_DIRS)
+        or path.startswith("cl/_test")
+    ):
+        return "test"
+    if _under(path, "benchmark"):
+        return "benchmark"
+    if _under_any(path, {"_demo", "examples"}):
+        return "example"
+
+    # runtime/_patch and runtime/internal/lib mirror or replace Go standard
+    # library packages.  Keep them distinct from LLGo's runtime support.
+    if _under_any(path, {"runtime/_patch", "runtime/internal/lib"}):
+        return "stdlib"
+    if _under(path, "runtime"):
+        return "runtime"
+
+    if path in {"go.mod", "go.sum"} or path.startswith("cmd/llgo/"):
+        return "compiler"
+    if _under_any(path, COMPILER_DIRS):
+        return "compiler"
+
+    if _under_any(path, {"_xtool", "chore", "dev"}) or path == "install.sh":
+        return "tooling"
+    return "other"
+
+
+def parse_name_status_z(data: bytes) -> list[Change]:
+    """Parse ``git diff --name-status -z`` output."""
+    fields = data.decode("utf-8", errors="surrogateescape").split("\0")
+    if fields and not fields[-1]:
+        fields.pop()
+
+    changes: list[Change] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        index += 1
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        if index + path_count > len(fields):
+            raise ValueError(f"incomplete git name-status record for {status!r}")
+        paths = tuple(fields[index : index + path_count])
+        index += path_count
+        changes.append(Change(status=status, paths=paths))
+    return changes
+
+
+def _git(*args: str) -> bytes:
+    return subprocess.run(
+        ["git", *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ).stdout
+
+
+def _valid_commit(revision: str) -> bool:
+    if not revision or set(revision) == {"0"}:
+        return False
+    return subprocess.run(
+        ["git", "cat-file", "-e", f"{revision}^{{commit}}"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def changes_from_git(base: str, head: str) -> list[Change]:
+    if not _valid_commit(head):
+        raise ValueError(f"head is not a local Git commit: {head}")
+    if not _valid_commit(base):
+        fallback = f"{head}^"
+        if not _valid_commit(fallback):
+            raise ValueError(f"base is not a local Git commit: {base}")
+        print(
+            f"warning: base {base or '<empty>'} is unavailable; using {fallback}",
+            file=sys.stderr,
+        )
+        base = fallback
+    return parse_name_status_z(
+        _git("diff", "--name-status", "-z", "--find-renames", base, head)
+    )
+
+
+def build_report(changes: Sequence[Change]) -> dict[str, object]:
+    files: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for change in changes:
+        for path in change.paths:
+            if path in seen:
+                continue
+            seen.add(path)
+            files.append(
+                {"path": path, "status": change.status, "category": classify_path(path)}
+            )
+
+    by_category = {
+        category: [entry["path"] for entry in files if entry["category"] == category]
+        for category in CATEGORIES
+    }
+    return {
+        "schemaVersion": 1,
+        "categories": {category: bool(by_category[category]) for category in CATEGORIES},
+        "filesByCategory": by_category,
+        "files": files,
+    }
+
+
+def write_github_output(path: str, report: dict[str, object]) -> None:
+    categories = report["categories"]
+    assert isinstance(categories, dict)
+    selected = [name for name in CATEGORIES if categories[name]]
+    files = report["files"]
+    assert isinstance(files, list)
+    with open(path, "a", encoding="utf-8") as output:
+        for category in CATEGORIES:
+            output.write(f"{category}={'true' if categories[category] else 'false'}\n")
+        output.write(f"categories={','.join(selected)}\n")
+        output.write(f"changed_files={len(files)}\n")
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def write_github_summary(path: str, report: dict[str, object]) -> None:
+    files_by_category = report["filesByCategory"]
+    assert isinstance(files_by_category, dict)
+    with open(path, "a", encoding="utf-8") as summary:
+        summary.write("## LLGo change classification\n\n")
+        summary.write("| Category | Files | Paths |\n")
+        summary.write("| --- | ---: | --- |\n")
+        for category in CATEGORIES:
+            paths = files_by_category[category]
+            if paths:
+                shown = ", ".join(f"`{_markdown_cell(item)}`" for item in paths[:12])
+                if len(paths) > 12:
+                    shown += f", and {len(paths) - 12} more"
+                summary.write(f"| {category} | {len(paths)} | {shown} |\n")
+        compiler = bool(report["categories"]["compiler"])
+        summary.write(
+            "\nBinary-size and compile-time benchmarks: "
+            + ("**triggered**" if compiler else "**not triggered**")
+            + ".\n"
+        )
+
+
+def print_text(report: dict[str, object]) -> None:
+    files_by_category = report["filesByCategory"]
+    assert isinstance(files_by_category, dict)
+    for category in CATEGORIES:
+        paths = files_by_category[category]
+        if not paths:
+            continue
+        print(f"{category} ({len(paths)}):")
+        for path in paths:
+            print(f"  {path}")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="paths to classify instead of a Git diff")
+    parser.add_argument("--base", help="base Git revision")
+    parser.add_argument("--head", default="HEAD", help="head Git revision (default: HEAD)")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--github-output", help="append reusable outputs to this file")
+    parser.add_argument("--github-summary", help="append a Markdown summary to this file")
+    args = parser.parse_args(argv)
+    if args.paths and args.base:
+        parser.error("paths and --base cannot be used together")
+    if not args.paths and not args.base:
+        parser.error("provide paths or --base")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        changes = (
+            [Change(status="M", paths=(path,)) for path in args.paths]
+            if args.paths
+            else changes_from_git(args.base, args.head)
+        )
+        report = build_report(changes)
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        print(f"classification failed: {error}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        print()
+    else:
+        print_text(report)
+    if args.github_output:
+        write_github_output(args.github_output, report)
+    if args.github_summary:
+        write_github_summary(args.github_summary, report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_classify_benchmark_changes.py
+++ b/.github/scripts/test_classify_benchmark_changes.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("classify_benchmark_changes.py")
+SPEC = importlib.util.spec_from_file_location("classify_benchmark_changes", SCRIPT)
+assert SPEC and SPEC.loader
+classifier = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = classifier
+SPEC.loader.exec_module(classifier)
+
+
+class ClassifyPathTests(unittest.TestCase):
+    def test_representative_categories(self):
+        cases = {
+            "cl/compile.go": "compiler",
+            "cmd/llgo/main.go": "compiler",
+            "internal/build/build.go": "compiler",
+            "targets/device/riscv64.json": "compiler",
+            "go.mod": "compiler",
+            "runtime/abi/abi.go": "runtime",
+            "runtime/go.mod": "runtime",
+            "runtime/_patch/runtime/runtime.go": "stdlib",
+            "runtime/internal/lib/reflect/value.go": "stdlib",
+            "test/std/fmt.go": "test",
+            "cl/compile_test.go": "test",
+            "runtime/runtime_test.go": "test",
+            "runtime/_patch/_test/skipall/main.go": "test",
+            "cl/_testgo/foo.go": "test",
+            "cl/_testdata/foo.go": "test",
+            "benchmark/binary_size/README.txt": "benchmark",
+            "_demo/go/hello.go": "example",
+            "README.md": "docs",
+            "internal/gohex/LICENSE": "docs",
+            ".github/workflows/ci.yml": "ci",
+            "chore/gentests/main.go": "tooling",
+            "_xtool/astdump/main.go": "tooling",
+            "CODEOWNERS": "other",
+        }
+        for path, expected in cases.items():
+            with self.subTest(path=path):
+                self.assertEqual(classifier.classify_path(path), expected)
+
+    def test_mixed_report_only_sets_present_categories(self):
+        report = classifier.build_report(
+            [
+                classifier.Change("M", ("README.md",)),
+                classifier.Change("M", ("cl/compile.go",)),
+                classifier.Change("M", ("cl/compile_test.go",)),
+            ]
+        )
+        self.assertTrue(report["categories"]["compiler"])
+        self.assertTrue(report["categories"]["docs"])
+        self.assertTrue(report["categories"]["test"])
+        self.assertFalse(report["categories"]["runtime"])
+
+
+class GitNameStatusTests(unittest.TestCase):
+    def test_rename_checks_old_and_new_paths(self):
+        changes = classifier.parse_name_status_z(
+            b"R100\0cl/old.go\0doc/new.md\0D\0runtime/old.go\0"
+        )
+        report = classifier.build_report(changes)
+        self.assertEqual(
+            report["filesByCategory"]["compiler"], ["cl/old.go"]
+        )
+        self.assertEqual(report["filesByCategory"]["docs"], ["doc/new.md"])
+        self.assertEqual(
+            report["filesByCategory"]["runtime"], ["runtime/old.go"]
+        )
+
+    def test_incomplete_record_is_rejected(self):
+        with self.assertRaises(ValueError):
+            classifier.parse_name_status_z(b"R100\0only-one-path\0")
+
+
+class OutputTests(unittest.TestCase):
+    def test_github_output_is_reusable(self):
+        report = classifier.build_report(
+            [classifier.Change("M", ("cl/compile.go",))]
+        )
+        with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8") as output:
+            classifier.write_github_output(output.name, report)
+            output.seek(0)
+            values = dict(line.rstrip().split("=", 1) for line in output)
+        self.assertEqual(values["compiler"], "true")
+        self.assertEqual(values["runtime"], "false")
+        self.assertEqual(values["categories"], "compiler")
+        self.assertEqual(values["changed_files"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -2,9 +2,40 @@ name: Notify benchmarks
 
 on:
   # A push to main is the authoritative post-merge state, including squash and
-  # rebase merges. The dispatched SHA is the exact LLGo version to measure.
+  # rebase merges. Only changes that can affect the compiler, generated
+  # binaries, or the LTO plugin should start the expensive binary-size and
+  # compile-time benchmarks. Documentation, CI, release metadata, and tests do
+  # not change those measurements.
   push:
     branches: [main]
+    paths:
+      - cl/**
+      - cmd/llgo/*.go
+      - cmd/internal/base/**
+      - cmd/internal/build/**
+      - cmd/internal/compile/**
+      - cmd/internal/compilerhash/**
+      - cmd/internal/flags/**
+      - internal/**
+      - ltoplugin/**
+      - runtime/**
+      - ssa/**
+      - xtool/**
+      - go.mod
+      - go.sum
+      - '!**/*.md'
+      - '!**/*_test.go'
+      - '!**/testdata/**'
+      - '!cl/_test*/**'
+      - '!cl/cltest/**'
+      - '!internal/filecheck/**'
+      - '!internal/littest/**'
+      - '!internal/llgen/**'
+      - '!runtime/_test/**'
+      - '!runtime/internal/test/**'
+      - '!ssa/ssatest/**'
+      - '!**/LICENSE'
+      - '!**/LICENSES/**'
   # Compatibility is intentionally release-based: publishing a stable release
   # or prerelease records one durable open-source test result for that tag.
   release:

--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -2,50 +2,34 @@ name: Notify benchmarks
 
 on:
   # A push to main is the authoritative post-merge state, including squash and
-  # rebase merges. Only changes that can affect the compiler, generated
-  # binaries, or the LTO plugin should start the expensive binary-size and
-  # compile-time benchmarks. Documentation, CI, release metadata, and tests do
-  # not change those measurements.
+  # rebase merges. The classifier below decides whether the change affects the
+  # compiler and should start the expensive benchmarks.
   push:
     branches: [main]
+  pull_request:
     paths:
-      - cl/**
-      - cmd/llgo/*.go
-      - cmd/internal/base/**
-      - cmd/internal/build/**
-      - cmd/internal/compile/**
-      - cmd/internal/compilerhash/**
-      - cmd/internal/flags/**
-      - internal/**
-      - ltoplugin/**
-      - runtime/**
-      - ssa/**
-      - xtool/**
-      - go.mod
-      - go.sum
-      - '!**/*.md'
-      - '!**/*_test.go'
-      - '!**/testdata/**'
-      - '!cl/_test*/**'
-      - '!cl/cltest/**'
-      - '!internal/filecheck/**'
-      - '!internal/littest/**'
-      - '!internal/llgen/**'
-      - '!runtime/_test/**'
-      - '!runtime/internal/test/**'
-      - '!ssa/ssatest/**'
-      - '!**/LICENSE'
-      - '!**/LICENSES/**'
+      - .github/scripts/classify_benchmark_changes.py
+      - .github/scripts/test_classify_benchmark_changes.py
+      - .github/workflows/notify-benchmarks.yml
   # Compatibility is intentionally release-based: publishing a stable release
   # or prerelease records one durable open-source test result for that tag.
   release:
     types: [published]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
+  classifier-tests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test benchmark change classifier
+        run: python3 .github/scripts/test_classify_benchmark_changes.py
+
   dispatch:
-    if: github.repository == 'xgo-dev/llgo'
+    if: github.repository == 'xgo-dev/llgo' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     env:
       # Set this repository variable to the temporary personal repository
@@ -54,7 +38,28 @@ jobs:
       BENCHMARKS_DISPATCH_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
+      - name: Check out LLGo history
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changes
+        if: github.event_name == 'push'
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          python3 .github/scripts/classify_benchmark_changes.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --format json \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
+
       - name: Request benchmarks for this LLGo revision
+        if: github.event_name == 'release' || steps.changes.outputs.compiler == 'true'
         run: |
           set -euo pipefail
           if [[ -z "$BENCHMARKS_DISPATCH_TOKEN" ]]; then
@@ -99,3 +104,7 @@ jobs:
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "https://api.github.com/repos/${BENCHMARKS_REPOSITORY}/dispatches" \
             --data "$payload"
+
+      - name: Skip benchmarks for non-compiler changes
+        if: github.event_name == 'push' && steps.changes.outputs.compiler != 'true'
+        run: echo "No compiler changes; benchmark dispatch is not required."

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ build.dir/
 ltoplugin/build/
 .vscode/
 .venv/
+__pycache__/
+*.pyc
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
## Summary
- add a reusable Python classifier for compiler, runtime, standard-library, test, benchmark, example, documentation, CI, tooling, and uncategorized changes
- handle additions, deletions, copies, and renames, and publish booleans plus a categorized table in the GitHub job summary
- dispatch `llgo-main-updated` only when the classifier reports `compiler=true`
- keep published-release notifications unchanged
- run focused classifier tests when the classifier or notification workflow changes in a PR

## Validation
- `python3 .github/scripts/test_classify_benchmark_changes.py`
- `python3 -m py_compile .github/scripts/classify_benchmark_changes.py .github/scripts/test_classify_benchmark_changes.py`
- `actionlint v1.7.12 .github/workflows/notify-benchmarks.yml`
- `git diff --check`
- replayed recent LLGo history: README-only commits classify as `docs`, Actions-only commits as `ci`, and compiler/mixed commits as `compiler` plus their secondary categories