### PR TITLE
compiler: default host to Os and targets to Oz

### DIFF
--- a/_demo/embed/testdata/esp32-serial/gc-runtime/main.go
+++ b/_demo/embed/testdata/esp32-serial/gc-runtime/main.go
@@ -976,6 +976,11 @@ func testNestedStructPointers() bool {
 	}
 
 	globalNested = nil
+	// This collector scans stack words conservatively. On Xtensa, a dead
+	// register-window spill can keep the deepest nested pointer alive for one
+	// cycle. The first collection also overwrites that spill, so verify complete
+	// reclamation after a settling cycle instead of requiring precise-GC behavior.
+	collectAndPrint("nested-drop-first")
 	_, afterDrop := collectAndPrint("nested-drop")
 	// 3 nested + 3 node = 6 objects (at minimum)
 	if afterDrop.Frees < after.Frees+6 {

--- a/cl/_testgo/sigsegv/in.go
+++ b/cl/_testgo/sigsegv/in.go
@@ -9,7 +9,7 @@ func f() *T {
 	return nil
 }
 
-// CHECK: ; Function Attrs: null_pointer_is_valid
+// CHECK: ; Function Attrs: {{(minsize )?}}null_pointer_is_valid{{( optsize)?}}
 // CHECK-LABEL: define void @"main.init#1"() #0 {
 func init() {
 	println("init")
@@ -29,4 +29,4 @@ func main() {
 	println("main")
 }
 
-// CHECK: attributes #0 = { null_pointer_is_valid "frame-pointer"="non-leaf" }
+// CHECK: attributes #0 = { {{(minsize )?}}null_pointer_is_valid{{( optsize)?}} "frame-pointer"="non-leaf" }

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
@@ -30,6 +30,7 @@ func (S) Drop() string {
 
 // Keep this helper call visible so the LTO plugin, rather than the pre-link
 // inliner, must recover its finite return set.
+//
 //go:noinline
 func methodName() string {
 	name := "KeepA"

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
@@ -28,6 +28,9 @@ func (S) Drop() string {
 	panic("Drop should be unreachable")
 }
 
+// Keep this helper call visible so the LTO plugin, rather than the pre-link
+// inliner, must recover its finite return set.
+//go:noinline
 func methodName() string {
 	name := "KeepA"
 	if os.Args[0] == "" {

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -200,7 +200,7 @@ func AddOptLevelFlags(fs *flag.FlagSet) {
 	fs.BoolFunc("O3", "Optimize aggressively", optLevelBoolFunc(optlevel.O3, "-O3"))
 	fs.BoolFunc("Os", "Optimize for size", optLevelBoolFunc(optlevel.Os, "-Os"))
 	fs.BoolFunc("Oz", "Optimize aggressively for size", optLevelBoolFunc(optlevel.Oz, "-Oz"))
-	fs.Func("O", "Optimization level (0,1,2,3,s,z)", func(val string) error {
+	fs.Func("O", "Optimization level (0,1,2,3,s,z; default z)", func(val string) error {
 		level, err := optlevel.Parse(val)
 		if err != nil {
 			return err

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -200,7 +200,7 @@ func AddOptLevelFlags(fs *flag.FlagSet) {
 	fs.BoolFunc("O3", "Optimize aggressively", optLevelBoolFunc(optlevel.O3, "-O3"))
 	fs.BoolFunc("Os", "Optimize for size", optLevelBoolFunc(optlevel.Os, "-Os"))
 	fs.BoolFunc("Oz", "Optimize aggressively for size", optLevelBoolFunc(optlevel.Oz, "-Oz"))
-	fs.Func("O", "Optimization level (0,1,2,3,s,z; default z)", func(val string) error {
+	fs.Func("O", "Optimization level (0,1,2,3,s,z; default s for host, z for targets)", func(val string) error {
 		level, err := optlevel.Parse(val)
 		if err != nil {
 			return err

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2054,6 +2054,7 @@ func compilePackageModule(ctx *context, aPkg *aPackage, externs []string, verbos
 	llabi.LowerLargeAggregates(ctx.prog.TargetData(), ret.Module())
 	ctx.cTransformer.TransformModule(ret.Path(), ret.Module())
 	ctx.cTransformer.SetSkipFuncs(nil)
+	applySizeOptimizationAttributes(ret.Module(), ctx.buildConf.OptLevel)
 
 	// Run the default LLVM optimization pipeline selected by the requested -O level.
 	if ctx.passOpt {
@@ -2141,6 +2142,7 @@ func printCompiledPackage(conf *Config, pkg *aPackage) {
 }
 
 func exportObject(ctx *context, pkgPath string, exportFile string, pkg llssa.Package) (string, error) {
+	applySizeOptimizationAttributes(pkg.Module(), ctx.buildConf.OptLevel)
 	if useInMemoryNativeCodegen(ctx) {
 		return exportObjectInMemory(ctx, pkgPath, exportFile, pkg)
 	}
@@ -2795,10 +2797,33 @@ func effectiveOptLevel(conf *Config) optlevel.Level {
 	if conf != nil && conf.OptLevel.IsValid() {
 		return conf.OptLevel
 	}
-	if conf != nil && conf.Target != "" {
-		return optlevel.Oz
+	return optlevel.Default
+}
+
+// applySizeOptimizationAttributes records the per-function size policy that
+// LLVM preserves in bitcode and consumes during both ordinary and LTO
+// optimization/code generation. The PassBuilder's Os/Oz pipeline selection is
+// not sufficient by itself: unlike Clang's frontend, it does not add these
+// attributes to existing IR.
+func applySizeOptimizationAttributes(mod gllvm.Module, level optlevel.Level) {
+	if level != optlevel.Os && level != optlevel.Oz {
+		return
 	}
-	return optlevel.O2
+	ctx := mod.Context()
+	optSize := ctx.CreateEnumAttribute(gllvm.AttributeKindID("optsize"), 0)
+	var minSize gllvm.Attribute
+	if level == optlevel.Oz {
+		minSize = ctx.CreateEnumAttribute(gllvm.AttributeKindID("minsize"), 0)
+	}
+	for fn := mod.FirstFunction(); !fn.IsNil(); fn = gllvm.NextFunction(fn) {
+		if fn.IsDeclaration() {
+			continue
+		}
+		fn.AddFunctionAttr(optSize)
+		if !minSize.IsNil() {
+			fn.AddFunctionAttr(minSize)
+		}
+	}
 }
 
 func llvmPassPipeline(level optlevel.Level, ltoMode lto.Mode) string {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2797,6 +2797,9 @@ func effectiveOptLevel(conf *Config) optlevel.Level {
 	if conf != nil && conf.OptLevel.IsValid() {
 		return conf.OptLevel
 	}
+	if conf != nil && conf.Target != "" {
+		return optlevel.TargetDefault
+	}
 	return optlevel.Default
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -101,8 +101,8 @@ func TestResolveBuildConfigDefaultsAndValidation(t *testing.T) {
 	if resolved.SizeFormat != "text" || resolved.SizeLevel != "module" {
 		t.Fatalf("size report defaults = %q, %q", resolved.SizeFormat, resolved.SizeLevel)
 	}
-	if resolved.OptLevel != optlevel.Oz {
-		t.Fatalf("default optimization level = %v, want %v", resolved.OptLevel, optlevel.Oz)
+	if resolved.OptLevel != optlevel.Os {
+		t.Fatalf("default optimization level = %v, want %v", resolved.OptLevel, optlevel.Os)
 	}
 	if _, err := resolveBuildConfig(&Config{SizeReport: true, SizeLevel: "invalid"}); err == nil {
 		t.Fatal("invalid size-reporting level succeeded")

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/xgo-dev/llgo/internal/lto"
 	"github.com/xgo-dev/llgo/internal/meta"
 	"github.com/xgo-dev/llgo/internal/mockable"
+	"github.com/xgo-dev/llgo/internal/optlevel"
 	"github.com/xgo-dev/llgo/internal/packages"
 	llssa "github.com/xgo-dev/llgo/ssa"
 	"github.com/xgo-dev/llvm"
@@ -99,6 +100,9 @@ func TestResolveBuildConfigDefaultsAndValidation(t *testing.T) {
 	}
 	if resolved.SizeFormat != "text" || resolved.SizeLevel != "module" {
 		t.Fatalf("size report defaults = %q, %q", resolved.SizeFormat, resolved.SizeLevel)
+	}
+	if resolved.OptLevel != optlevel.Oz {
+		t.Fatalf("default optimization level = %v, want %v", resolved.OptLevel, optlevel.Oz)
 	}
 	if _, err := resolveBuildConfig(&Config{SizeReport: true, SizeLevel: "invalid"}); err == nil {
 		t.Fatal("invalid size-reporting level succeeded")

--- a/internal/build/optlevel_test.go
+++ b/internal/build/optlevel_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestEffectiveOptLevelDefaults(t *testing.T) {
 	t.Setenv(llgoOptimize, "")
-	if got := effectiveOptLevel(&Config{}); got != optlevel.Oz {
-		t.Fatalf("host default opt level = %v, want %v", got, optlevel.Oz)
+	if got := effectiveOptLevel(&Config{}); got != optlevel.Os {
+		t.Fatalf("host default opt level = %v, want %v", got, optlevel.Os)
 	}
 	if got := effectiveOptLevel(&Config{Target: "rp2040"}); got != optlevel.Oz {
 		t.Fatalf("target default opt level = %v, want %v", got, optlevel.Oz)
@@ -29,13 +29,13 @@ func TestEffectiveOptLevelOverride(t *testing.T) {
 
 func TestEffectiveOptLevelIgnoresLegacyEnv(t *testing.T) {
 	t.Setenv(llgoOptimize, "off")
-	if got := effectiveOptLevel(&Config{}); got != optlevel.Oz {
-		t.Fatalf("LLGO_OPTIMIZE=off opt level = %v, want %v", got, optlevel.Oz)
+	if got := effectiveOptLevel(&Config{}); got != optlevel.Os {
+		t.Fatalf("LLGO_OPTIMIZE=off opt level = %v, want %v", got, optlevel.Os)
 	}
 
 	t.Setenv(llgoOptimize, "on")
-	if got := effectiveOptLevel(&Config{}); got != optlevel.Oz {
-		t.Fatalf("LLGO_OPTIMIZE=on opt level = %v, want %v", got, optlevel.Oz)
+	if got := effectiveOptLevel(&Config{}); got != optlevel.Os {
+		t.Fatalf("LLGO_OPTIMIZE=on opt level = %v, want %v", got, optlevel.Os)
 	}
 }
 

--- a/internal/build/optlevel_test.go
+++ b/internal/build/optlevel_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/xgo-dev/llgo/internal/lto"
 	"github.com/xgo-dev/llgo/internal/optlevel"
+	"github.com/xgo-dev/llvm"
 )
 
 func TestEffectiveOptLevelDefaults(t *testing.T) {
 	t.Setenv(llgoOptimize, "")
-	if got := effectiveOptLevel(&Config{}); got != optlevel.O2 {
-		t.Fatalf("host default opt level = %v, want %v", got, optlevel.O2)
+	if got := effectiveOptLevel(&Config{}); got != optlevel.Oz {
+		t.Fatalf("host default opt level = %v, want %v", got, optlevel.Oz)
 	}
 	if got := effectiveOptLevel(&Config{Target: "rp2040"}); got != optlevel.Oz {
 		t.Fatalf("target default opt level = %v, want %v", got, optlevel.Oz)
@@ -28,13 +29,56 @@ func TestEffectiveOptLevelOverride(t *testing.T) {
 
 func TestEffectiveOptLevelIgnoresLegacyEnv(t *testing.T) {
 	t.Setenv(llgoOptimize, "off")
-	if got := effectiveOptLevel(&Config{}); got != optlevel.O2 {
-		t.Fatalf("LLGO_OPTIMIZE=off opt level = %v, want %v", got, optlevel.O2)
+	if got := effectiveOptLevel(&Config{}); got != optlevel.Oz {
+		t.Fatalf("LLGO_OPTIMIZE=off opt level = %v, want %v", got, optlevel.Oz)
 	}
 
 	t.Setenv(llgoOptimize, "on")
-	if got := effectiveOptLevel(&Config{}); got != optlevel.O2 {
-		t.Fatalf("LLGO_OPTIMIZE=on opt level = %v, want %v", got, optlevel.O2)
+	if got := effectiveOptLevel(&Config{}); got != optlevel.Oz {
+		t.Fatalf("LLGO_OPTIMIZE=on opt level = %v, want %v", got, optlevel.Oz)
+	}
+}
+
+func TestApplySizeOptimizationAttributes(t *testing.T) {
+	tests := []struct {
+		level       optlevel.Level
+		wantOptSize bool
+		wantMinSize bool
+	}{
+		{level: optlevel.O2},
+		{level: optlevel.Os, wantOptSize: true},
+		{level: optlevel.Oz, wantOptSize: true, wantMinSize: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.level.String(), func(t *testing.T) {
+			ctx := llvm.NewContext()
+			defer ctx.Dispose()
+			mod := ctx.NewModule("size-attributes")
+			defer mod.Dispose()
+
+			fnType := llvm.FunctionType(ctx.VoidType(), nil, false)
+			defined := llvm.AddFunction(mod, "defined", fnType)
+			block := ctx.AddBasicBlock(defined, "entry")
+			builder := ctx.NewBuilder()
+			builder.SetInsertPointAtEnd(block)
+			builder.CreateRetVoid()
+			builder.Dispose()
+			declared := llvm.AddFunction(mod, "declared", fnType)
+
+			applySizeOptimizationAttributes(mod, tt.level)
+			optSizeKind := llvm.AttributeKindID("optsize")
+			minSizeKind := llvm.AttributeKindID("minsize")
+			if got := !defined.GetEnumFunctionAttribute(optSizeKind).IsNil(); got != tt.wantOptSize {
+				t.Fatalf("defined optsize = %v, want %v", got, tt.wantOptSize)
+			}
+			if got := !defined.GetEnumFunctionAttribute(minSizeKind).IsNil(); got != tt.wantMinSize {
+				t.Fatalf("defined minsize = %v, want %v", got, tt.wantMinSize)
+			}
+			if !declared.GetEnumFunctionAttribute(optSizeKind).IsNil() ||
+				!declared.GetEnumFunctionAttribute(minSizeKind).IsNil() {
+				t.Fatal("size attributes should not be added to declarations")
+			}
+		})
 	}
 }
 

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -86,6 +86,7 @@ func compilePkgSFiles(ctx *context, aPkg *aPackage, pkg *packages.Package, verbo
 			llabi.LowerLargeAggregates(ctx.prog.TargetData(), mod)
 			ctx.cTransformer.TransformModule(pkg.PkgPath, mod)
 		}
+		applySizeOptimizationAttributes(mod, ctx.buildConf.OptLevel)
 		ll := mod.String()
 		mod.Dispose()
 

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -217,6 +217,21 @@ func compileWithConfig(
 	return
 }
 
+// ltoLinkerOptFlag maps LLGo's optimization level to lld's numeric LTO
+// optimizer level. lld accepts only O0 through O3 here; Os/Oz are carried by
+// the optsize/minsize function attributes in LLGo's bitcode and use O2 as
+// LLVM's corresponding speed level.
+func ltoLinkerOptFlag(level optlevel.Level) string {
+	switch level {
+	case optlevel.O0, optlevel.O1, optlevel.O2, optlevel.O3:
+		return "--lto-" + level.Name()
+	case optlevel.Os, optlevel.Oz:
+		return "--lto-O2"
+	default:
+		return ""
+	}
+}
+
 func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode, goGlobalDCE bool) (export Export, err error) {
 	targetTriple := llvm.GetTargetTriple(goos, goarch)
 	llgoRoot := env.LLGoROOT()
@@ -252,7 +267,10 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 			"-Wl,--icf=none",
 		}
 		if ltoMode.Enabled() {
-			export.LDFLAGS = append(export.LDFLAGS, ltoMode.ClangFlag(), "-Wl,--lto"+level.Flag())
+			export.LDFLAGS = append(export.LDFLAGS, ltoMode.ClangFlag())
+			if optFlag := ltoLinkerOptFlag(level); optFlag != "" {
+				export.LDFLAGS = append(export.LDFLAGS, "-Wl,"+optFlag)
+			}
 		}
 		if clangRoot != "" {
 			clangLib := filepath.Join(clangRoot, "lib")
@@ -543,7 +561,9 @@ func UseTarget(targetName string, level optlevel.Level, ltoMode lto.Mode) (expor
 	cflags = append(cflags, expandedCFlags...)
 
 	if config.Linker == "ld.lld" && ltoMode.Enabled() {
-		ldflags = append(ldflags, "--lto"+level.Flag())
+		if optFlag := ltoLinkerOptFlag(level); optFlag != "" {
+			ldflags = append(ldflags, optFlag)
+		}
 		cflags = append(cflags, ltoMode.ClangFlag())
 		ccflags = append(ccflags, ltoMode.ClangFlag())
 	}

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -394,6 +394,28 @@ func TestOptimizationFlagPlacement(t *testing.T) {
 	}
 }
 
+func TestLTOLinkerOptFlag(t *testing.T) {
+	tests := []struct {
+		level optlevel.Level
+		want  string
+	}{
+		{level: optlevel.O0, want: "--lto-O0"},
+		{level: optlevel.O1, want: "--lto-O1"},
+		{level: optlevel.O2, want: "--lto-O2"},
+		{level: optlevel.O3, want: "--lto-O3"},
+		{level: optlevel.Os, want: "--lto-O2"},
+		{level: optlevel.Oz, want: "--lto-O2"},
+		{level: optlevel.Unset, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.level.String(), func(t *testing.T) {
+			if got := ltoLinkerOptFlag(tt.level); got != tt.want {
+				t.Fatalf("ltoLinkerOptFlag(%v) = %q, want %q", tt.level, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 	export, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Off, false)
 	if err != nil {
@@ -428,6 +450,17 @@ func TestDevLTOGlobalDCEUseLTOFlagsControlledByOption(t *testing.T) {
 	}
 	if !slices.Contains(thin.LDFLAGS, "-Wl,--lto-O2") {
 		t.Fatalf("missing thin LTO linker opt flag: %v", thin.LDFLAGS)
+	}
+
+	thinSize, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.Oz, lto.Thin, false)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !slices.Contains(thinSize.LDFLAGS, "-Wl,--lto-O2") {
+		t.Fatalf("missing numeric thin LTO linker opt flag for Oz: %v", thinSize.LDFLAGS)
+	}
+	if slices.Contains(thinSize.LDFLAGS, "-Wl,--lto-Oz") {
+		t.Fatalf("invalid size-valued thin LTO linker opt flag: %v", thinSize.LDFLAGS)
 	}
 
 	full, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Full, false)
@@ -503,6 +536,12 @@ func TestUseTargetCodegenFlagsOnlyAddedToLDFlagsWithLTO(t *testing.T) {
 	}
 	if !slices.Contains(withLTO.CCFLAGS, "-flto=thin") {
 		t.Fatalf("missing thin LTO ccflag: %v", withLTO.CCFLAGS)
+	}
+	if !slices.Contains(withLTO.LDFLAGS, "--lto-O2") {
+		t.Fatalf("missing numeric thin LTO linker opt flag for Oz: %v", withLTO.LDFLAGS)
+	}
+	if slices.Contains(withLTO.LDFLAGS, "--lto-Oz") {
+		t.Fatalf("invalid size-valued thin LTO linker opt flag: %v", withLTO.LDFLAGS)
 	}
 	if !hasMllvmOption(withLTO.LDFLAGS, "-code-model=medium") {
 		t.Fatalf("missing -mllvm -code-model=medium in LDFLAGS when LTO enabled: %v", withLTO.LDFLAGS)

--- a/internal/optlevel/optlevel.go
+++ b/internal/optlevel/optlevel.go
@@ -17,6 +17,8 @@ const (
 	Oz
 )
 
+const Default = Oz
+
 func Parse(level string) (Level, error) {
 	normalized := strings.TrimSpace(strings.ToLower(level))
 	normalized = strings.TrimPrefix(normalized, "-")

--- a/internal/optlevel/optlevel.go
+++ b/internal/optlevel/optlevel.go
@@ -17,7 +17,10 @@ const (
 	Oz
 )
 
-const Default = Oz
+const (
+	Default       = Os
+	TargetDefault = Oz
+)
 
 func Parse(level string) (Level, error) {
 	normalized := strings.TrimSpace(strings.ToLower(level))

--- a/internal/pclnpost/external.go
+++ b/internal/pclnpost/external.go
@@ -179,22 +179,24 @@ func externalPCLineSites(info *binaryInfo, records []siteRecord) []ExternalSite 
 			OwnerSymbol: sym.name,
 		})
 	}
-	sort.Slice(sites, func(i, j int) bool {
-		if sites[i].PCOffset != sites[j].PCOffset {
-			return sites[i].PCOffset < sites[j].PCOffset
-		}
-		if sites[i].ID != sites[j].ID {
-			return sites[i].ID < sites[j].ID
-		}
-		return sites[i].OwnerSymbol < sites[j].OwnerSymbol
+	// Preserve linker-section order for records at the same PC. Consecutive
+	// zero-byte anchors use that order to make the last source statement win.
+	sort.SliceStable(sites, func(i, j int) bool {
+		return sites[i].PCOffset < sites[j].PCOffset
 	})
 	if len(sites) < 2 {
 		return sites
 	}
-	out := sites[:1]
-	for _, site := range sites[1:] {
-		last := out[len(out)-1]
-		if site.PCOffset == last.PCOffset && site.ID == last.ID && site.OwnerSymbol == last.OwnerSymbol {
+	out := sites[:0]
+	for _, site := range sites {
+		duplicate := false
+		for i := len(out) - 1; i >= 0 && out[i].PCOffset == site.PCOffset; i-- {
+			if out[i].ID == site.ID && out[i].OwnerSymbol == site.OwnerSymbol {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
 			continue
 		}
 		out = append(out, site)

--- a/internal/pclnpost/external_test.go
+++ b/internal/pclnpost/external_test.go
@@ -330,12 +330,14 @@ func TestExternalSitesFilterSortAndDedupe(t *testing.T) {
 
 	pcRecords := []siteRecord{
 		{pc: 0x1148, symbolID: 2},
+		{pc: 0x1108, symbolID: 3},
 		{pc: 0x1108, symbolID: 1},
-		{pc: 0x1108, symbolID: 1},
+		{pc: 0x1108, symbolID: 3}, // exact duplicate separated by another ID
 		{pc: 0x1180, symbolID: 3}, // text but no symbol owner
 		{pc: 0x1080, symbolID: 4},
 	}
 	wantPC := []ExternalSite{
+		{PCOffset: 0x108, ID: 3, OwnerSymbol: "example.com/p.A"},
 		{PCOffset: 0x108, ID: 1, OwnerSymbol: "example.com/p.A"},
 		{PCOffset: 0x148, ID: 2, OwnerSymbol: "example.com/p.B"},
 	}

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -939,6 +939,35 @@ bool collectStringSetFromFunctionStringValueArg(
   return true;
 }
 
+// Size-oriented pre-link pipelines can deliberately leave small string
+// helpers uninlined. Follow a direct callee's return values so a finite set of
+// names remains visible to the MethodByName refinement without depending on
+// the inliner. Unknown or recursive return flows still fail closed through the
+// existing depth bound.
+bool collectStringSetFromDirectCallReturn(
+    CallBase *CB, const DataLayout &DL,
+    SmallVectorImpl<std::string> &Names, unsigned Depth) {
+  if (!CB)
+    return false;
+
+  auto *Callee = dyn_cast<Function>(CB->getCalledOperand()->stripPointerCasts());
+  if (!Callee || Callee->isDeclaration())
+    return false;
+
+  bool SawReturn = false;
+  for (BasicBlock &BB : *Callee) {
+    auto *Ret = dyn_cast<ReturnInst>(BB.getTerminator());
+    if (!Ret)
+      continue;
+    Value *ReturnValue = Ret->getReturnValue();
+    if (!ReturnValue ||
+        !collectStringSetFromStringValue(ReturnValue, DL, Names, Depth + 1))
+      return false;
+    SawReturn = true;
+  }
+  return SawReturn;
+}
+
 bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
                                      SmallVectorImpl<std::string> &Names,
                                      unsigned Depth) {
@@ -952,6 +981,8 @@ bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
     if (collectStringSetFromStringSlice2(CB, DL, Names, Depth))
       return true;
     if (collectStringSetFromStringCat(CB, DL, Names, Depth))
+      return true;
+    if (collectStringSetFromDirectCallReturn(CB, DL, Names, Depth))
       return true;
   }
 

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -221,6 +221,7 @@ var runtimePCSiteEnd *runtimePCSiteRecord
 
 type runtimePCLineFrame struct {
 	pc        uintptr
+	sequence  uintptr
 	entry     uintptr
 	function  string
 	file      string
@@ -1672,6 +1673,7 @@ func initRuntimePCLineFramesOnce() {
 		}
 		*(*runtimePCLineFrame)(unsafe.Add(frameBase, uintptr(nframes)*frameSize)) = runtimePCLineFrame{
 			pc:        pc,
+			sequence:  i,
 			entry:     entry,
 			function:  fc.function,
 			file:      file,
@@ -1740,25 +1742,35 @@ func swapRuntimePCLineFrames(base unsafe.Pointer, i, j int) {
 	*right = tmp
 }
 
+func runtimePCLineFrameLess(left, right *runtimePCLineFrame) bool {
+	if left.pc != right.pc {
+		return left.pc < right.pc
+	}
+	// PC anchors do not emit text bytes, so consecutive source statements can
+	// have the same address after optimization. Preserve their linker-section
+	// order and let deduplication below retain the last emitted statement.
+	return left.sequence < right.sequence
+}
+
 func quickSortRuntimePCLineFrames(base unsafe.Pointer, lo, hi int) {
 	for hi-lo > 16 {
 		mid := int(uint(lo+hi) >> 1)
-		if runtimePCLineFrameAt(base, mid).pc < runtimePCLineFrameAt(base, lo).pc {
+		if runtimePCLineFrameLess(runtimePCLineFrameAt(base, mid), runtimePCLineFrameAt(base, lo)) {
 			swapRuntimePCLineFrames(base, mid, lo)
 		}
-		if runtimePCLineFrameAt(base, hi).pc < runtimePCLineFrameAt(base, mid).pc {
+		if runtimePCLineFrameLess(runtimePCLineFrameAt(base, hi), runtimePCLineFrameAt(base, mid)) {
 			swapRuntimePCLineFrames(base, hi, mid)
 		}
-		if runtimePCLineFrameAt(base, mid).pc < runtimePCLineFrameAt(base, lo).pc {
+		if runtimePCLineFrameLess(runtimePCLineFrameAt(base, mid), runtimePCLineFrameAt(base, lo)) {
 			swapRuntimePCLineFrames(base, mid, lo)
 		}
-		pivot := runtimePCLineFrameAt(base, mid).pc
+		pivot := *runtimePCLineFrameAt(base, mid)
 		i, j := lo, hi
 		for {
-			for runtimePCLineFrameAt(base, i).pc < pivot {
+			for runtimePCLineFrameLess(runtimePCLineFrameAt(base, i), &pivot) {
 				i++
 			}
-			for runtimePCLineFrameAt(base, j).pc > pivot {
+			for runtimePCLineFrameLess(&pivot, runtimePCLineFrameAt(base, j)) {
 				j--
 			}
 			if i >= j {
@@ -1779,7 +1791,7 @@ func quickSortRuntimePCLineFrames(base unsafe.Pointer, lo, hi int) {
 	for i := lo + 1; i <= hi; i++ {
 		x := *runtimePCLineFrameAt(base, i)
 		j := i - 1
-		for j >= lo && runtimePCLineFrameAt(base, j).pc > x.pc {
+		for j >= lo && runtimePCLineFrameLess(&x, runtimePCLineFrameAt(base, j)) {
 			*runtimePCLineFrameAt(base, j+1) = *runtimePCLineFrameAt(base, j)
 			j--
 		}

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -75,6 +75,9 @@ func (p *Target) effectiveOptLevel() optlevel.Level {
 	if p != nil && p.OptLevel.IsValid() {
 		return p.OptLevel
 	}
+	if p != nil && p.Target != "" {
+		return optlevel.TargetDefault
+	}
 	return optlevel.Default
 }
 

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -75,10 +75,7 @@ func (p *Target) effectiveOptLevel() optlevel.Level {
 	if p != nil && p.OptLevel.IsValid() {
 		return p.OptLevel
 	}
-	if p != nil && p.Target != "" {
-		return optlevel.Oz
-	}
-	return optlevel.O2
+	return optlevel.Default
 }
 
 func (p *Target) codeGenOptLevel() llvm.CodeGenOptLevel {

--- a/ssa/target_optlevel_test.go
+++ b/ssa/target_optlevel_test.go
@@ -51,8 +51,8 @@ func TestTargetCodeGenOptLevel(t *testing.T) {
 }
 
 func TestTargetDefaultOptLevel(t *testing.T) {
-	if got := (&Target{}).effectiveOptLevel(); got != optlevel.O2 {
-		t.Fatalf("host default opt level = %v, want %v", got, optlevel.O2)
+	if got := (&Target{}).effectiveOptLevel(); got != optlevel.Oz {
+		t.Fatalf("host default opt level = %v, want %v", got, optlevel.Oz)
 	}
 	if got := (&Target{Target: "rp2040"}).effectiveOptLevel(); got != optlevel.Oz {
 		t.Fatalf("target default opt level = %v, want %v", got, optlevel.Oz)

--- a/ssa/target_optlevel_test.go
+++ b/ssa/target_optlevel_test.go
@@ -51,8 +51,8 @@ func TestTargetCodeGenOptLevel(t *testing.T) {
 }
 
 func TestTargetDefaultOptLevel(t *testing.T) {
-	if got := (&Target{}).effectiveOptLevel(); got != optlevel.Oz {
-		t.Fatalf("host default opt level = %v, want %v", got, optlevel.Oz)
+	if got := (&Target{}).effectiveOptLevel(); got != optlevel.Os {
+		t.Fatalf("host default opt level = %v, want %v", got, optlevel.Os)
 	}
 	if got := (&Target{Target: "rp2040"}).effectiveOptLevel(); got != optlevel.Oz {
 		t.Fatalf("target default opt level = %v, want %v", got, optlevel.Oz)


### PR DESCRIPTION
## Summary

- default native host builds to `Os` and named-target builds to `Oz`, while preserving explicit `-O0` through `-Oz` overrides
- avoid the AArch64 Machine Outliner and Mach-O symbol-table regressions observed with host-wide `Oz`, while keeping the strongest size policy for embedded and other named targets
- attach LLVM `optsize`/`minsize` function attributes to LLGo and translated Plan 9 assembly modules so the target `Oz` policy survives in bitcode and is visible to Full/Thin LTO
- keep the size-oriented pre-link pipelines and map `Os`/`Oz` to the numeric `--lto-O2` linker setting, since lld does not accept `--lto-Os` or `--lto-Oz`
- let the LTO MethodByName pass recover finite string sets from direct helper returns, so size-oriented pre-link inlining decisions do not prevent method pruning
- preserve linker-section order for same-PC line anchors in embedded and external PCLN data, so the later source statement wins when optimized instructions collapse to one address
- let the bare-metal conservative GC fixture settle for one extra cycle before requiring complete nested-graph reclamation, accounting for dead Xtensa register-window spills without weakening the final six-object check

## Testing

- `go test ./internal/optlevel ./cmd/internal/flags ./internal/build ./ssa`
- `go test ./internal/crosscompile ./cmd/llgo ./cmd/internal/...`
- native default output matched explicit `-Os` byte-for-byte at the same output path and contained no `_OUTLINED_FUNCTION_*` symbols
- ESP32-C3 default build completed with `-Oz`; Full LTO completed with `-Oz -flto=full`, linker `--lto-O2`, and `optsize minsize` on retained LLGo IR
- `go test ./cmd/internal/flags ./internal/build ./internal/crosscompile ./internal/optlevel ./internal/lto ./ssa ./cl -count=1`
- `go test ./internal/pclnpost -count=1`
- `GOWORK=off go test ./internal/lib/runtime -count=1` (from `runtime`)
- `go test -vet=off ./test/go -run ^TestRuntimeStatementLineInfo$ -count=1 -v` on macOS/Go 1.26 and Ubuntu/Go 1.25 with LLVM 19
- full Ubuntu LLVM 19 `TestBuildAndCheckSymbolsFromTestltoLTOPlugin` matrix with a freshly rebuilt plugin
- focused Ubuntu runtime and symbol checks for `globaldce_reflect_method_by_name_ltoplugin`
- Ubuntu runtime statement-line probe with both embedded and external PCLN
- ESP32/Xtensa and ESP32-C3/RISC-V full `gc-runtime` fixtures under the CI-matched Espressif QEMU, both ending in `OK`
- `./dev/llgo.sh run -a -lto=full ./cl/_testrt/hello`
- `./dev/llgo.sh run -a -lto=thin ./cl/_testrt/hello`
- `git diff --check`