### PR TITLE
cl: extend static initialization for aggregate values

### DIFF
--- a/cl/_testrt/mapclosure/in.go
+++ b/cl/_testrt/mapclosure/in.go
@@ -5,6 +5,7 @@ type Type interface {
 	String() string
 }
 
+// CHECK: @"main.list$data" = global [1 x { ptr, ptr }] [{ ptr, ptr } { ptr @main.demo, ptr null }]
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.demo(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK: [[DEMO_DATA:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
 // CHECK: [[DEMO_METHOD:%[0-9]+]] = load ptr, ptr %{{[0-9]+}}
@@ -32,8 +33,6 @@ var (
 // CHECK: [[OP_SLOT:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.MapAssignFastStr"(ptr @"map[_llgo_string]_llgo_closure${{[-A-Za-z0-9_]+}}", ptr [[OP_MAP]], %"{{.*}}/runtime/internal/runtime.String" {{.*}})
 // CHECK-NEXT: store { ptr, ptr } { ptr @main.demo, ptr null }, ptr [[OP_SLOT]]
 // CHECK-NEXT: store ptr [[OP_MAP]], ptr @main.op
-// CHECK: store { ptr, ptr } { ptr @main.demo, ptr null }, ptr [[LIST_ELEM:%[0-9]+]]
-// CHECK: store %"{{.*}}/runtime/internal/runtime.Slice" [[LIST:%[0-9]+]], ptr @main.list
 // CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: [[TYP:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK: [[LOADED_MAP:%[0-9]+]] = load ptr, ptr @main.op

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -513,6 +513,143 @@ func Use() int { return Entries[0].Points[1].X + len(Entries[0].Label) }
 	}
 }
 
+func TestStaticGlobalNestedSliceLiteralInit(t *testing.T) {
+	const src = `package staticinit
+
+type EventSpec struct {
+	Name     string
+	Args     []string
+	StackIDs []int
+}
+
+var specs = [2]EventSpec{
+	{Name: "first", Args: []string{"time", "stack"}, StackIDs: []int{1}},
+	{Name: "second", Args: []string{"id"}},
+}
+
+func Use() int { return len(specs[0].Args) + specs[0].StackIDs[0] }
+`
+	ir := compileWithRewrites(t, src, nil)
+	for _, want := range []string{
+		`@staticinit.specs = global [2 x %staticinit.EventSpec]`,
+		`@"staticinit.specs$data$0$1" = global [2 x %"github.com/xgo-dev/llgo/runtime/internal/runtime.String"]`,
+		`@"staticinit.specs$data$0$2" = global [1 x i64]`,
+		`@"staticinit.specs$data$1$1" = global [1 x %"github.com/xgo-dev/llgo/runtime/internal/runtime.String"]`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing nested slice initializer %q in IR:\n%s", want, ir)
+		}
+	}
+	if strings.Contains(ir, `@staticinit.specs = global [2 x %staticinit.EventSpec] zeroinitializer`) {
+		t.Fatalf("nested slices left the root global zero-initialized:\n%s", ir)
+	}
+	assertNoStoreToGlobal(t, ir, "@staticinit.specs")
+	if strings.Contains(ir, "runtime.AllocZ") {
+		t.Fatalf("nested slice initializer still allocates at runtime:\n%s", ir)
+	}
+}
+
+func TestStaticGlobalFunctionTableInit(t *testing.T) {
+	const src = `package staticinit
+
+type Handler struct {
+	Name string
+	Call func(int) int
+}
+
+func plusOne(v int) int { return v + 1 }
+func timesTwo(v int) int { return v * 2 }
+
+var Handlers = []*Handler{
+	{Name: "plus", Call: plusOne},
+	{Name: "times", Call: timesTwo},
+}
+
+func Use(v int) int { return Handlers[0].Call(v) }
+`
+	ir := compileWithRewrites(t, src, nil)
+	for _, want := range []string{
+		`@"staticinit.Handlers$data" = global [2 x ptr] [ptr @"staticinit.Handlers$data$0", ptr @"staticinit.Handlers$data$1"]`,
+		`@"staticinit.Handlers$data$0" = global %staticinit.Handler`,
+		`@"staticinit.Handlers$data$1" = global %staticinit.Handler`,
+		`{ ptr @staticinit.plusOne, ptr null }`,
+		`{ ptr @staticinit.timesTwo, ptr null }`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing static function table initializer %q in IR:\n%s", want, ir)
+		}
+	}
+	assertNoStoreToGlobal(t, ir, "@staticinit.Handlers")
+	if strings.Contains(ir, "runtime.AllocZ") {
+		t.Fatalf("static function table still allocates at runtime:\n%s", ir)
+	}
+}
+
+func TestStaticGlobalExplicitEnvFunctionFallsBack(t *testing.T) {
+	const src = `package staticinit
+
+//llgo:env
+func withEnv(v int) int { return v }
+
+var Handlers = []func(int) int{withEnv}
+
+func Use(v int) int { return Handlers[0](v) }
+`
+	ir := compileWithRewrites(t, src, nil)
+	if strings.Contains(ir, `@"staticinit.Handlers$data"`) {
+		t.Fatalf("explicit-env function unexpectedly used a static function table:\n%s", ir)
+	}
+	assertStoreToGlobal(t, ir, "@staticinit.Handlers")
+}
+
+func TestStaticGlobalZeroSizedPointerLiteralFallsBack(t *testing.T) {
+	const src = `package foo
+
+var Values = []*struct{}{{}}
+`
+	ssapkg := buildSSAPackage(t, src)
+	global := ssapkg.Members["Values"].(*ssa.Global)
+	initFn := ssapkg.Func("init")
+	var globalStore *ssa.Store
+	for _, block := range initFn.Blocks {
+		for _, instr := range block.Instrs {
+			if store, ok := instr.(*ssa.Store); ok && store.Addr == global {
+				globalStore = store
+			}
+		}
+	}
+	if globalStore == nil {
+		t.Fatal("store to Values not found")
+	}
+	if _, ok := staticSliceInitOf(globalStore); ok {
+		t.Fatal("zero-sized pointer values unexpectedly accepted by static slice folding")
+	}
+}
+
+func TestStaticGlobalInterfaceLiteralFallsBack(t *testing.T) {
+	const src = `package foo
+
+var Values = []any{1, "two"}
+`
+	ssapkg := buildSSAPackage(t, src)
+	global := ssapkg.Members["Values"].(*ssa.Global)
+	initFn := ssapkg.Func("init")
+	var globalStore *ssa.Store
+	for _, block := range initFn.Blocks {
+		for _, instr := range block.Instrs {
+			if store, ok := instr.(*ssa.Store); ok && store.Addr == global {
+				globalStore = store
+			}
+		}
+	}
+	if globalStore == nil {
+		t.Fatal("store to Values not found")
+	}
+	if _, ok := staticSliceInitOf(globalStore); ok {
+		t.Fatal("interface values unexpectedly accepted by static slice folding")
+	}
+}
+
 func TestStaticGlobalStructSliceDynamicFieldFallsBack(t *testing.T) {
 	const src = `package staticinit
 
@@ -769,7 +906,7 @@ func Use() string { return Zulu + Alpha }
 	}
 }
 
-func TestStaticGlobalInitSkipsLargeArray(t *testing.T) {
+func TestStaticGlobalInitFoldsLargeByteArray(t *testing.T) {
 	length := maxStaticInitArrayElements + 1
 	src := fmt.Sprintf(`package staticinit
 
@@ -778,11 +915,14 @@ var Large = [%d]byte{%d: 1}
 func Use() byte { return Large[%d] }
 `, length, length-1, length-1)
 	ir := compileWithRewrites(t, src, nil)
-	want := fmt.Sprintf("@staticinit.Large = global [%d x i8] zeroinitializer", length)
+	want := fmt.Sprintf("@staticinit.Large = global [%d x i8] c\"", length)
 	if !strings.Contains(ir, want) {
-		t.Fatalf("large array should keep a zero initializer:\n%s", ir)
+		t.Fatalf("large byte array should use a compact static initializer")
 	}
-	assertStoreToGlobal(t, ir, "@staticinit.Large")
+	if strings.Contains(ir, fmt.Sprintf("@staticinit.Large = global [%d x i8] zeroinitializer", length)) {
+		t.Fatal("large byte array still uses a zero initializer")
+	}
+	assertNoStoreToGlobal(t, ir, "@staticinit.Large")
 }
 
 func TestStaticInitHelperRejectsUnsupportedPaths(t *testing.T) {

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -585,6 +585,25 @@ func Use(v int) int { return Handlers[0].Call(v) }
 	}
 }
 
+func TestStaticGlobalPointerArrayInit(t *testing.T) {
+	const src = `package staticinit
+
+var Values = []*[2]int{{1, 2}}
+
+func Use() int { return Values[0][1] }
+`
+	ir := compileWithRewrites(t, src, nil)
+	for _, want := range []string{
+		`@"staticinit.Values$data" = global [1 x ptr] [ptr @"staticinit.Values$data$0"]`,
+		`@"staticinit.Values$data$0" = global [2 x i64] [i64 1, i64 2]`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing static pointer-array initializer %q in IR:\n%s", want, ir)
+		}
+	}
+	assertNoStoreToGlobal(t, ir, "@staticinit.Values")
+}
+
 func TestStaticGlobalExplicitEnvFunctionFallsBack(t *testing.T) {
 	const src = `package staticinit
 
@@ -925,6 +944,21 @@ func Use() byte { return Large[%d] }
 	assertNoStoreToGlobal(t, ir, "@staticinit.Large")
 }
 
+func TestStaticGlobalInitSkipsLargeByteSlice(t *testing.T) {
+	length := maxStaticInitArrayElements + 1
+	src := fmt.Sprintf(`package staticinit
+
+var Large = []byte{%d: 1}
+
+func Use() byte { return Large[%d] }
+`, length-1, length-1)
+	ir := compileWithRewrites(t, src, nil)
+	if strings.Contains(ir, `@"staticinit.Large$data"`) {
+		t.Fatal("large byte slice should retain runtime backing allocation")
+	}
+	assertStoreToGlobal(t, ir, "@staticinit.Large")
+}
+
 func TestStaticInitHelperRejectsUnsupportedPaths(t *testing.T) {
 	if _, ok := staticInitConstIndex(nil); ok {
 		t.Fatal("nil index should not be accepted")
@@ -1203,6 +1237,117 @@ var G int
 	}
 	if _, ok := ctx.buildStaticInitExpr(types.NewPointer(types.Typ[types.Int]), new(staticInitNode)); !ok {
 		t.Fatal("empty unsupported scalar node should build a zero initializer")
+	}
+
+	if new(staticInitNode).addStore(staticInitStore{}) {
+		t.Fatal("store without a static leaf should be rejected")
+	}
+
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	if _, ok := ctx.buildStaticInitExpr(types.Typ[types.Int], &staticInitNode{
+		function: &ssa.Function{Signature: sig},
+	}); ok {
+		t.Fatal("function leaf for a non-signature type should be rejected")
+	}
+	if _, ok := ctx.buildStaticInitExpr(
+		types.NewArray(types.Typ[types.Int], maxStaticInitArrayElements+1),
+		new(staticInitNode),
+	); ok {
+		t.Fatal("large non-byte array should be rejected")
+	}
+
+	array := types.NewArray(types.Typ[types.Int], 1)
+	if _, ok := ctx.buildStaticSliceValue("data", types.Typ[types.Int], &staticSliceInit{array: array}); ok {
+		t.Fatal("non-slice type should be rejected by static slice builder")
+	}
+	if _, ok := ctx.buildStaticSliceValue("data", types.NewSlice(types.Typ[types.String]), &staticSliceInit{array: array}); ok {
+		t.Fatal("mismatched slice element type should be rejected")
+	}
+	if _, ok := ctx.buildStaticSliceValue("data", types.NewSlice(types.Typ[types.Int]), &staticSliceInit{
+		array:  array,
+		stores: []staticInitStore{{value: c}},
+	}); ok {
+		t.Fatal("slice element store without an index path should be rejected")
+	}
+	if _, ok := ctx.buildStaticSliceValue("data", types.NewSlice(types.Typ[types.Int]), &staticSliceInit{
+		array: array,
+		stores: []staticInitStore{{
+			path:  []staticInitPathElem{{index: 1}},
+			value: c,
+		}},
+	}); ok {
+		t.Fatal("out-of-range slice element store should be rejected")
+	}
+	duplicate := staticInitStore{path: []staticInitPathElem{{index: 0}}, value: c}
+	if _, ok := ctx.buildStaticSliceValue("data", types.NewSlice(types.Typ[types.Int]), &staticSliceInit{
+		array:  array,
+		stores: []staticInitStore{duplicate, duplicate},
+	}); ok {
+		t.Fatal("duplicate slice element stores should be rejected")
+	}
+	if _, ok := ctx.buildStaticPointerValue("data", types.Typ[types.Int], nil); ok {
+		t.Fatal("non-pointer type should be rejected by static pointer builder")
+	}
+
+	byteArray := types.NewArray(types.Typ[types.Uint8], 1)
+	if _, ok := staticInitByteArray(&staticInitNode{children: map[int]*staticInitNode{
+		0: {value: ssa.NewConst(constant.MakeString("x"), types.Typ[types.String])},
+	}}, byteArray); ok {
+		t.Fatal("non-integer byte array element should be rejected")
+	}
+	if _, ok := staticInitByteArray(&staticInitNode{children: map[int]*staticInitNode{
+		0: {value: ssa.NewConst(constant.MakeInt64(256), types.Typ[types.Uint8])},
+	}}, byteArray); ok {
+		t.Fatal("out-of-range byte array element should be rejected")
+	}
+}
+
+func TestStaticInitFunctionLeafVariants(t *testing.T) {
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	function := &ssa.Function{Signature: sig}
+	terminal := new(ssa.Store)
+	closure := &ssa.MakeClosure{Fn: function}
+	terminal.Val = closure
+	refs := closure.Referrers()
+	if refs == nil {
+		t.Fatal("closure referrers unavailable")
+	}
+	*refs = []ssa.Instruction{terminal}
+
+	if got, ok := staticInitFunctionOf(function, terminal); !ok || got != function {
+		t.Fatalf("direct function leaf = (%v, %v), want (%v, true)", got, ok, function)
+	}
+	if got, ok := staticInitFunctionOf(closure, terminal); !ok || got != function {
+		t.Fatalf("closure function leaf = (%v, %v), want (%v, true)", got, ok, function)
+	}
+	var stores []staticInitStore
+	var instrs []ssa.Instruction
+	if !handleStoreVal(terminal, nil, &stores, &instrs, nil) {
+		t.Fatal("valid closure leaf was rejected")
+	}
+	if len(stores) != 1 || stores[0].function != function || len(instrs) != 1 || instrs[0] != closure {
+		t.Fatalf("closure leaf collection = (%+v, %+v)", stores, instrs)
+	}
+
+	bound := &ssa.MakeClosure{Fn: function, Bindings: []ssa.Value{
+		ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int]),
+	}}
+	if _, ok := staticInitFunctionOf(bound, terminal); ok {
+		t.Fatal("closure with bindings should be rejected")
+	}
+	if _, ok := staticInitFunctionOf(&ssa.MakeClosure{
+		Fn: ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int]),
+	}, terminal); ok {
+		t.Fatal("closure with non-function code should be rejected")
+	}
+	if _, ok := staticInitFunctionOf(&ssa.MakeClosure{
+		Fn: &ssa.Function{Signature: sig, FreeVars: []*ssa.FreeVar{new(ssa.FreeVar)}},
+	}, terminal); ok {
+		t.Fatal("closure with free variables should be rejected")
+	}
+	*refs = append(*refs, new(ssa.Store))
+	if _, ok := staticInitFunctionOf(closure, terminal); ok {
+		t.Fatal("closure with an additional executable referrer should be rejected")
 	}
 }
 

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -1289,6 +1289,52 @@ var G int
 		t.Fatal("non-pointer type should be rejected by static pointer builder")
 	}
 
+	pointerPkg := buildSSAPackage(t, `package foo
+var P = &[1]int{1}
+`)
+	pointerGlobal, ok := pointerPkg.Members["P"].(*ssa.Global)
+	if !ok {
+		t.Fatalf("missing P global: %T", pointerPkg.Members["P"])
+	}
+	var pointerStore *ssa.Store
+	for _, block := range pointerPkg.Func("init").Blocks {
+		for _, instr := range block.Instrs {
+			if store, ok := instr.(*ssa.Store); ok && store.Addr == pointerGlobal {
+				pointerStore = store
+			}
+		}
+	}
+	if pointerStore == nil {
+		t.Fatal("missing store to P")
+	}
+	pointerInit, ok := staticPointerInitOfVisited(pointerStore, nil)
+	if !ok {
+		t.Fatal("valid pointer initializer was rejected")
+	}
+	if _, ok := staticPointerInitOfVisited(pointerStore, map[*ssa.Alloc]bool{pointerInit.alloc: true}); ok {
+		t.Fatal("cyclic pointer initializer should be rejected")
+	}
+	if _, ok := ctx.buildStaticPointerValue("data", types.NewPointer(types.Typ[types.Int]), pointerInit); ok {
+		t.Fatal("mismatched pointer element type should be rejected")
+	}
+	if len(pointerInit.stores) == 0 {
+		t.Fatal("pointer initializer has no element stores")
+	}
+	duplicatePointer := *pointerInit
+	duplicatePointer.stores = append(append([]staticInitStore(nil), pointerInit.stores...), pointerInit.stores[0])
+	pointerType := pointerGlobal.Type().Underlying().(*types.Pointer).Elem()
+	if _, ok := ctx.buildStaticPointerValue("data", pointerType, &duplicatePointer); ok {
+		t.Fatal("duplicate pointer element stores should be rejected")
+	}
+	invalidPointer := *pointerInit
+	invalidPointer.stores = []staticInitStore{{
+		path:  []staticInitPathElem{{index: 1}},
+		value: c,
+	}}
+	if _, ok := ctx.buildStaticPointerValue("data", pointerType, &invalidPointer); ok {
+		t.Fatal("invalid pointer element initializer should be rejected")
+	}
+
 	byteArray := types.NewArray(types.Typ[types.Uint8], 1)
 	if _, ok := staticInitByteArray(&staticInitNode{children: map[int]*staticInitNode{
 		0: {value: ssa.NewConst(constant.MakeString("x"), types.Typ[types.String])},

--- a/cl/static_init.go
+++ b/cl/static_init.go
@@ -21,14 +21,16 @@ import (
 	"go/token"
 	"go/types"
 	"sort"
+	"strconv"
 	"strings"
 
 	llssa "github.com/xgo-dev/llgo/ssa"
 	"golang.org/x/tools/go/ssa"
 )
 
-// Static folding is an optimization. Keep sparse large arrays in the package
-// initializer instead of materializing every zero element as an LLVM constant.
+// Static folding is an optimization. Keep sparse large non-byte arrays in the
+// package initializer instead of materializing every zero element as an LLVM
+// constant. Byte arrays use a compact LLVM string constant and are not capped.
 const maxStaticInitArrayElements = 1 << 16
 
 type staticInitPathElem struct {
@@ -36,9 +38,12 @@ type staticInitPathElem struct {
 }
 
 type staticInitStore struct {
-	store *ssa.Store
-	path  []staticInitPathElem
-	value *ssa.Const
+	store    *ssa.Store
+	path     []staticInitPathElem
+	value    *ssa.Const
+	function *ssa.Function
+	slice    *staticSliceInit
+	pointer  *staticPointerInit
 }
 
 type staticInitCandidate struct {
@@ -57,8 +62,17 @@ type staticSliceInit struct {
 	instrs []ssa.Instruction
 }
 
+type staticPointerInit struct {
+	alloc  *ssa.Alloc
+	stores []staticInitStore
+	instrs []ssa.Instruction
+}
+
 type staticInitNode struct {
 	value    *ssa.Const
+	function *ssa.Function
+	slice    *staticSliceInit
+	pointer  *staticPointerInit
 	children map[int]*staticInitNode
 }
 
@@ -145,6 +159,29 @@ func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
 					path:  path,
 					value: value,
 				})
+			} else if function, ok := staticInitFunctionOf(store.Val, store); ok {
+				candidate.stores = append(candidate.stores, staticInitStore{
+					store:    store,
+					path:     path,
+					function: function,
+				})
+				if closure, ok := store.Val.(*ssa.MakeClosure); ok {
+					candidate.instrs = append(candidate.instrs, closure)
+				}
+			} else if slice, ok := staticSliceInitOfVisited(store, make(map[*ssa.Alloc]bool)); ok {
+				candidate.stores = append(candidate.stores, staticInitStore{
+					store: store,
+					path:  path,
+					slice: slice,
+				})
+				candidate.instrs = append(candidate.instrs, slice.instrs...)
+			} else if pointer, ok := staticPointerInitOfVisited(store, make(map[*ssa.Alloc]bool)); ok {
+				candidate.stores = append(candidate.stores, staticInitStore{
+					store:   store,
+					path:    path,
+					pointer: pointer,
+				})
+				candidate.instrs = append(candidate.instrs, pointer.instrs...)
 			} else if unop, ok := store.Val.(*ssa.UnOp); ok && unop.Op == token.MUL {
 				if alloc, ok := unop.X.(*ssa.Alloc); ok && !alloc.Heap {
 					if !collectAllocStores(alloc, unop, store, path, &candidate.stores, &candidate.instrs, make(map[*ssa.Alloc]bool)) {
@@ -352,12 +389,118 @@ func handleStoreVal(store *ssa.Store, fullPath []staticInitPathElem, out *[]stat
 		})
 		return true
 	}
+	if function, ok := staticInitFunctionOf(store.Val, store); ok {
+		*out = append(*out, staticInitStore{
+			store:    store,
+			path:     fullPath,
+			function: function,
+		})
+		if closure, ok := store.Val.(*ssa.MakeClosure); ok {
+			*instrs = append(*instrs, closure)
+		}
+		return true
+	}
+	if slice, ok := staticSliceInitOfVisited(store, visited); ok {
+		*out = append(*out, staticInitStore{
+			store: store,
+			path:  fullPath,
+			slice: slice,
+		})
+		*instrs = append(*instrs, slice.instrs...)
+		return true
+	}
+	if pointer, ok := staticPointerInitOfVisited(store, visited); ok {
+		*out = append(*out, staticInitStore{
+			store:   store,
+			path:    fullPath,
+			pointer: pointer,
+		})
+		*instrs = append(*instrs, pointer.instrs...)
+		return true
+	}
 	if unop, ok := store.Val.(*ssa.UnOp); ok && unop.Op == token.MUL {
 		if innerAlloc, ok := unop.X.(*ssa.Alloc); ok && !innerAlloc.Heap {
 			return collectAllocStores(innerAlloc, unop, store, fullPath, out, instrs, visited)
 		}
 	}
 	return false
+}
+
+func staticPointerInitOfVisited(store *ssa.Store, visited map[*ssa.Alloc]bool) (*staticPointerInit, bool) {
+	if store == nil || store.Block() == nil {
+		return nil, false
+	}
+	alloc, ok := store.Val.(*ssa.Alloc)
+	if !ok || alloc.Parent() != store.Parent() || visited[alloc] {
+		return nil, false
+	}
+	ptr, ok := alloc.Type().Underlying().(*types.Pointer)
+	if !ok || staticInitZeroSized(ptr.Elem()) {
+		return nil, false
+	}
+	refs, ok := nonDebugReferrers(alloc)
+	if !ok {
+		return nil, false
+	}
+
+	visited[alloc] = true
+	ret := &staticPointerInit{alloc: alloc, instrs: []ssa.Instruction{store, alloc}}
+	seenTerminal := false
+	for _, ref := range refs {
+		switch ref := ref.(type) {
+		case *ssa.FieldAddr:
+			if !collectAddrStores(ref, alloc, nil, &ret.stores, &ret.instrs, visited) {
+				return nil, false
+			}
+			ret.instrs = append(ret.instrs, ref)
+		case *ssa.IndexAddr:
+			if !collectAddrStores(ref, alloc, nil, &ret.stores, &ret.instrs, visited) {
+				return nil, false
+			}
+			ret.instrs = append(ret.instrs, ref)
+		case *ssa.Store:
+			if ref == store && ref.Val == alloc {
+				if seenTerminal {
+					return nil, false
+				}
+				seenTerminal = true
+				continue
+			}
+			if ref.Addr != alloc || !handleStoreVal(ref, nil, &ret.stores, &ret.instrs, visited) {
+				return nil, false
+			}
+			ret.instrs = append(ret.instrs, ref)
+		default:
+			return nil, false
+		}
+	}
+	if !seenTerminal {
+		return nil, false
+	}
+	return ret, true
+}
+
+func staticInitFunctionOf(value ssa.Value, terminalStore *ssa.Store) (*ssa.Function, bool) {
+	switch value := value.(type) {
+	case *ssa.Function:
+		if value.Parent() == nil && len(value.FreeVars) == 0 {
+			return value, true
+		}
+	case *ssa.MakeClosure:
+		if len(value.Bindings) != 0 {
+			return nil, false
+		}
+		function, ok := value.Fn.(*ssa.Function)
+		if !ok || function.Parent() != nil || len(function.FreeVars) != 0 {
+			return nil, false
+		}
+		refs, ok := nonDebugReferrers(value)
+		if !ok || len(refs) != 1 || refs[0] != terminalStore {
+			return nil, false
+		}
+		return function, true
+	}
+	return nil, false
 }
 
 // staticInitStorePathToAlloc resolves the nested path elements from an address expression
@@ -391,6 +534,13 @@ func staticInitStorePathToAlloc(addr ssa.Value, target *ssa.Alloc) ([]staticInit
 }
 
 func staticSliceInitOf(store *ssa.Store) (*staticSliceInit, bool) {
+	return staticSliceInitOfVisited(store, make(map[*ssa.Alloc]bool))
+}
+
+func staticSliceInitOfVisited(store *ssa.Store, visited map[*ssa.Alloc]bool) (*staticSliceInit, bool) {
+	if store == nil || store.Block() == nil {
+		return nil, false
+	}
 	slice, ok := store.Val.(*ssa.Slice)
 	if !ok || slice.Low != nil || slice.High != nil || slice.Max != nil {
 		return nil, false
@@ -404,7 +554,7 @@ func staticSliceInitOf(store *ssa.Store) (*staticSliceInit, bool) {
 		return nil, false
 	}
 	array, ok := ptr.Elem().Underlying().(*types.Array)
-	if !ok || array.Len() == 0 || array.Len() > maxStaticInitArrayElements || staticInitZeroSized(array.Elem()) {
+	if !ok || array.Len() == 0 || !staticInitArraySizeAllowed(array) || staticInitZeroSized(array.Elem()) {
 		return nil, false
 	}
 
@@ -413,11 +563,20 @@ func staticSliceInitOf(store *ssa.Store) (*staticSliceInit, bool) {
 		instrs: []ssa.Instruction{store},
 	}
 
-	visited := make(map[*ssa.Alloc]bool)
 	if !collectAllocStores(alloc, slice, store, nil, &ret.stores, &ret.instrs, visited) {
 		return nil, false
 	}
 	return ret, true
+}
+
+func staticInitArraySizeAllowed(array *types.Array) bool {
+	if array.Len() < 0 || int64(int(array.Len())) != array.Len() {
+		return false
+	}
+	if basic, ok := array.Elem().Underlying().(*types.Basic); ok && basic.Kind() == types.Uint8 {
+		return true
+	}
+	return array.Len() <= maxStaticInitArrayElements
 }
 
 func staticInitZeroSized(typ types.Type) bool {
@@ -437,6 +596,21 @@ func staticInitZeroSized(typ types.Type) bool {
 }
 
 func (p *context) buildStaticSliceInit(global *ssa.Global, init *staticSliceInit) (llssa.Expr, bool) {
+	if global == nil || global.Object() == nil {
+		return llssa.Expr{}, false
+	}
+	sliceType, ok := global.Type().(*types.Pointer)
+	if !ok {
+		return llssa.Expr{}, false
+	}
+	return p.buildStaticSliceValue(p.globalFullName(global)+"$data", sliceType.Elem(), init)
+}
+
+func (p *context) buildStaticSliceValue(name string, typ types.Type, init *staticSliceInit) (llssa.Expr, bool) {
+	sliceType, ok := typ.Underlying().(*types.Slice)
+	if !ok || !types.Identical(sliceType.Elem(), init.array.Elem()) {
+		return llssa.Expr{}, false
+	}
 	n := int(init.array.Len())
 	elemType := init.array.Elem()
 	elemStores := make(map[int][]staticInitStore, n)
@@ -449,9 +623,12 @@ func (p *context) buildStaticSliceInit(global *ssa.Global, init *staticSliceInit
 			return llssa.Expr{}, false
 		}
 		elemStores[idx] = append(elemStores[idx], staticInitStore{
-			store: s.store,
-			path:  s.path[1:],
-			value: s.value,
+			store:    s.store,
+			path:     s.path[1:],
+			value:    s.value,
+			function: s.function,
+			slice:    s.slice,
+			pointer:  s.pointer,
 		})
 	}
 	values := make([]llssa.Expr, n)
@@ -459,18 +636,17 @@ func (p *context) buildStaticSliceInit(global *ssa.Global, init *staticSliceInit
 		stores := elemStores[i]
 		root := new(staticInitNode)
 		for _, store := range stores {
-			if !root.add(store.path, store.value) {
+			if !root.addStore(store) {
 				return llssa.Expr{}, false
 			}
 		}
 		var ok bool
-		values[i], ok = p.buildStaticInitExpr(elemType, root)
+		values[i], ok = p.buildStaticInitExprNamed(elemType, root, name+"$"+strconv.Itoa(i))
 		if !ok {
 			return llssa.Expr{}, false
 		}
 	}
-	sliceType := p.type_(global.Type().(*types.Pointer).Elem(), llssa.InGo)
-	return p.pkg.ConstSlice(p.globalFullName(global)+"$data", sliceType, values), true
+	return p.pkg.ConstSlice(name, p.type_(typ, llssa.InGo), values), true
 }
 
 func staticInitRootGlobal(addr ssa.Value) *ssa.Global {
@@ -531,22 +707,38 @@ func (p *context) buildStaticGlobalInit(global *ssa.Global, stores []staticInitS
 
 	root := new(staticInitNode)
 	for _, store := range stores {
-		if !root.add(store.path, store.value) {
+		if !root.addStore(store) {
 			return llssa.Expr{}, false
 		}
 	}
-	return p.buildStaticInitExpr(ptr.Elem(), root)
+	return p.buildStaticInitExprNamed(ptr.Elem(), root, p.globalFullName(global)+"$data")
+}
+
+func (n *staticInitNode) addStore(store staticInitStore) bool {
+	leaf := &staticInitNode{
+		value: store.value, function: store.function,
+		slice: store.slice, pointer: store.pointer,
+	}
+	if !leaf.hasLeaf() {
+		return false
+	}
+	return n.addLeaf(store.path, leaf)
 }
 
 func (n *staticInitNode) add(path []staticInitPathElem, value *ssa.Const) bool {
+	return n.addLeaf(path, &staticInitNode{value: value})
+}
+
+func (n *staticInitNode) addLeaf(path []staticInitPathElem, leaf *staticInitNode) bool {
 	if len(path) == 0 {
-		if n.value != nil || len(n.children) != 0 {
+		if n.hasLeaf() || len(n.children) != 0 {
 			return false
 		}
-		n.value = value
+		n.value, n.function = leaf.value, leaf.function
+		n.slice, n.pointer = leaf.slice, leaf.pointer
 		return true
 	}
-	if n.value != nil {
+	if n.hasLeaf() {
 		return false
 	}
 	head := path[0]
@@ -558,16 +750,46 @@ func (n *staticInitNode) add(path []staticInitPathElem, value *ssa.Const) bool {
 		child = new(staticInitNode)
 		n.children[head.index] = child
 	}
-	return child.add(path[1:], value)
+	return child.addLeaf(path[1:], leaf)
+}
+
+func (n *staticInitNode) hasLeaf() bool {
+	return n.value != nil || n.function != nil || n.slice != nil || n.pointer != nil
 }
 
 func (p *context) buildStaticInitExpr(typ types.Type, node *staticInitNode) (llssa.Expr, bool) {
+	return p.buildStaticInitExprNamed(typ, node, "__llgo.staticinit$data")
+}
+
+func (p *context) buildStaticInitExprNamed(typ types.Type, node *staticInitNode, name string) (llssa.Expr, bool) {
 	lltyp := p.type_(typ, llssa.InGo)
 	if node == nil {
 		return p.prog.Zero(lltyp), true
 	}
 	if node.value != nil {
 		return p.staticConstExpr(node.value, lltyp)
+	}
+	if node.function != nil {
+		if _, ok := typ.Underlying().(*types.Signature); !ok {
+			return llssa.Expr{}, false
+		}
+		// compileFunction is required here rather than funcOf: source declarations
+		// carrying //llgo:env must be materialized with their environment ABI before
+		// NeedsEnv is checked. Such functions then fail closed to runtime init.
+		function, _, ftype := p.compileFunction(node.function)
+		if function == nil || ftype != goFunc || function.NeedsEnv() {
+			return llssa.Expr{}, false
+		}
+		return p.prog.ConstStruct(lltyp, []llssa.Expr{
+			function.Expr,
+			p.prog.Nil(p.prog.VoidPtr()),
+		}), true
+	}
+	if node.slice != nil {
+		return p.buildStaticSliceValue(name, typ, node.slice)
+	}
+	if node.pointer != nil {
+		return p.buildStaticPointerValue(name, typ, node.pointer)
 	}
 
 	switch u := typ.Underlying().(type) {
@@ -578,7 +800,7 @@ func (p *context) buildStaticInitExpr(typ types.Type, node *staticInitNode) (lls
 			if u.Field(i).Name() == "_" {
 				child = nil
 			}
-			value, ok := p.buildStaticInitExpr(u.Field(i).Type(), child)
+			value, ok := p.buildStaticInitExprNamed(u.Field(i).Type(), child, name+"$"+strconv.Itoa(i))
 			if !ok {
 				return llssa.Expr{}, false
 			}
@@ -589,14 +811,17 @@ func (p *context) buildStaticInitExpr(typ types.Type, node *staticInitNode) (lls
 		}
 		return p.prog.ConstStruct(lltyp, values), true
 	case *types.Array:
-		if u.Len() > maxStaticInitArrayElements {
+		if !staticInitArraySizeAllowed(u) {
 			return llssa.Expr{}, false
+		}
+		if value, ok := staticInitByteArray(node, u); ok {
+			return p.prog.ConstByteArray(lltyp, value), true
 		}
 		n := int(u.Len())
 		values := make([]llssa.Expr, n)
 		for i := range values {
 			child := node.children[i]
-			value, ok := p.buildStaticInitExpr(u.Elem(), child)
+			value, ok := p.buildStaticInitExprNamed(u.Elem(), child, name+"$"+strconv.Itoa(i))
 			if !ok {
 				return llssa.Expr{}, false
 			}
@@ -612,6 +837,50 @@ func (p *context) buildStaticInitExpr(typ types.Type, node *staticInitNode) (lls
 		}
 		return llssa.Expr{}, false
 	}
+}
+
+func (p *context) buildStaticPointerValue(name string, typ types.Type, init *staticPointerInit) (llssa.Expr, bool) {
+	ptr, ok := typ.Underlying().(*types.Pointer)
+	if !ok {
+		return llssa.Expr{}, false
+	}
+	allocPtr, ok := init.alloc.Type().Underlying().(*types.Pointer)
+	if !ok || !types.Identical(ptr.Elem(), allocPtr.Elem()) {
+		return llssa.Expr{}, false
+	}
+	root := new(staticInitNode)
+	for _, store := range init.stores {
+		if !root.addStore(store) {
+			return llssa.Expr{}, false
+		}
+	}
+	value, ok := p.buildStaticInitExprNamed(ptr.Elem(), root, name+"$value")
+	if !ok {
+		return llssa.Expr{}, false
+	}
+	data := p.pkg.NewVarEx(name, p.prog.Pointer(p.type_(ptr.Elem(), llssa.InGo)))
+	data.Init(value)
+	return data.Expr, true
+}
+
+func staticInitByteArray(node *staticInitNode, array *types.Array) ([]byte, bool) {
+	basic, ok := array.Elem().Underlying().(*types.Basic)
+	if !ok || basic.Kind() != types.Uint8 || !staticInitChildrenInRange(node, int(array.Len())) {
+		return nil, false
+	}
+	value := make([]byte, int(array.Len()))
+	for index, child := range node.children {
+		if child == nil || child.value == nil || child.value.Value == nil || child.value.Value.Kind() != constant.Int ||
+			child.function != nil || child.slice != nil || child.pointer != nil || len(child.children) != 0 {
+			return nil, false
+		}
+		v, exact := constant.Uint64Val(constant.ToInt(child.value.Value))
+		if !exact || v > 0xff {
+			return nil, false
+		}
+		value[index] = byte(v)
+	}
+	return value, true
 }
 
 func staticInitChildrenInRange(node *staticInitNode, n int) bool {

--- a/cl/static_init.go
+++ b/cl/static_init.go
@@ -153,36 +153,10 @@ func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
 					continue
 				}
 			}
-			if value, isConst := store.Val.(*ssa.Const); isConst {
-				candidate.stores = append(candidate.stores, staticInitStore{
-					store: store,
-					path:  path,
-					value: value,
-				})
-			} else if function, ok := staticInitFunctionOf(store.Val, store); ok {
-				candidate.stores = append(candidate.stores, staticInitStore{
-					store:    store,
-					path:     path,
-					function: function,
-				})
-				if closure, ok := store.Val.(*ssa.MakeClosure); ok {
-					candidate.instrs = append(candidate.instrs, closure)
-				}
-			} else if slice, ok := staticSliceInitOfVisited(store, make(map[*ssa.Alloc]bool)); ok {
-				candidate.stores = append(candidate.stores, staticInitStore{
-					store: store,
-					path:  path,
-					slice: slice,
-				})
-				candidate.instrs = append(candidate.instrs, slice.instrs...)
-			} else if pointer, ok := staticPointerInitOfVisited(store, make(map[*ssa.Alloc]bool)); ok {
-				candidate.stores = append(candidate.stores, staticInitStore{
-					store:   store,
-					path:    path,
-					pointer: pointer,
-				})
-				candidate.instrs = append(candidate.instrs, pointer.instrs...)
-			} else if unop, ok := store.Val.(*ssa.UnOp); ok && unop.Op == token.MUL {
+			if collectStaticInitLeaf(store, path, &candidate.stores, &candidate.instrs, nil) {
+				continue
+			}
+			if unop, ok := store.Val.(*ssa.UnOp); ok && unop.Op == token.MUL {
 				if alloc, ok := unop.X.(*ssa.Alloc); ok && !alloc.Heap {
 					if !collectAllocStores(alloc, unop, store, path, &candidate.stores, &candidate.instrs, make(map[*ssa.Alloc]bool)) {
 						candidate.invalid = true
@@ -193,10 +167,9 @@ func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
 					candidate.invalid = true
 					continue
 				}
-			} else {
-				candidate.invalid = true
 				continue
 			}
+			candidate.invalid = true
 		}
 	}
 
@@ -381,6 +354,18 @@ func appendStaticInitPath(base, sub []staticInitPathElem) []staticInitPathElem {
 // tracks the store instruction in instrs for compilation suppression) or recursing into inner nested
 // local allocs reached through pointer indirection (*ssa.UnOp).
 func handleStoreVal(store *ssa.Store, fullPath []staticInitPathElem, out *[]staticInitStore, instrs *[]ssa.Instruction, visited map[*ssa.Alloc]bool) bool {
+	if collectStaticInitLeaf(store, fullPath, out, instrs, visited) {
+		return true
+	}
+	if unop, ok := store.Val.(*ssa.UnOp); ok && unop.Op == token.MUL {
+		if innerAlloc, ok := unop.X.(*ssa.Alloc); ok && !innerAlloc.Heap {
+			return collectAllocStores(innerAlloc, unop, store, fullPath, out, instrs, visited)
+		}
+	}
+	return false
+}
+
+func collectStaticInitLeaf(store *ssa.Store, fullPath []staticInitPathElem, out *[]staticInitStore, instrs *[]ssa.Instruction, visited map[*ssa.Alloc]bool) bool {
 	if val, ok := store.Val.(*ssa.Const); ok {
 		*out = append(*out, staticInitStore{
 			store: store,
@@ -418,11 +403,6 @@ func handleStoreVal(store *ssa.Store, fullPath []staticInitPathElem, out *[]stat
 		*instrs = append(*instrs, pointer.instrs...)
 		return true
 	}
-	if unop, ok := store.Val.(*ssa.UnOp); ok && unop.Op == token.MUL {
-		if innerAlloc, ok := unop.X.(*ssa.Alloc); ok && !innerAlloc.Heap {
-			return collectAllocStores(innerAlloc, unop, store, fullPath, out, instrs, visited)
-		}
-	}
 	return false
 }
 
@@ -431,7 +411,13 @@ func staticPointerInitOfVisited(store *ssa.Store, visited map[*ssa.Alloc]bool) (
 		return nil, false
 	}
 	alloc, ok := store.Val.(*ssa.Alloc)
-	if !ok || alloc.Parent() != store.Parent() || visited[alloc] {
+	if !ok || alloc.Parent() != store.Parent() {
+		return nil, false
+	}
+	if visited == nil {
+		visited = make(map[*ssa.Alloc]bool)
+	}
+	if visited[alloc] {
 		return nil, false
 	}
 	ptr, ok := alloc.Type().Underlying().(*types.Pointer)
@@ -549,12 +535,15 @@ func staticSliceInitOfVisited(store *ssa.Store, visited map[*ssa.Alloc]bool) (*s
 	if !ok || alloc.Parent() != store.Parent() {
 		return nil, false
 	}
+	if visited == nil {
+		visited = make(map[*ssa.Alloc]bool)
+	}
 	ptr, ok := alloc.Type().Underlying().(*types.Pointer)
 	if !ok {
 		return nil, false
 	}
 	array, ok := ptr.Elem().Underlying().(*types.Array)
-	if !ok || array.Len() == 0 || !staticInitArraySizeAllowed(array) || staticInitZeroSized(array.Elem()) {
+	if !ok || array.Len() == 0 || array.Len() > maxStaticInitArrayElements || staticInitZeroSized(array.Elem()) {
 		return nil, false
 	}
 

--- a/ssa/globals.go
+++ b/ssa/globals.go
@@ -69,6 +69,12 @@ func (prog Program) ConstArray(t Type, values []Expr) Expr {
 	return Expr{llvm.ConstArray(elem.ll, fields), t}
 }
 
+// ConstByteArray creates a compact LLVM constant for a Go byte array. Unlike
+// ConstArray, it does not allocate one LLVM value wrapper per array element.
+func (prog Program) ConstByteArray(t Type, value []byte) Expr {
+	return Expr{prog.ctx.ConstString(string(value), false), t}
+}
+
 // ConstSlice creates a slice constant backed by a writable package global.
 // The backing store must remain writable because a Go slice literal may be
 // mutated after package initialization.


### PR DESCRIPTION
## Summary

- recursively fold nested slices, pointer composite literals, and direct no-environment function values into writable static backing storage
- represent large byte arrays with compact LLVM string constants instead of per-element LLVM wrappers
- keep interfaces/static itabs, captured or explicit-environment closures, zero-sized pointer targets, cycles, aliases, and executable referrers on the runtime initialization path
- update the map/closure IR fixture and add focused regression coverage

## Motivation

Several standard-library package initializers build large aggregate tables from values that are statically known. Keeping those stores executable makes initializer functions roots for otherwise unused code and limits both LLGo deadcodedrop and full-LTO DCE.

This change expands the existing conservative static initializer analysis while preserving fail-closed behavior for unsupported or identity-sensitive cases. Static itab generation is intentionally out of scope.

## Validation

- LLGO_BUILD_CACHE=off GOCACHE=/private/tmp/llgo-static-init-test-gocache go test ./cl ./ssa -count=1 -timeout=20m
- Zap v1.27.0 focused test binary execution with deadcodedrop and full LTO
- git diff --check

Zap zapcore test binary size on darwin/arm64:

- deadcodedrop: 10,152,864 -> 10,047,488 bytes (-105,376)
- deadcodedrop + full LTO: 9,170,432 -> 9,045,424 bytes (-125,008)

Representative initializer reductions with deadcodedrop:

- crypto/tls.init: 5,356 -> 3,844 bytes
- crypto/internal/fips140/nistec.init: 65,336 -> 72 bytes
- internal/trace/tracev2.init: 30,764 -> 24 bytes