### PR TITLE
build: use loaded package metadata for assembly files

### DIFF
--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -2,10 +2,8 @@ package build
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -18,12 +16,9 @@ import (
 	gllvm "github.com/xgo-dev/llvm"
 )
 
-// compilePkgSFiles translates Go/Plan9 assembly files selected by `go list -json`
-// for this package/target into LLVM IR, compiles them to .o, and returns the
-// object files for linking.
-//
-// NOTE: golang.org/x/tools/go/packages.Package does not expose SFiles, so we
-// query `go list -json` here to get the exact filtered set for GOOS/GOARCH.
+// compilePkgSFiles translates Go/Plan9 assembly files selected by the package
+// loader for this package/target into LLVM IR, compiles them to .o, and returns
+// the object files for linking.
 func compilePkgSFiles(ctx *context, aPkg *aPackage, pkg *packages.Package, verbose bool) ([]string, error) {
 	if len(ctx.patchFiles[pkg.PkgPath]) != 0 && llruntime.SourcePatchReplacesAsmForGOARCH(pkg.PkgPath, ctx.buildConf.Goarch) {
 		return nil, nil
@@ -392,75 +387,28 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	if v, ok := ctx.sfilesCache[pkg.ID]; ok {
 		return v, nil
 	}
-	// The synthetic test main shares the tested package's directory, so a
-	// directory scan may find assembly files that do not belong to testmain.
-	// Its generated import path (for example, example.com/p.test) is also not
-	// a package that can be queried directly with `go list`.
+	// The synthetic test main shares the tested package's directory, but it does
+	// not own that package's assembly files.
 	if ctx.mode == ModeTest && pkg.Name == "main" && strings.HasSuffix(pkg.ID, ".test") {
 		ctx.sfilesCache[pkg.ID] = nil
 		return nil, nil
 	}
-	// Some unit tests construct synthetic packages that are not loadable via
-	// `go list` (PkgPath not in any module, and Dir/Standard/Goroot unset).
-	// In that case, treat the package as having no selected .s files.
+	// Some unit tests construct synthetic packages without an on-disk package
+	// directory. Treat those packages as having no selected assembly files.
 	if pkg.Dir == "" {
 		ctx.sfilesCache[pkg.ID] = nil
 		return nil, nil
 	}
-	// Fast path: if directory has no .s/.S at all, skip `go list`.
-	if ss, _ := filepath.Glob(filepath.Join(pkg.Dir, "*.s")); len(ss) == 0 {
-		if ss, _ := filepath.Glob(filepath.Join(pkg.Dir, "*.S")); len(ss) == 0 {
-			ctx.sfilesCache[pkg.ID] = nil
-			return nil, nil
-		}
-	}
-
 	if ctx.sfilesFrozen {
 		return nil, fmt.Errorf("package %s assembly files were not prepared before backend execution", pkg.PkgPath)
 	}
-
-	args := []string{"list", "-json"}
-	if ctx.conf != nil && len(ctx.conf.BuildFlags) > 0 {
-		args = append(args, ctx.conf.BuildFlags...)
-	}
-	args = append(args, pkg.PkgPath)
-
-	cmd := exec.Command("go", args...)
-	ctx.commands.configure(cmd)
-	// Resolve dependencies from the module or workspace used by packages.Load.
-	// A dependency directory in the module cache may not contain a go.mod.
-	if ctx.conf != nil && ctx.conf.Dir != "" {
-		cmd.Dir = ctx.conf.Dir
-	}
-	if ctx.conf != nil && len(ctx.conf.Env) > 0 {
-		cmd.Env = append([]string(nil), ctx.conf.Env...)
-	}
-	cmd.Env = withEnv(cmd.Env,
-		"GOOS="+ctx.buildConf.Goos,
-		"GOARCH="+ctx.buildConf.Goarch,
-	)
-	out, err := cmd.Output()
-	if err != nil {
-		var errBuf bytes.Buffer
-		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
-			errBuf.Write(ee.Stderr)
-		}
-		return nil, fmt.Errorf("go list -json %s failed: %w\n%s", pkg.PkgPath, err, strings.TrimSpace(errBuf.String()))
-	}
-
-	var lp struct {
-		Dir    string   `json:"Dir"`
-		SFiles []string `json:"SFiles"`
-	}
-	if err := json.Unmarshal(out, &lp); err != nil {
-		return nil, fmt.Errorf("go list -json %s: parse: %w", pkg.PkgPath, err)
-	}
+	paths := selectedSFiles(pkg.OtherFiles)
 
 	// internal/chacha8rand has highly optimized arch asm on amd64/arm64.
 	// Until full vector lowering lands, force the generic stub entry, which
 	// tail-jumps to block_generic and preserves package behavior.
-	if pkg.PkgPath == "internal/chacha8rand" && lp.Dir != "" {
-		stub := filepath.Join(lp.Dir, "chacha8_stub.s")
+	if len(paths) != 0 && pkg.PkgPath == "internal/chacha8rand" && pkg.Dir != "" {
+		stub := filepath.Join(pkg.Dir, "chacha8_stub.s")
 		if _, err := os.Stat(stub); err == nil {
 			paths := []string{stub}
 			ctx.sfilesCache[pkg.ID] = paths
@@ -475,21 +423,23 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 		return nil, nil
 	}
 
-	paths := selectedSFiles(lp.Dir, lp.SFiles)
 	ctx.sfilesCache[pkg.ID] = paths
 	return paths, nil
 }
 
-func selectedSFiles(dir string, files []string) []string {
-	if dir == "" || len(files) == 0 {
+func selectedSFiles(files []string) []string {
+	if len(files) == 0 {
 		return nil
 	}
-	paths := make([]string, 0, len(files))
+	var paths []string
 	for _, f := range files {
+		if !strings.HasSuffix(f, ".s") && !strings.HasSuffix(f, ".S") {
+			continue
+		}
 		if strings.HasSuffix(f, "_test.s") || strings.HasSuffix(f, "_test.S") {
 			continue
 		}
-		paths = append(paths, filepath.Join(dir, f))
+		paths = append(paths, f)
 	}
 	return paths
 }

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -407,10 +407,11 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	// internal/chacha8rand has highly optimized arch asm on amd64/arm64.
 	// Until full vector lowering lands, force the generic stub entry, which
 	// tail-jumps to block_generic and preserves package behavior.
-	if len(paths) != 0 && pkg.PkgPath == "internal/chacha8rand" && pkg.Dir != "" {
+	// Scope the stub override to targets that actually select chacha8 assembly.
+	if len(paths) != 0 && pkg.PkgPath == "internal/chacha8rand" {
 		stub := filepath.Join(pkg.Dir, "chacha8_stub.s")
 		if _, err := os.Stat(stub); err == nil {
-			paths := []string{stub}
+			paths = []string{stub}
 			ctx.sfilesCache[pkg.ID] = paths
 			return paths, nil
 		}

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/xgo-dev/llgo/internal/packages"
@@ -15,11 +14,12 @@ import (
 
 func TestSelectedSFilesSkipsTestAsm(t *testing.T) {
 	dir := "/tmp/pkg"
-	got := selectedSFiles(dir, []string{
-		"abi_test.s",
-		"stub.s",
-		"helper.S",
-		"compare_test.S",
+	got := selectedSFiles([]string{
+		filepath.Join(dir, "abi_test.s"),
+		filepath.Join(dir, "stub.s"),
+		filepath.Join(dir, "helper.S"),
+		filepath.Join(dir, "compare_test.S"),
+		filepath.Join(dir, "helper.c"),
 	})
 	want := []string{
 		filepath.Join(dir, "stub.s"),
@@ -31,11 +31,11 @@ func TestSelectedSFilesSkipsTestAsm(t *testing.T) {
 }
 
 func TestSelectedSFilesHandlesEmptyInput(t *testing.T) {
-	if got := selectedSFiles("", []string{"stub.s"}); got != nil {
-		t.Fatalf("selectedSFiles(empty dir) = %#v, want nil", got)
-	}
-	if got := selectedSFiles("/tmp/pkg", nil); got != nil {
+	if got := selectedSFiles(nil); got != nil {
 		t.Fatalf("selectedSFiles(nil files) = %#v, want nil", got)
+	}
+	if got := selectedSFiles([]string{"helper.c"}); got != nil {
+		t.Fatalf("selectedSFiles(non-assembly files) = %#v, want nil", got)
 	}
 }
 
@@ -54,53 +54,19 @@ func TestShouldSkipPlan9AsmSFilesForTarget(t *testing.T) {
 	}
 }
 
-func TestPkgSFilesUsesPackageLoadDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses a shell script as a fake go command")
-	}
-
-	loadDir := t.TempDir()
-	expectedLoadDir, err := filepath.EvalSymlinks(loadDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestPkgSFilesUsesLoadedOtherFiles(t *testing.T) {
 	pkgDir := t.TempDir()
 	sfile := filepath.Join(pkgDir, "asm_amd64.s")
-	if err := os.WriteFile(sfile, nil, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	binDir := t.TempDir()
-	goCmd := filepath.Join(binDir, "go")
-	script := `#!/bin/sh
-if [ "$PWD" != "$EXPECTED_GO_LIST_DIR" ]; then
-	echo "go list ran in $PWD; want $EXPECTED_GO_LIST_DIR" >&2
-	exit 1
-fi
-if [ "$PACKAGE_LOAD_ENV" != "used" ]; then
-	echo "go list did not inherit the package load environment" >&2
-	exit 1
-fi
-printf '{"Dir":"%s","SFiles":["asm_amd64.s"]}\n' "$PACKAGE_DIR"
-`
-	if err := os.WriteFile(goCmd, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("EXPECTED_GO_LIST_DIR", expectedLoadDir)
-	t.Setenv("PACKAGE_DIR", pkgDir)
+	t.Setenv("PATH", t.TempDir()) // pkgSFiles must not invoke a second go list.
 
 	ctx := &context{
-		conf: &packages.Config{
-			Dir: loadDir,
-			Env: append(os.Environ(), "PACKAGE_LOAD_ENV=used"),
-		},
 		buildConf: &Config{Goos: "linux", Goarch: "amd64"},
 	}
 	got, err := pkgSFiles(ctx, &packages.Package{
-		ID:      "example.com/asm",
-		PkgPath: "example.com/asm",
-		Dir:     pkgDir,
+		ID:         "example.com/asm",
+		PkgPath:    "example.com/asm",
+		Dir:        pkgDir,
+		OtherFiles: []string{sfile, filepath.Join(pkgDir, "helper.c")},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- use the assembly files already selected by the package loader instead of running a second `go list`
- retain `.s`/`.S`, test-assembly, synthetic test-main, and `internal/chacha8rand` handling
- add a regression test that makes any second `go list` invocation fail

This fixes the `k8s.io/client-go@v0.36.2` root-package compile gap from the LLGo compatibility suite. Dependencies loaded from the module cache remain tied to the original module/workspace context, rather than being queried again from a dependency directory.

Compatibility result: https://xgo-dev.github.io/benchmarks/compatibility.html

## Verification

- `go test ./internal/build -run 'Test(SelectedSFiles|PkgSFiles|ShouldSkipPlan9AsmSFiles)' -count=1`
- `go test ./internal/build -count=1`
- `go vet ./internal/build`
- `llgo test -short k8s.io/client-go` in a module pinned to `k8s.io/client-go@v0.36.2` (`PASS`)
