### PR TITLE
ssa: lower large array comparisons to runtime equality algorithms

### DIFF
--- a/cl/array_compare_compile_test.go
+++ b/cl/array_compare_compile_test.go
@@ -109,12 +109,18 @@ func heap() bool {
 	if _, ok := immutableLocalArrayLoadAddr(immutable.Y); !ok {
 		t.Fatal("immutable right array was not recognized")
 	}
+	if !canElideArrayCompareLoad(immutable.X.(*ssa.UnOp)) || !canElideArrayCompareLoad(immutable.Y.(*ssa.UnOp)) {
+		t.Fatal("immutable comparison loads were not eligible for elision")
+	}
 	snapshot := findCompare("snapshot")
 	if _, ok := immutableLocalArrayLoadAddr(snapshot.X); ok {
 		t.Fatal("array changed after its load was treated as immutable")
 	}
 	if _, ok := immutableLocalArrayLoadAddr(snapshot.Y); !ok {
 		t.Fatal("unchanged snapshot operand was not recognized")
+	}
+	if canElideArrayCompareLoad(snapshot.X.(*ssa.UnOp)) || canElideArrayCompareLoad(snapshot.Y.(*ssa.UnOp)) {
+		t.Fatal("comparison without two stable addresses was eligible for load elision")
 	}
 	parameters := findCompare("parameters")
 	if _, ok := immutableLocalArrayLoadAddr(parameters.X); ok {
@@ -134,7 +140,25 @@ func heap() bool {
 	if _, ok := immutableLocalArrayLoadAddr(scalarLoad); ok {
 		t.Fatal("scalar load was treated as reusable array storage")
 	}
+	if canElideArrayCompareLoad(scalarLoad) || canElideArrayCompareLoad(nil) {
+		t.Fatal("non-array load was eligible for array comparison load elision")
+	}
+	small := findCompare("small")
+	if canElideArrayCompareLoad(small.X.(*ssa.UnOp)) {
+		t.Fatal("inline array comparison load was eligible for elision")
+	}
 	immutableLoad := immutable.X.(*ssa.UnOp)
+	loadRefs := immutableLoad.Referrers()
+	originalLoadRefs := append([]ssa.Instruction(nil), (*loadRefs)...)
+	*loadRefs = nil
+	if canElideArrayCompareLoad(immutableLoad) {
+		t.Fatal("array load without executable comparisons was eligible for elision")
+	}
+	*loadRefs = []ssa.Instruction{&ssa.BinOp{Op: token.EQL}}
+	if canElideArrayCompareLoad(immutableLoad) {
+		t.Fatal("unrelated comparison was treated as a use of the array load")
+	}
+	*loadRefs = originalLoadRefs
 	rejectRef := func(name string, ref ssa.Instruction) {
 		t.Helper()
 		refs := immutableLoad.X.Referrers()
@@ -185,6 +209,9 @@ func heap() bool {
 	snapshotIR := mustNamedFunction(t, mod, "foo.snapshot").String()
 	if !strings.Contains(snapshotIR, ".memequal") || !strings.Contains(snapshotIR, "store [32 x i8]") || !strings.Contains(snapshotIR, "stacksave") {
 		t.Fatalf("mutable source did not preserve the loaded array snapshot:\n%s", snapshotIR)
+	}
+	if strings.Contains(immutableIR, "load [32 x i8]") {
+		t.Fatalf("immutable comparison retained unused aggregate loads:\n%s", immutableIR)
 	}
 	smallIR := mustNamedFunction(t, mod, "foo.small").String()
 	if strings.Contains(smallIR, ".memequal") || strings.Contains(smallIR, "stacksave") {

--- a/cl/array_compare_compile_test.go
+++ b/cl/array_compare_compile_test.go
@@ -20,6 +20,7 @@ package cl
 
 import (
 	"go/token"
+	"go/types"
 	"strings"
 	"testing"
 
@@ -49,6 +50,23 @@ func small() bool {
 	y := [4]byte{2}
 	return x == y
 }
+
+func parameters(x, y [32]byte) bool {
+	return x == y
+}
+
+func scalar(p *int) int {
+	return *p
+}
+
+func crossBlock(change bool) bool {
+	x := [32]byte{1}
+	y := [32]byte{2}
+	if change {
+		x[0] = 3
+	}
+	return x == y
+}
 `
 	ssaPkg, _, _ := buildGoSSAPkg(t, source)
 	findCompare := func(name string) *ssa.BinOp {
@@ -56,7 +74,9 @@ func small() bool {
 		for _, block := range ssaPkg.Func(name).Blocks {
 			for _, instr := range block.Instrs {
 				if bin, ok := instr.(*ssa.BinOp); ok && bin.Op == token.EQL {
-					return bin
+					if _, ok := bin.X.Type().Underlying().(*types.Array); ok {
+						return bin
+					}
 				}
 			}
 		}
@@ -76,6 +96,41 @@ func small() bool {
 	}
 	if _, ok := immutableLocalArrayLoadAddr(snapshot.Y); !ok {
 		t.Fatal("unchanged snapshot operand was not recognized")
+	}
+	parameters := findCompare("parameters")
+	if _, ok := immutableLocalArrayLoadAddr(parameters.X); ok {
+		t.Fatal("array parameter was treated as reusable local storage")
+	}
+	var scalarLoad *ssa.UnOp
+	for _, block := range ssaPkg.Func("scalar").Blocks {
+		for _, instr := range block.Instrs {
+			if load, ok := instr.(*ssa.UnOp); ok && load.Op == token.MUL {
+				scalarLoad = load
+			}
+		}
+	}
+	if scalarLoad == nil {
+		t.Fatal("scalar load not found")
+	}
+	if _, ok := immutableLocalArrayLoadAddr(scalarLoad); ok {
+		t.Fatal("scalar load was treated as reusable array storage")
+	}
+	immutableLoad := immutable.X.(*ssa.UnOp)
+	refs := immutableLoad.X.Referrers()
+	func() {
+		original := *refs
+		defer func() { *refs = original }()
+		*refs = append(*refs, &ssa.BinOp{})
+		if _, ok := immutableLocalArrayLoadAddr(immutable.X); ok {
+			t.Fatal("array with an unknown address use was treated as immutable")
+		}
+	}()
+	crossBlock := findCompare("crossBlock")
+	if _, ok := immutableLocalArrayLoadAddr(crossBlock.X); ok {
+		t.Fatal("array written from another block was treated as immutable")
+	}
+	if _, ok := immutableLocalArrayLoadAddr(crossBlock.Y); !ok {
+		t.Fatal("unchanged cross-block operand was not recognized")
 	}
 
 	_, mod := mustCompileLLPkgFromSrc(t, source)

--- a/cl/array_compare_compile_test.go
+++ b/cl/array_compare_compile_test.go
@@ -43,6 +43,12 @@ func snapshot() bool {
 	x[0] = 3
 	return old == y
 }
+
+func small() bool {
+	x := [4]byte{1}
+	y := [4]byte{2}
+	return x == y
+}
 `
 	ssaPkg, _, _ := buildGoSSAPkg(t, source)
 	findCompare := func(name string) *ssa.BinOp {
@@ -83,5 +89,9 @@ func snapshot() bool {
 	snapshotIR := mustNamedFunction(t, mod, "foo.snapshot").String()
 	if !strings.Contains(snapshotIR, ".memequal") || !strings.Contains(snapshotIR, "store [32 x i8]") || !strings.Contains(snapshotIR, "stacksave") {
 		t.Fatalf("mutable source did not preserve the loaded array snapshot:\n%s", snapshotIR)
+	}
+	smallIR := mustNamedFunction(t, mod, "foo.small").String()
+	if strings.Contains(smallIR, ".memequal") || strings.Contains(smallIR, "stacksave") {
+		t.Fatalf("small array comparison used the runtime path:\n%s", smallIR)
 	}
 }

--- a/cl/array_compare_compile_test.go
+++ b/cl/array_compare_compile_test.go
@@ -67,6 +67,25 @@ func crossBlock(change bool) bool {
 	}
 	return x == y
 }
+
+type item struct {
+	value byte
+}
+
+func structs() bool {
+	x := [32]item{{value: 1}}
+	y := [32]item{{value: 2}}
+	return x == y
+}
+
+var escaped *[32]byte
+
+func heap() bool {
+	x := [32]byte{1}
+	y := [32]byte{2}
+	escaped = &x
+	return x == y
+}
 `
 	ssaPkg, _, _ := buildGoSSAPkg(t, source)
 	findCompare := func(name string) *ssa.BinOp {
@@ -116,21 +135,43 @@ func crossBlock(change bool) bool {
 		t.Fatal("scalar load was treated as reusable array storage")
 	}
 	immutableLoad := immutable.X.(*ssa.UnOp)
-	refs := immutableLoad.X.Referrers()
-	func() {
+	rejectRef := func(name string, ref ssa.Instruction) {
+		t.Helper()
+		refs := immutableLoad.X.Referrers()
 		original := *refs
 		defer func() { *refs = original }()
-		*refs = append(*refs, &ssa.BinOp{})
+		*refs = append(*refs, ref)
 		if _, ok := immutableLocalArrayLoadAddr(immutable.X); ok {
-			t.Fatal("array with an unknown address use was treated as immutable")
+			t.Fatalf("array with %s was treated as immutable", name)
 		}
-	}()
+	}
+	rejectRef("an unknown address use", &ssa.BinOp{})
+	rejectRef("a foreign field address", &ssa.FieldAddr{})
+	rejectRef("a non-load unary use", &ssa.UnOp{})
+	noReferrers := ssa.NewConst(nil, types.NewPointer(types.Typ[types.Int]))
+	if immutableArrayAddrUses(noReferrers, immutableLoad, make(map[ssa.Value]bool)) {
+		t.Fatal("address without referrer metadata was treated as immutable")
+	}
+	if !immutableArrayAddrUses(noReferrers, immutableLoad, map[ssa.Value]bool{noReferrers: true}) {
+		t.Fatal("previously visited address did not terminate the use walk")
+	}
 	crossBlock := findCompare("crossBlock")
 	if _, ok := immutableLocalArrayLoadAddr(crossBlock.X); ok {
 		t.Fatal("array written from another block was treated as immutable")
 	}
 	if _, ok := immutableLocalArrayLoadAddr(crossBlock.Y); !ok {
 		t.Fatal("unchanged cross-block operand was not recognized")
+	}
+	structs := findCompare("structs")
+	if _, ok := immutableLocalArrayLoadAddr(structs.X); !ok {
+		t.Fatal("immutable struct array with field stores was not recognized")
+	}
+	if _, ok := immutableLocalArrayLoadAddr(structs.Y); !ok {
+		t.Fatal("second immutable struct array with field stores was not recognized")
+	}
+	heap := findCompare("heap")
+	if _, ok := immutableLocalArrayLoadAddr(heap.X); ok {
+		t.Fatal("escaping heap array was treated as reusable local storage")
 	}
 
 	_, mod := mustCompileLLPkgFromSrc(t, source)

--- a/cl/array_compare_compile_test.go
+++ b/cl/array_compare_compile_test.go
@@ -1,0 +1,87 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"go/token"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+func TestArrayCompareReusesImmutableLocalStorage(t *testing.T) {
+	const source = `
+package foo
+
+func immutable() bool {
+	x := [32]byte{1}
+	y := [32]byte{2}
+	return x == y
+}
+
+func snapshot() bool {
+	x := [32]byte{1}
+	y := [32]byte{2}
+	old := x
+	x[0] = 3
+	return old == y
+}
+`
+	ssaPkg, _, _ := buildGoSSAPkg(t, source)
+	findCompare := func(name string) *ssa.BinOp {
+		t.Helper()
+		for _, block := range ssaPkg.Func(name).Blocks {
+			for _, instr := range block.Instrs {
+				if bin, ok := instr.(*ssa.BinOp); ok && bin.Op == token.EQL {
+					return bin
+				}
+			}
+		}
+		t.Fatalf("array comparison not found in %s", name)
+		return nil
+	}
+	immutable := findCompare("immutable")
+	if _, ok := immutableLocalArrayLoadAddr(immutable.X); !ok {
+		t.Fatal("immutable left array was not recognized")
+	}
+	if _, ok := immutableLocalArrayLoadAddr(immutable.Y); !ok {
+		t.Fatal("immutable right array was not recognized")
+	}
+	snapshot := findCompare("snapshot")
+	if _, ok := immutableLocalArrayLoadAddr(snapshot.X); ok {
+		t.Fatal("array changed after its load was treated as immutable")
+	}
+	if _, ok := immutableLocalArrayLoadAddr(snapshot.Y); !ok {
+		t.Fatal("unchanged snapshot operand was not recognized")
+	}
+
+	_, mod := mustCompileLLPkgFromSrc(t, source)
+	immutableIR := mustNamedFunction(t, mod, "foo.immutable").String()
+	if got := strings.Count(immutableIR, "alloca [32 x i8]"); got != 2 {
+		t.Fatalf("immutable comparison has %d array allocations, want only its two source values:\n%s", got, immutableIR)
+	}
+	if !strings.Contains(immutableIR, ".memequal") || strings.Contains(immutableIR, "store [32 x i8]") || strings.Contains(immutableIR, "stacksave") {
+		t.Fatalf("immutable comparison copied an aggregate value:\n%s", immutableIR)
+	}
+	snapshotIR := mustNamedFunction(t, mod, "foo.snapshot").String()
+	if !strings.Contains(snapshotIR, ".memequal") || !strings.Contains(snapshotIR, "store [32 x i8]") || !strings.Contains(snapshotIR, "stacksave") {
+		t.Fatalf("mutable source did not preserve the loaded array snapshot:\n%s", snapshotIR)
+	}
+}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1334,7 +1334,11 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		}
 		x := p.compileValueAs(b, v.X, v.Y.Type())
 		y := p.compileValueAs(b, v.Y, v.X.Type())
-		ret = b.BinOp(v.Op, x, y)
+		if _, ok := v.X.Type().Underlying().(*types.Array); ok && (v.Op == token.EQL || v.Op == token.NEQ) {
+			ret = b.ArrayBinOp(v.Op, x, y, p.arrayCompareAddr(b, v.X), p.arrayCompareAddr(b, v.Y))
+		} else {
+			ret = b.BinOp(v.Op, x, y)
+		}
 	case *ssa.UnOp:
 		if v.Op == token.MUL {
 			if _, ok := p.methodNilDerefChecks[v]; ok {
@@ -1718,6 +1722,87 @@ func (p *context) compileValueAs(b llssa.Builder, v ssa.Value, typ types.Type) l
 		return p.nilOf(typ)
 	}
 	return p.compileValue(b, v)
+}
+
+func (p *context) arrayCompareAddr(b llssa.Builder, v ssa.Value) llssa.Expr {
+	addr, ok := immutableLocalArrayLoadAddr(v)
+	if !ok {
+		return llssa.Nil
+	}
+	return p.compileValue(b, addr)
+}
+
+// immutableLocalArrayLoadAddr recognizes array values loaded from a local
+// allocation that cannot change after the load. Reusing the allocation lets
+// equality helpers read the value in place, as cmd/compile does for its
+// addressable comparison operands, and avoids scalarizing a copied array.
+func immutableLocalArrayLoadAddr(v ssa.Value) (ssa.Value, bool) {
+	load, ok := v.(*ssa.UnOp)
+	if !ok || load.Op != token.MUL {
+		return nil, false
+	}
+	if _, ok := load.Type().Underlying().(*types.Array); !ok {
+		return nil, false
+	}
+	alloc, ok := load.X.(*ssa.Alloc)
+	if !ok || alloc.Heap {
+		return nil, false
+	}
+	seen := make(map[ssa.Value]bool)
+	var immutable func(ssa.Value) bool
+	immutable = func(ptr ssa.Value) bool {
+		if seen[ptr] {
+			return true
+		}
+		seen[ptr] = true
+		refs, available := nonDebugReferrers(ptr)
+		if !available {
+			return false
+		}
+		for _, ref := range refs {
+			switch ref := ref.(type) {
+			case *ssa.IndexAddr:
+				if ref.X != ptr || !immutable(ref) {
+					return false
+				}
+			case *ssa.FieldAddr:
+				if ref.X != ptr || !immutable(ref) {
+					return false
+				}
+			case *ssa.UnOp:
+				if ref.X != ptr || ref.Op != token.MUL {
+					return false
+				}
+			case *ssa.Store:
+				if ref.Addr != ptr || !instructionPrecedes(ref, load) {
+					return false
+				}
+			default:
+				return false
+			}
+		}
+		return true
+	}
+	if !immutable(alloc) {
+		return nil, false
+	}
+	return load.X, true
+}
+
+func instructionPrecedes(before, after ssa.Instruction) bool {
+	block := before.Block()
+	if block == nil || block != after.Block() {
+		return false
+	}
+	for _, instr := range block.Instrs {
+		if instr == before {
+			return true
+		}
+		if instr == after {
+			return false
+		}
+	}
+	return false
 }
 
 func (p *context) assertNilDerefBase(b llssa.Builder, addr ssa.Value) {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1334,8 +1334,13 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		}
 		x := p.compileValueAs(b, v.X, v.Y.Type())
 		y := p.compileValueAs(b, v.Y, v.X.Type())
-		if _, ok := v.X.Type().Underlying().(*types.Array); ok && (v.Op == token.EQL || v.Op == token.NEQ) {
-			ret = b.ArrayBinOp(v.Op, x, y, p.arrayCompareAddr(b, v.X), p.arrayCompareAddr(b, v.Y))
+		if typ, ok := v.X.Type().Underlying().(*types.Array); ok && (v.Op == token.EQL || v.Op == token.NEQ) {
+			xaddr, yaddr := llssa.Nil, llssa.Nil
+			if !llssa.CanInlineArrayEqual(typ) {
+				xaddr = p.arrayCompareAddr(b, v.X)
+				yaddr = p.arrayCompareAddr(b, v.Y)
+			}
+			ret = b.ArrayBinOp(v.Op, x, y, xaddr, yaddr)
 		} else {
 			ret = b.BinOp(v.Op, x, y)
 		}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1804,7 +1804,7 @@ func instructionPrecedes(before, after ssa.Instruction) bool {
 			return true
 		}
 		if instr == after {
-			return false
+			break
 		}
 	}
 	return false

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1332,22 +1332,36 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 				break
 			}
 		}
-		x := p.compileValueAs(b, v.X, v.Y.Type())
-		y := p.compileValueAs(b, v.Y, v.X.Type())
 		if typ, ok := v.X.Type().Underlying().(*types.Array); ok && (v.Op == token.EQL || v.Op == token.NEQ) {
 			xaddr, yaddr := llssa.Nil, llssa.Nil
 			if !llssa.CanInlineArrayEqual(typ) {
 				xaddr = p.arrayCompareAddr(b, v.X)
 				yaddr = p.arrayCompareAddr(b, v.Y)
 			}
+			var x, y llssa.Expr
+			if !xaddr.IsNil() && !yaddr.IsNil() {
+				// The runtime helper consumes the proven-stable addresses. Keep
+				// typed placeholders for ArrayBinOp without materializing the
+				// otherwise unused aggregate loads.
+				x = p.prog.Zero(p.type_(v.X.Type(), llssa.InGo))
+				y = p.prog.Zero(p.type_(v.Y.Type(), llssa.InGo))
+			} else {
+				x = p.compileValueAs(b, v.X, v.Y.Type())
+				y = p.compileValueAs(b, v.Y, v.X.Type())
+			}
 			ret = b.ArrayBinOp(v.Op, x, y, xaddr, yaddr)
 		} else {
+			x := p.compileValueAs(b, v.X, v.Y.Type())
+			y := p.compileValueAs(b, v.Y, v.X.Type())
 			ret = b.BinOp(v.Op, x, y)
 		}
 	case *ssa.UnOp:
 		if v.Op == token.MUL {
 			if _, ok := p.methodNilDerefChecks[v]; ok {
 				return p.compileCheckedDeref(b, v)
+			}
+			if canElideArrayCompareLoad(v) {
+				return
 			}
 			effectfulArrayDeref := isEffectfulArrayPointerDeref(v)
 			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 0 {
@@ -1735,6 +1749,46 @@ func (p *context) arrayCompareAddr(b llssa.Builder, v ssa.Value) llssa.Expr {
 		return llssa.Nil
 	}
 	return p.compileValue(b, addr)
+}
+
+// canElideArrayCompareLoad reports whether every executable use of load is a
+// non-inline equality comparison whose two operands can both be read from
+// proven-stable local storage. Such comparisons never consume the aggregate
+// value itself, so generating its load only increases the pre-optimization IR.
+func canElideArrayCompareLoad(load *ssa.UnOp) bool {
+	if load == nil || load.Op != token.MUL {
+		return false
+	}
+	typ, ok := load.Type().Underlying().(*types.Array)
+	if !ok || llssa.CanInlineArrayEqual(typ) {
+		return false
+	}
+	if _, ok := immutableLocalArrayLoadAddr(load); !ok {
+		return false
+	}
+	refs, available := nonDebugReferrers(load)
+	if !available || len(refs) == 0 {
+		return false
+	}
+	for _, ref := range refs {
+		bin, ok := ref.(*ssa.BinOp)
+		if !ok || (bin.Op != token.EQL && bin.Op != token.NEQ) {
+			return false
+		}
+		var other ssa.Value
+		switch {
+		case bin.X == load:
+			other = bin.Y
+		case bin.Y == load:
+			other = bin.X
+		default:
+			return false
+		}
+		if _, ok := immutableLocalArrayLoadAddr(other); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // immutableLocalArrayLoadAddr recognizes array values loaded from a local

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1753,45 +1753,44 @@ func immutableLocalArrayLoadAddr(v ssa.Value) (ssa.Value, bool) {
 	if !ok || alloc.Heap {
 		return nil, false
 	}
-	seen := make(map[ssa.Value]bool)
-	var immutable func(ssa.Value) bool
-	immutable = func(ptr ssa.Value) bool {
-		if seen[ptr] {
-			return true
-		}
-		seen[ptr] = true
-		refs, available := nonDebugReferrers(ptr)
-		if !available {
-			return false
-		}
-		for _, ref := range refs {
-			switch ref := ref.(type) {
-			case *ssa.IndexAddr:
-				if ref.X != ptr || !immutable(ref) {
-					return false
-				}
-			case *ssa.FieldAddr:
-				if ref.X != ptr || !immutable(ref) {
-					return false
-				}
-			case *ssa.UnOp:
-				if ref.X != ptr || ref.Op != token.MUL {
-					return false
-				}
-			case *ssa.Store:
-				if ref.Addr != ptr || !instructionPrecedes(ref, load) {
-					return false
-				}
-			default:
-				return false
-			}
-		}
-		return true
-	}
-	if !immutable(alloc) {
+	if !immutableArrayAddrUses(alloc, load, make(map[ssa.Value]bool)) {
 		return nil, false
 	}
 	return load.X, true
+}
+
+func immutableArrayAddrUses(ptr ssa.Value, load *ssa.UnOp, seen map[ssa.Value]bool) bool {
+	if seen[ptr] {
+		return true
+	}
+	seen[ptr] = true
+	refs, available := nonDebugReferrers(ptr)
+	if !available {
+		return false
+	}
+	for _, ref := range refs {
+		switch ref := ref.(type) {
+		case *ssa.IndexAddr:
+			if ref.X != ptr || !immutableArrayAddrUses(ref, load, seen) {
+				return false
+			}
+		case *ssa.FieldAddr:
+			if ref.X != ptr || !immutableArrayAddrUses(ref, load, seen) {
+				return false
+			}
+		case *ssa.UnOp:
+			if ref.X != ptr || ref.Op != token.MUL {
+				return false
+			}
+		case *ssa.Store:
+			if ref.Addr != ptr || !instructionPrecedes(ref, load) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func instructionPrecedes(before, after ssa.Instruction) bool {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -776,11 +776,12 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 	panic("todo")
 }
 
-// inlineArrayEqual reports whether comparing an array element by element is
-// cheaper than calling its equality algorithm. Keep this aligned with the Go
-// compiler's comparison lowering: a single element is always safe to inline,
-// while only small arrays of scalar values are expanded.
-func (b Builder) inlineArrayEqual(t *types.Array) bool {
+// CanInlineArrayEqual reports whether comparing an array element by element is
+// cheaper than calling its equality algorithm. A single element is always
+// safe to inline. For simple elements, use cmd/compile's four-element budget,
+// but not its size-based allowance: this builder emits element-wise compares
+// rather than merging adjacent loads into wider compares.
+func CanInlineArrayEqual(t *types.Array) bool {
 	n := t.Len()
 	if n <= 1 {
 		return true
@@ -789,7 +790,7 @@ func (b Builder) inlineArrayEqual(t *types.Array) bool {
 	if !ok || basic.Info()&(types.IsBoolean|types.IsInteger|types.IsFloat|types.IsComplex) == 0 {
 		return false
 	}
-	return n <= 4 || uint64(b.Prog.abi.Size(t)) <= uint64(2*b.Prog.PointerSize())
+	return n <= 4
 }
 
 // ArrayBinOp compares two array values while reusing their backing addresses
@@ -809,7 +810,7 @@ func (b Builder) arrayBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
 	prog := b.Prog
 	tret := prog.Bool()
 	typ := x.raw.Type.Underlying().(*types.Array)
-	if b.inlineArrayEqual(typ) {
+	if CanInlineArrayEqual(typ) {
 		elem := prog.Elem(x.Type)
 		ret := prog.BoolVal(true)
 		for i, n := 0, int(typ.Len()); i < n; i++ {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -727,21 +727,7 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 				return Expr{llvm.CreateICmp(b.impl, pred, x.impl, y.impl), tret}
 			}
 		case vkArray:
-			typ := x.raw.Type.Underlying().(*types.Array)
-			elem := b.Prog.Elem(x.Type)
-			ret := prog.BoolVal(true)
-			for i, n := 0, int(typ.Len()); i < n; i++ {
-				fx := b.impl.CreateExtractValue(x.impl, i, "")
-				fy := b.impl.CreateExtractValue(y.impl, i, "")
-				r := b.BinOp(token.EQL, Expr{fx, elem}, Expr{fy, elem})
-				ret = Expr{b.impl.CreateAnd(ret.impl, r.impl, ""), tret}
-			}
-			switch op {
-			case token.EQL:
-				return ret
-			case token.NEQ:
-				return Expr{b.impl.CreateNot(ret.impl, ""), tret}
-			}
+			return b.arrayBinOp(op, x, y, Nil, Nil)
 		case vkStruct:
 			typ := x.raw.Type.Underlying().(*types.Struct)
 			ret := prog.BoolVal(true)
@@ -788,6 +774,90 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 		}
 	}
 	panic("todo")
+}
+
+// inlineArrayEqual reports whether comparing an array element by element is
+// cheaper than calling its equality algorithm. Keep this aligned with the Go
+// compiler's comparison lowering: a single element is always safe to inline,
+// while only small arrays of scalar values are expanded.
+func (b Builder) inlineArrayEqual(t *types.Array) bool {
+	n := t.Len()
+	if n <= 1 {
+		return true
+	}
+	basic, ok := t.Elem().Underlying().(*types.Basic)
+	if !ok || basic.Info()&(types.IsBoolean|types.IsInteger|types.IsFloat|types.IsComplex) == 0 {
+		return false
+	}
+	return n <= 4 || uint64(b.Prog.abi.Size(t)) <= uint64(2*b.Prog.PointerSize())
+}
+
+// ArrayBinOp compares two array values while reusing their backing addresses
+// when the frontend has proved that those addresses still hold the loaded
+// values. A nil address falls back to a value-preserving temporary.
+func (b Builder) ArrayBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
+	if x.kind != vkArray || y.kind != vkArray {
+		panic("ArrayBinOp requires array operands")
+	}
+	if op != token.EQL && op != token.NEQ {
+		panic("ArrayBinOp requires an equality operator")
+	}
+	return b.arrayBinOp(op, x, y, xaddr, yaddr)
+}
+
+func (b Builder) arrayBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
+	prog := b.Prog
+	tret := prog.Bool()
+	typ := x.raw.Type.Underlying().(*types.Array)
+	if b.inlineArrayEqual(typ) {
+		elem := prog.Elem(x.Type)
+		ret := prog.BoolVal(true)
+		for i, n := 0, int(typ.Len()); i < n; i++ {
+			fx := b.impl.CreateExtractValue(x.impl, i, "")
+			fy := b.impl.CreateExtractValue(y.impl, i, "")
+			r := b.BinOp(token.EQL, Expr{fx, elem}, Expr{fy, elem})
+			ret = Expr{b.impl.CreateAnd(ret.impl, r.impl, ""), tret}
+		}
+		if op == token.NEQ {
+			ret.impl = llvm.CreateNot(b.impl, ret.impl)
+		}
+		return ret
+	}
+	ret := b.callArrayEqual(x, y, xaddr, yaddr, typ)
+	if op == token.NEQ {
+		ret.impl = llvm.CreateNot(b.impl, ret.impl)
+	}
+	return ret
+}
+
+func (b Builder) callArrayEqual(x, y, xaddr, yaddr Expr, t *types.Array) Expr {
+	prog := b.Prog
+	var sp Expr
+	if xaddr.IsNil() || yaddr.IsNil() {
+		sp = b.StackSave()
+	}
+	if xaddr.IsNil() {
+		xaddr = b.toPtr(x)
+	} else {
+		xaddr = b.PtrCast(prog.VoidPtr(), xaddr)
+	}
+	if yaddr.IsNil() {
+		yaddr = b.toPtr(y)
+	} else {
+		yaddr = b.PtrCast(prog.VoidPtr(), yaddr)
+	}
+	var ret Expr
+	if prog.abi.IsRegularMemory(t) {
+		ret = b.Call(b.Pkg.rtFunc("memequal"), xaddr, yaddr, prog.IntVal(prog.SizeOf(x.Type), prog.Uintptr()))
+	} else {
+		equal := b.Pkg.rtEnvFunc("arrayequal")
+		equal = b.aggregateValue(prog.Type(equalFunc, InGo), equal.impl, b.abiType(x.raw.Type).impl)
+		ret = b.Call(equal, xaddr, yaddr)
+	}
+	if !sp.IsNil() {
+		b.StackRestore(sp)
+	}
+	return ret
 }
 
 // The UnOp instruction yields the result of (op x).

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2448,7 +2448,7 @@ func TestArrayEqualLowering(t *testing.T) {
 		return pkg
 	})
 	pkg := prog.NewPackage("main", "main")
-	compare := func(name string, elem types.Type, n int64, op token.Token) llvm.Value {
+	compare := func(name string, elem types.Type, n int64, op token.Token, addrMask uint) llvm.Value {
 		array := types.NewArray(elem, n)
 		sig := types.NewSignatureType(nil, nil, nil,
 			types.NewTuple(
@@ -2460,24 +2460,58 @@ func TestArrayEqualLowering(t *testing.T) {
 		)
 		fn := pkg.NewFunc(name, sig, InGo)
 		b := fn.MakeBody(1)
-		b.Return(b.BinOp(op, fn.Param(0), fn.Param(1)))
+		xaddr, yaddr := Nil, Nil
+		if addrMask&1 != 0 {
+			xaddr = b.AllocaT(fn.Param(0).Type)
+			b.Store(xaddr, fn.Param(0))
+		}
+		if addrMask&2 != 0 {
+			yaddr = b.AllocaT(fn.Param(1).Type)
+			b.Store(yaddr, fn.Param(1))
+		}
+		b.Return(b.ArrayBinOp(op, fn.Param(0), fn.Param(1), xaddr, yaddr))
 		return pkg.Module().NamedFunction(name)
 	}
 
-	small := compare("small", types.Typ[types.Uint8], 4, token.EQL).String()
+	small := compare("small", types.Typ[types.Uint8], 4, token.EQL, 0).String()
 	if strings.Contains(small, "memequal") || strings.Contains(small, "arrayequal") {
 		t.Fatalf("small scalar array comparison was not inlined:\n%s", small)
 	}
-	large := compare("large", types.Typ[types.Uint8], 1024, token.NEQ).String()
+	medium := compare("medium", types.Typ[types.Uint8], 16, token.EQL, 3).String()
+	if !strings.Contains(medium, ".memequal") || strings.Contains(medium, "extractvalue [16 x i8]") {
+		t.Fatalf("medium scalar array comparison was expanded element by element:\n%s", medium)
+	}
+	large := compare("large", types.Typ[types.Uint8], 1024, token.NEQ, 0).String()
 	if !strings.Contains(large, ".memequal") || strings.Contains(large, "extractvalue [1024 x i8]") {
 		t.Fatalf("large regular-memory array comparison was not lowered to memequal:\n%s", large)
 	}
-	nonMemory := compare("nonmemory", types.Typ[types.Float64], 5, token.EQL).String()
+	nonMemory := compare("nonmemory", types.Typ[types.Float64], 5, token.EQL, 0).String()
 	if !strings.Contains(nonMemory, ".arrayequal") || strings.Contains(nonMemory, "extractvalue [5 x double]") {
 		t.Fatalf("non-memory array comparison was not lowered to arrayequal:\n%s", nonMemory)
 	}
 	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
 		t.Fatalf("array comparison module is invalid: %v\n%s", err, pkg.String())
+	}
+}
+
+func TestCanInlineArrayEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  *types.Array
+		want bool
+	}{
+		{"single interface", types.NewArray(types.NewInterfaceType(nil, nil), 1), true},
+		{"four bytes", types.NewArray(types.Typ[types.Uint8], 4), true},
+		{"five bytes", types.NewArray(types.Typ[types.Uint8], 5), false},
+		{"two strings", types.NewArray(types.Typ[types.String], 2), false},
+		{"two structs", types.NewArray(types.NewStruct(nil, nil), 2), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanInlineArrayEqual(tt.typ); got != tt.want {
+				t.Fatalf("CanInlineArrayEqual(%v) = %v, want %v", tt.typ, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2489,6 +2489,34 @@ func TestArrayEqualLowering(t *testing.T) {
 	if !strings.Contains(nonMemory, ".arrayequal") || strings.Contains(nonMemory, "extractvalue [5 x double]") {
 		t.Fatalf("non-memory array comparison was not lowered to arrayequal:\n%s", nonMemory)
 	}
+
+	array := types.NewArray(types.Typ[types.Uint8], 4)
+	sig := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(
+			types.NewVar(token.NoPos, nil, "x", array),
+			types.NewVar(token.NoPos, nil, "y", array),
+		),
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Bool])),
+		false,
+	)
+	fn := pkg.NewFunc("direct", sig, InGo)
+	b := fn.MakeBody(1)
+	mustPanic := func(want string, call func()) {
+		t.Helper()
+		defer func() {
+			if got := recover(); got != want {
+				t.Fatalf("panic = %v, want %q", got, want)
+			}
+		}()
+		call()
+	}
+	mustPanic("ArrayBinOp requires array operands", func() {
+		b.ArrayBinOp(token.EQL, prog.Val(1), prog.Val(2), Nil, Nil)
+	})
+	mustPanic("ArrayBinOp requires an equality operator", func() {
+		b.ArrayBinOp(token.ADD, fn.Param(0), fn.Param(1), Nil, Nil)
+	})
+	b.Return(b.BinOp(token.EQL, fn.Param(0), fn.Param(1)))
 	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
 		t.Fatalf("array comparison module is invalid: %v\n%s", err, pkg.String())
 	}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2436,6 +2436,51 @@ attributes #0 = { null_pointer_is_valid "frame-pointer"="non-leaf" }
 `)
 }
 
+func TestArrayEqualLowering(t *testing.T) {
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("main", "main")
+	compare := func(name string, elem types.Type, n int64, op token.Token) llvm.Value {
+		array := types.NewArray(elem, n)
+		sig := types.NewSignatureType(nil, nil, nil,
+			types.NewTuple(
+				types.NewVar(token.NoPos, nil, "x", array),
+				types.NewVar(token.NoPos, nil, "y", array),
+			),
+			types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Bool])),
+			false,
+		)
+		fn := pkg.NewFunc(name, sig, InGo)
+		b := fn.MakeBody(1)
+		b.Return(b.BinOp(op, fn.Param(0), fn.Param(1)))
+		return pkg.Module().NamedFunction(name)
+	}
+
+	small := compare("small", types.Typ[types.Uint8], 4, token.EQL).String()
+	if strings.Contains(small, "memequal") || strings.Contains(small, "arrayequal") {
+		t.Fatalf("small scalar array comparison was not inlined:\n%s", small)
+	}
+	large := compare("large", types.Typ[types.Uint8], 1024, token.NEQ).String()
+	if !strings.Contains(large, ".memequal") || strings.Contains(large, "extractvalue [1024 x i8]") {
+		t.Fatalf("large regular-memory array comparison was not lowered to memequal:\n%s", large)
+	}
+	nonMemory := compare("nonmemory", types.Typ[types.Float64], 5, token.EQL).String()
+	if !strings.Contains(nonMemory, ".arrayequal") || strings.Contains(nonMemory, "extractvalue [5 x double]") {
+		t.Fatalf("non-memory array comparison was not lowered to arrayequal:\n%s", nonMemory)
+	}
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("array comparison module is invalid: %v\n%s", err, pkg.String())
+	}
+}
+
 func TestUnOp(t *testing.T) {
 	prog := NewProgram(nil)
 	pkg := prog.NewPackage("bar", "foo/bar")

--- a/test/go/array_equality_test.go
+++ b/test/go/array_equality_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"math"
+	"testing"
+)
+
+func TestLargeArrayEquality(t *testing.T) {
+	x := [1024]byte{1}
+	y := [1024]byte{1}
+	if x != y {
+		t.Fatal("equal byte arrays compared unequal")
+	}
+	y[len(y)-1] = 2
+	if x == y {
+		t.Fatal("unequal byte arrays compared equal")
+	}
+}
+
+func TestArrayEqualityPreservesLoadedValue(t *testing.T) {
+	x := [32]byte{1}
+	want := [32]byte{1}
+	snapshot := x
+	x[0] = 2
+	if snapshot != want {
+		t.Fatalf("comparison observed a later source mutation: got %v, want %v", snapshot, want)
+	}
+}
+
+func TestArrayEqualityUsesElementSemantics(t *testing.T) {
+	x := [5]float64{math.NaN()}
+	if x == x {
+		t.Fatal("array comparison treated NaN as regular memory")
+	}
+
+	// Array equality stops at the first unequal element. Comparing the second
+	// interface value would panic because slices are not comparable.
+	a := [2]any{0, []int{1}}
+	b := [2]any{1, []int{1}}
+	if a == b {
+		t.Fatal("arrays with unequal first elements compared equal")
+	}
+}

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -30,6 +30,7 @@ import (
 	"unicode"
 
 	"go.yaml.in/yaml/v3"
+	"golang.org/x/mod/modfile"
 )
 
 var (
@@ -752,12 +753,21 @@ func prepareCaseWorkspace(repoRoot string) (caseWorkspace, error) {
 		return caseWorkspace{}, err
 	}
 	gopath := filepath.Join(root, "gopath")
-	llgoPath := filepath.Join(gopath, "src", "github.com", "goplus")
-	if err := os.MkdirAll(llgoPath, 0o755); err != nil {
+	goMod, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
+	if err != nil {
+		_ = os.RemoveAll(root)
+		return caseWorkspace{}, fmt.Errorf("read repository module path: %w", err)
+	}
+	modulePath := modfile.ModulePath(goMod)
+	if modulePath == "" {
+		_ = os.RemoveAll(root)
+		return caseWorkspace{}, fmt.Errorf("read repository module path: go.mod has no module directive")
+	}
+	linkPath := filepath.Join(gopath, "src", filepath.FromSlash(modulePath))
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
 		_ = os.RemoveAll(root)
 		return caseWorkspace{}, err
 	}
-	linkPath := filepath.Join(llgoPath, "llgo")
 	if err := os.Symlink(repoRoot, linkPath); err != nil && !errors.Is(err, os.ErrExist) {
 		_ = os.RemoveAll(root)
 		return caseWorkspace{}, fmt.Errorf("symlink %q -> %q: %w", linkPath, repoRoot, err)

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -11,6 +11,31 @@ import (
 	"time"
 )
 
+func TestPrepareCaseWorkspaceUsesRepositoryModulePath(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/owner/project\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ws, err := prepareCaseWorkspace(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(ws.cleanup)
+
+	linkPath := filepath.Join(ws.gopath, "src", "example.com", "owner", "project")
+	linkInfo, err := os.Stat(linkPath)
+	if err != nil {
+		t.Fatalf("stat module workspace link: %v", err)
+	}
+	repoInfo, err := os.Stat(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(linkInfo, repoInfo) {
+		t.Fatalf("workspace path %q does not link to repository %q", linkPath, repo)
+	}
+}
+
 func TestParseDirective(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "case.go")
@@ -1216,6 +1241,9 @@ func TestRunOutputCaseGeneratesWithBaselineGoOnly(t *testing.T) {
 	dir := t.TempDir()
 	repoRoot := filepath.Join(dir, "repo")
 	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/llgo\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	goroot := filepath.Join(dir, "goroot")

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -69,26 +69,6 @@ host_skips:
     directive: run
     case: chanlinear.go
     reason: go1.24 goroot run is host-sensitive on darwin/arm64
-  - version: go1.24
-    platform: darwin/arm64
-    directive: runoutput
-    case: fixedbugs/bug449.go
-    reason: go1.24 bug449 generated build exceeds the darwin/arm64 hosted runner resource budget
-  - version: go1.26
-    platform: darwin/arm64
-    directive: runoutput
-    case: fixedbugs/bug449.go
-    reason: go1.26 bug449 generated build exceeds the darwin/arm64 hosted runner resource budget
-  - version: go1.24
-    platform: linux/amd64
-    directive: runoutput
-    case: fixedbugs/bug449.go
-    reason: go1.24 bug449 generated build exceeds the linux/amd64 hosted runner memory budget
-  - version: go1.26
-    platform: linux/amd64
-    directive: runoutput
-    case: fixedbugs/bug449.go
-    reason: go1.26 bug449 generated build exceeds the linux/amd64 hosted runner memory budget
 timeouts:
   - version: go1.26
     platform: darwin/arm64


### PR DESCRIPTION
## Summary

LLGo currently expands every array equality operation element by element. The Go compiler only inlines small, simple arrays and uses type equality algorithms for larger values. For `GOROOT/test/fixedbugs/bug449.go`, LLGo's expansion creates more than a million comparisons and causes LLVM to exhaust the runner resource budget.

This PR:

- keeps small scalar arrays inline, following the Go compiler's comparison heuristic;
- lowers regular-memory arrays to `runtime.memequal` and other comparable arrays to `runtime.arrayequal`;
- reuses backing storage only for non-escaping local arrays proven unchanged after the SSA load, while retaining a snapshot temporary for mutable or non-addressable operands;
- omits dead whole-array loads when every executable use is a non-inline comparison with two proven-stable addresses;
- derives the GOROOT runner's temporary GOPATH link from the repository's current module path instead of the pre-migration `github.com/goplus/llgo` path;
- removes the four Darwin/Linux resource expectations for `fixedbugs/bug449.go`.

The runtime algorithm also restores Go's required left-to-right short-circuit behavior for arrays containing interfaces; the previous eager element expansion could compare a later uncomparable dynamic value and panic after an earlier mismatch.

## Measured result

Increasing the Windows test environment to 7 GiB was not sufficient: the old lowering still timed out after 10 minutes, with about 6.2 GiB sampled RSS and heavy paging. Before the final frontend load-elision optimization, runtime lowering alone already made the official Go 1.26.5 case pass without increasing the runner limit:

| Host | LLGo build | Peak process-group RSS | Result |
|---|---:|---:|---|
| macOS/arm64 | 15.989 s | 1679.1 MiB | pass |
| Linux/amd64 (OrbStack) | 21.802 s | 1488.2 MiB | pass |

The Linux timing includes amd64 translation on an Apple Silicon host and is recorded as a functional/resource check, not a host-to-host speed comparison.

### Why the frontend reuses proven-stable addresses

Array size is sufficient to choose between inline comparison and a runtime equality helper, and `CanInlineArrayEqual` already provides that gate. It is not sufficient to decide whether the runtime helper may read an operand's original address: a loaded array is a value snapshot, and the source allocation may be modified before the comparison.

An A/B run of the same Go 1.26.5 `fixedbugs/bug449.go` case shows why always materializing runtime operands into temporary arrays is not viable:

| Runtime operand strategy | LLGo generated build | Peak process-group RSS | Result |
|---|---:|---:|---|
| Reuse non-escaping local storage proven unchanged | 8.982 s | 1669.0 MiB | pass |
| Always copy values to temporary arrays | 5.266 s before termination | 4146.5 MiB | failed 4096 MiB guard |

The address-use walk is therefore deliberately conservative: it reuses storage only when all stores precede the SSA load and falls back to a snapshot temporary for heap, aliased, mutated, cross-block, or otherwise unknown operands. This avoids LLVM's aggregate-copy memory growth without changing Go value semantics.

### Avoiding dead aggregate loads before LLVM

Once both operands have proven-stable addresses, the runtime equality helper does not consume their SSA aggregate values. The frontend previously emitted those whole-array loads anyway because it compiled each SSA load before reaching the comparison. LLVM eventually removed the dead loads, but constructing and optimizing them still dominated this generated case.

The final optimization omits a load only when every executable user is a non-inline array equality/inequality operation and both operands of every such comparison have reusable local addresses. Three alternating runs of prebuilt baseline and optimized compilers on the same macOS/arm64 Go 1.26.5 case produced:

| Frontend lowering | Median LLGo build | Median peak process-group RSS | Samples |
|---|---:|---:|---|
| Runtime address reuse, dead aggregate loads retained | 8.740 s | 1669.4 MiB | 3 |
| Runtime address reuse, dead aggregate loads omitted | 3.328 s | 250.9 MiB | 3 |

This reduces the median build time by about 62% and peak RSS by about 85% on this stress case. The optimized Go 1.25.0 run also passed (`4.277 s`, `244.2 MiB`). Mutable snapshots, small inline comparisons, heap values, parameters, and unknown uses keep their existing value-preserving lowering.

### Why `fixedbugs/bug449.go` stresses time and memory

The measurements above come from this generator in Go's `fixedbugs/bug449.go`. It deliberately emits 1,024 progressively larger array-equality tests:

```go
const ntest = 1024

func main() {
	var decls, calls bytes.Buffer

	for i := 1; i <= ntest; i++ {
		s := strconv.Itoa(i)
		decls.WriteString(strings.Replace(decl, "$", s, -1))
		calls.WriteString(strings.Replace("call(test$)\n\t", "$", s, -1))
	}

	program = strings.Replace(program, "$DECLS", decls.String(), 1)
	program = strings.Replace(program, "$CALLS", calls.String(), 1)
	fmt.Print(program)
}

const decl = `
type T$ [$]uint8
func test$() bool {
	v := T${1}
	return v == [$]uint8{2} || v != [$]uint8{1}
}`
```

Each iteration substitutes `i` for `$`, generating a distinct array type `[i]uint8` and its equality/inequality function. With 1,024 such functions, expanding large array comparisons makes compilation consume excessive time and memory. This change keeps small comparisons inline but lowers large arrays through the runtime equality path, which produces the measured reduction.

## Validation

- Go 1.25.0 and Go 1.26.5: `go test ./ssa ./cl -run 'Test(ArrayEqualLowering|ArrayCompareReusesImmutableLocalStorage|CanInlineArrayEqual)$' -count=1`
- Go 1.25.0 and Go 1.26.5 LLGo execution of `TestLargeArrayEquality`, `TestArrayEqualityPreservesLoadedValue`, and `TestArrayEqualityUsesElementSemantics`
- `cl/_testgo/equal` and `cl/_testrt/slice2array` lowering/execution tests
- Go 1.25.0 and Go 1.26.5 GOROOT `fixedbugs/bug449.go` on macOS/arm64; Go 1.26.5 on Linux/amd64
- full `go test ./ssa -count=1`
- `go test ./test/goroot -count=1`

The full local `cl` suite reaches an unrelated existing LLVM 19 warning in `TestRunAndTestFromTestlto/abitype_runtime` (`+zcm`/`+zcz` target features); all changed and array-specific `cl` tests pass.
