### PR TITLE
ci: bound GOROOT jobs to one Go worker

### DIFF
--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       GOPROXY: https://proxy.golang.org,direct
       LLGO_GOROOT_HEARTBEAT_SECONDS: "60"
+      LLGO_GOROOT_GOMAXPROCS: "1"
       LLGO_GOROOT_VERBOSE: "1"
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Run hosted GOROOT jobs with `LLGO_GOROOT_GOMAXPROCS=1` so each shard uses the same bounded execution model as the full-matrix validation.
- Preserve the current `main` GOROOT workflow, matrix, runner selection, reporting, and expectation files unchanged.

## Rebase note

The original runtime hooks, live `NumGoroutine` reporting, target-toolchain isolation, GOROOT classifications, and host-skip coverage have since landed on `main` through newer and more complete implementations. This rebase intentionally drops those superseded patches instead of restoring their older forms. The only remaining behavior specific to this PR is the GOROOT worker bound above.

## Validation

- `actionlint .github/workflows/goroot.yml`
- YAML parse validation for `.github/workflows/goroot.yml`
- `git diff --check`