### PR TITLE
ci: run GOROOT for go-test-compat pull requests

### DIFF
--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -1,6 +1,8 @@
 name: GOROOT
 
 on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
   schedule:
     # 02:00 Asia/Shanghai (18:00 UTC on the previous day).
@@ -15,6 +17,10 @@ concurrency:
 
 jobs:
   goroot:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat'))
     name: GOROOT (${{ matrix.lane }}, ${{ matrix.os }}, Go ${{ matrix.go-version }}, shard ${{ matrix.shard-index }}/4)
     timeout-minutes: 180
     env:
@@ -146,7 +152,11 @@ jobs:
 
   goroot-summary:
     name: GOROOT summary
-    if: always()
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat')))
     needs: goroot
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -152,11 +152,7 @@ jobs:
 
   goroot-summary:
     name: GOROOT summary
-    if: >-
-      always() &&
-      (github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat')))
+    if: always() && needs.goroot.result != 'skipped'
     needs: goroot
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Run the existing GOROOT matrix as opt-in pull-request checks when a PR has the existing `go-test-compat` label.

- adding `go-test-compat` starts the matrix automatically;
- pushing another commit or reopening the PR reruns the matrix while the label remains present;
- adding an unrelated label does not restart an already labeled PR;
- PRs without `go-test-compat` skip the GOROOT jobs;
- manual dispatch and the nightly schedule remain unchanged;
- no required-check or repository-ruleset change is included.

The existing pull-request concurrency key cancels an older GOROOT run when a labeled PR receives a newer commit.

## Validation

- `GOTOOLCHAIN=local go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/goroot.yml`
- `git diff --check`
