### PR TITLE
test: enable host-compatible tests under llgo

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -56,7 +56,7 @@ runs:
           "libunwind-$package_version"
           "gettext-runtime-0.22.5-2"
           "libffi-3.4.6-1"
-          "libiconv-1.17-4"
+          "libiconv-1.19-1"
           "libxml2-2.12.9-2"
           "xz-5.6.3-3"
           "zlib-1.3.1-1"

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -19,6 +19,7 @@ jobs:
     name: self-host (${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest
@@ -68,16 +69,16 @@ jobs:
           set -euo pipefail
 
           test "$(command -v llgo)" = "$RUNNER_TEMP/llgo-stage2/llgo"
-          llgo test -timeout=10m ./test/std/io/ioutil
-          llgo test -timeout=10m -run '^TestRuntimeGMPLinks$' ./test/llgoext
+          LLGO_BUILD_CACHE=off llgo test -timeout=10m ./test/std/io/ioutil
+          LLGO_BUILD_CACHE=off llgo test -timeout=10m -run '^TestRuntimeGMPLinks$' ./test/llgoext
 
       - name: Run demos with stage 2
         run: |
           set -euo pipefail
 
           test "$(command -v llgo)" = "$RUNNER_TEMP/llgo-stage2/llgo"
-          (cd _demo/go && llgo run ./defer)
-          (cd _demo/c && llgo run ./hello)
+          (cd _demo/go && LLGO_BUILD_CACHE=off llgo run ./defer)
+          (cd _demo/c && LLGO_BUILD_CACHE=off llgo run ./hello)
 
   llgo:
     name: llgo (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -15,6 +15,70 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  self-host:
+    name: self-host (${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        llvm: [19]
+        go: ["1.26.5"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          llvm-version: ${{ matrix.llvm }}
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Set LLGO_ROOT
+        run: echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+
+      - name: Build stage 1 with Go
+        run: |
+          set -euo pipefail
+
+          stage1_dir="$RUNNER_TEMP/llgo-stage1"
+          mkdir -p "$stage1_dir"
+          go build -o "$stage1_dir/llgo" ./cmd/llgo
+          "$stage1_dir/llgo" version
+
+      - name: Build stage 2 with LLGo
+        run: |
+          set -euo pipefail
+
+          stage1="$RUNNER_TEMP/llgo-stage1/llgo"
+          stage2_dir="$RUNNER_TEMP/llgo-stage2"
+          mkdir -p "$stage2_dir"
+          "$stage1" build -o "$stage2_dir/llgo" ./cmd/llgo
+          "$stage2_dir/llgo" version
+          file "$stage2_dir/llgo"
+          echo "$stage2_dir" >> "$GITHUB_PATH"
+
+      - name: Test with stage 2
+        run: |
+          set -euo pipefail
+
+          test "$(command -v llgo)" = "$RUNNER_TEMP/llgo-stage2/llgo"
+          llgo test -timeout=10m ./test/std/io/ioutil
+          llgo test -timeout=10m -run '^TestRuntimeGMPLinks$' ./test/llgoext
+
+      - name: Run demos with stage 2
+        run: |
+          set -euo pipefail
+
+          test "$(command -v llgo)" = "$RUNNER_TEMP/llgo-stage2/llgo"
+          (cd _demo/go && llgo run ./defer)
+          (cd _demo/c && llgo run ./hello)
+
   llgo:
     name: llgo (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})
     continue-on-error: ${{ matrix.lane == 'compatibility' }}

--- a/chore/llgen/llgen_test.go
+++ b/chore/llgen/llgen_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package main
 
 import (

--- a/chore/llpyg/pysig/parse_test.go
+++ b/chore/llpyg/pysig/parse_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/blocks/block_test.go
+++ b/cl/blocks/block_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/caller_frame_test.go
+++ b/cl/caller_frame_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/caller_tracking_compile_test.go
+++ b/cl/caller_tracking_compile_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl_test
 
 import (

--- a/cl/caller_tracking_precompute_test.go
+++ b/cl/caller_tracking_precompute_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/cgo_test.go
+++ b/cl/cgo_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -817,6 +817,8 @@ func filterRunOutput(in []byte) []byte {
 			continue
 		case bytes.HasPrefix(trim, []byte("ld: warning: ")):
 			continue
+		case isUnrecognizedTargetFeatureWarning(trim):
+			continue
 		}
 		out.Write(p)
 	}
@@ -824,6 +826,12 @@ func filterRunOutput(in []byte) []byte {
 		return nil
 	}
 	return out.Bytes()
+}
+
+func isUnrecognizedTargetFeatureWarning(line []byte) bool {
+	const suffix = "' is not a recognized feature for this target (ignoring feature)"
+	return len(line) > len(suffix)+2 && line[0] == '\'' &&
+		(line[1] == '+' || line[1] == '-') && bytes.HasSuffix(line, []byte(suffix))
 }
 
 func CompileIREx(t *testing.T, src any, fname string, dbg bool, configure func(llssa.Program)) string {

--- a/cl/cltest/cltest_test.go
+++ b/cl/cltest/cltest_test.go
@@ -1,6 +1,7 @@
 package cltest
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,17 @@ import (
 
 	"github.com/xgo-dev/llgo/internal/littest"
 )
+
+func TestFilterRunOutputToolchainWarnings(t *testing.T) {
+	in := []byte("ld64.lld: warning: library is newer than target minimum\n" +
+		"'+zcm' is not a recognized feature for this target (ignoring feature)\n" +
+		"'+zcz' is not a recognized feature for this target (ignoring feature)\n" +
+		"pass\n")
+	want := []byte("pass\n")
+	if got := filterRunOutput(in); !bytes.Equal(got, want) {
+		t.Fatalf("filterRunOutput() = %q, want %q", got, want)
+	}
+}
 
 func TestAdditionalIRTargets(t *testing.T) {
 	targets := []littest.Target{

--- a/cl/compile_nil_test.go
+++ b/cl/compile_nil_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/debug_compile_test.go
+++ b/cl/debug_compile_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package cl
 
 import (

--- a/cl/embed_compile_test.go
+++ b/cl/embed_compile_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl_test
 
 import (

--- a/cl/embed_patch_test.go
+++ b/cl/embed_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/embed_test.go
+++ b/cl/embed_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/embed_with_map_compile_test.go
+++ b/cl/embed_with_map_compile_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl_test
 
 import (

--- a/cl/float_int_amd64_compile_test.go
+++ b/cl/float_int_amd64_compile_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package cl
 
 import (

--- a/cl/float_int_conversion_compile_test.go
+++ b/cl/float_int_conversion_compile_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package cl
 
 import (

--- a/cl/funcinfo_metadata_test.go
+++ b/cl/funcinfo_metadata_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/funcname_nested_closure_test.go
+++ b/cl/funcname_nested_closure_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/import_coverage_test.go
+++ b/cl/import_coverage_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/import_patch_test.go
+++ b/cl/import_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/instr_offsetof_test.go
+++ b/cl/instr_offsetof_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/linkonce_test.go
+++ b/cl/linkonce_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/named_closure_internal_test.go
+++ b/cl/named_closure_internal_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package cl
 
 import (

--- a/cl/preloaded_syntax_test.go
+++ b/cl/preloaded_syntax_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/range_array_compile_test.go
+++ b/cl/range_array_compile_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/recover_activation_test.go
+++ b/cl/recover_activation_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cl/ssawrap/wrap_test.go
+++ b/cl/ssawrap/wrap_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssawrap
 
 import (

--- a/cl/zero_size_deref_test.go
+++ b/cl/zero_size_deref_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cl
 
 import (

--- a/cmd/internal/build/build_test.go
+++ b/cmd/internal/build/build_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/cmd/internal/compile/compile.go
+++ b/cmd/internal/compile/compile.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package compile
 
 import (

--- a/cmd/internal/compilerhash/compilerhash_test.go
+++ b/cmd/internal/compilerhash/compilerhash_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package compilerhash
 
 import (

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -53,13 +53,16 @@ var DeadcodeDrop bool
 var PthreadStackSize byteSizeFlag
 var OptLevel optlevel.Level
 
-type byteSizeFlag int64
+type byteSizeFlag struct {
+	value int64
+	set   bool
+}
 
 func (p *byteSizeFlag) String() string {
 	if p == nil {
 		return "0"
 	}
-	return strconv.FormatInt(int64(*p), 10)
+	return strconv.FormatInt(p.value, 10)
 }
 
 func (p *byteSizeFlag) Set(v string) error {
@@ -67,7 +70,8 @@ func (p *byteSizeFlag) Set(v string) error {
 	if err != nil {
 		return err
 	}
-	*p = byteSizeFlag(n)
+	p.value = n
+	p.set = true
 	return nil
 }
 
@@ -211,7 +215,7 @@ func AddOptLevelFlags(fs *flag.FlagSet) {
 
 func AddBuildFlags(fs *flag.FlagSet) {
 	DeadcodeDrop = false
-	PthreadStackSize = 0
+	PthreadStackSize = byteSizeFlag{}
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
 	if buildenv.Dev {
@@ -373,7 +377,9 @@ func UpdateConfig(conf *build.Config) error {
 	conf.Port = Port
 	conf.BaudRate = BaudRate
 	conf.ForceRebuild = ForceRebuild
-	conf.PthreadStackSize = int64(PthreadStackSize)
+	if PthreadStackSize.set {
+		conf.PthreadStackSize = PthreadStackSize.value
+	}
 	if LTO.Specified {
 		conf.LTO = LTO.Mode
 	}

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -354,6 +354,22 @@ func TestBuildPthreadStackSizeFlag(t *testing.T) {
 	}
 }
 
+func TestBuildPthreadStackSizeFlagPreservesDefaultWhenUnset(t *testing.T) {
+	fs := flag.NewFlagSet("pthread-stack-size-unset", flag.ContinueOnError)
+	fs.SetOutput(new(bytes.Buffer))
+	AddBuildFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("Parse unexpected error: %v", err)
+	}
+	conf := &build.Config{PthreadStackSize: 32 << 20}
+	if err := UpdateConfig(conf); err != nil {
+		t.Fatalf("UpdateConfig error: %v", err)
+	}
+	if conf.PthreadStackSize != 32<<20 {
+		t.Fatalf("conf.PthreadStackSize = %d, want %d", conf.PthreadStackSize, 32<<20)
+	}
+}
+
 func TestBuildPthreadStackSizeFlagRejectsNegative(t *testing.T) {
 	fs := flag.NewFlagSet("pthread-stack-size-negative", flag.ContinueOnError)
 	fs.SetOutput(new(bytes.Buffer))

--- a/cmd/internal/install/install_test.go
+++ b/cmd/internal/install/install_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package install
 
 import "testing"

--- a/cmd/internal/lldb/lldb_test.go
+++ b/cmd/internal/lldb/lldb_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/cmd/internal/run/run_test.go
+++ b/cmd/internal/run/run_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package run
 
 import "testing"

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package test
 
 import (

--- a/cmd/internal/test/test_test.go
+++ b/cmd/internal/test/test_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package test
 
 import (

--- a/internal/abi/large_test.go
+++ b/internal/abi/large_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package abi
 
 import (

--- a/internal/build/bounds_checks_test.go
+++ b/internal/build/bounds_checks_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -81,6 +81,8 @@ const (
 	ModeGen
 )
 
+const defaultTestPthreadStackSize = 32 << 20
+
 type BuildMode string
 
 const (
@@ -381,6 +383,9 @@ func NewDefaultConf(mode Mode) *Config {
 		AbiMode:            cabi.ModeAllFunc,
 		OmitDWARFByDefault: mode != ModeGen,
 		PCLNMode:           PCLNEmbedded,
+	}
+	if mode == ModeTest {
+		conf.PthreadStackSize = defaultTestPthreadStackSize
 	}
 	return conf
 }

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (
@@ -133,6 +130,16 @@ func TestNewDefaultConfDoesNotCreateBinDir(t *testing.T) {
 	}
 	if _, err := os.Stat(binDir); !os.IsNotExist(err) {
 		t.Fatalf("NewDefaultConf created bin directory: %v", err)
+	}
+}
+
+func TestNewDefaultConfPthreadStackSize(t *testing.T) {
+	t.Setenv("GOBIN", t.TempDir())
+	if got := NewDefaultConf(ModeTest).PthreadStackSize; got != defaultTestPthreadStackSize {
+		t.Fatalf("test PthreadStackSize = %d, want %d", got, defaultTestPthreadStackSize)
+	}
+	if got := NewDefaultConf(ModeBuild).PthreadStackSize; got != 0 {
+		t.Fatalf("build PthreadStackSize = %d, want 0", got)
 	}
 }
 

--- a/internal/build/build_trace_test.go
+++ b/internal/build/build_trace_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/cgo.go
+++ b/internal/build/cgo.go
@@ -36,10 +36,11 @@ import (
 )
 
 type cgoDecl struct {
-	tag      string
-	cflags   []string
-	cxxflags []string
-	ldflags  []string
+	tag       string
+	pkgConfig string
+	cflags    []string
+	cxxflags  []string
+	ldflags   []string
 }
 
 type cgoSrcFile struct {
@@ -77,28 +78,9 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 	if err != nil {
 		return
 	}
-	tagUsed := make(map[string]bool)
-	for _, cdecl := range cdecls {
-		if cdecl.tag != "" {
-			tagUsed[cdecl.tag] = false
-		}
-	}
-	buildtags.CheckTags(ctx.conf.BuildFlags, tagUsed)
-	cflags := []string{}
-	cxxflags := []string{}
-	ldflags := []string{}
-	for _, cdecl := range cdecls {
-		if cdecl.tag == "" || tagUsed[cdecl.tag] {
-			if len(cdecl.cflags) > 0 {
-				cflags = append(cflags, cdecl.cflags...)
-			}
-			if len(cdecl.cxxflags) > 0 {
-				cxxflags = append(cxxflags, cdecl.cxxflags...)
-			}
-			if len(cdecl.ldflags) > 0 {
-				ldflags = append(ldflags, cdecl.ldflags...)
-			}
-		}
+	cflags, cxxflags, ldflags, err := selectCgoFlags(ctx.commands, ctx.conf.BuildFlags, cdecls)
+	if err != nil {
+		return nil, nil, err
 	}
 	incDirs := make(map[string]none)
 	for _, preamble := range preambles {
@@ -138,9 +120,19 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 		}, verbose)
 	}
 	for _, ldflag := range ldflags {
-		cgoLdflags = append(cgoLdflags, safesplit.SplitPkgConfigFlags(ldflag)...)
+		cgoLdflags = append(cgoLdflags, splitCgoLinkerFlag(ldflag)...)
 	}
 	return
+}
+
+func splitCgoLinkerFlag(flag string) []string {
+	if framework, ok := strings.CutPrefix(flag, "-framework "); ok {
+		framework = strings.TrimSpace(framework)
+		if framework != "" {
+			return []string{"-framework", framework}
+		}
+	}
+	return safesplit.SplitPkgConfigFlags(flag)
 }
 
 func collectCgoSymbols(externs []string) map[string]string {
@@ -475,24 +467,9 @@ func parseCgoDeclWithCommandEnv(commands commandEnv, line string) (cgoDecls []cg
 
 	switch flag {
 	case "pkg-config":
-		libsCmd := exec.Command("pkg-config", "--libs", arg)
-		commands.configure(libsCmd)
-		ldflags, e := libsCmd.Output()
-		if e != nil {
-			err = fmt.Errorf("pkg-config: %v", e)
-			return
-		}
-		flagsCmd := exec.Command("pkg-config", "--cflags", arg)
-		commands.configure(flagsCmd)
-		cflags, e := flagsCmd.Output()
-		if e != nil {
-			err = fmt.Errorf("pkg-config: %v", e)
-			return
-		}
 		cgoDecls = append(cgoDecls, cgoDecl{
-			tag:     tag,
-			cflags:  safesplit.SplitPkgConfigFlags(string(cflags)),
-			ldflags: safesplit.SplitPkgConfigFlags(string(ldflags)),
+			tag:       tag,
+			pkgConfig: arg,
 		})
 	case "CPPFLAGS", "CFLAGS":
 		cgoDecls = append(cgoDecls, cgoDecl{
@@ -513,4 +490,51 @@ func parseCgoDeclWithCommandEnv(commands commandEnv, line string) (cgoDecls []cg
 		err = fmt.Errorf("unsupported cgo flag type: %s", flag)
 	}
 	return
+}
+
+// selectCgoFlags filters conditional directives before resolving pkg-config.
+// Running pkg-config while parsing would make an inactive directive, such as
+// a Windows-only LLVM dependency on Darwin, fail the whole build.
+func selectCgoFlags(commands commandEnv, buildFlags []string, decls []cgoDecl) (cflags, cxxflags, ldflags []string, err error) {
+	tagUsed := make(map[string]bool)
+	for _, decl := range decls {
+		if decl.tag != "" {
+			tagUsed[decl.tag] = false
+		}
+	}
+	buildtags.CheckTags(buildFlags, tagUsed)
+	for _, decl := range decls {
+		if decl.tag != "" && !tagUsed[decl.tag] {
+			continue
+		}
+		if decl.pkgConfig != "" {
+			decl, err = resolveCgoPkgConfig(commands, decl)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
+		cflags = append(cflags, decl.cflags...)
+		cxxflags = append(cxxflags, decl.cxxflags...)
+		ldflags = append(ldflags, decl.ldflags...)
+	}
+	return
+}
+
+func resolveCgoPkgConfig(commands commandEnv, decl cgoDecl) (cgoDecl, error) {
+	libsCmd := exec.Command("pkg-config", "--libs", decl.pkgConfig)
+	commands.configure(libsCmd)
+	ldflags, err := libsCmd.Output()
+	if err != nil {
+		return cgoDecl{}, fmt.Errorf("pkg-config: %v", err)
+	}
+	flagsCmd := exec.Command("pkg-config", "--cflags", decl.pkgConfig)
+	commands.configure(flagsCmd)
+	cflags, err := flagsCmd.Output()
+	if err != nil {
+		return cgoDecl{}, fmt.Errorf("pkg-config: %v", err)
+	}
+	decl.pkgConfig = ""
+	decl.cflags = append(decl.cflags, safesplit.SplitPkgConfigFlags(string(cflags))...)
+	decl.ldflags = append(decl.ldflags, safesplit.SplitPkgConfigFlags(string(ldflags))...)
+	return decl, nil
 }

--- a/internal/build/cgo_test.go
+++ b/internal/build/cgo_test.go
@@ -156,6 +156,15 @@ printf '%s\n' '-I/request/include -DREQUEST="request value"'
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("parseCgoDeclWithCommandEnv(pkg-config) = %#v, want %#v", got, want)
 	}
+	active := decls[0]
+	active.tag = ""
+	cflags, cxxflags, ldflags, err := selectCgoFlags(commands, nil, []cgoDecl{active})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cflags, want[0].cflags) || len(cxxflags) != 0 || !reflect.DeepEqual(ldflags, want[0].ldflags) {
+		t.Fatalf("selectCgoFlags() = %v, %v, %v, want %v, [], %v", cflags, cxxflags, ldflags, want[0].cflags, want[0].ldflags)
+	}
 
 	for _, arg := range []string{"--libs", "--cflags"} {
 		t.Run("failed "+arg, func(t *testing.T) {
@@ -163,6 +172,9 @@ printf '%s\n' '-I/request/include -DREQUEST="request value"'
 			decl := cgoDecl{pkgConfig: "request"}
 			if _, err := resolveCgoPkgConfig(commands, decl); err == nil || !strings.Contains(err.Error(), "pkg-config") {
 				t.Fatalf("resolveCgoPkgConfig() error = %v, want pkg-config failure", err)
+			}
+			if _, _, _, err := selectCgoFlags(commands, nil, []cgoDecl{decl}); err == nil || !strings.Contains(err.Error(), "pkg-config") {
+				t.Fatalf("selectCgoFlags() error = %v, want pkg-config failure", err)
 			}
 		})
 	}

--- a/internal/build/cgo_test.go
+++ b/internal/build/cgo_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (
@@ -139,10 +136,18 @@ printf '%s\n' '-I/request/include -DREQUEST="request value"'
 	t.Setenv("PATH", dir)
 
 	commands := commandEnv{dir: dir, environ: []string{"PATH=" + dir}}
-	got, err := parseCgoDeclWithCommandEnv(commands, "#cgo linux pkg-config: request")
+	decls, err := parseCgoDeclWithCommandEnv(commands, "#cgo linux pkg-config: request")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(decls) != 1 {
+		t.Fatalf("parseCgoDeclWithCommandEnv(pkg-config) = %#v, want one declaration", decls)
+	}
+	gotDecl, err := resolveCgoPkgConfig(commands, decls[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := []cgoDecl{gotDecl}
 	want := []cgoDecl{{
 		tag:     "linux",
 		cflags:  []string{"-I/request/include", `-DREQUEST="request value"`},
@@ -155,10 +160,47 @@ printf '%s\n' '-I/request/include -DREQUEST="request value"'
 	for _, arg := range []string{"--libs", "--cflags"} {
 		t.Run("failed "+arg, func(t *testing.T) {
 			commands := commandEnv{dir: dir, environ: []string{"PATH=" + dir, "PKG_CONFIG_TEST_FAIL=" + arg}}
-			if _, err := parseCgoDeclWithCommandEnv(commands, "#cgo pkg-config: request"); err == nil || !strings.Contains(err.Error(), "pkg-config") {
-				t.Fatalf("parseCgoDeclWithCommandEnv(pkg-config) error = %v, want pkg-config failure", err)
+			decl := cgoDecl{pkgConfig: "request"}
+			if _, err := resolveCgoPkgConfig(commands, decl); err == nil || !strings.Contains(err.Error(), "pkg-config") {
+				t.Fatalf("resolveCgoPkgConfig() error = %v, want pkg-config failure", err)
 			}
 		})
+	}
+}
+
+func TestSelectCgoFlagsSkipsInactivePkgConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper uses a shell script")
+	}
+
+	dir := t.TempDir()
+	tool := filepath.Join(dir, "pkg-config")
+	if err := os.WriteFile(tool, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	commands := commandEnv{dir: dir, environ: []string{"PATH=" + dir}}
+	decls := []cgoDecl{{tag: "llgo_missing_cgo_tag", pkgConfig: "missing"}}
+	cflags, cxxflags, ldflags, err := selectCgoFlags(commands, nil, decls)
+	if err != nil {
+		t.Fatalf("inactive pkg-config directive was resolved: %v", err)
+	}
+	if len(cflags) != 0 || len(cxxflags) != 0 || len(ldflags) != 0 {
+		t.Fatalf("inactive pkg-config flags = %v, %v, %v, want empty", cflags, cxxflags, ldflags)
+	}
+}
+
+func TestSplitCgoLinkerFlagFramework(t *testing.T) {
+	tests := []struct {
+		flag string
+		want []string
+	}{
+		{"-framework CoreFoundation", []string{"-framework", "CoreFoundation"}},
+		{"-L/request/lib", []string{"-L/request/lib"}},
+	}
+	for _, test := range tests {
+		if got := splitCgoLinkerFlag(test.flag); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("splitCgoLinkerFlag(%q) = %v, want %v", test.flag, got, test.want)
+		}
 	}
 }
 

--- a/internal/build/clean_test.go
+++ b/internal/build/clean_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -141,6 +141,7 @@ func (c *context) collectCommonInputs(m *manifestBuilder) {
 	m.common.DisableBoundsChecks = c.buildConf.DisableBoundsChecks
 	m.common.SaturatingFloatToUint32 = c.buildConf.SaturatingFloatToUint32
 	m.common.LocalContext = c.prog != nil && c.prog.NeedsLocalContext()
+	m.common.PthreadStackSize = c.buildConf.PthreadStackSize
 
 	// Compiler configuration
 	if c.crossCompile.CC != "" {

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/dwarf_standard_test.go
+++ b/internal/build/dwarf_standard_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -131,6 +131,7 @@ type commonSection struct {
 	DisableBoundsChecks     bool         `yaml:"DISABLE_BOUNDS_CHECKS,omitempty"`
 	SaturatingFloatToUint32 bool         `yaml:"SATURATING_FLOAT_TO_UINT32,omitempty"`
 	LocalContext            bool         `yaml:"LOCAL_CONTEXT,omitempty"`
+	PthreadStackSize        int64        `yaml:"PTHREAD_STACK_SIZE,omitempty"`
 	CC                      string       `yaml:"CC,omitempty"`
 	CCFlags                 []string     `yaml:"CCFLAGS,omitempty"`
 	CFlags                  []string     `yaml:"CFLAGS,omitempty"`
@@ -143,7 +144,7 @@ func (s *commonSection) empty() bool {
 	return s.AbiMode == "" && len(s.BuildTags) == 0 && s.Target == "" && s.TargetABI == "" &&
 		s.PlatformABI == "" && s.ObjectFormat == "" && s.DriverFlavor == "" && s.LinkerFlavor == "" &&
 		!s.GoGlobalDCE && !s.EnableLTOPlugin && !s.EmitDWARF && s.PCLNMode == "" &&
-		!s.DisableBoundsChecks && !s.SaturatingFloatToUint32 && !s.LocalContext &&
+		!s.DisableBoundsChecks && !s.SaturatingFloatToUint32 && !s.LocalContext && s.PthreadStackSize == 0 &&
 		s.CC == "" && len(s.CCFlags) == 0 && len(s.CFlags) == 0 && len(s.LDFlags) == 0 &&
 		s.Linker == "" && len(s.ExtraFiles) == 0
 }

--- a/internal/build/fingerprint_test.go
+++ b/internal/build/fingerprint_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *
@@ -151,6 +149,26 @@ func TestManifestBuilder_DisableBoundsChecks(t *testing.T) {
 	}
 	if data.Common == nil || !data.Common.DisableBoundsChecks {
 		t.Fatalf("decoded common section = %#v, want disabled bounds checks", data.Common)
+	}
+}
+
+func TestManifestBuilder_PthreadStackSize(t *testing.T) {
+	platformDefault := newManifestBuilder()
+	largeStack := newManifestBuilder()
+	largeStack.common.PthreadStackSize = 32 << 20
+
+	if largeStack.common.empty() {
+		t.Fatal("pthread stack size did not make the common section non-empty")
+	}
+	if platformDefault.Fingerprint() == largeStack.Fingerprint() {
+		t.Fatal("pthread stack size did not change the build fingerprint")
+	}
+	data, err := decodeManifest(largeStack.Build())
+	if err != nil {
+		t.Fatalf("decodeManifest: %v", err)
+	}
+	if data.Common == nil || data.Common.PthreadStackSize != 32<<20 {
+		t.Fatalf("decoded common section = %#v, want pthread stack size %d", data.Common, 32<<20)
 	}
 }
 

--- a/internal/build/init_order.go
+++ b/internal/build/init_order.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/interface_method_identity_test.go
+++ b/internal/build/interface_method_identity_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/link_options_test.go
+++ b/internal/build/link_options_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/macho_size_test.go
+++ b/internal/build/macho_size_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/module_hook_test.go
+++ b/internal/build/module_hook_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/outputs_test.go
+++ b/internal/build/outputs_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/package_archive.go
+++ b/internal/build/package_archive.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	gllvm "github.com/xgo-dev/llvm"
 )
@@ -63,6 +64,15 @@ func (c *context) createPackageArchiveFile(archivePath string, pkg *aPackage, ve
 	if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err != nil {
 		return err
 	}
+	// LLVM's in-process archive writer installs fatal-signal handlers while
+	// creating its temporary archive. On Linux that replaces the SIGXCPU
+	// handler BDWGC uses to resume stopped threads, so a self-hosted compiler
+	// can terminate during its next collection. Keep in-memory code generation,
+	// but let an external archiver publish those buffers when llgo is the host
+	// compiler.
+	if useExternalPackageArchiver {
+		return c.createPackageArchiveFileWithExternalArchiver(archivePath, pkg, verbose)
+	}
 	tmp, err := os.CreateTemp(filepath.Dir(archivePath), filepath.Base(archivePath)+".tmp-*")
 	if err != nil {
 		return err
@@ -96,4 +106,32 @@ func (c *context) createPackageArchiveFile(archivePath string, pkg *aPackage, ve
 		return fmt.Errorf("publish archive %s: %w", archivePath, err)
 	}
 	return nil
+}
+
+func (c *context) createPackageArchiveFileWithExternalArchiver(archivePath string, pkg *aPackage, verbose bool) error {
+	membersDir, err := os.MkdirTemp(filepath.Dir(archivePath), filepath.Base(archivePath)+".members-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(membersDir)
+
+	objFiles := append([]string(nil), pkg.ObjFiles...)
+	for i, member := range pkg.ObjBuffers {
+		if member.name == "" {
+			return fmt.Errorf("archive member %d has an empty name", i)
+		}
+		if member.buffer.IsNil() {
+			return fmt.Errorf("archive member %d (%q) has a nil buffer", i, member.name)
+		}
+		memberDir := filepath.Join(membersDir, strconv.Itoa(i))
+		if err := os.Mkdir(memberDir, 0o755); err != nil {
+			return err
+		}
+		memberPath := filepath.Join(memberDir, filepath.Base(member.name))
+		if err := os.WriteFile(memberPath, member.buffer.Bytes(), 0o644); err != nil {
+			return err
+		}
+		objFiles = append(objFiles, memberPath)
+	}
+	return c.createArchiveFile(archivePath, objFiles, verbose)
 }

--- a/internal/build/package_archive_host_go.go
+++ b/internal/build/package_archive_host_go.go
@@ -1,0 +1,21 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+const useExternalPackageArchiver = false

--- a/internal/build/package_archive_host_llgo.go
+++ b/internal/build/package_archive_host_llgo.go
@@ -1,0 +1,21 @@
+//go:build llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+const useExternalPackageArchiver = true

--- a/internal/build/package_archive_test.go
+++ b/internal/build/package_archive_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -79,6 +80,70 @@ func TestNormalizeToArchiveUsesMemoryBuffer(t *testing.T) {
 			t.Errorf("archive does not contain member %q", name)
 		}
 	}
+}
+
+func TestCreatePackageArchiveFileWithExternalArchiver(t *testing.T) {
+	llvmCtx := gllvm.NewContext()
+	defer llvmCtx.Dispose()
+	mod := llvmCtx.NewModule("external-archive")
+	defer mod.Dispose()
+	mod.SetTarget(gllvm.DefaultTargetTriple())
+	gllvm.AddFunction(mod, "external_archive_symbol", gllvm.FunctionType(llvmCtx.Int32Type(), nil, false))
+
+	buffer := gllvm.WriteBitcodeToMemoryBuffer(mod)
+	defer buffer.Dispose()
+	pkg := &aPackage{ObjBuffers: []packageArchiveBuffer{{name: "memory-member.bc", buffer: buffer}}}
+	ctx := &context{
+		buildConf: &Config{Goos: runtime.GOOS, Goarch: runtime.GOARCH},
+		commands:  commandEnv{environ: os.Environ()},
+	}
+	archivePath := filepath.Join(t.TempDir(), "external.a")
+	if err := ctx.createPackageArchiveFileWithExternalArchiver(archivePath, pkg, false); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(data, []byte("!<arch>\n")) {
+		t.Fatalf("archive has invalid magic: %q", data[:8])
+	}
+	if !bytes.Contains(data, []byte("memory-member.bc")) {
+		t.Fatal("archive does not contain memory-member.bc")
+	}
+
+	t.Run("invalid members", func(t *testing.T) {
+		for _, member := range []packageArchiveBuffer{
+			{buffer: buffer},
+			{name: "nil.bc"},
+			{name: ".", buffer: buffer},
+		} {
+			pkg := &aPackage{ObjBuffers: []packageArchiveBuffer{member}}
+			if err := ctx.createPackageArchiveFileWithExternalArchiver(filepath.Join(t.TempDir(), "invalid.a"), pkg, false); err == nil {
+				t.Fatalf("createPackageArchiveFileWithExternalArchiver succeeded for member %+v", member)
+			}
+		}
+	})
+
+	t.Run("invalid archive parent", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "file")
+		if err := os.WriteFile(parent, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ctx.createPackageArchiveFileWithExternalArchiver(filepath.Join(parent, "invalid.a"), pkg, false); err == nil {
+			t.Fatal("createPackageArchiveFileWithExternalArchiver succeeded below a regular file")
+		}
+	})
+
+	t.Run("missing file member", func(t *testing.T) {
+		pkg := &aPackage{
+			ObjFiles:   []string{filepath.Join(t.TempDir(), "missing.o")},
+			ObjBuffers: []packageArchiveBuffer{{name: "memory-member.bc", buffer: buffer}},
+		}
+		if err := ctx.createPackageArchiveFileWithExternalArchiver(filepath.Join(t.TempDir(), "invalid.a"), pkg, false); err == nil {
+			t.Fatal("createPackageArchiveFileWithExternalArchiver succeeded with a missing file member")
+		}
+	})
 }
 
 func TestPackageArchiveEdgeCases(t *testing.T) {

--- a/internal/build/package_archive_test.go
+++ b/internal/build/package_archive_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/pcln_mode_test.go
+++ b/internal/build/pcln_mode_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/pclntab_llvm.go
+++ b/internal/build/pclntab_llvm.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/pclntab_llvm_test.go
+++ b/internal/build/pclntab_llvm_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/pclntab_modes_integration_test.go
+++ b/internal/build/pclntab_modes_integration_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/build/plan9asm_altpkg_test.go
+++ b/internal/build/plan9asm_altpkg_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package build
 
 import (

--- a/internal/build/run_test.go
+++ b/internal/build/run_test.go
@@ -1,4 +1,4 @@
-//go:build !llgo && !windows
+//go:build !windows
 
 package build
 

--- a/internal/build/size_report_test.go
+++ b/internal/build/size_report_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/internal/build/windows_artifacts_test.go
+++ b/internal/build/windows_artifacts_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package build
 
 import (

--- a/internal/buildtags/buildtags_test.go
+++ b/internal/buildtags/buildtags_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package buildtags
 
 import (

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cabi
 
 import (

--- a/internal/cabi/cabi_test.go
+++ b/internal/cabi/cabi_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package cabi_test
 
 import (

--- a/internal/clang/clang_test.go
+++ b/internal/clang/clang_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/internal/crosscompile/compile/compile_test.go
+++ b/internal/crosscompile/compile/compile_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package compile
 
 import (

--- a/internal/crosscompile/compile/libc/libc_test.go
+++ b/internal/crosscompile/compile/libc/libc_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package libc
 
 import (

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package crosscompile
 
 import (

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package crosscompile
 
 import (

--- a/internal/crosscompile/libc_test.go
+++ b/internal/crosscompile/libc_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package crosscompile
 
 import (

--- a/internal/debuginfo/builder_test.go
+++ b/internal/debuginfo/builder_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package debuginfo
 
 import (

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package env
 
 import (

--- a/internal/env/utils_test.go
+++ b/internal/env/utils_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package env
 
 import "testing"

--- a/internal/env/version_test.go
+++ b/internal/env/version_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package env
 
 import (

--- a/internal/header/header_test.go
+++ b/internal/header/header_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package header
 
 import (

--- a/internal/packages/load_test.go
+++ b/internal/packages/load_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package packages
 
 import (

--- a/internal/plan9asm/bytealg_arm_sigs_test.go
+++ b/internal/plan9asm/bytealg_arm_sigs_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package plan9asm
 
 import (

--- a/internal/plan9asm/bytealg_sigs_test.go
+++ b/internal/plan9asm/bytealg_sigs_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package plan9asm
 
 import (

--- a/internal/plan9asm/filter_test.go
+++ b/internal/plan9asm/filter_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package plan9asm
 
 import (

--- a/internal/plan9asm/indexbyte_return_test.go
+++ b/internal/plan9asm/indexbyte_return_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package plan9asm
 
 import (

--- a/internal/plan9asm/translate_helpers_test.go
+++ b/internal/plan9asm/translate_helpers_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package plan9asm
 
 import (

--- a/internal/targets/example_test.go
+++ b/internal/targets/example_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package targets
 
 import (

--- a/internal/targets/targets_test.go
+++ b/internal/targets/targets_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package targets
 
 import (

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package llvm
 
 import (

--- a/runtime/abi/map_test.go
+++ b/runtime/abi/map_test.go
@@ -1,7 +1,4 @@
-//go:build !llgo
-// +build !llgo
-
-package abi
+package abi_test
 
 import (
 	"fmt"

--- a/runtime/internal/lib/runtime/link_darwin_llgo.go
+++ b/runtime/internal/lib/runtime/link_darwin_llgo.go
@@ -33,7 +33,19 @@ func os_runtime_args() []string {
 		args = append(args, c.GoString(p))
 	}
 	if executablePath == "" {
-		executablePath = externalPCLNExecutablePath()
+		// Darwin puts the executable path in the first Apple vector entry,
+		// after argv, envv, and their terminating nil pointers.
+		n := argc + 1
+		for c.Index(c.Argv, n) != nil {
+			n++
+		}
+		if p := c.Index(c.Argv, n+1); p != nil {
+			executablePath = c.GoString(p)
+			const prefix = "executable_path="
+			if len(executablePath) >= len(prefix) && executablePath[:len(prefix)] == prefix {
+				executablePath = executablePath[len(prefix):]
+			}
+		}
 		if executablePath == "" && len(args) > 0 {
 			executablePath = args[0]
 		}

--- a/runtime/internal/lib/runtime/link_darwin_llgo.go
+++ b/runtime/internal/lib/runtime/link_darwin_llgo.go
@@ -10,8 +10,7 @@ import (
 )
 
 // os.Executable (darwin) expects runtime to populate os.executablePath.
-// Upstream Go runtime sets this during startup; llgo sets it from argv[0],
-// which is sufficient for stdlib os tests.
+// Upstream Go runtime sets this during startup.
 //
 //go:linkname executablePath os.executablePath
 var executablePath string
@@ -33,8 +32,11 @@ func os_runtime_args() []string {
 		}
 		args = append(args, c.GoString(p))
 	}
-	if len(args) > 0 && executablePath == "" {
-		executablePath = args[0]
+	if executablePath == "" {
+		executablePath = externalPCLNExecutablePath()
+		if executablePath == "" && len(args) > 0 {
+			executablePath = args[0]
+		}
 	}
 	return args
 }

--- a/runtime/internal/lib/runtime/pclntab_external_darwin.go
+++ b/runtime/internal/lib/runtime/pclntab_external_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build llgo_pclntab_external && darwin
 
 package runtime
 

--- a/runtime/internal/lib/runtime/pclntab_external_darwin.go
+++ b/runtime/internal/lib/runtime/pclntab_external_darwin.go
@@ -1,4 +1,4 @@
-//go:build llgo_pclntab_external && darwin
+//go:build darwin
 
 package runtime
 

--- a/ssa/abi/abi_coverage_test.go
+++ b/ssa/abi/abi_coverage_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package abi
 
 import (

--- a/ssa/abi/abi_patch_test.go
+++ b/ssa/abi/abi_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package abi
 
 import (

--- a/ssa/abi/abi_test.go
+++ b/ssa/abi/abi_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package abi_test
 
 import (

--- a/ssa/bounds_checks_test.go
+++ b/ssa/bounds_checks_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ssa_test
 
 import (

--- a/ssa/cl_test.go
+++ b/ssa/cl_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/ssa/closure_env_test.go
+++ b/ssa/closure_env_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ssa
 
 import (

--- a/ssa/coff_comdat_test.go
+++ b/ssa/coff_comdat_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ssa
 
 import (

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ssa
 
 import (

--- a/ssa/di_test.go
+++ b/ssa/di_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2025 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/ssa/eh_defer_test.go
+++ b/ssa/eh_defer_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssa_test
 
 import (

--- a/ssa/eh_loop_test.go
+++ b/ssa/eh_loop_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2025 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/ssa/eh_patch_test.go
+++ b/ssa/eh_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssa_test
 
 import (

--- a/ssa/float_int_conversion_test.go
+++ b/ssa/float_int_conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/ssa/goroutine_patch_test.go
+++ b/ssa/goroutine_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssa_test
 
 import (

--- a/ssa/memory_large_test.go
+++ b/ssa/memory_large_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ssa
 
 import (

--- a/ssa/method_identity_test.go
+++ b/ssa/method_identity_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/ssa/needsfp_test.go
+++ b/ssa/needsfp_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssa
 
 import "testing"

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -476,8 +476,8 @@ type closureEnvDirectiveKey struct {
 	pos  token.Pos
 }
 
-// SetClosureEnvDirective records that a source function declaration has the
-// llgo:env directive. name and pos identify the source declaration rather
+// SetClosureEnvDirective records that a source function declaration has an
+// LLGo closure-environment directive. name and pos identify the declaration
 // than its resolved linker symbol, so aliases retain independent ABI metadata.
 func (p Program) SetClosureEnvDirective(fset *token.FileSet, name string, pos token.Pos) {
 	key := closureEnvDirectiveKey{fset: fset, name: name, pos: pos}

--- a/ssa/recover_metadata_test.go
+++ b/ssa/recover_metadata_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ssa
 
 import (

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/ssa/ssatest/ssautil_test.go
+++ b/ssa/ssatest/ssautil_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssatest
 
 import (

--- a/ssa/target_optlevel_test.go
+++ b/ssa/target_optlevel_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssa
 
 import (

--- a/ssa/type_patch_test.go
+++ b/ssa/type_patch_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 package ssa
 
 import (

--- a/test/go/dwarf_semantics_acceptance_test.go
+++ b/test/go/dwarf_semantics_acceptance_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package gotest
 
 import (

--- a/test/go/large_array_return_test.go
+++ b/test/go/large_array_return_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package gotest
 
 import (

--- a/test/std/io/ioutil/ioutil_readdir_llgo_test.go
+++ b/test/std/io/ioutil/ioutil_readdir_llgo_test.go
@@ -1,9 +1,0 @@
-//go:build llgo
-
-package ioutil_test
-
-import "testing"
-
-func TestReadDir(t *testing.T) {
-	t.Skip("TODO(llgo#os-readdir): os.File.Readdir not implemented")
-}

--- a/test/std/io/ioutil/ioutil_readdir_test.go
+++ b/test/std/io/ioutil/ioutil_readdir_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package ioutil_test
 
 import (

--- a/test/std/os/os_test.go
+++ b/test/std/os/os_test.go
@@ -120,6 +120,12 @@ func TestExecutable(t *testing.T) {
 	if exe == "" {
 		t.Error("Executable() returned empty string")
 	}
+	if !filepath.IsAbs(exe) {
+		t.Errorf("Executable() returned non-absolute path %q", exe)
+	}
+	if _, err := os.Stat(exe); err != nil {
+		t.Errorf("Executable() returned unusable path %q: %v", exe, err)
+	}
 }
 
 func TestExpand(t *testing.T) {

--- a/xtool/clang/_types/parser/_parser_test.go
+++ b/xtool/clang/_types/parser/_parser_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2022 The XGo Authors (xgo.dev). All rights reserved.
  *

--- a/xtool/env/llvm/llvm_test.go
+++ b/xtool/env/llvm/llvm_test.go
@@ -1,5 +1,3 @@
-//go:build !llgo
-
 package llvm
 
 import (

--- a/xtool/safesplit/safesplit_test.go
+++ b/xtool/safesplit/safesplit_test.go
@@ -1,6 +1,3 @@
-//go:build !llgo
-// +build !llgo
-
 /*
  * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
  *


### PR DESCRIPTION
## Summary

- remove obsolete `!llgo` constraints from host-compatible compiler, tooling, and standard-library tests and fix the LLGo compatibility issues they expose
- keep the intentional LLGo-specific expectations for `nointerface` and `debug/buildinfo`, while making `io/ioutil.ReadDir` match Go
- add macOS and Linux self-host CI: Go builds stage 1, stage 1 builds stage 2, and stage 2 runs representative Go/C demos and tests

## Validation

- `git diff --check`
- Go-built LLGo successfully builds `cmd/llgo`; the resulting stage-2 compiler reports `llgo (devel)` and runs the self-host smoke set
- stage-2 `llgo test` passes 33 affected root-module packages plus `runtime/abi` and `xtool/clang/_types/parser`
- `go test -vet=off ./test/go` passes; vet is disabled only because the Go 1.26.5 printf analyzer panics on the compiler edge-case fixtures
- full stage-2 `llgo test ./cl` has not completed within the local 60-minute limit; it reached `TestRunAndTestFromTestgo/strucintf` without an assertion failure

The PR remains draft while CI and the long-running `cl` coverage are evaluated.