### PR TITLE
ci: resolve rolling MSYS2 runtime dependencies

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -36,6 +36,7 @@ runs:
           19)
             llvm_version=19.1.7
             package_version=19.1.7-1
+            libxml2_version=2.12.9-2
             ;;
           *)
             echo "unsupported Windows LLVM version: $llvm_major" >&2
@@ -54,33 +55,33 @@ runs:
           "lld-$package_version"
           "libc++-$package_version"
           "libunwind-$package_version"
-          "gettext-runtime-0.22.5-2"
-          "libffi-3.4.6-1"
-          "libiconv-1.17-4"
-          "libxml2-2.12.9-2"
-          "xz-5.6.3-3"
-          "zlib-1.3.1-1"
-          "zstd-1.5.6-2"
-          "libuv-1.52.1-1"
-          "gc-8.2.12-1"
-          "libatomic_ops-7.10.0-1"
+          # LLVM 19 imports libxml2-2.dll. Current MSYS2 libxml2 releases
+          # provide libxml2-16.dll after an ABI version bump.
+          "libxml2-$libxml2_version"
         )
         urls=()
         for package in "${packages[@]}"; do
           urls+=("$repo/$prefix-$package-any.pkg.tar.zst")
         done
 
-        # LLVM 19 packages predate MSYS2's compiler-runtime dependency rename
-        # from gcc-libs to cc-libs. libc++ 19 already supplies the runtime, so
-        # satisfy only the renamed package metadata while installing the
-        # archived, mutually compatible package set.
+        # Keep the mutually versioned LLVM split packages and pinned libxml2
+        # on archived URLs. Their ordinary runtime dependencies have no version
+        # constraint in the package metadata, so let pacman resolve current
+        # versions instead of relying on old package files that MSYS2 eventually
+        # prunes.
+        # LLVM 19 predates MSYS2's compiler-runtime dependency rename from
+        # gcc-libs to cc-libs. libc++ 19 already supplies the runtime, so
+        # satisfy only the renamed package metadata.
         assumed_cc_runtime="$prefix-cc-libs=$llvm_version"
         pacman --noconfirm -U \
           --assume-installed "$assumed_cc_runtime" \
           "${urls[@]}"
         pacman --noconfirm -S --needed \
           --assume-installed "$assumed_cc_runtime" \
-          "$prefix-pkgconf"
+          "$prefix-pkgconf" \
+          "$prefix-libuv" \
+          "$prefix-gc" \
+          "$prefix-libatomic_ops"
 
         for package in clang clang-libs compiler-rt llvm llvm-libs lld libc++ libunwind; do
           installed="$(pacman -Q "$prefix-$package" | awk '{print $2}')"
@@ -90,17 +91,14 @@ runs:
           fi
         done
 
-        for spec in \
-          "libuv=1.52.1-1" \
-          "gc=8.2.12-1" \
-          "libatomic_ops=7.10.0-1"; do
-          package="${spec%%=*}"
-          expected="${spec#*=}"
-          installed="$(pacman -Q "$prefix-$package" | awk '{print $2}')"
-          if [[ "$installed" != "$expected" ]]; then
-            echo "expected $package $expected, got $installed" >&2
-            exit 1
-          fi
+        installed_libxml2="$(pacman -Q "$prefix-libxml2" | awk '{print $2}')"
+        if [[ "$installed_libxml2" != "$libxml2_version" ]]; then
+          echo "expected libxml2 $libxml2_version, got $installed_libxml2" >&2
+          exit 1
+        fi
+        # Log resolved rolling dependency versions for CI diagnostics.
+        for package in libuv gc libatomic_ops; do
+          pacman -Q "$prefix-$package"
         done
 
         # The released LLVM binding discovers its host flags through


### PR DESCRIPTION
## Summary

- Keep archived package URLs only for the mutually versioned LLVM 19 split packages and `libxml2 2.12.9-2`, which preserves the `libxml2-2.dll` ABI required by LLVM 19.
- Let pacman resolve current ordinary runtime dependencies instead of pinning package files that the rolling MSYS2 repository eventually removes.
- Install and verify `libuv`, `gc`, and `libatomic_ops` through pacman while continuing to verify the exact LLVM and libxml2 versions.

## Why

The Windows native compiler workflow on `main` currently fails during dependency setup because MSYS2 removed `libiconv-1.17-4` from its rolling repository:

https://github.com/xgo-dev/llgo/actions/runs/33058178796/job/98471213265

Refreshing only the libiconv pin would postpone the same failure for another package. This change removes direct version pins for ordinary dependencies while retaining the two compatibility boundaries that cannot follow the rolling repository: LLVM 19 itself and its libxml2 ABI.

## Validation

The equivalent dependency setup and the complete native PE/COFF test passed in the rebased Windows integration CI:

https://github.com/xgo-dev/llgo/actions/runs/33059117715/job/98473195987

No local tests were run; this is a CI-only extraction of the already validated dependency fix.
