### PR TITLE
test: synchronize Windows CPU profile sampling

### DIFF
--- a/runtime/internal/lib/runtime/_wrap/profile_windows.c
+++ b/runtime/internal/lib/runtime/_wrap/profile_windows.c
@@ -109,6 +109,10 @@ static volatile int llgo_prof_ring_lock;
 static volatile int llgo_prof_active;
 static volatile int llgo_prof_sampler_running;
 static volatile uint64_t llgo_prof_lost;
+/* Test-only synchronization state. A zero target leaves normal profiling with
+ * only one atomic comparison per captured thread. */
+static volatile llgo_dword llgo_prof_test_thread_id;
+static volatile uint64_t llgo_prof_test_thread_samples;
 static llgo_handle llgo_prof_thread;
 static llgo_handle llgo_prof_stop_event;
 
@@ -285,8 +289,14 @@ static void llgo_prof_sample_process(void)
                 ResumeThread(thread);
             }
             CloseHandle(thread);
-            if (captured)
+            if (captured) {
                 llgo_prof_record(&sample);
+                if (entry.thread_id ==
+                    __atomic_load_n(&llgo_prof_test_thread_id,
+                                    __ATOMIC_ACQUIRE))
+                    __atomic_fetch_add(&llgo_prof_test_thread_samples, 1,
+                                       __ATOMIC_RELEASE);
+            }
         } while (Thread32Next(snapshot, &entry));
     }
     CloseHandle(snapshot);
@@ -449,4 +459,23 @@ int llgo_cpu_profile_test_fault_recovery(void)
 #else
     return -1;
 #endif
+}
+
+uint64_t llgo_cpu_profile_test_current_thread_samples(void)
+{
+    llgo_dword thread_id = GetCurrentThreadId();
+
+    if (__atomic_load_n(&llgo_prof_test_thread_id, __ATOMIC_ACQUIRE) !=
+        thread_id) {
+        __atomic_store_n(&llgo_prof_test_thread_id, 0, __ATOMIC_RELEASE);
+        __atomic_store_n(&llgo_prof_test_thread_samples, 0, __ATOMIC_RELAXED);
+        __atomic_store_n(&llgo_prof_test_thread_id, thread_id,
+                         __ATOMIC_RELEASE);
+    }
+    return __atomic_load_n(&llgo_prof_test_thread_samples, __ATOMIC_ACQUIRE);
+}
+
+void llgo_cpu_profile_test_clear_thread(void)
+{
+    __atomic_store_n(&llgo_prof_test_thread_id, 0, __ATOMIC_RELEASE);
 }

--- a/test/std/runtime/pprof/pprof_test.go
+++ b/test/std/runtime/pprof/pprof_test.go
@@ -14,6 +14,7 @@ import (
 func cpuProfileHotLoop(d time.Duration) uint64 {
 	deadline := time.Now().Add(d)
 	x := uint64(1)
+	waitForCPUProfileSample()
 	for time.Now().Before(deadline) {
 		for i := 0; i < 10000; i++ {
 			x = x*1664525 + 1013904223
@@ -21,6 +22,11 @@ func cpuProfileHotLoop(d time.Duration) uint64 {
 	}
 	return x
 }
+
+// waitForCPUProfileSample is overridden on LLGo/Windows so the statistical
+// profile checks wait for the real sampler instead of guessing a longer run
+// time. Other targets keep the existing duration-based behavior.
+var waitForCPUProfileSample = func() {}
 
 func requireCPUProfileContains(t *testing.T, data []byte, function string) {
 	t.Helper()

--- a/test/std/runtime/pprof/pprof_windows_llgo_test.go
+++ b/test/std/runtime/pprof/pprof_windows_llgo_test.go
@@ -4,11 +4,32 @@ package pprof_test
 
 import (
 	"testing"
+	"time"
 	_ "unsafe"
 )
 
 //go:linkname testCPUProfileWindowsFaultRecovery C.llgo_cpu_profile_test_fault_recovery
 func testCPUProfileWindowsFaultRecovery() int32
+
+//go:linkname currentThreadCPUProfileSamples C.llgo_cpu_profile_test_current_thread_samples
+func currentThreadCPUProfileSamples() uint64
+
+//go:linkname clearCPUProfileTestThread C.llgo_cpu_profile_test_clear_thread
+func clearCPUProfileTestThread()
+
+func init() {
+	waitForCPUProfileSample = func() {
+		before := currentThreadCPUProfileSamples()
+		deadline := time.Now().Add(time.Second)
+		for currentThreadCPUProfileSamples() == before {
+			if time.Now().After(deadline) {
+				clearCPUProfileTestThread()
+				panic("Windows CPU profiler did not sample the current thread within 1s")
+			}
+		}
+		clearCPUProfileTestThread()
+	}
+}
 
 func TestCPUProfileWindowsFaultRecovery(t *testing.T) {
 	if got := testCPUProfileWindowsFaultRecovery(); got != 1 {


### PR DESCRIPTION
> **Superseded by #2422.** The implementation and all four review follow-ups are included there in commit `4973ccf10`. Please review and merge #2422 instead of this standalone PR.

## Summary

- make the LLGo/Windows `runtime/pprof` checks wait until the real background profiler has sampled the current test thread
- keep the existing `StartCPUProfile`, duplicate-start, `StopCPUProfile`, goroutine, hot-loop, and gzip/profile-symbol calls in place
- retain the existing 300–500 ms workloads; use a 1-second timeout only to report a profiler that makes no progress

## Background

The [Windows native CI job](https://github.com/xgo-dev/llgo/actions/runs/33065310668/job/98493819318) produced valid compressed CPU profiles, but two statistical checks did not find `cpuProfileHotLoop`. A preceding run of the same tests passed, while this run used a newer `windows-2022` runner image.

Instead of increasing every profile duration or retrying until a random sample lands in the expected function, this change adds a test-only synchronization target to the Windows sampler. The hot loop registers its current OS thread and waits until the normal `SuspendThread`/`GetThreadContext` sampling path records that thread. The resulting profile still travels through the native ring buffer and `runtime/pprof`; no sample is injected or fabricated.

Outside LLGo/Windows amd64 and arm64 the hook is a no-op, so the stdlib coverage calls and behavior on the other CI targets remain unchanged.

## Tests

- `go test ./test/std/runtime/pprof`
- `(cd runtime && go test ./internal/lib/runtime)`
- `clang -D_WIN64 -fdeclspec -fsyntax-only runtime/internal/lib/runtime/_wrap/profile_windows.c`

The full Windows native link and execution are left to CI because the local machine does not have a Windows sysroot.
