### PR TITLE
build: print verbose packages after completion

### DIFF
--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -357,8 +357,9 @@ func UpdateConfig(conf *build.Config) error {
 	conf.PrintPackages = false
 	switch conf.Mode {
 	case build.ModeBuild:
-		// Match go build -v: print package names as they are compiled. The
-		// legacy LLGo compiler output is available through -compiler-verbose.
+		// Keep go build -v's package-only output, but report packages only after
+		// successful compilation. The legacy LLGo compiler output is available
+		// through -compiler-verbose.
 		conf.Verbose = CompilerVerbose
 		conf.PrintPackages = Verbose
 	case build.ModeTest:

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -157,7 +157,7 @@ type Config struct {
 	AbiMode            AbiMode
 	GenExpect          bool // only valid for ModeCmpTest
 	Verbose            bool
-	PrintPackages      bool // print package paths as they are compiled, like go build -v
+	PrintPackages      bool // print package paths after successful compilation
 	PrintCommands      bool
 	GenLL              bool // generate pkg .ll files
 	DeadcodeDrop       bool // enable Go dead code drop (development builds only)
@@ -1323,6 +1323,7 @@ func finalizePackageBuild(ctx *context, task *packageBuildTask, verbose bool) er
 	if err := ctx.saveToCache(aPkg); err != nil && verbose {
 		fmt.Fprintf(os.Stderr, "warning: failed to save cache for %s: %v\n", aPkg.PkgPath, err)
 	}
+	printCompletedPackage(ctx.buildConf, aPkg)
 	return nil
 }
 
@@ -2227,10 +2228,8 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 func preparePackageModule(ctx *context, aPkg *aPackage, verbose bool) ([]string, error) {
 	pkg := aPkg.Package
 	pkgPath := pkg.PkgPath
-	if debugBuild || verbose {
+	if debugBuild || verbose && !ctx.buildConf.PrintPackages {
 		fmt.Fprintln(os.Stderr, pkgPath)
-	} else {
-		printCompiledPackage(ctx.buildConf, aPkg)
 	}
 	if llruntime.SkipToBuild(pkgPath) {
 		pkg.ExportFile = ""
@@ -2410,7 +2409,7 @@ func dropUnusedWindowsTestMain(ctx *context, pkg *aPackage, mod gllvm.Module) {
 	fn.EraseFromParentAsFunction()
 }
 
-func printCompiledPackage(conf *Config, pkg *aPackage) {
+func printCompletedPackage(conf *Config, pkg *aPackage) {
 	if conf.PrintPackages && !pkg.CacheHit {
 		fmt.Fprintln(os.Stderr, pkg.PkgPath)
 	}

--- a/internal/build/package_build_test.go
+++ b/internal/build/package_build_test.go
@@ -97,14 +97,18 @@ var content string
 	}}
 	ctx := &context{
 		conf:      &packages.Config{Fset: fset},
-		buildConf: &Config{},
+		buildConf: &Config{PrintPackages: true},
 	}
+	readStderr := captureStderr(t)
 	externs, err := preparePackageModule(ctx, pkg, true)
 	if err == nil || !strings.Contains(err.Error(), "only allowed in Go files that import") {
 		t.Fatalf("preparePackageModule embed error = %v", err)
 	}
 	if externs != nil {
 		t.Fatalf("preparePackageModule externs = %v, want nil", externs)
+	}
+	if got := readStderr(); got != "" {
+		t.Fatalf("stderr before package completion = %q, want empty", got)
 	}
 }
 

--- a/internal/build/verbose_test.go
+++ b/internal/build/verbose_test.go
@@ -17,36 +17,69 @@
 package build
 
 import (
+	"go/types"
 	"os"
 	"testing"
 
 	"github.com/xgo-dev/llgo/internal/packages"
 )
 
-func TestPrintCompiledPackage(t *testing.T) {
+func captureStderr(t *testing.T) func() string {
+	t.Helper()
 	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
 	if err != nil {
 		t.Fatal(err)
 	}
 	oldStderr := os.Stderr
 	os.Stderr = stderr
-	t.Cleanup(func() { os.Stderr = oldStderr })
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			os.Stderr = oldStderr
+			_ = stderr.Close()
+		}
+	})
+	return func() string {
+		t.Helper()
+		if closed {
+			t.Fatal("stderr capture already read")
+		}
+		os.Stderr = oldStderr
+		closed = true
+		if err := stderr.Close(); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(stderr.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(got)
+	}
+}
 
-	pkg := &aPackage{Package: &packages.Package{PkgPath: "example.com/rebuilt"}}
-	printCompiledPackage(&Config{PrintPackages: true}, pkg)
+func TestFinalizePackageBuildPrintsCompletedPackage(t *testing.T) {
+	readStderr := captureStderr(t)
+
+	pkg := &aPackage{Package: &packages.Package{
+		PkgPath: "example.com/rebuilt",
+		Types:   types.NewPackage("example.com/rebuilt", "rebuilt"),
+	}}
+	ctx := &context{buildConf: &Config{PrintPackages: true}}
+	if err := finalizePackageBuild(ctx, newPackageBuildTask(pkg), false); err != nil {
+		t.Fatal(err)
+	}
+
 	pkg.CacheHit = true
-	printCompiledPackage(&Config{PrintPackages: true}, pkg)
-	pkg.CacheHit = false
-	printCompiledPackage(&Config{}, pkg)
+	if err := finalizePackageBuild(ctx, newPackageBuildTask(pkg), false); err != nil {
+		t.Fatal(err)
+	}
 
-	if err := stderr.Close(); err != nil {
+	pkg.CacheHit = false
+	if err := finalizePackageBuild(&context{buildConf: &Config{}}, newPackageBuildTask(pkg), false); err != nil {
 		t.Fatal(err)
 	}
-	got, err := os.ReadFile(stderr.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := "example.com/rebuilt\n"; string(got) != want {
+
+	if got, want := readStderr(), "example.com/rebuilt\n"; got != want {
 		t.Fatalf("stderr = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- print ordinary `llgo build -v` package names after successful backend finalization instead of at backend start
- preserve `-compiler-verbose` start diagnostics without duplicating bare package lines when both flags are combined
- preserve cache-hit suppression and cover both successful completion and frontend failure before completion

## Motivation

Parallel backends can start hundreds of packages quickly while one earlier package remains on the critical path. Printing at start leaves an unrelated fast package as the last visible line for a long time; in the IXGo reproduction, the final main-package line remained visible for about 100 seconds even though that package completed in milliseconds.

## Testing

- `go test ./internal/build ./cmd/internal/flags -count=1` (Ubuntu, LLVM 19)
- real `llgo build -O0 -v -debug-trace=... ./internal/build/testdata/boundschecks`; package output followed backend completion by 0.02-0.14 ms