### PR TITLE
support Go 1.27 in CI and runtime

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,12 +27,21 @@ jobs:
           - os: macos-latest
             llvm: 19
             go: "1.26.7"
+          - os: macos-latest
+            llvm: 19
+            go: "1.27.0"
           - os: ubuntu-latest
+            llvm: 19
+            go: "1.26.7"
+          - os: ubuntu-latest
+            llvm: 19
+            go: "1.27.0"
+          - os: windows-2022
             llvm: 19
             go: "1.26.7"
           - os: windows-2022
             llvm: 19
-            go: "1.26.7"
+            go: "1.27.0"
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -28,10 +28,12 @@ jobs:
         # line. Old xfail/not-applicable classifications are retired with the
         # corpus.
         os: [macos-latest, ubuntu-latest, windows-2022]
-        go-version: ["1.26.7"]
+        go-version: ["1.26.7", "1.27.0"]
         shard-index: ["0", "1", "2", "3"]
         include:
           - go-version: "1.26.7"
+            lane: primary
+          - go-version: "1.27.0"
             lane: primary
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -191,7 +191,7 @@ jobs:
           - ubuntu-latest
           - windows-2022
         llvm: [19]
-        go: ["1.25.0", "1.26.7"]
+        go: ["1.25.0", "1.26.7", "1.27.0"]
         # In-command package parallelism lets Ubuntu use two shards while
         # retaining headroom for the serial std build-mode checks.
         shard: ["0", "1"]
@@ -199,6 +199,8 @@ jobs:
           - go: "1.25.0"
             lane: compatibility
           - go: "1.26.7"
+            lane: primary
+          - go: "1.27.0"
             lane: primary
         exclude:
           # The full demo lane above exercises Go 1.25 user-project/runtime
@@ -226,8 +228,13 @@ jobs:
       - name: Install further optional dependencies for demos
         uses: ./.github/actions/setup-demo-deps
 
-      - name: Set up Go for build
+      - name: Set up Go for build and testing
         uses: ./.github/actions/setup-go
+        with:
+          # Build with the newest toolchain so the resulting llgo remains
+          # runnable against older Go standard libraries in compatibility
+          # jobs, while Go 1.27 is built and run with the same toolchain.
+          go-version: "1.27.0"
 
       - name: Install
         shell: bash
@@ -322,6 +329,18 @@ jobs:
           - os: windows-2022
             llvm: 19
             go: "1.26.7"
+            lane: primary
+          - os: ubuntu-latest
+            llvm: 19
+            go: "1.27.0"
+            lane: primary
+          - os: macos-latest
+            llvm: 19
+            go: "1.27.0"
+            lane: primary
+          - os: windows-2022
+            llvm: 19
+            go: "1.27.0"
             lane: primary
     runs-on: ${{matrix.os}}
     steps:
@@ -427,7 +446,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.25.0", "1.26.7"]
+        go: ["1.25.0", "1.26.7", "1.27.0"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ LLGo is compatible with the C ecosystem through the C **Application Binary Inter
 
 ## Go support
 
-LLGo is compatible with Go 1.20+ source code and supports the complete Go 1.26 language syntax, as well as `cgo`.
+LLGo is compatible with Go 1.20+ source code and supports the complete Go 1.27 language syntax, as well as `cgo`.
 
-Compatibility is checked against applicable upstream [`GOROOT/test`](test/goroot/README.md) cases using pinned Go 1.25 and Go 1.26 toolchains. Remaining applicable differences are recorded in [`xfail.yaml`](test/goroot/xfail.yaml); gc-specific mechanisms outside LLGo's compatibility goals are documented in [`notapplicable.yaml`](test/goroot/notapplicable.yaml).
+Compatibility is checked against applicable upstream [`GOROOT/test`](test/goroot/README.md) cases using pinned Go 1.25, Go 1.26, and Go 1.27 toolchains. Remaining applicable differences are recorded in [`xfail.yaml`](test/goroot/xfail.yaml); gc-specific mechanisms outside LLGo's compatibility goals are documented in [`notapplicable.yaml`](test/goroot/notapplicable.yaml).
 
 ### Runtime
 
@@ -286,7 +286,7 @@ llgo run .
 
 ## Dependencies
 
-- [Go 1.25+](https://go.dev) (to build LLGo; CI also validates user packages with pinned Go 1.25 and Go 1.26 toolchains)
+- [Go 1.25+](https://go.dev) (to build LLGo; CI also validates user packages with pinned Go 1.25, Go 1.26, and Go 1.27 toolchains)
 - [LLVM 19](https://llvm.org)
 - [Clang 19](https://clang.llvm.org)
 - [LLD 19](https://lld.llvm.org)

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -422,7 +422,7 @@ type I2 interface {
 // IP.Store and IP.Load must operate on the same Pointer[any] interface value.
 // CHECK-LABEL: define void @main.testGeneric(){{.*}} {
 // CHECK: [[P_OBJECT:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT: [[P_ITAB:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.Pointer[any]")
+// CHECK-NEXT: [[P_ITAB:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.Pointer{{\[.*\]}}")
 // CHECK: [[P_I0:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr [[P_ITAB]], 0
 // CHECK-NEXT: [[P_IFACE:%[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.iface" [[P_I0]], ptr [[P_OBJECT]], 1
 // CHECK: [[P_VALUE:%[0-9]+]] = call ptr @"main.testGeneric$1"()
@@ -595,15 +595,15 @@ type I2 interface {
 // CHECK: ret %"{{.*}}/runtime/internal/runtime.String" [[BSP_STRING]]
 
 // Atomic Load and Store must address Pointer[any].v and preserve seq_cst ordering.
-// CHECK-LABEL: define linkonce ptr @"main.(*Pointer[any]).Load"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce ptr @"main.(*Pointer{{\[.*\]}}).Load"(ptr %0){{.*}} {
 // CHECK: [[LOAD_NIL:%[0-9]+]] = icmp eq ptr %0, null
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[LOAD_NIL]])
-// CHECK: [[LOAD_V:%[0-9]+]] = getelementptr inbounds %"main.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK: [[LOAD_V:%[0-9]+]] = getelementptr inbounds %"main.Pointer{{\[.*\]}}", ptr %0, i32 0, i32 1
 // CHECK: [[LOAD_VALUE:%[0-9]+]] = load atomic ptr, ptr [[LOAD_V]] seq_cst
 // CHECK: ret ptr [[LOAD_VALUE]]
 
-// CHECK-LABEL: define linkonce void @"main.(*Pointer[any]).Store"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*Pointer{{\[.*\]}}).Store"(ptr %0, ptr %1){{.*}} {
 // CHECK: [[STORE_NIL:%[0-9]+]] = icmp eq ptr %0, null
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[STORE_NIL]])
-// CHECK: [[STORE_V:%[0-9]+]] = getelementptr inbounds %"main.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK: [[STORE_V:%[0-9]+]] = getelementptr inbounds %"main.Pointer{{\[.*\]}}", ptr %0, i32 0, i32 1
 // CHECK: store atomic ptr %1, ptr [[STORE_V]] seq_cst

--- a/cl/_testrt/tpmap/in.go
+++ b/cl/_testrt/tpmap/in.go
@@ -42,19 +42,19 @@ func main() {
 // CHECK-NEXT:   store i64 0, ptr %[[TMP5]], align 8
 // CHECK-NEXT:   %[[TMP6:[0-9]+]] = load %main.T2, ptr %[[TMP4]], align 8
 // CHECK-NEXT:   %[[TMP7:[0-9]+]] = getelementptr inbounds %main.cacheKey, ptr %[[TMP1]], i32 0, i32 2
-// CHECK-NEXT:   %[[TMP8:[0-9]+]] = alloca %"main.T3[any]", align 8
+// CHECK-NEXT:   %[[TMP8:[0-9]+]] = alloca %"main.T3{{\[.*\]}}", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %[[TMP8]], i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %[[TMP9:[0-9]+]] = getelementptr inbounds %"main.T3[any]", ptr %[[TMP8]], i32 0, i32 0
+// CHECK-NEXT:   %[[TMP9:[0-9]+]] = getelementptr inbounds %"main.T3{{\[.*\]}}", ptr %[[TMP8]], i32 0, i32 0
 // CHECK-NEXT:   %[[TMP10:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 0, ptr %[[TMP10]], align 8
 // CHECK-NEXT:   %[[TMP11:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %[[TMP10]], 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %[[TMP11]], ptr %[[TMP9]], align 8
-// CHECK-NEXT:   %[[TMP12:[0-9]+]] = load %"main.T3[any]", ptr %[[TMP8]], align 8
+// CHECK-NEXT:   %[[TMP12:[0-9]+]] = load %"main.T3{{\[.*\]}}", ptr %[[TMP8]], align 8
 // CHECK-NEXT:   %[[TMP13:[0-9]+]] = getelementptr inbounds %main.cacheKey, ptr %[[TMP1]], i32 0, i32 3
 // CHECK-NEXT:   %[[TMP14:[0-9]+]] = getelementptr inbounds %main.cacheKey, ptr %[[TMP1]], i32 0, i32 4
 // CHECK-NEXT:   store i64 0, ptr %[[TMP2]], align 8
 // CHECK-NEXT:   store %main.T2 %[[TMP6]], ptr %[[TMP3]], align 8
-// CHECK-NEXT:   store %"main.T3[any]" %[[TMP12]], ptr %[[TMP7]], align 8
+// CHECK-NEXT:   store %"main.T3{{\[.*\]}}" %[[TMP12]], ptr %[[TMP7]], align 8
 // CHECK-NEXT:   store ptr null, ptr %[[TMP13]], align 8
 // CHECK-NEXT:   store i64 0, ptr %[[TMP14]], align 8
 // CHECK-NEXT:   %[[TMP15:[0-9]+]] = load %main.cacheKey, ptr %[[TMP1]], align 8
@@ -72,19 +72,19 @@ func main() {
 // CHECK-NEXT:   store i64 0, ptr %[[TMP22]], align 8
 // CHECK-NEXT:   %[[TMP23:[0-9]+]] = load %main.T2, ptr %[[TMP21]], align 8
 // CHECK-NEXT:   %[[TMP24:[0-9]+]] = getelementptr inbounds %main.cacheKey, ptr %[[TMP18]], i32 0, i32 2
-// CHECK-NEXT:   %[[TMP25:[0-9]+]] = alloca %"main.T3[any]", align 8
+// CHECK-NEXT:   %[[TMP25:[0-9]+]] = alloca %"main.T3{{\[.*\]}}", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %[[TMP25]], i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %[[TMP26:[0-9]+]] = getelementptr inbounds %"main.T3[any]", ptr %[[TMP25]], i32 0, i32 0
+// CHECK-NEXT:   %[[TMP26:[0-9]+]] = getelementptr inbounds %"main.T3{{\[.*\]}}", ptr %[[TMP25]], i32 0, i32 0
 // CHECK-NEXT:   %[[TMP27:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 0, ptr %[[TMP27]], align 8
 // CHECK-NEXT:   %[[TMP28:[0-9]+]] = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %[[TMP27]], 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %[[TMP28]], ptr %[[TMP26]], align 8
-// CHECK-NEXT:   %[[TMP29:[0-9]+]] = load %"main.T3[any]", ptr %[[TMP25]], align 8
+// CHECK-NEXT:   %[[TMP29:[0-9]+]] = load %"main.T3{{\[.*\]}}", ptr %[[TMP25]], align 8
 // CHECK-NEXT:   %[[TMP30:[0-9]+]] = getelementptr inbounds %main.cacheKey, ptr %[[TMP18]], i32 0, i32 3
 // CHECK-NEXT:   %[[TMP31:[0-9]+]] = getelementptr inbounds %main.cacheKey, ptr %[[TMP18]], i32 0, i32 4
 // CHECK-NEXT:   store i64 0, ptr %[[TMP19]], align 8
 // CHECK-NEXT:   store %main.T2 %[[TMP23]], ptr %[[TMP20]], align 8
-// CHECK-NEXT:   store %"main.T3[any]" %[[TMP29]], ptr %[[TMP24]], align 8
+// CHECK-NEXT:   store %"main.T3{{\[.*\]}}" %[[TMP29]], ptr %[[TMP24]], align 8
 // CHECK-NEXT:   store ptr null, ptr %[[TMP30]], align 8
 // CHECK-NEXT:   store i64 0, ptr %[[TMP31]], align 8
 // CHECK-NEXT:   %[[TMP32:[0-9]+]] = load %main.cacheKey, ptr %[[TMP18]], align 8

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/xgo-dev/llgo/cl/blocks"
 	"github.com/xgo-dev/llgo/cl/ssawrap"
+	"github.com/xgo-dev/llgo/internal/genmethod"
 	"github.com/xgo-dev/llgo/internal/goembed"
 	"github.com/xgo-dev/llgo/internal/typepatch"
 	"golang.org/x/tools/go/ssa"
@@ -373,6 +374,9 @@ func (p *context) compileMethodsIf(pkg llssa.Package, typ types.Type, keep func(
 	mthds := prog.MethodSets.MethodSet(typ)
 	for i, n := 0, mthds.Len(); i < n; i++ {
 		mthd := mthds.At(i)
+		if genmethod.SupportsGenericMethods && genmethod.IsGenericMethod(mthd.Type()) {
+			continue
+		}
 		if ssaMthd := p.methodValue(mthd); ssaMthd != nil {
 			if keep != nil && !keep(ssaMthd) {
 				continue

--- a/cl/import.go
+++ b/cl/import.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/xgo-dev/llgo/internal/directive"
 	"github.com/xgo-dev/llgo/internal/env"
+	"github.com/xgo-dev/llgo/internal/genmethod"
 	"github.com/xgo-dev/llgo/internal/locality"
 	llssa "github.com/xgo-dev/llgo/ssa"
 )
@@ -555,6 +556,11 @@ func funcName(pkg *types.Package, fn *ssa.Function, org bool) string {
 		// will diverge for promoted unexported methods.
 		if method, ok := fn.Object().(*types.Func); ok {
 			fnName = llssa.MethodSymbolName(pkg, method, fnName)
+			if genmethod.SupportsGenericMethods && genmethod.IsGenericMethod(method.Type()) {
+				if targs := fn.TypeArgs(); len(targs) > 0 {
+					fnName += llssa.TypeArgs(targs)
+				}
+			}
 		}
 		// Synthesized $thunk/$bound functions have no Object. Their references
 		// are produced through this same funcName path, so the wrapper name is

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -30,6 +30,7 @@ import (
 
 	"golang.org/x/tools/go/ssa"
 
+	"github.com/xgo-dev/llgo/internal/genmethod"
 	llssa "github.com/xgo-dev/llgo/ssa"
 )
 
@@ -1493,7 +1494,11 @@ func collectRuntimeCallerMethods(pkg *ssa.Package, runtimeTypes []types.Type) []
 	addMethods := func(typ types.Type) {
 		methodSet := pkg.Prog.MethodSets.MethodSet(typ)
 		for i := 0; i < methodSet.Len(); i++ {
-			fn := pkg.Prog.MethodValue(methodSet.At(i))
+			meth := methodSet.At(i)
+			if genmethod.SupportsGenericMethods && genmethod.IsGenericMethod(meth.Type()) {
+				continue
+			}
+			fn := pkg.Prog.MethodValue(meth)
 			if fn != nil && !seen[fn] {
 				seen[fn] = true
 				methods = append(methods, fn)
@@ -1803,6 +1808,9 @@ func (a *runtimeCallerAnalysis) methodTargetsForType(typ types.Type, method *typ
 	for i := 0; i < methods.Len(); i++ {
 		sel := methods.At(i)
 		if sel.Obj().Name() != method.Name() {
+			continue
+		}
+		if genmethod.SupportsGenericMethods && genmethod.IsGenericMethod(sel.Type()) {
 			continue
 		}
 		fn := a.pkg.Prog.MethodValue(sel)

--- a/internal/genmethod/method.go
+++ b/internal/genmethod/method.go
@@ -1,0 +1,5 @@
+//go:build !go1.27
+
+package genmethod
+
+const SupportsGenericMethods = false

--- a/internal/genmethod/method_go127.go
+++ b/internal/genmethod/method_go127.go
@@ -1,0 +1,5 @@
+//go:build go1.27
+
+package genmethod
+
+const SupportsGenericMethods = true

--- a/internal/genmethod/types.go
+++ b/internal/genmethod/types.go
@@ -1,0 +1,7 @@
+package genmethod
+
+import "go/types"
+
+func IsGenericMethod(typ types.Type) bool {
+	return typ.(*types.Signature).TypeParams().Len() > 0
+}

--- a/runtime/internal/lib/runtime/fips140deps_go127_llgo.go
+++ b/runtime/internal/lib/runtime/fips140deps_go127_llgo.go
@@ -1,0 +1,13 @@
+//go:build go1.27 && !windows
+
+package runtime
+
+import _ "unsafe"
+
+// Go 1.27's crypto FIPS helpers link to this runtime monotonic-clock hook.
+// LLGo already exposes the same clock through runtimeNano.
+//
+//go:linkname crypto_internal_fips140deps_time_monoTime crypto/internal/fips140deps/time.monoTime
+func crypto_internal_fips140deps_time_monoTime() int64 {
+	return runtimeNano()
+}

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -24,6 +24,7 @@ import (
 	"go/types"
 	"sort"
 
+	"github.com/xgo-dev/llgo/internal/genmethod"
 	"github.com/xgo-dev/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 )
@@ -580,6 +581,9 @@ func (b Builder) abiInterfaceMethods(mset *types.MethodSet) []*types.Selection {
 	methods := make([]*types.Selection, 0, n)
 	for i := 0; i < n; i++ {
 		m := mset.At(i)
+		if genmethod.SupportsGenericMethods && genmethod.IsGenericMethod(m.Type()) {
+			continue
+		}
 		fn, _ := m.Obj().(*types.Func)
 		if b.Prog.isNoInterfaceMethod(fn) {
 			continue


### PR DESCRIPTION
## Summary
- supports Go 1.27 generic concrete method
- add Go 1.27 runtime support for crypto/internal/fips140deps/time.monoTime
- add Go 1.27 to Go, GOROOT, LLGo, and wasm CI matrices
- make generic IR checks resilient to Go 1.27 type spelling changes
- document Go 1.27 compatibility

## Validation
- Go 1.27 internal/build, crosscompile, genmethod, and ssa tests pass