### PR TITLE
test: stabilize protected-memory fault recovery

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -107,6 +107,7 @@ jobs:
           set -euo pipefail
 
           go_test=(go test)
+          test_go_flags=()
           if [[ "$RUNNER_OS" == Windows ]]; then
             # Go's internal linker cannot consume every GNU COFF import
             # archive used by the race runtime and LLVM. Use the configured
@@ -115,6 +116,12 @@ jobs:
             go_test+=("-ldflags=-linkmode=external -extldflags=-lsynchronization")
             export LLGO_REQUIRE_MSVC=1
             export LLGO_STDIO_NOBUF=1
+
+            # test/go deliberately raises access violations. If one escapes
+            # unexpectedly, retain the active test name and runtime stacks in
+            # the job log instead of reporting only exit status 0xc0000005.
+            test_go_flags+=("-v")
+            export GOTRACEBACK=system
           fi
 
           # test/go intentionally contains compiler edge cases that make the
@@ -124,7 +131,7 @@ jobs:
             | grep -v '^github.com/xgo-dev/llgo/test/go$' \
             | xargs "${go_test[@]}" -timeout 45m -coverprofile="coverage-main.txt" -covermode=atomic \
                 -bench '^BenchmarkGo126' -benchtime=1x
-          "${go_test[@]}" -timeout 45m -vet=off \
+          "${go_test[@]}" "${test_go_flags[@]}" -timeout 45m -vet=off \
             -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
 
           head -n 1 coverage-main.txt > coverage.txt

--- a/test/go/recover_fault_test.go
+++ b/test/go/recover_fault_test.go
@@ -23,6 +23,13 @@ func faultCopy(dst, src []byte) (n int, err error) {
 }
 
 func TestRecoverAfterFaultPreservesNamedResult(t *testing.T) {
+	// Automatic GC is orthogonal to this test and can perturb the host's
+	// signal/exception recovery path while the fault is being converted into
+	// a panic. Disable it only around the intentional fault so Go and LLGo run
+	// the same deterministic recovery check.
+	oldGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGCPercent)
+
 	old := debug.SetPanicOnFault(true)
 	defer debug.SetPanicOnFault(old)
 


### PR DESCRIPTION
## Summary

- keep the protected-memory recovery checks identical in standard Go and LLGo test builds
- temporarily disable automatic GC around the intentional hardware fault, then restore the previous GC setting
- make the existing Windows `test/go` coverage run verbose and request system tracebacks, without adding another test pass

## Why

The failed job ran natively on `windows-2022` with `go1.26.7 windows/amd64`; it did not use Rosetta and it was not a timeout. The host `test/go` process exited with the unhandled Windows access-violation status `0xc0000005`. Because the original command was not verbose, the log did not identify which test was active.

`TestRecoverAfterFaultPreservesNamedResult` deliberately crosses a protected-memory boundary and checks that `debug.SetPanicOnFault` converts the hardware fault into a recoverable panic while preserving both named return values and the fault address. Automatic GC is unrelated to those semantics but adds concurrent runtime activity to the signal/exception recovery path.

Host stress provided evidence that this extra activity makes the test timing-sensitive: on macOS amd64 under Rosetta, `GOGC=1` and `GOMAXPROCS=16` produced 10 failures in 300,000 runs, while disabling automatic GC removed the failures. Rosetta is only a local stress reproducer; it is not claimed as the cause of the native Windows failure.

This revision therefore keeps the same semantic coverage in Go and LLGo instead of excluding the test from host Go. On Windows, the existing coverage invocation now uses `-v` and `GOTRACEBACK=system`, so any recurrence records the active test and runtime stacks rather than only the process exit status.

Failed job: https://github.com/xgo-dev/llgo/actions/runs/33137920568/job/98742022037

## Validation

- host Go, `GOGC=1 GOMAXPROCS=16 GOARCH=amd64`, 100,000 repetitions passed under Rosetta
- LLGo, `GOGC=1 GOMAXPROCS=16`, 1,000 repetitions passed
- full host `test/go` atomic coverage run passed in 414.211s
- standard Go `test/go` test binary cross-compiled successfully for Windows/amd64
- `git diff --check`
