### PR TITLE
ci: adopt fork-first review-gated pull request checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - macos-15-intel

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Describe what changed and why. -->
+
+## Validation
+
+<!-- List the checks you ran. -->
+
+## Fork CI
+
+<!-- See CONTRIBUTING.md for the fork-first validation workflow. -->
+
+- [ ] I created a test PR in my fork and its relevant CI passed.
+- Fork test PR: <!-- https://github.com/<user>/llgo/pull/<number> -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 ## Summary
 
-<!-- Describe what changed and why. -->
+<!-- Required. Describe what changed and why. Do not remove or rename this heading. -->
 
 ## Validation
 
-<!-- List the checks you ran. -->
+<!-- Required. List the checks you ran. Do not remove or rename this heading. -->
 
 ## Fork CI
 
-<!-- See CONTRIBUTING.md for the fork-first validation workflow. -->
+<!-- Required. Keep the two fields below and see CONTRIBUTING.md for the fork-first workflow. -->
 
 - [ ] I created a test PR in my fork and its relevant CI passed.
 - Fork test PR: <!-- https://github.com/<user>/llgo/pull/<number> -->

--- a/.github/scripts/ci_gate.py
+++ b/.github/scripts/ci_gate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Decide whether a heavy LLGo workflow may use a runner."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+UPSTREAM_REPOSITORY = "xgo-dev/llgo"
+REVIEW_LABEL = "need-review"
+
+
+@dataclass(frozen=True)
+class Event:
+    name: str
+    repository: str
+    repository_is_fork: bool = False
+    ref_type: str = ""
+    ref_name: str = ""
+    default_branch: str = "main"
+    action: str = ""
+    event_label: str = ""
+    pr_labels: frozenset[str] = frozenset()
+
+
+def decide(event: Event) -> tuple[bool, str]:
+    """Return the gate decision and a diagnostic reason."""
+    if event.name in {"workflow_dispatch", "schedule"}:
+        return True, f"running heavy CI for {event.name}"
+
+    if event.name == "push":
+        if event.ref_type == "tag":
+            return True, "running tag validation/release CI"
+        if (
+            event.repository_is_fork
+            and event.repository != UPSTREAM_REPOSITORY
+            and event.ref_name != event.default_branch
+        ):
+            return True, "running heavy CI on a fork feature branch"
+        return False, "upstream and fork-default-branch pushes do not run heavy CI"
+
+    if event.name != "pull_request":
+        return False, f"unsupported heavy-CI event: {event.name}"
+
+    if event.repository != UPSTREAM_REPOSITORY:
+        return False, "fork pull requests reuse the feature-branch push CI"
+
+    if REVIEW_LABEL not in event.pr_labels:
+        return False, f"waiting for the {REVIEW_LABEL} label"
+
+    if event.action == "labeled" and event.event_label != REVIEW_LABEL:
+        return False, "an unrelated label must not restart full CI"
+
+    return True, f"{REVIEW_LABEL} authorizes full upstream CI for this SHA"
+
+
+def _event_from_environment() -> Event:
+    labels = frozenset(
+        label.strip()
+        for label in os.environ.get("CI_PR_LABELS", "").split(",")
+        if label.strip()
+    )
+    return Event(
+        name=os.environ.get("CI_EVENT_NAME", ""),
+        repository=os.environ.get("CI_REPOSITORY", ""),
+        repository_is_fork=os.environ.get("CI_REPOSITORY_IS_FORK", "").lower()
+        == "true",
+        ref_type=os.environ.get("CI_REF_TYPE", ""),
+        ref_name=os.environ.get("CI_REF_NAME", ""),
+        default_branch=os.environ.get("CI_DEFAULT_BRANCH", "main"),
+        action=os.environ.get("CI_EVENT_ACTION", ""),
+        event_label=os.environ.get("CI_EVENT_LABEL", ""),
+        pr_labels=labels,
+    )
+
+
+if __name__ == "__main__":
+    run, reason = decide(_event_from_environment())
+    print(f"run={'true' if run else 'false'}")
+    print(f"reason={reason}")

--- a/.github/scripts/ci_gate.py
+++ b/.github/scripts/ci_gate.py
@@ -22,6 +22,7 @@ class Event:
     action: str = ""
     event_label: str = ""
     pr_labels: frozenset[str] = frozenset()
+    review_ready: bool = False
 
 
 def decide(event: Event) -> tuple[bool, str]:
@@ -45,6 +46,9 @@ def decide(event: Event) -> tuple[bool, str]:
 
     if event.repository != UPSTREAM_REPOSITORY:
         return False, "fork pull requests reuse the feature-branch push CI"
+
+    if not event.review_ready:
+        return False, "pull request template and matching fork CI evidence are not review-ready"
 
     if REVIEW_LABEL not in event.pr_labels:
         return False, f"waiting for the {REVIEW_LABEL} label"
@@ -72,6 +76,7 @@ def _event_from_environment() -> Event:
         action=os.environ.get("CI_EVENT_ACTION", ""),
         event_label=os.environ.get("CI_EVENT_LABEL", ""),
         pr_labels=labels,
+        review_ready=os.environ.get("CI_REVIEW_READY", "").lower() == "true",
     )
 
 

--- a/.github/scripts/pr_metadata.js
+++ b/.github/scripts/pr_metadata.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const REQUIRED_HEADINGS = ['Summary', 'Validation', 'Fork CI'];
+const CONFIRMATION =
+  '- [x] I created a test PR in my fork and its relevant CI passed.';
+
+function stripHtmlComments(value) {
+  return value.replace(/<!--[\s\S]*?-->/g, '').trim();
+}
+
+function parseTemplate(body) {
+  const text = typeof body === 'string' ? body : '';
+  const headingPattern = /^##[ \t]+(Summary|Validation|Fork CI)[ \t]*$/gm;
+  const headings = [...text.matchAll(headingPattern)];
+  const names = headings.map((match) => match[1]);
+
+  if (
+    names.length !== REQUIRED_HEADINGS.length ||
+    !names.every((name, index) => name === REQUIRED_HEADINGS[index])
+  ) {
+    throw new Error(
+      'Keep the required headings exactly once and in this order: Summary, Validation, Fork CI.',
+    );
+  }
+
+  const sections = {};
+  headings.forEach((heading, index) => {
+    const start = heading.index + heading[0].length;
+    const end = index + 1 < headings.length ? headings[index + 1].index : text.length;
+    sections[heading[1]] = text.slice(start, end);
+  });
+
+  for (const name of ['Summary', 'Validation']) {
+    const visible = stripHtmlComments(sections[name]);
+    if (!/[\p{L}\p{N}]/u.test(visible)) {
+      throw new Error(`Fill in the ${name} section instead of leaving only the template comment.`);
+    }
+  }
+
+  const forkLines = stripHtmlComments(sections['Fork CI'])
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (forkLines.length !== 2 || forkLines[0] !== CONFIRMATION) {
+    throw new Error('Check the fork-CI confirmation and keep the required Fork CI fields.');
+  }
+
+  const link = forkLines[1].match(
+    /^- Fork test PR: (https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/([1-9][0-9]*))\/?$/i,
+  );
+  if (!link) {
+    throw new Error('Provide one valid GitHub fork pull request URL after "Fork test PR:".');
+  }
+
+  return {
+    url: link[1],
+    owner: link[2],
+    repo: link[3],
+    number: Number(link[4]),
+  };
+}
+
+function sameRepository(left, right) {
+  return Boolean(left && right && left.toLowerCase() === right.toLowerCase());
+}
+
+async function validatePullRequest({body, upstreamRepository, source, github}) {
+  const evidence = parseTemplate(body);
+  const linkedRepository = `${evidence.owner}/${evidence.repo}`;
+
+  if (!sameRepository(linkedRepository, source.head.repo?.full_name)) {
+    throw new Error(
+      `Fork test PR repository ${linkedRepository} does not match contribution repository ${source.head.repo?.full_name}.`,
+    );
+  }
+
+  const {data: fork} = await github.rest.repos.get({
+    owner: evidence.owner,
+    repo: evidence.repo,
+  });
+  if (!fork.fork || !sameRepository(fork.parent?.full_name, upstreamRepository)) {
+    throw new Error(`${evidence.url} is not a pull request in a fork of ${upstreamRepository}.`);
+  }
+
+  const {data: testPR} = await github.rest.pulls.get({
+    owner: evidence.owner,
+    repo: evidence.repo,
+    pull_number: evidence.number,
+  });
+  if (!sameRepository(testPR.head.repo?.full_name, source.head.repo?.full_name)) {
+    throw new Error(
+      `Fork test PR head repository ${testPR.head.repo?.full_name} does not match ${source.head.repo?.full_name}.`,
+    );
+  }
+  if (testPR.head.ref !== source.head.ref) {
+    throw new Error(
+      `Fork test PR branch ${testPR.head.ref} does not match contribution branch ${source.head.ref}.`,
+    );
+  }
+  if (testPR.head.sha !== source.head.sha) {
+    throw new Error(
+      `Fork test PR checks ${testPR.head.sha}, but this contribution uses ${source.head.sha}.`,
+    );
+  }
+
+  return evidence;
+}
+
+module.exports = {parseTemplate, validatePullRequest};

--- a/.github/scripts/test_ci_gate.py
+++ b/.github/scripts/test_ci_gate.py
@@ -61,6 +61,16 @@ class GateTests(unittest.TestCase):
             repository="xgo-dev/llgo",
             action="synchronize",
             pr_labels=frozenset({"need-review"}),
+            review_ready=True,
+        )
+
+    def test_upstream_pr_requires_review_ready_metadata(self) -> None:
+        self.assert_gate(
+            False,
+            name="pull_request",
+            repository="xgo-dev/llgo",
+            action="synchronize",
+            pr_labels=frozenset({"need-review"}),
         )
 
     def test_only_need_review_label_restarts_full_ci(self) -> None:
@@ -72,6 +82,7 @@ class GateTests(unittest.TestCase):
             action="labeled",
             event_label="need-review",
             pr_labels=labels,
+            review_ready=True,
         )
         self.assert_gate(
             False,
@@ -80,6 +91,7 @@ class GateTests(unittest.TestCase):
             action="labeled",
             event_label="go-test-compat",
             pr_labels=labels,
+            review_ready=True,
         )
 
     def test_fork_pr_does_not_duplicate_push_ci(self) -> None:

--- a/.github/scripts/test_ci_gate.py
+++ b/.github/scripts/test_ci_gate.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from ci_gate import Event, decide
+
+
+class GateTests(unittest.TestCase):
+    def assert_gate(self, expected: bool, **kwargs: object) -> None:
+        actual, _ = decide(Event(**kwargs))
+        self.assertEqual(expected, actual)
+
+    def test_fork_feature_push_runs(self) -> None:
+        self.assert_gate(
+            True,
+            name="push",
+            repository="contributor/llgo",
+            repository_is_fork=True,
+            ref_type="branch",
+            ref_name="feature",
+        )
+
+    def test_upstream_and_fork_default_pushes_skip(self) -> None:
+        self.assert_gate(
+            False,
+            name="push",
+            repository="xgo-dev/llgo",
+            ref_type="branch",
+            ref_name="feature",
+        )
+        self.assert_gate(
+            False,
+            name="push",
+            repository="contributor/llgo",
+            repository_is_fork=True,
+            ref_type="branch",
+            ref_name="main",
+        )
+
+    def test_tags_and_manual_events_run(self) -> None:
+        self.assert_gate(
+            True,
+            name="push",
+            repository="xgo-dev/llgo",
+            ref_type="tag",
+            ref_name="v1.0.0",
+        )
+        self.assert_gate(True, name="workflow_dispatch", repository="xgo-dev/llgo")
+        self.assert_gate(True, name="schedule", repository="xgo-dev/llgo")
+
+    def test_upstream_pr_requires_need_review(self) -> None:
+        self.assert_gate(
+            False,
+            name="pull_request",
+            repository="xgo-dev/llgo",
+            action="synchronize",
+        )
+        self.assert_gate(
+            True,
+            name="pull_request",
+            repository="xgo-dev/llgo",
+            action="synchronize",
+            pr_labels=frozenset({"need-review"}),
+        )
+
+    def test_only_need_review_label_restarts_full_ci(self) -> None:
+        labels = frozenset({"need-review", "go-test-compat"})
+        self.assert_gate(
+            True,
+            name="pull_request",
+            repository="xgo-dev/llgo",
+            action="labeled",
+            event_label="need-review",
+            pr_labels=labels,
+        )
+        self.assert_gate(
+            False,
+            name="pull_request",
+            repository="xgo-dev/llgo",
+            action="labeled",
+            event_label="go-test-compat",
+            pr_labels=labels,
+        )
+
+    def test_fork_pr_does_not_duplicate_push_ci(self) -> None:
+        self.assert_gate(
+            False,
+            name="pull_request",
+            repository="contributor/llgo",
+            repository_is_fork=True,
+            action="synchronize",
+            pr_labels=frozenset({"need-review"}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_pr_metadata.js
+++ b/.github/scripts/test_pr_metadata.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {parseTemplate, validatePullRequest} = require('./pr_metadata');
+
+const VALID_BODY = `## Summary
+
+Require staged CI for upstream pull requests.
+
+## Validation
+
+- Workflow lint passed in the fork.
+
+## Fork CI
+
+- [x] I created a test PR in my fork and its relevant CI passed.
+- Fork test PR: https://github.com/contributor/llgo/pull/42
+`;
+
+function githubWithHead({ref = 'staged-ci', sha = 'abc123'} = {}) {
+  return {
+    rest: {
+      repos: {
+        get: async () => ({
+          data: {fork: true, parent: {full_name: 'xgo-dev/llgo'}},
+        }),
+      },
+      pulls: {
+        get: async () => ({
+          data: {
+            head: {
+              repo: {full_name: 'contributor/llgo'},
+              ref,
+              sha,
+            },
+          },
+        }),
+      },
+    },
+  };
+}
+
+const SOURCE = {
+  head: {
+    repo: {full_name: 'contributor/llgo'},
+    ref: 'staged-ci',
+    sha: 'abc123',
+  },
+};
+
+test('parses a completed pull request template', () => {
+  assert.deepEqual(parseTemplate(VALID_BODY), {
+    url: 'https://github.com/contributor/llgo/pull/42',
+    owner: 'contributor',
+    repo: 'llgo',
+    number: 42,
+  });
+});
+
+test('rejects missing template content and unchecked evidence', () => {
+  assert.throws(
+    () => parseTemplate(VALID_BODY.replace('Require staged CI for upstream pull requests.', '<!-- unchanged -->')),
+    /Fill in the Summary section/,
+  );
+  assert.throws(
+    () => parseTemplate(VALID_BODY.replace('- [x]', '- [ ]')),
+    /fork-CI confirmation/,
+  );
+});
+
+test('accepts evidence from the same repository, branch, and commit', async () => {
+  const evidence = await validatePullRequest({
+    body: VALID_BODY,
+    upstreamRepository: 'xgo-dev/llgo',
+    source: SOURCE,
+    github: githubWithHead(),
+  });
+  assert.equal(evidence.number, 42);
+});
+
+test('rejects a fork PR for another branch or commit', async () => {
+  await assert.rejects(
+    validatePullRequest({
+      body: VALID_BODY,
+      upstreamRepository: 'xgo-dev/llgo',
+      source: SOURCE,
+      github: githubWithHead({ref: 'other-branch'}),
+    }),
+    /branch other-branch does not match contribution branch staged-ci/,
+  );
+  await assert.rejects(
+    validatePullRequest({
+      body: VALID_BODY,
+      upstreamRepository: 'xgo-dev/llgo',
+      source: SOURCE,
+      github: githubWithHead({sha: 'outdated'}),
+    }),
+    /checks outdated, but this contribution uses abc123/,
+  );
+});

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: ["**"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   gate:
+    if: github.event_name != 'pull_request' || github.repository == 'xgo-dev/llgo'
     uses: ./.github/workflows/ci-gate.yml
 
   build-cache:

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -5,17 +5,29 @@ name: Build Cache
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+      - "release/**"
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["**"]
+    types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    uses: ./.github/workflows/ci-gate.yml
+
   build-cache:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   gate:
@@ -26,6 +27,34 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
+      - id: review-readiness
+        name: Validate review readiness
+        if: github.event_name == 'pull_request' && github.repository == 'xgo-dev/llgo'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ github.token }}
+          result-encoding: string
+          script: |
+            const path = require('path');
+            const {validatePullRequest} = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/pr_metadata.js',
+            ));
+
+            try {
+              const evidence = await validatePullRequest({
+                body: context.payload.pull_request.body,
+                upstreamRepository: context.payload.repository.full_name,
+                source: context.payload.pull_request,
+                github,
+              });
+              core.notice(`Review-ready fork evidence: ${evidence.url}`);
+              return 'true';
+            } catch (error) {
+              core.notice(`Full CI remains blocked: ${error.message}`);
+              return 'false';
+            }
+
       - id: gate
         name: Decide whether heavy CI may run
         env:
@@ -38,6 +67,7 @@ jobs:
           CI_EVENT_ACTION: ${{ github.event.action }}
           CI_EVENT_LABEL: ${{ github.event.label.name }}
           CI_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          CI_REVIEW_READY: ${{ steps.review-readiness.outputs.result }}
         run: python3 .github/scripts/ci_gate.py >> "$GITHUB_OUTPUT"
 
       - name: Report decision

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,46 @@
+name: CI Gate
+
+on:
+  workflow_call:
+    outputs:
+      run:
+        description: Whether the calling workflow may allocate heavy runners.
+        value: ${{ jobs.gate.outputs.run }}
+      reason:
+        description: Human-readable gate decision.
+        value: ${{ jobs.gate.outputs.reason }}
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - name: Check out gate implementation
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - id: gate
+        name: Decide whether heavy CI may run
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_REPOSITORY: ${{ github.repository }}
+          CI_REPOSITORY_IS_FORK: ${{ github.event.repository.fork }}
+          CI_REF_TYPE: ${{ github.ref_type }}
+          CI_REF_NAME: ${{ github.ref_name }}
+          CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CI_EVENT_ACTION: ${{ github.event.action }}
+          CI_EVENT_LABEL: ${{ github.event.label.name }}
+          CI_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: python3 .github/scripts/ci_gate.py >> "$GITHUB_OUTPUT"
+
+      - name: Report decision
+        env:
+          CI_GATE_REASON: ${{ steps.gate.outputs.reason }}
+        run: echo "::notice title=CI gate::$CI_GATE_REASON"

--- a/.github/workflows/doc-link-checker.yml
+++ b/.github/workflows/doc-link-checker.yml
@@ -2,14 +2,15 @@ name: Doc Link Checker
 
 on:
   push:
-    branches:
-      - main
+    branches: ["**"]
     paths:
-      - "README.md"
+      - "**/*.md"
+      - ".github/workflows/doc-link-checker.yml"
   pull_request:
     branches: ["**"]
     paths:
-      - "README.md"
+      - "**/*.md"
+      - ".github/workflows/doc-link-checker.yml"
   schedule:
     # Run daily at 00:00 UTC
     - cron: "0 0 * * *"
@@ -20,6 +21,12 @@ concurrency:
 
 jobs:
   doc_verify:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request' && github.repository == 'xgo-dev/llgo' ||
+      github.event_name == 'push' &&
+      (github.event.repository.fork && github.ref_name != github.event.repository.default_branch ||
+      github.repository == 'xgo-dev/llgo' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -40,4 +47,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --max-concurrency 3 --retry-wait-time 15 README.md
+          args: --max-concurrency 3 --retry-wait-time 15 "./**/*.md"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,17 +2,41 @@ name: Docs
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+      - "release/**"
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/ci-gate.yml"
+      - ".github/workflows/doc.yml"
+      - "doc/**"
+      - "go.mod"
+      - "go.sum"
+      - "README.md"
   pull_request:
     branches: ["**"]
+    types: [labeled, synchronize, reopened]
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/ci-gate.yml"
+      - ".github/workflows/doc.yml"
+      - "doc/**"
+      - "go.mod"
+      - "go.sum"
+      - "README.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    uses: ./.github/workflows/ci-gate.yml
+
   remote_install:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       matrix:
@@ -47,6 +71,8 @@ jobs:
           source doc/_readme/scripts/run.sh
 
   local_install:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       matrix:
@@ -116,6 +142,8 @@ jobs:
           source doc/_readme/scripts/run.sh
 
   local_install_full:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   gate:
+    if: github.event_name != 'pull_request' || github.repository == 'xgo-dev/llgo'
     uses: ./.github/workflows/ci-gate.yml
 
   remote_install:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,8 +2,7 @@ name: Format Check
 
 on:
   push:
-    branches:
-      - main
+    branches: ["**"]
   pull_request:
     branches: ["**"]
 
@@ -13,6 +12,11 @@ concurrency:
 
 jobs:
   fmt:
+    if: >-
+      github.event_name == 'pull_request' && github.repository == 'xgo-dev/llgo' ||
+      github.event_name == 'push' &&
+      (github.event.repository.fork && github.ref_name != github.event.repository.default_branch ||
+      github.repository == 'xgo-dev/llgo' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   gate:
+    if: github.event_name != 'pull_request' || github.repository == 'xgo-dev/llgo'
     uses: ./.github/workflows/ci-gate.yml
 
   test:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,17 +5,29 @@ name: Go
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+      - "release/**"
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["**"]
+    types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    uses: ./.github/workflows/ci-gate.yml
+
   test:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     # The known-good #172 Windows coverage run took about 56 minutes. Leave
     # room for runner variance and the additional shared-matrix checks without
     # changing the established Linux/macOS budget.
@@ -146,6 +158,8 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
 
   dev-lto-globaldce:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     name: Dev LTO GlobalDCE
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -227,6 +241,8 @@ jobs:
   # Tests deletion of unreachable Go methods.
   # See https://github.com/xgo-dev/llgo/issues/1853.
   dev-go-methoddrop:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     name: Dev Go Method Drop
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -3,6 +3,8 @@ name: GOROOT
 on:
   pull_request:
     types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
   workflow_dispatch:
   schedule:
     # 02:00 Asia/Shanghai (18:00 UTC on the previous day).
@@ -19,8 +21,15 @@ jobs:
   goroot:
     if: >-
       github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat'))
+      github.repository == 'xgo-dev/llgo' &&
+      contains(github.event.pull_request.labels.*.name, 'need-review') &&
+      contains(github.event.pull_request.labels.*.name, 'go-test-compat') &&
+      (github.event.action != 'labeled' ||
+      github.event.label.name == 'need-review' ||
+      github.event.label.name == 'go-test-compat') ||
+      github.repository != 'xgo-dev/llgo' &&
+      contains(github.event.pull_request.labels.*.name, 'go-test-compat') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'go-test-compat')
     name: GOROOT (${{ matrix.lane }}, ${{ matrix.os }}, Go ${{ matrix.go-version }}, shard ${{ matrix.shard-index }}/4)
     timeout-minutes: 180
     env:

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -158,11 +158,7 @@ jobs:
 
   goroot-summary:
     name: GOROOT summary
-    if: >-
-      always() &&
-      (github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat')))
+    if: always() && needs.goroot.result != 'skipped'
     needs: goroot
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -1,6 +1,8 @@
 name: GOROOT
 
 on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
   schedule:
     # 02:00 Asia/Shanghai (18:00 UTC on the previous day).
@@ -15,6 +17,10 @@ concurrency:
 
 jobs:
   goroot:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat'))
     name: GOROOT (${{ matrix.lane }}, ${{ matrix.os }}, Go ${{ matrix.go-version }}, shard ${{ matrix.shard-index }}/4)
     timeout-minutes: 180
     env:
@@ -152,7 +158,11 @@ jobs:
 
   goroot-summary:
     name: GOROOT summary
-    if: always()
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'go-test-compat') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'go-test-compat')))
     needs: goroot
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -5,17 +5,29 @@ name: LLGo
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+      - "release/**"
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["**"]
+    types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    uses: ./.github/workflows/ci-gate.yml
+
   llgo:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     name: llgo (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})
     continue-on-error: ${{ matrix.lane == 'compatibility' }}
     timeout-minutes: 60
@@ -179,6 +191,8 @@ jobs:
         run: go test -timeout 15m ./internal/build -run '^TestStandardDWARF$' -count=1 -v
 
   test:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     name: test (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }}, shard ${{ matrix.shard }})
     continue-on-error: ${{ matrix.lane == 'compatibility' }}
     timeout-minutes: ${{ startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 45 || 30 }}
@@ -299,6 +313,8 @@ jobs:
           fi
 
   hello:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     name: hello (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})
     continue-on-error: ${{ matrix.lane == 'compatibility' }}
     timeout-minutes: 30
@@ -374,6 +390,8 @@ jobs:
           mod-version: "1.26"
 
   cross-compile:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       matrix:
@@ -423,6 +441,8 @@ jobs:
           iwasm --stack-size=819200000 --heap-size=800000000 hello.wasm
 
   wasm-runtime:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   gate:
+    if: github.event_name != 'pull_request' || github.repository == 'xgo-dev/llgo'
     uses: ./.github/workflows/ci-gate.yml
 
   llgo:

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -2,13 +2,39 @@ name: PR Metadata
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
 
 permissions:
   contents: read
   pull-requests: read
 
 jobs:
+  full-ci-authorization:
+    name: full CI authorization
+    if: github.repository == 'xgo-dev/llgo'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require reviewer authorization
+        env:
+          HAS_NEED_REVIEW: ${{ contains(github.event.pull_request.labels.*.name, 'need-review') }}
+        run: |
+          if [[ "$HAS_NEED_REVIEW" != "true" ]]; then
+            {
+              echo "### Full CI is blocked"
+              echo
+              echo "A reviewer must inspect the linked fork CI and add the \`need-review\` label."
+              echo "Until then, this check intentionally fails so the pull request cannot look fully validated."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Full CI blocked::A reviewer must add the need-review label after checking the fork CI."
+            exit 1
+          fi
+
+          {
+            echo "### Full CI authorized"
+            echo
+            echo "The \`need-review\` label is present. Relevant full workflows are authorized for this SHA."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   fork-ci-evidence:
     name: fork CI evidence
     if: github.repository == 'xgo-dev/llgo'

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -9,15 +9,63 @@ permissions:
   pull-requests: read
 
 jobs:
+  review-readiness:
+    name: review readiness
+    if: github.repository == 'xgo-dev/llgo'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out metadata validator
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/pr_metadata.js
+          sparse-checkout-cone-mode: false
+      - name: Validate fork test PR
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const path = require('path');
+            const {validatePullRequest} = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/pr_metadata.js',
+            ));
+
+            try {
+              const evidence = await validatePullRequest({
+                body: context.payload.pull_request.body,
+                upstreamRepository: context.payload.repository.full_name,
+                source: context.payload.pull_request,
+                github,
+              });
+              core.notice(
+                `Fork CI evidence matches ${context.payload.pull_request.head.label}` +
+                `@${context.payload.pull_request.head.sha}: ${evidence.url}`,
+              );
+            } catch (error) {
+              core.setFailed(error.message);
+            }
+
   full-ci-authorization:
     name: full CI authorization
-    if: github.repository == 'xgo-dev/llgo'
+    needs: review-readiness
+    if: always() && github.repository == 'xgo-dev/llgo'
     runs-on: ubuntu-latest
     steps:
       - name: Require reviewer authorization
         env:
+          REVIEW_READY: ${{ needs.review-readiness.result == 'success' }}
           HAS_NEED_REVIEW: ${{ contains(github.event.pull_request.labels.*.name, 'need-review') }}
         run: |
+          if [[ "$REVIEW_READY" != "true" ]]; then
+            {
+              echo "### Review is blocked"
+              echo
+              echo "Complete the pull request template and link fork CI from the same repository, branch, and commit."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Review blocked::The review readiness check must pass before reviewer authorization."
+            exit 1
+          fi
+
           if [[ "$HAS_NEED_REVIEW" != "true" ]]; then
             {
               echo "### Full CI is blocked"
@@ -32,49 +80,5 @@ jobs:
           {
             echo "### Full CI authorized"
             echo
-            echo "The \`need-review\` label is present. Relevant full workflows are authorized for this SHA."
+            echo "The template and fork evidence passed review readiness, and the \`need-review\` label is present."
           } >> "$GITHUB_STEP_SUMMARY"
-
-  fork-ci-evidence:
-    name: fork CI evidence
-    if: github.repository == 'xgo-dev/llgo'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate fork test PR
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const body = context.payload.pull_request.body || '';
-            const checked = /-\s*\[[xX]\]\s*I created a test PR in my fork and its relevant CI passed\./.test(body);
-            if (!checked) {
-              core.setFailed('Check the fork-CI confirmation in the pull request template.');
-              return;
-            }
-
-            const match = body.match(/Fork test PR:\s*(https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+))/i);
-            if (!match) {
-              core.setFailed('Provide a valid GitHub fork pull request URL after "Fork test PR:".');
-              return;
-            }
-
-            const [, url, owner, repo, numberText] = match;
-            const number = Number(numberText);
-            const source = context.payload.pull_request;
-
-            const {data: fork} = await github.rest.repos.get({owner, repo});
-            if (!fork.fork || fork.parent?.full_name !== context.payload.repository.full_name) {
-              core.setFailed(`${url} is not a pull request in a fork of ${context.payload.repository.full_name}.`);
-              return;
-            }
-
-            const {data: testPR} = await github.rest.pulls.get({owner, repo, pull_number: number});
-            if (testPR.head.repo?.full_name !== source.head.repo?.full_name) {
-              core.setFailed(`Fork test PR head repository ${testPR.head.repo?.full_name} does not match ${source.head.repo?.full_name}.`);
-              return;
-            }
-            if (testPR.head.sha !== source.head.sha) {
-              core.setFailed(`Fork test PR checks ${testPR.head.sha}, but this PR uses ${source.head.sha}.`);
-              return;
-            }
-
-            core.notice(`Fork CI evidence matches ${source.head.sha}: ${url}`);

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,54 @@
+name: PR Metadata
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  fork-ci-evidence:
+    name: fork CI evidence
+    if: github.repository == 'xgo-dev/llgo'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate fork test PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const checked = /-\s*\[[xX]\]\s*I created a test PR in my fork and its relevant CI passed\./.test(body);
+            if (!checked) {
+              core.setFailed('Check the fork-CI confirmation in the pull request template.');
+              return;
+            }
+
+            const match = body.match(/Fork test PR:\s*(https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+))/i);
+            if (!match) {
+              core.setFailed('Provide a valid GitHub fork pull request URL after "Fork test PR:".');
+              return;
+            }
+
+            const [, url, owner, repo, numberText] = match;
+            const number = Number(numberText);
+            const source = context.payload.pull_request;
+
+            const {data: fork} = await github.rest.repos.get({owner, repo});
+            if (!fork.fork || fork.parent?.full_name !== context.payload.repository.full_name) {
+              core.setFailed(`${url} is not a pull request in a fork of ${context.payload.repository.full_name}.`);
+              return;
+            }
+
+            const {data: testPR} = await github.rest.pulls.get({owner, repo, pull_number: number});
+            if (testPR.head.repo?.full_name !== source.head.repo?.full_name) {
+              core.setFailed(`Fork test PR head repository ${testPR.head.repo?.full_name} does not match ${source.head.repo?.full_name}.`);
+              return;
+            }
+            if (testPR.head.sha !== source.head.sha) {
+              core.setFailed(`Fork test PR checks ${testPR.head.sha}, but this PR uses ${source.head.sha}.`);
+              return;
+            }
+
+            core.notice(`Fork CI evidence matches ${source.head.sha}: ${url}`);

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -2,12 +2,19 @@ name: Release Build
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+      - "release/**"
     tags:
       - "*"
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["**"]
+    types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,7 +26,12 @@ env:
   GORELEASER_CROSS_IMAGE: ghcr.io/goreleaser/goreleaser-cross:v1.26.4
 
 jobs:
+  gate:
+    uses: ./.github/workflows/ci-gate.yml
+
   setup:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     outputs:
       linux-cache-key: ${{ steps.cache-keys.outputs.linux-key }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,6 +27,7 @@ env:
 
 jobs:
   gate:
+    if: github.event_name != 'pull_request' || github.repository == 'xgo-dev/llgo'
     uses: ./.github/workflows/ci-gate.yml
 
   setup:

--- a/.github/workflows/stdlib-coverage.yml
+++ b/.github/workflows/stdlib-coverage.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: ["**"]
+  workflow_dispatch:
 
 concurrency:
   group: stdlib-coverage-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   gate:
+    if: github.event_name != 'pull_request' || github.repository == 'xgo-dev/llgo'
     uses: ./.github/workflows/ci-gate.yml
 
   llgo:

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -2,17 +2,29 @@ name: Targets
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+      - "release/**"
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["**"]
+    types: [labeled, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    uses: ./.github/workflows/ci-gate.yml
+
   llgo:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,38 @@
+name: Workflow Lint
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - ".github/actionlint.yaml"
+      - ".github/actions/**"
+      - ".github/scripts/ci_gate.py"
+      - ".github/scripts/test_ci_gate.py"
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/actionlint.yaml"
+      - ".github/actions/**"
+      - ".github/scripts/ci_gate.py"
+      - ".github/scripts/test_ci_gate.py"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    if: >-
+      github.event_name == 'pull_request' && github.repository == 'xgo-dev/llgo' ||
+      github.event_name == 'push' &&
+      (github.event.repository.fork && github.ref_name != github.event.repository.default_branch ||
+      github.repository == 'xgo-dev/llgo' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-go
+      - name: Check workflow syntax
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck= -pyflakes=
+      - name: Test CI gate decisions
+        run: python3 .github/scripts/test_ci_gate.py

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -6,16 +6,14 @@ on:
     paths:
       - ".github/actionlint.yaml"
       - ".github/actions/**"
-      - ".github/scripts/ci_gate.py"
-      - ".github/scripts/test_ci_gate.py"
+      - ".github/scripts/**"
       - ".github/workflows/**"
   pull_request:
     branches: ["**"]
     paths:
       - ".github/actionlint.yaml"
       - ".github/actions/**"
-      - ".github/scripts/ci_gate.py"
-      - ".github/scripts/test_ci_gate.py"
+      - ".github/scripts/**"
       - ".github/workflows/**"
 
 permissions:
@@ -36,3 +34,5 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck= -pyflakes=
       - name: Test CI gate decisions
         run: python3 .github/scripts/test_ci_gate.py
+      - name: Test PR metadata validation
+        run: node --test .github/scripts/test_pr_metadata.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,13 @@ the linked fork CI. The reviewer adds `need-review` to authorize the relevant
 full CI in `xgo-dev/llgo`. Pushing another commit reruns fork CI and invalidates
 the fork-PR evidence until both pull requests point to the same commit again.
 
+Until `need-review` is present, the upstream `full CI authorization` check
+fails intentionally. Repository maintainers must configure this check as a
+required status check on the default branch so a pull request cannot merge
+without reviewer-authorized full CI. The `need-review` label must also be
+created once in `xgo-dev/llgo`; only users with triage or write permission
+should be able to apply it.
+
 ## Request GOROOT compatibility tests
 
 GOROOT is an expensive opt-in suite. Fork labels are not inherited from the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,20 +15,23 @@ LLGo uses fork-first CI so work-in-progress commits do not consume the
    pass. Keep this pull request available for the upstream reviewer.
 4. Open the upstream pull request from the same feature branch. Complete the
    fork-CI checkbox and paste the fork test PR URL in the template. The
-   `PR Metadata` check verifies that both pull requests use the same head
-   repository and commit.
+   `review readiness` check verifies the required template format and that
+   both pull requests use the same head repository, branch, and commit.
 
-After the lightweight upstream checks pass, a reviewer inspects the change and
-the linked fork CI. The reviewer adds `need-review` to authorize the relevant
-full CI in `xgo-dev/llgo`. Pushing another commit reruns fork CI and invalidates
-the fork-PR evidence until both pull requests point to the same commit again.
+The pull request is not ready for review while `review readiness` fails. After
+the lightweight upstream checks pass, a reviewer inspects the change and the
+linked fork CI. The reviewer adds `need-review` to authorize the relevant full
+CI in `xgo-dev/llgo`. Pushing another commit reruns fork CI and invalidates the
+fork-PR evidence until both pull requests point to the same branch and commit
+again.
 
 Until `need-review` is present, the upstream `full CI authorization` check
-fails intentionally. Repository maintainers must configure this check as a
-required status check on the default branch so a pull request cannot merge
-without reviewer-authorized full CI. The `need-review` label must also be
-created once in `xgo-dev/llgo`; only users with triage or write permission
-should be able to apply it.
+fails intentionally. Repository maintainers must configure both `review
+readiness` and `full CI authorization` as required status checks on the default
+branch so a pull request cannot merge with an incomplete template or without
+reviewer-authorized full CI. The `need-review` label must also be created once
+in `xgo-dev/llgo`; only users with triage or write permission should be able to
+apply it.
 
 ## Request GOROOT compatibility tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to LLGo
+
+LLGo uses fork-first CI so work-in-progress commits do not consume the
+`xgo-dev` GitHub Actions capacity.
+
+## Validate a change
+
+1. Sync the default branch of your fork with `xgo-dev/llgo` and enable GitHub
+   Actions in the fork.
+2. Create a feature branch and push it to the fork. Relevant full CI workflows
+   run on that push with the fork's Actions capacity. Documentation-only
+   changes run formatting, link, and documentation checks without the general
+   compiler and test matrices.
+3. Open a test pull request in the fork and wait for its relevant checks to
+   pass. Keep this pull request available for the upstream reviewer.
+4. Open the upstream pull request from the same feature branch. Complete the
+   fork-CI checkbox and paste the fork test PR URL in the template. The
+   `PR Metadata` check verifies that both pull requests use the same head
+   repository and commit.
+
+After the lightweight upstream checks pass, a reviewer inspects the change and
+the linked fork CI. The reviewer adds `need-review` to authorize the relevant
+full CI in `xgo-dev/llgo`. Pushing another commit reruns fork CI and invalidates
+the fork-PR evidence until both pull requests point to the same commit again.
+
+## Request GOROOT compatibility tests
+
+GOROOT is an expensive opt-in suite. Fork labels are not inherited from the
+upstream repository, so create the label once in your fork:
+
+```sh
+gh label create go-test-compat \
+  --repo <your-account>/llgo \
+  --description "Go standard-library and GOROOT test compatibility" \
+  --color 1D76DB
+```
+
+Apply `go-test-compat` to the test PR in your fork to run GOROOT with the
+fork's capacity. In `xgo-dev/llgo`, GOROOT runs only when a reviewer has also
+added `need-review`. The daily scheduled and manual GOROOT runs are unchanged.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,12 @@ cd llgo
 
 For local workflows and test-golden refresh commands, see [dev/README.md](dev/README.md#6-refresh-test-goldens).
 
+## Contributing
+
+Before opening an upstream pull request, follow the
+[fork-first CI workflow](CONTRIBUTING.md) and provide the passing fork test PR
+requested by the pull request template.
+
 How do I generate these tools?
 
 <!-- embedme doc/_readme/scripts/install_full.sh#L2-L1000 -->

--- a/_demo/c/llama2-c/README.md
+++ b/_demo/c/llama2-c/README.md
@@ -91,7 +91,9 @@ python tokenizer.py --tokenizer-model=/path/to/CodeLlama-7b-Instruct/tokenizer.m
 
 ## huggingface models
 
-We can load any huggingface models that use the Llama 2 architecture. See the script [export.py](export.py) and the `--hf` flag to export the model .bin file.
+We can load any huggingface models that use the Llama 2 architecture. See the
+upstream [export.py](https://github.com/karpathy/llama2.c/blob/master/export.py)
+script and the `--hf` flag to export the model .bin file.
 
 ## models
 

--- a/internal/crc16/README.md
+++ b/internal/crc16/README.md
@@ -1,7 +1,6 @@
 
 # crc16
 [![Build Status](https://travis-ci.org/sigurn/crc16.svg?branch=master)](https://travis-ci.org/sigurn/crc16)
-[![Coverage Status](https://coveralls.io/repos/sigurn/crc16/badge.svg?branch=master&service=github)](https://coveralls.io/github/sigurn/crc16?branch=master)
 [![Go Reference](https://pkg.go.dev/badge/github.com/sigurn/crc16.svg)](https://pkg.go.dev/github.com/sigurn/crc16)
 
 Go implementation of CRC-16 calculation for majority of widely-used polynomials.</br>

--- a/runtime/internal/clite/zlib/README.md
+++ b/runtime/internal/clite/zlib/README.md
@@ -13,18 +13,3 @@ brew install zlib
 ```sh
 TODO
 ```
-
-## Demos
-
-The `_demo` directory contains our demos (it start with `_` to prevent the `go` command from compiling it):
-
-- [normal](_demo/normal/compress.go): a basic zlib demo
-
-### How to run demos
-
-To run the demos in directory `_demo`:
-
-```sh
-cd <demo-directory>  # eg. cd _demo/normal
-llgo run .
-```


### PR DESCRIPTION
## Summary

- Adopt a fork-first, change-aware CI model: full relevant workflows run on feature-branch pushes in contributor forks, while upstream pull requests start lightweight checks by default.
- Require a completed PR template and a linked fork test PR from the same head repository, branch, and SHA before review; keep full upstream CI blocked until a reviewer adds `need-review`.
- Preserve daily Markdown link checks, run PR link checks only for Markdown changes, keep `gofmt` validation broad, and path-gate documentation and heavy build/test workflows.
- Gate GOROOT compatibility using the effective commits from #2424: upstream requires both `need-review` and `go-test-compat`, while forks require `go-test-compat`.
- Move benchmark and stdlib-coverage work out of the default PR path.

Implements #2363 and incorporates #2424.

## Validation

- `python3 .github/scripts/test_ci_gate.py`
- `node --test .github/scripts/test_pr_metadata.js`
- `GOTOOLCHAIN=local go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck= -pyflakes=`
- `git diff --check`
- Fork feature-branch push: Format Check, Workflow Lint, Doc Link Checker, Docs, Go, LLGo, Targets, Build Cache, and Release Build all passed.
- Fork pull-request events allocated no heavy or gate runners; their jobs were skipped in favor of the feature-branch push results.

## Fork CI

- [x] I created a test PR in my fork and its relevant CI passed.
- Fork test PR: https://github.com/cpunion/llgo/pull/205
