### PR TITLE
build: support multiple package outputs

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -414,7 +414,7 @@ jobs:
           echo "Testing cross-compilation wasm with $(go env GOVERSION)"
 
           # Compile for wasm architecture
-          GOOS=wasip1 GOARCH=wasm llgo build -o hello -tags=nogc -v ./helloc
+          GOOS=wasip1 GOARCH=wasm llgo build -o hello.wasm -tags=nogc -v ./helloc
 
           # Check file type
           file hello.wasm

--- a/cmd/internal/build/build_test.go
+++ b/cmd/internal/build/build_test.go
@@ -4,11 +4,14 @@ package build
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
+	cmdflags "github.com/xgo-dev/llgo/cmd/internal/flags"
 	"github.com/xgo-dev/llgo/internal/mockable"
 )
 
@@ -65,5 +68,53 @@ func TestBuildCommandHasSchedulerTraceFlag(t *testing.T) {
 	}
 	if !strings.Contains(flag.Usage, "Chrome/Perfetto") {
 		t.Fatalf("-debug-trace usage = %q", flag.Usage)
+	}
+}
+
+func TestRunCmdBuildsMultiplePackagesToDirectory(t *testing.T) {
+	root := t.TempDir()
+	for name, output := range map[string]string{"first": "first", "second": "second"} {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		source := "package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"" + output + "\") }\n"
+		if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/cmdmultibuild\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(root, "bin")
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldDir)
+	oldOutput := cmdflags.OutputFile
+	oldPassArgs := append([]string(nil), goBuildFlags.Args...)
+	defer func() {
+		cmdflags.OutputFile = oldOutput
+		_ = Cmd.Flag.Set("o", oldOutput)
+		goBuildFlags.Args = oldPassArgs
+	}()
+	cmdflags.OutputFile = ""
+	goBuildFlags.Args = nil
+	runCmd(Cmd, []string{"-o", out + string(os.PathSeparator), "./..."})
+
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+	for _, name := range []string{"first", "second"} {
+		data, err := exec.Command(filepath.Join(out, name+ext)).CombinedOutput()
+		if err != nil || strings.TrimSpace(string(data)) != name {
+			t.Fatalf("run %s: %v, output %q", name, err, data)
+		}
 	}
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -144,7 +144,7 @@ type Config struct {
 	LTOPlugin          lto.PassPlugin
 	BinPath            string
 	AppExt             string  // ".exe" on Windows, empty on Unix
-	OutFile            string  // file for one package, or directory for multiple ModeBuild packages
+	OutFile            string  // output file, or directory for ModeBuild package executables
 	OutFmts            OutFmts // Output format specifications (only for Target != "")
 	CompileOnly        bool    // compile test binary but do not run it (only valid for ModeTest)
 	Emulator           bool    // run in emulator mode
@@ -806,7 +806,11 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 			continue
 		}
 		if err := linkInitialPackage(ctx, pkg, allPkgs, conf, verbose, linkMultiple && conf.OutFile == ""); err != nil {
-			linkErrs = append(linkErrs, fmt.Errorf("%s: %w", pkg.PkgPath, err))
+			if inv.disableMultiFallback {
+				linkErrs = append(linkErrs, err)
+			} else {
+				linkErrs = append(linkErrs, fmt.Errorf("%s: %w", pkg.PkgPath, err))
+			}
 		}
 	}
 	// The shared graph completed, so a link failure must not trigger the

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -28,7 +28,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -145,7 +144,7 @@ type Config struct {
 	LTOPlugin          lto.PassPlugin
 	BinPath            string
 	AppExt             string  // ".exe" on Windows, empty on Unix
-	OutFile            string  // only valid for ModeBuild when len(pkgs) == 1
+	OutFile            string  // file for one package, or directory for multiple ModeBuild packages
 	OutFmts            OutFmts // Output format specifications (only for Target != "")
 	CompileOnly        bool    // compile test binary but do not run it (only valid for ModeTest)
 	Emulator           bool    // run in emulator mode
@@ -445,7 +444,15 @@ func Do(args []string, conf *Config) ([]Package, error) {
 }
 
 // Build executes one build invocation.
-func Build(inv Invocation) ([]Package, error) {
+func Build(inv Invocation) (result []Package, resultErr error) {
+	var fallback *multiBuildFallback
+	defer func() {
+		if resultErr == nil || fallback == nil || inv.disableMultiFallback {
+			return
+		}
+		result, resultErr = fallback.run()
+	}()
+
 	dir := inv.Dir
 	if dir == "" {
 		var err error
@@ -644,13 +651,20 @@ func Build(inv Invocation) ([]Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := loadSyntaxErr(); err != nil {
-		return nil, err
-	}
 	if conf.AllowNoBody {
 		allowMissingFunctionBodies(initial)
 	}
 	mode := conf.Mode
+	var multiOutputDir string
+	if mode == ModeBuild && conf.OutFile != "" {
+		multiOutputDir, err = prepareBuildOutput(dir, conf.OutFile, len(initial) > 1, initial)
+		if err != nil {
+			return nil, err
+		}
+		if multiOutputDir != "" {
+			conf.OutFile = multiOutputDir
+		}
+	}
 	if mode == ModeTest {
 		initial, err = filterTestPackages(initial, conf.OutFile)
 		if err != nil {
@@ -662,9 +676,10 @@ func Build(inv Invocation) ([]Package, error) {
 	} else if len(initial) > 1 {
 		switch mode {
 		case ModeBuild:
-			if conf.OutFile != "" {
-				return nil, fmt.Errorf("cannot build multiple packages with -o")
+			if conf.BuildMode != BuildModeExe {
+				return nil, fmt.Errorf("-buildmode=%s requires exactly one main package", conf.BuildMode)
 			}
+			fallback = newMultiBuildFallback(conf, initial, dir, multiOutputDir)
 		case ModeInstall:
 			if conf.Target != "" {
 				return nil, fmt.Errorf("cannot install multiple packages to embedded target")
@@ -672,6 +687,9 @@ func Build(inv Invocation) ([]Package, error) {
 		case ModeRun:
 			return nil, fmt.Errorf("cannot run multiple packages")
 		}
+	}
+	if err := loadSyntaxErr(); err != nil {
+		return nil, err
 	}
 
 	altPkgPaths := altPkgs(initial, conf, llssa.PkgRuntime)
@@ -781,107 +799,103 @@ func Build(inv Invocation) ([]Package, error) {
 		return nil, fmt.Errorf("initial package not found")
 	}
 
+	linkMultiple := mode == ModeBuild && len(initial) > 1
+	var linkErrs []error
 	for _, pkg := range initial {
-		if needLink(pkg, mode) {
-			name := path.Base(pkg.PkgPath)
-
-			// Create output format details
-			outFmts, err := buildOutFmts(name, conf, len(ctx.initial) > 1, &ctx.crossCompile)
-			if err != nil {
-				return nil, err
-			}
-			resolveOutputs(ctx.commands.dir, outFmts)
-
-			// Link main package using the output path from buildOutFmts
-			linkSpan := buildTrace.startCoordinator("link "+pkg.PkgPath, map[string]any{
-				"package": pkg.PkgPath,
-				"output":  outFmts.Out,
-			})
-			err = linkMainPkg(ctx, pkg, allPkgs, outFmts.Out, verbose)
-			linkSpan.done()
-			if err != nil {
-				return nil, err
-			}
-			if err := finalizeRuntimePCLN(ctx, outFmts, verbose); err != nil {
-				return nil, err
-			}
-			if err := finalizeDarwinSizeExecutable(ctx, outFmts.Out, verbose); err != nil {
-				return nil, err
-			}
-			if conf.Mode == ModeBuild && conf.SizeReport {
-				if err := reportBinarySize(outFmts.Out, conf.SizeFormat, conf.SizeLevel, allPkgs); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: size report failed: %v\n", err)
-				}
-			}
-
-			// Generate C headers for c-archive and c-shared modes before linking
-			if ctx.buildConf.BuildMode == BuildModeCArchive || ctx.buildConf.BuildMode == BuildModeCShared {
-				libname := strings.TrimSuffix(filepath.Base(outFmts.Out), conf.AppExt)
-				headerPath := filepath.Join(filepath.Dir(outFmts.Out), libname) + ".h"
-				pkgs := cHeaderPackages(allPkgs)
-				headerErr := header.GenHeaderFile(prog, pkgs, libname, headerPath, verbose)
-				if headerErr != nil {
-					return nil, headerErr
-				}
-				continue
-			}
-
-			envMap := outFmts.ToEnvMap()
-
-			// Only convert formats when Target is specified
-			if conf.Target != "" {
-				// Process format conversions for embedded targets
-				err = firmware.ConvertFormats(ctx.crossCompile.BinaryFormat, ctx.crossCompile.FormatDetail, envMap)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			switch mode {
-			case ModeBuild:
-				// Do nothing
-
-			case ModeInstall:
-				// Native already installed in linkMainPkg
-				if conf.Target != "" {
-					err = flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose)
-					if err != nil {
-						return nil, err
-					}
-				}
-
-			case ModeRun, ModeTest, ModeCmpTest:
-				if conf.Target == "" {
-					err = runNative(ctx, outFmts.Out, pkg.Dir, pkg.PkgPath, conf, mode)
-				} else if conf.Emulator {
-					err = runInEmulator(ctx.commands, ctx.crossCompile.Emulator, envMap, pkg.Dir, pkg.PkgPath, conf, mode, verbose)
-				} else {
-					err = flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose)
-					if err != nil {
-						return nil, err
-					}
-					monitorConfig := monitor.MonitorConfig{
-						Port:       ctx.buildConf.Port,
-						Target:     conf.Target,
-						Executable: outFmts.Out,
-						BaudRate:   conf.BaudRate,
-						SerialPort: ctx.crossCompile.Device.SerialPort,
-					}
-					err = monitor.Monitor(monitorConfig, verbose)
-				}
-				if err != nil {
-					return nil, err
-				}
-			}
+		if !needLink(pkg, mode) || inv.compileOnly {
+			continue
+		}
+		if err := linkInitialPackage(ctx, pkg, allPkgs, conf, verbose, linkMultiple && conf.OutFile == ""); err != nil {
+			linkErrs = append(linkErrs, fmt.Errorf("%s: %w", pkg.PkgPath, err))
 		}
 	}
+	// The shared graph completed, so a link failure must not trigger the
+	// expensive per-root compile fallback. Other main packages were already
+	// attempted above and their link errors are returned together.
+	fallback = nil
 	ctx.disposeBackendPrograms()
 
 	if mode == ModeTest && ctx.testFail {
 		mockable.Exit(1)
 	}
 
-	return allPkgs, nil
+	return allPkgs, errors.Join(linkErrs...)
+}
+
+func linkInitialPackage(ctx *context, pkg *packages.Package, allPkgs []*aPackage, conf *Config, verbose, discardOutput bool) error {
+	name := defaultExecutableName(pkg.PkgPath)
+	outFmts, err := buildOutFmts(name, conf, len(ctx.initial) > 1, &ctx.crossCompile)
+	if err != nil {
+		return err
+	}
+	if discardOutput {
+		defer removeOutFmts(outFmts)
+	}
+	resolveOutputs(ctx.commands.dir, outFmts)
+	linkSpan := ctx.buildTrace.startCoordinator("link "+pkg.PkgPath, map[string]any{
+		"package": pkg.PkgPath,
+		"output":  outFmts.Out,
+	})
+	err = linkMainPkg(ctx, pkg, allPkgs, outFmts.Out, verbose)
+	linkSpan.done()
+	if err != nil {
+		return err
+	}
+	if err := finalizeRuntimePCLN(ctx, outFmts, verbose); err != nil {
+		return err
+	}
+	if err := finalizeDarwinSizeExecutable(ctx, outFmts.Out, verbose); err != nil {
+		return err
+	}
+	if conf.Mode == ModeBuild && conf.SizeReport {
+		if err := reportBinarySize(outFmts.Out, conf.SizeFormat, conf.SizeLevel, allPkgs); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: size report failed: %v\n", err)
+		}
+	}
+	if ctx.buildConf.BuildMode == BuildModeCArchive || ctx.buildConf.BuildMode == BuildModeCShared {
+		libname := strings.TrimSuffix(filepath.Base(outFmts.Out), conf.AppExt)
+		headerPath := filepath.Join(filepath.Dir(outFmts.Out), libname) + ".h"
+		return header.GenHeaderFile(ctx.prog, cHeaderPackages(allPkgs), libname, headerPath, verbose)
+	}
+
+	envMap := outFmts.ToEnvMap()
+	if conf.Target != "" {
+		if err := firmware.ConvertFormats(ctx.crossCompile.BinaryFormat, ctx.crossCompile.FormatDetail, envMap); err != nil {
+			return err
+		}
+	}
+	switch conf.Mode {
+	case ModeInstall:
+		if conf.Target != "" {
+			return flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose)
+		}
+	case ModeRun, ModeTest, ModeCmpTest:
+		if conf.Target == "" {
+			return runNative(ctx, outFmts.Out, pkg.Dir, pkg.PkgPath, conf, conf.Mode)
+		}
+		if conf.Emulator {
+			return runInEmulator(ctx.commands, ctx.crossCompile.Emulator, envMap, pkg.Dir, pkg.PkgPath, conf, conf.Mode, verbose)
+		}
+		if err := flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose); err != nil {
+			return err
+		}
+		return monitor.Monitor(monitor.MonitorConfig{
+			Port: ctx.buildConf.Port, Target: conf.Target, Executable: outFmts.Out,
+			BaudRate: conf.BaudRate, SerialPort: ctx.crossCompile.Device.SerialPort,
+		}, verbose)
+	}
+	return nil
+}
+
+func removeOutFmts(outFmts *OutFmtDetails) {
+	for _, output := range []string{
+		outFmts.Out, outFmts.PCLN, outFmts.Bin, outFmts.Hex,
+		outFmts.Img, outFmts.Uf2, outFmts.Zip,
+	} {
+		if output != "" {
+			_ = os.Remove(output)
+		}
+	}
 }
 
 // cHeaderPackages excludes the patched standard runtime implementation. Its
@@ -1536,45 +1550,13 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	var needAbiInit int
 	methodByIndex := make(map[int]none)
 	methodByName := make(map[string]none)
-	allPkgs := []*packages.Package{pkg}
-	for _, v := range pkgs {
-		if v.PkgPath != pkg.PkgPath && v.Types != nil && v.Types.Name() == "main" {
-			continue
-		}
-		allPkgs = append(allPkgs, v.Package)
-	}
-	visitRoots := allPkgs
-	if ctx.mode == ModeTest {
-		visitRoots = []*packages.Package{pkg}
-		for _, p := range allPkgs {
-			if isRuntimePkg(p.PkgPath) {
-				visitRoots = append(visitRoots, p)
-			}
-		}
-	}
 	// archiveInputs contains package .a files. Object files are prepended later so
 	// archive extraction can see their undefined references in a single linker pass.
 	var archiveInputs []string
 	var linkArgs []string
 	var rtLinkInputs []string
 	var rtLinkArgs []string
-	linkedPkgs := make(map[string]bool) // Track linked packages by ID to avoid duplicates
-	var linkedOrder []Package
-	packages.Visit(visitRoots, nil, func(p *packages.Package) {
-		// Skip if already linked this package (by ID)
-		if linkedPkgs[p.ID] {
-			return
-		}
-		aPkg := ctx.pkgs[p]
-		if aPkg == nil {
-			// Fallback: lookup by pkg.ID for packages that may be different instances
-			aPkg = ctx.pkgByID[p.ID]
-		}
-		if p.ExportFile != "" && aPkg != nil { // skip packages that only contain declarations
-			linkedPkgs[p.ID] = true
-			linkedOrder = append(linkedOrder, aPkg)
-		}
-	})
+	linkedOrder := linkedPackageClosure(ctx, pkg, pkgs)
 
 	// packages.Visit with a post callback yields dependencies before importers.
 	// Reverse that order so static archives are linked after the objects that use them.

--- a/internal/build/dependencies.go
+++ b/internal/build/dependencies.go
@@ -48,3 +48,38 @@ func effectiveDependencies(pkg *aPackage) []*packages.Package {
 	sort.Slice(ret, func(i, j int) bool { return ret[i].ID < ret[j].ID })
 	return ret
 }
+
+// linkedPackageClosure returns dependency-first packages for one link. It
+// follows alternate-package-only imports as well as the ordinary Go graph and
+// includes the prepared runtime tree without pulling in unrelated roots.
+func linkedPackageClosure(ctx *context, root *packages.Package, built []*aPackage) []Package {
+	seen := make(map[string]bool)
+	var order []Package
+	var visit func(*packages.Package)
+	visit = func(pkg *packages.Package) {
+		if pkg == nil || seen[pkg.ID] {
+			return
+		}
+		seen[pkg.ID] = true
+		aPkg := ctx.pkgs[pkg]
+		if aPkg == nil {
+			aPkg = ctx.pkgByID[pkg.ID]
+		}
+		if aPkg == nil {
+			return
+		}
+		for _, dep := range effectiveDependencies(aPkg) {
+			visit(dep)
+		}
+		if pkg.ExportFile != "" {
+			order = append(order, aPkg)
+		}
+	}
+	visit(root)
+	for _, pkg := range built {
+		if isRuntimePkg(pkg.PkgPath) {
+			visit(pkg.Package)
+		}
+	}
+	return order
+}

--- a/internal/build/dependencies_test.go
+++ b/internal/build/dependencies_test.go
@@ -50,3 +50,36 @@ func TestEffectiveDependenciesHandlesNilPackage(t *testing.T) {
 		t.Fatalf("effectiveDependencies(nil) = %v, want nil", deps)
 	}
 }
+
+func TestLinkedPackageClosureUsesOnlyRootAndEffectiveDependencies(t *testing.T) {
+	root := &packages.Package{ID: "root", ExportFile: "root.a"}
+	base := &packages.Package{ID: "base", ExportFile: "base.a"}
+	altOnly := &packages.Package{ID: "alt-only", ExportFile: "alt.a"}
+	unrelated := &packages.Package{ID: "unrelated", ExportFile: "unrelated.a"}
+	runtimePkg := &packages.Package{ID: "runtime", PkgPath: "github.com/xgo-dev/llgo/runtime", ExportFile: "runtime.a"}
+	root.Imports = map[string]*packages.Package{"base": base}
+
+	wrapped := func(pkg *packages.Package) *aPackage { return &aPackage{Package: pkg} }
+	rootPkg := wrapped(root)
+	rootPkg.AltPkg = &packages.Cached{Package: &packages.Package{
+		ID: "alt-root", Imports: map[string]*packages.Package{"alt-only": altOnly},
+	}}
+	basePkg, altPkg := wrapped(base), wrapped(altOnly)
+	unrelatedPkg, runtimeWrapped := wrapped(unrelated), wrapped(runtimePkg)
+	ctx := &context{
+		pkgs: map[*packages.Package]Package{
+			root: rootPkg, base: basePkg, altOnly: altPkg, unrelated: unrelatedPkg, runtimePkg: runtimeWrapped,
+		},
+		pkgByID: map[string]Package{
+			"root": rootPkg, "base": basePkg, "alt-only": altPkg, "unrelated": unrelatedPkg, "runtime": runtimeWrapped,
+		},
+	}
+	gotPkgs := linkedPackageClosure(ctx, root, []*aPackage{rootPkg, basePkg, altPkg, unrelatedPkg, runtimeWrapped})
+	got := make([]string, len(gotPkgs))
+	for i, pkg := range gotPkgs {
+		got[i] = pkg.ID
+	}
+	if want := []string{"alt-only", "base", "root", "runtime"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("linkedPackageClosure = %v, want %v", got, want)
+	}
+}

--- a/internal/build/invocation.go
+++ b/internal/build/invocation.go
@@ -16,6 +16,12 @@ type Invocation struct {
 	Args   []string
 	Config *Config
 	Dir    string
+
+	// compileOnly and disableMultiFallback are used by the multi-package
+	// failure recovery path. They are intentionally not part of Config: a
+	// caller-visible ModeBuild still has normal cmd/go output semantics.
+	compileOnly          bool
+	disableMultiFallback bool
 }
 
 // commandEnv is the per-invocation process-execution state. It deliberately

--- a/internal/build/multi_build.go
+++ b/internal/build/multi_build.go
@@ -1,0 +1,157 @@
+package build
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/xgo-dev/llgo/internal/packages"
+)
+
+// prepareBuildOutput implements the directory form of cmd/go's -o contract.
+// A plain non-directory remains a valid output file for exactly one package.
+func prepareBuildOutput(root, output string, multiple bool, pkgs []*packages.Package) (string, error) {
+	if output == "" {
+		return "", nil
+	}
+	resolved := resolvePath(root, output)
+	info, statErr := os.Stat(resolved)
+	isDirectory := statErr == nil && info.IsDir()
+	trailingSeparator := strings.HasSuffix(output, "/") || strings.HasSuffix(output, `\`)
+	if !isDirectory && !trailingSeparator && multiple {
+		return "", fmt.Errorf("cannot write multiple packages to non-directory %s", output)
+	}
+	if !isDirectory && !trailingSeparator {
+		return "", nil
+	}
+	hasMain := false
+	for _, pkg := range pkgs {
+		hasMain = hasMain || pkg.Name == "main"
+	}
+	if !hasMain {
+		return "", errors.New("no main packages to build")
+	}
+	// On non-Windows hosts a final backslash is still accepted as the
+	// documented directory marker rather than becoming part of the name.
+	if !isDirectory && filepath.Separator != '\\' && strings.HasSuffix(output, `\`) {
+		trimmed := strings.TrimSuffix(output, `\`)
+		if trimmed == "" {
+			resolved = root
+		} else {
+			resolved = resolvePath(root, trimmed)
+		}
+	}
+	resolved = filepath.Clean(resolved)
+	if err := os.MkdirAll(resolved, 0o755); err != nil {
+		return "", fmt.Errorf("create build output directory %s: %w", resolved, err)
+	}
+	return resolved, nil
+}
+
+func defaultExecutableName(pkgPath string) string {
+	name := path.Base(pkgPath)
+	if len(name) > 1 && name[0] == 'v' && name[1] != '0' {
+		if major, err := strconv.Atoi(name[1:]); err == nil && major >= 2 {
+			name = path.Base(path.Dir(pkgPath))
+		}
+	}
+	return name
+}
+
+// multiBuildFallback is used only after the shared graph fails. The normal
+// path loads and compiles the union graph once; isolating roots here lets an
+// unrelated good command still produce its output and makes every failure
+// visible, at the acceptable cost of repeated failure-path work.
+type multiBuildFallback struct {
+	conf      *Config
+	pkgs      []*packages.Package
+	root      string
+	outputDir string
+}
+
+func newMultiBuildFallback(conf *Config, pkgs []*packages.Package, root, outputDir string) *multiBuildFallback {
+	return &multiBuildFallback{conf: conf.clone(), pkgs: pkgs, root: root, outputDir: outputDir}
+}
+
+func (fallback *multiBuildFallback) run() ([]Package, error) {
+	results := make([][]Package, len(fallback.pkgs))
+	errs := make([]error, len(fallback.pkgs))
+	jobs := make(chan int, len(fallback.pkgs))
+	workers := min(fallback.conf.parallelism(), len(fallback.pkgs))
+	var outputLocks sync.Map
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				pkg := fallback.pkgs[index]
+				conf := fallback.conf.clone()
+				conf.BuildParallelism = 1
+				conf.BuildTrace = ""
+				conf.OutFile = ""
+				compileOnly := pkg.Name != "main"
+				discardOutput := ""
+				if pkg.Name == "main" {
+					if fallback.outputDir != "" {
+						conf.OutFile = filepath.Join(fallback.outputDir, defaultExecutableName(pkg.PkgPath)+conf.AppExt)
+					} else {
+						var err error
+						discardOutput, err = genTempOutputFile(defaultExecutableName(pkg.PkgPath), conf.AppExt)
+						if err != nil {
+							errs[index] = fmt.Errorf("%s: create temporary output: %w", pkg.PkgPath, err)
+							continue
+						}
+						conf.OutFile = discardOutput
+					}
+				}
+				var outputLock *sync.Mutex
+				if conf.OutFile != "" {
+					value, _ := outputLocks.LoadOrStore(conf.OutFile, new(sync.Mutex))
+					outputLock = value.(*sync.Mutex)
+					outputLock.Lock()
+				}
+				func() {
+					if discardOutput != "" {
+						defer os.Remove(discardOutput)
+						defer os.Remove(pclnSidecarPath(discardOutput))
+					}
+					if outputLock != nil {
+						defer outputLock.Unlock()
+					}
+					errs[index] = runPackageJob(index, func(int) error {
+						var err error
+						results[index], err = Build(Invocation{
+							Args: []string{pkg.PkgPath}, Config: conf, Dir: fallback.root,
+							compileOnly: compileOnly, disableMultiFallback: true,
+						})
+						return err
+					})
+				}()
+				if errs[index] != nil {
+					errs[index] = fmt.Errorf("%s: %w", pkg.PkgPath, errs[index])
+				}
+			}
+		}()
+	}
+	for index := range fallback.pkgs {
+		jobs <- index
+	}
+	close(jobs)
+	wg.Wait()
+
+	var all []Package
+	var failures []error
+	for index := range results {
+		all = append(all, results[index]...)
+		if errs[index] != nil {
+			failures = append(failures, errs[index])
+		}
+	}
+	return all, errors.Join(failures...)
+}

--- a/internal/build/multi_build.go
+++ b/internal/build/multi_build.go
@@ -14,7 +14,8 @@ import (
 )
 
 // prepareBuildOutput implements the directory form of cmd/go's -o contract.
-// A plain non-directory remains a valid output file for exactly one package.
+// A plain non-directory remains a valid output file for exactly one package;
+// a directory output requires at least one main package.
 func prepareBuildOutput(root, output string, multiple bool, pkgs []*packages.Package) (string, error) {
 	if output == "" {
 		return "", nil
@@ -118,8 +119,7 @@ func (fallback *multiBuildFallback) run() ([]Package, error) {
 				}
 				func() {
 					if discardOutput != "" {
-						defer os.Remove(discardOutput)
-						defer os.Remove(pclnSidecarPath(discardOutput))
+						defer removeTemporaryBuildOutputs(discardOutput)
 					}
 					if outputLock != nil {
 						defer outputLock.Unlock()
@@ -154,4 +154,13 @@ func (fallback *multiBuildFallback) run() ([]Package, error) {
 		}
 	}
 	return all, errors.Join(failures...)
+}
+
+func removeTemporaryBuildOutputs(output string) {
+	base := strings.TrimSuffix(output, filepath.Ext(output))
+	removeOutFmts(&OutFmtDetails{
+		Out: output, PCLN: pclnSidecarPath(output),
+		Bin: base + ".bin", Hex: base + ".hex", Img: base + ".img",
+		Uf2: base + ".uf2", Zip: base + ".zip",
+	})
 }

--- a/internal/build/multi_build_test.go
+++ b/internal/build/multi_build_test.go
@@ -1,0 +1,173 @@
+//go:build !llgo
+
+package build
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestModeBuildMultiplePackagesMatchesGoOutputContract(t *testing.T) {
+	root := writeMultiBuildModule(t, map[string]string{
+		"cmd/first/main.go":  mainSource("first"),
+		"cmd/second/main.go": mainSource("second"),
+		"cmd/a/same/main.go": mainSource("same-a"),
+		"cmd/b/same/main.go": mainSource("same-b"),
+		"cmd/badlink/main.go": `package main
+import _ "unsafe"
+//go:linkname missing C.llgo_multi_build_missing_symbol
+func missing()
+func main() { missing() }
+`,
+		"lib/lib.go": "package lib\nfunc Value() int { return 1 }\n",
+	})
+
+	conf := multiBuildConfig()
+	if _, err := Build(Invocation{Args: []string{"./..."}, Config: conf, Dir: root}); err == nil ||
+		!strings.Contains(err.Error(), "example.com/multibuild/cmd/badlink") {
+		t.Fatalf("multi-package build link error = %v", err)
+	}
+	for _, name := range []string{"first", "second", "same", "badlink"} {
+		if _, err := os.Stat(filepath.Join(root, name+conf.AppExt)); !os.IsNotExist(err) {
+			t.Fatalf("check-only build left output %q: %v", name, err)
+		}
+	}
+
+	out := filepath.Join(root, "out")
+	if err := os.Mkdir(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withOutput := multiBuildConfig()
+	withOutput.OutFile = out
+	_, err := Build(Invocation{Args: []string{"./..."}, Config: withOutput, Dir: root})
+	if err == nil {
+		t.Fatal("directory build unexpectedly linked the missing symbol")
+	}
+	for name, want := range map[string]string{"first": "first", "second": "second"} {
+		assertBuiltProgram(t, filepath.Join(out, name+withOutput.AppExt), want)
+	}
+	if got := runBuiltProgram(t, filepath.Join(out, "same"+withOutput.AppExt)); got != "same-a" && got != "same-b" {
+		t.Fatalf("same-basename output = %q, want either main package", got)
+	}
+	if _, err := os.Stat(filepath.Join(out, "lib"+withOutput.AppExt)); !os.IsNotExist(err) {
+		t.Fatalf("non-main package produced output: %v", err)
+	}
+
+	fileOutput := multiBuildConfig()
+	fileOutput.OutFile = filepath.Join(root, "not-a-directory")
+	if _, err := Build(Invocation{Args: []string{"./cmd/first", "./cmd/second"}, Config: fileOutput, Dir: root}); err == nil ||
+		!strings.Contains(err.Error(), "cannot write multiple packages to non-directory") {
+		t.Fatalf("multi-package -o file error = %v", err)
+	}
+
+	trailingDir := filepath.Join(root, "created") + string(os.PathSeparator)
+	trailing := multiBuildConfig()
+	trailing.OutFile = trailingDir
+	if _, err := Build(Invocation{Args: []string{"./cmd/first", "./cmd/second"}, Config: trailing, Dir: root}); err != nil {
+		t.Fatalf("trailing-directory build: %v", err)
+	}
+	assertBuiltProgram(t, filepath.Join(trailingDir, "first"+trailing.AppExt), "first")
+	assertBuiltProgram(t, filepath.Join(trailingDir, "second"+trailing.AppExt), "second")
+}
+
+func TestModeBuildMultiplePackagesRecoversIndependentRoots(t *testing.T) {
+	root := writeMultiBuildModule(t, map[string]string{
+		"cmd/good/main.go": mainSource("good"),
+		"cmd/bad/main.go":  "package main\nfunc main() { _ = undefinedName }\n",
+		"cmd/badlink/main.go": `package main
+import _ "unsafe"
+//go:linkname missing C.llgo_multi_build_fallback_missing_symbol
+func missing()
+func main() { missing() }
+`,
+	})
+	out := filepath.Join(root, "out")
+	conf := multiBuildConfig()
+	conf.OutFile = out + string(os.PathSeparator)
+	_, err := Build(Invocation{Args: []string{"./..."}, Config: conf, Dir: root})
+	if err == nil || !strings.Contains(err.Error(), "example.com/multibuild/cmd/bad:") ||
+		!strings.Contains(err.Error(), "example.com/multibuild/cmd/badlink:") {
+		t.Fatalf("multi-package compile error = %v", err)
+	}
+	assertBuiltProgram(t, filepath.Join(out, "good"+conf.AppExt), "good")
+}
+
+func TestModeBuildOutputDirectoryRequiresMain(t *testing.T) {
+	root := writeMultiBuildModule(t, map[string]string{
+		"one/one.go": "package one\n",
+		"two/two.go": "package two\n",
+	})
+	for _, args := range [][]string{{"./..."}, {"./one"}} {
+		conf := multiBuildConfig()
+		conf.OutFile = filepath.Join(root, "out") + string(os.PathSeparator)
+		if _, err := Build(Invocation{Args: args, Config: conf, Dir: root}); err == nil ||
+			!strings.Contains(err.Error(), "no main packages to build") {
+			t.Fatalf("Build(%v) non-main directory output error = %v", args, err)
+		}
+	}
+}
+
+func TestModeBuildSinglePackageAcceptsOutputDirectory(t *testing.T) {
+	root := writeMultiBuildModule(t, map[string]string{"cmd/only/main.go": mainSource("only")})
+	out := filepath.Join(root, "out")
+	if err := os.Mkdir(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	conf := multiBuildConfig()
+	conf.OutFile = out
+	if _, err := Build(Invocation{Args: []string{"./cmd/only"}, Config: conf, Dir: root}); err != nil {
+		t.Fatal(err)
+	}
+	assertBuiltProgram(t, filepath.Join(out, "only"+conf.AppExt), "only")
+}
+
+func multiBuildConfig() *Config {
+	conf := NewDefaultConf(ModeBuild)
+	conf.BuildParallelism = 2
+	conf.PCLNMode = PCLNNone
+	conf.PCLNModeSet = true
+	return conf
+}
+
+func writeMultiBuildModule(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	files["go.mod"] = "module example.com/multibuild\n\ngo 1.25\n"
+	for name, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func mainSource(output string) string {
+	return "package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"" + output + "\") }\n"
+}
+
+func assertBuiltProgram(t *testing.T, path, want string) {
+	t.Helper()
+	if got := runBuiltProgram(t, path); got != want {
+		t.Fatalf("%s output = %q, want %q", path, got, want)
+	}
+}
+
+func runBuiltProgram(t *testing.T, path string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" && filepath.Ext(path) == "" {
+		path += ".exe"
+	}
+	out, err := exec.Command(path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run %s: %v\n%s", path, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/build/multi_build_test.go
+++ b/internal/build/multi_build_test.go
@@ -9,7 +9,53 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/xgo-dev/llgo/internal/packages"
 )
+
+func TestPrepareBuildOutputEdges(t *testing.T) {
+	root := t.TempDir()
+	mainPackages := []*packages.Package{{Name: "main"}}
+	if got, err := prepareBuildOutput(root, "", false, nil); err != nil || got != "" {
+		t.Fatalf("empty output = %q, %v", got, err)
+	}
+
+	blocking := filepath.Join(root, "blocking")
+	if err := os.WriteFile(blocking, []byte("file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareBuildOutput(root, filepath.Join("blocking", "child")+string(os.PathSeparator), false, mainPackages); err == nil ||
+		!strings.Contains(err.Error(), "create build output directory") {
+		t.Fatalf("blocked output directory error = %v", err)
+	}
+
+	if filepath.Separator != '\\' {
+		if got, err := prepareBuildOutput(root, `\`, false, mainPackages); err != nil || got != root {
+			t.Fatalf("root backslash output = %q, %v; want %q", got, err, root)
+		}
+		want := filepath.Join(root, "nested")
+		if got, err := prepareBuildOutput(root, `nested\`, false, mainPackages); err != nil || got != want {
+			t.Fatalf("nested backslash output = %q, %v; want %q", got, err, want)
+		}
+	}
+}
+
+func TestDefaultExecutableName(t *testing.T) {
+	for _, test := range []struct {
+		path string
+		want string
+	}{
+		{"example.com/tool", "tool"},
+		{"example.com/tool/v2", "tool"},
+		{"example.com/tool/v0", "v0"},
+		{"example.com/tool/v1", "v1"},
+		{"example.com/tool/vnext", "vnext"},
+	} {
+		if got := defaultExecutableName(test.path); got != test.want {
+			t.Errorf("defaultExecutableName(%q) = %q, want %q", test.path, got, test.want)
+		}
+	}
+}
 
 func TestModeBuildMultiplePackagesMatchesGoOutputContract(t *testing.T) {
 	root := writeMultiBuildModule(t, map[string]string{
@@ -67,6 +113,13 @@ func main() { missing() }
 	if _, err := Build(Invocation{Args: []string{"./cmd/first", "./cmd/second"}, Config: fileOutput, Dir: root}); err == nil ||
 		!strings.Contains(err.Error(), "cannot write multiple packages to non-directory") {
 		t.Fatalf("multi-package -o file error = %v", err)
+	}
+
+	archive := multiBuildConfig()
+	archive.BuildMode = BuildModeCArchive
+	if _, err := Build(Invocation{Args: []string{"./cmd/first", "./cmd/second"}, Config: archive, Dir: root}); err == nil ||
+		!strings.Contains(err.Error(), "-buildmode=c-archive requires exactly one main package") {
+		t.Fatalf("multi-package c-archive error = %v", err)
 	}
 
 	trailingDir := filepath.Join(root, "created") + string(os.PathSeparator)

--- a/internal/build/multi_build_test.go
+++ b/internal/build/multi_build_test.go
@@ -47,9 +47,14 @@ func main() { missing() }
 	if err == nil {
 		t.Fatal("directory build unexpectedly linked the missing symbol")
 	}
+	if count := strings.Count(err.Error(), "example.com/multibuild/cmd/badlink:"); count != 1 {
+		t.Fatalf("badlink error package prefix count = %d, want 1: %v", count, err)
+	}
 	for name, want := range map[string]string{"first": "first", "second": "second"} {
 		assertBuiltProgram(t, filepath.Join(out, name+withOutput.AppExt), want)
 	}
+	// cmd/go also accepts colliding DefaultExecName values for a directory
+	// output. One executable remains, but the winning package is unspecified.
 	if got := runBuiltProgram(t, filepath.Join(out, "same"+withOutput.AppExt)); got != "same-a" && got != "same-b" {
 		t.Fatalf("same-basename output = %q, want either main package", got)
 	}
@@ -72,6 +77,27 @@ func main() { missing() }
 	}
 	assertBuiltProgram(t, filepath.Join(trailingDir, "first"+trailing.AppExt), "first")
 	assertBuiltProgram(t, filepath.Join(trailingDir, "second"+trailing.AppExt), "second")
+}
+
+func TestRemoveTemporaryBuildOutputs(t *testing.T) {
+	root := t.TempDir()
+	output := filepath.Join(root, "program.elf")
+	base := strings.TrimSuffix(output, filepath.Ext(output))
+	artifacts := []string{
+		output, pclnSidecarPath(output), base + ".bin", base + ".hex",
+		base + ".img", base + ".uf2", base + ".zip",
+	}
+	for _, artifact := range artifacts {
+		if err := os.WriteFile(artifact, []byte("generated"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removeTemporaryBuildOutputs(output)
+	for _, artifact := range artifacts {
+		if _, err := os.Stat(artifact); !os.IsNotExist(err) {
+			t.Errorf("temporary artifact %q remains: %v", artifact, err)
+		}
+	}
 }
 
 func TestModeBuildMultiplePackagesRecoversIndependentRoots(t *testing.T) {

--- a/internal/build/multi_build_test.go
+++ b/internal/build/multi_build_test.go
@@ -57,6 +57,30 @@ func TestDefaultExecutableName(t *testing.T) {
 	}
 }
 
+func TestLinkInitialPackagePropagatesOutputCreationError(t *testing.T) {
+	root := t.TempDir()
+	blocking := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(blocking, []byte("file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"TMPDIR", "TMP", "TEMP"} {
+		t.Setenv(name, blocking)
+	}
+	ctx := &context{initial: []*packages.Package{{}, {}}}
+	conf := multiBuildConfig()
+	conf.Mode = ModeRun
+	err := linkInitialPackage(ctx, &packages.Package{PkgPath: "example.com/tool"}, nil, conf, false, false)
+	if err == nil {
+		t.Fatalf("temporary output creation error = %v", err)
+	}
+	fallback := newMultiBuildFallback(multiBuildConfig(), []*packages.Package{{
+		Name: "main", PkgPath: "example.com/tool",
+	}}, root, "")
+	if _, err := fallback.run(); err == nil || !strings.Contains(err.Error(), "create temporary output") {
+		t.Fatalf("fallback temporary output creation error = %v", err)
+	}
+}
+
 func TestModeBuildMultiplePackagesMatchesGoOutputContract(t *testing.T) {
 	root := writeMultiBuildModule(t, map[string]string{
 		"cmd/first/main.go":  mainSource("first"),
@@ -121,6 +145,17 @@ func main() { missing() }
 		!strings.Contains(err.Error(), "-buildmode=c-archive requires exactly one main package") {
 		t.Fatalf("multi-package c-archive error = %v", err)
 	}
+	singleArchive := multiBuildConfig()
+	singleArchive.BuildMode = BuildModeCArchive
+	singleArchive.OutFile = filepath.Join(root, "first.a")
+	if _, err := Build(Invocation{Args: []string{"./cmd/first"}, Config: singleArchive, Dir: root}); err != nil {
+		t.Fatalf("single-package c-archive build: %v", err)
+	}
+	for _, artifact := range []string{singleArchive.OutFile, strings.TrimSuffix(singleArchive.OutFile, ".a") + ".h"} {
+		if _, err := os.Stat(artifact); err != nil {
+			t.Fatalf("single-package c-archive artifact %q: %v", artifact, err)
+		}
+	}
 
 	trailingDir := filepath.Join(root, "created") + string(os.PathSeparator)
 	trailing := multiBuildConfig()
@@ -173,6 +208,18 @@ func main() { missing() }
 		t.Fatalf("multi-package compile error = %v", err)
 	}
 	assertBuiltProgram(t, filepath.Join(out, "good"+conf.AppExt), "good")
+
+	checkOnly := multiBuildConfig()
+	_, checkErr := Build(Invocation{Args: []string{"./..."}, Config: checkOnly, Dir: root})
+	if checkErr == nil || !strings.Contains(checkErr.Error(), "example.com/multibuild/cmd/bad:") ||
+		!strings.Contains(checkErr.Error(), "example.com/multibuild/cmd/badlink:") {
+		t.Fatalf("check-only multi-package compile error = %v", checkErr)
+	}
+	for _, name := range []string{"good", "badlink"} {
+		if _, err := os.Stat(filepath.Join(root, name+checkOnly.AppExt)); !os.IsNotExist(err) {
+			t.Fatalf("check-only fallback left output %q: %v", name, err)
+		}
+	}
 }
 
 func TestModeBuildOutputDirectoryRequiresMain(t *testing.T) {
@@ -198,6 +245,8 @@ func TestModeBuildSinglePackageAcceptsOutputDirectory(t *testing.T) {
 	}
 	conf := multiBuildConfig()
 	conf.OutFile = out
+	conf.SizeReport = true
+	conf.SizeFormat = "invalid" // A report failure is intentionally non-fatal after a successful build.
 	if _, err := Build(Invocation{Args: []string{"./cmd/only"}, Config: conf, Dir: root}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/build/outputs.go
+++ b/internal/build/outputs.go
@@ -61,6 +61,9 @@ func determineBaseNameAndDir(pkgName string, conf *Config, multiPkg bool) (baseN
 	case ModeInstall:
 		return pkgName, conf.BinPath
 	case ModeBuild:
+		if conf.OutFile != "" && isDir(conf.OutFile) {
+			return pkgName, conf.OutFile
+		}
 		if !multiPkg && conf.OutFile != "" {
 			dir = filepath.Dir(conf.OutFile)
 			baseName = strings.TrimSuffix(filepath.Base(conf.OutFile), conf.AppExt)


### PR DESCRIPTION
## Summary

- support `llgo build -o <directory>/ <multiple packages>` and write one executable for every selected `main` package
- compile the union dependency graph once on the normal path, then link each main with only its effective dependency closure
- continue linking independent mains after one link failure and return all link errors while preserving successful outputs
- if the shared graph has a compile/type error, retry roots independently within the configured `-p` budget so unrelated commands can still be built
- keep `llgo build ./...` aligned with `go build`: main packages are linked to temporary outputs so link errors are checked, but no executables are left in the working directory
- accept an existing output directory or a trailing separator, create the marked directory when needed, and reject ambiguous multi-package `-o <file>` and no-main directory builds
- preserve exact single-package `-o` names, including cross-compiled WASM outputs; the workflow now requests `hello.wasm` explicitly

This is intentionally separate from the demo-suite refactor. Local measurement showed that the demo suite is faster with bounded per-directory builds, so that PR does not depend on this feature; this PR fixes the general multi-package build contract on its own merits.

## Failure behavior

For `llgo build -p=4 -o out/ ./...`, a bad package does not hide independent results:

- successful main packages remain in `out/`
- compile, type-check, and link failures are reported
- other roots continue through compilation and linking
- link failures carry one package-path prefix
- failure-only temporary executables and `.pclntab/.bin/.hex/.img/.uf2/.zip` sidecars are removed
- packages with the same executable basename follow Go 1.26/1.27 overwrite behavior; one output remains and the winner is unspecified

## Validation

- Go 1.25 and Go 1.26: `go test ./internal/build -run 'Test(ModeBuild|EffectiveDependencies|LinkedPackageClosure|RemoveTemporaryBuildOutputs)' -count=1`
- Go 1.26: `go test ./cmd/internal/build -count=1`
- Go 1.26 focused edge tests for empty/directory/backslash outputs, directory-creation and temporary-output errors, semantic-import-version executable names, and multi-main non-executable build modes
- integration coverage for directory creation, single/multiple main packages, no-main errors, non-directory errors, missing link symbols, compile-error fallback with and without an output directory, successful output execution, temporary cleanup, single-package c-archive post-link artifacts, non-fatal size-report errors, same-basename behavior, and alternate-package dependency closure
- isolated-cache focused run of the four added post-link/fallback cases passed in 22.3 seconds
- local merged coverage profiles exercised all changed statements in `multi_build.go`, `dependencies.go`, and `outputs.go`; the remaining unexecuted `linkInitialPackage` paths are target/device error branches
- built this PR's LLGo and reproduced the cross-compile workflow with `GOOS=wasip1 GOARCH=wasm llgo build -o hello.wasm -tags=nogc ./helloc`; the result is a valid WebAssembly module
- compared same-basename directory output with the official Go 1.26 and Go 1.27 commands
- `git diff --check`
