### PR TITLE
lto: refine interface method type IDs

### DIFF
--- a/cl/_testlto/globaldce_interface_method_typeid/crossiface/crossiface.go
+++ b/cl/_testlto/globaldce_interface_method_typeid/crossiface/crossiface.go
@@ -1,0 +1,15 @@
+package crossiface
+
+type Wide interface {
+	M() int
+	N() int
+}
+
+// Call deliberately lives in a dependency module while its concrete
+// implementation lives in main. The Full LTO test therefore proves that the
+// checked-load interface attributes survive package bitcode linking.
+//
+//go:noinline
+func Call(v Wide) int {
+	return v.M()
+}

--- a/cl/_testlto/globaldce_interface_method_typeid/expect.txt
+++ b/cl/_testlto/globaldce_interface_method_typeid/expect.txt
@@ -1,0 +1,1 @@
+7 true true

--- a/cl/_testlto/globaldce_interface_method_typeid/expect.txt
+++ b/cl/_testlto/globaldce_interface_method_typeid/expect.txt
@@ -1,1 +1,1 @@
-7 true true
+7 true true 13

--- a/cl/_testlto/globaldce_interface_method_typeid/in.go
+++ b/cl/_testlto/globaldce_interface_method_typeid/in.go
@@ -1,0 +1,64 @@
+// LITTEST
+package main
+
+import "reflect"
+
+// SYMBOL-DAG: main{{.*}}Full{{.*}}M
+// SYMBOL-NOT: main{{.*}}Full{{.*}}N
+// SYMBOL-NOT: main{{.*}}Partial{{.*}}M
+// SYMBOL-NOT: __typeid_go.method.i.
+
+type Wide interface {
+	M() int
+	N() int
+}
+
+type Full struct{}
+
+//go:noinline
+func (Full) M() int { return 7 }
+
+//go:noinline
+func (Full) N() int { return 9 }
+
+type Partial struct{}
+
+//go:noinline
+func (Partial) M() int { return 11 }
+
+//go:noinline
+func callWide(v any) int {
+	return v.(Wide).M()
+}
+
+//go:noinline
+func keepPartialDescriptor() bool {
+	return reflect.TypeOf(Partial{}).Name() == "Partial"
+}
+
+type matcher interface {
+	verify(string, func(string, string) (bool, error)) error
+}
+
+type simpleMatch struct{}
+
+//go:noinline
+func (simpleMatch) verify(name string, matchString func(string, string) (bool, error)) error {
+	matched, err := matchString(name, "want")
+	if err != nil || !matched {
+		return err
+	}
+	return nil
+}
+
+//go:noinline
+func callMatcher(v any) bool {
+	err := v.(matcher).verify("want", func(name, pattern string) (bool, error) {
+		return name == pattern, nil
+	})
+	return err == nil
+}
+
+func main() {
+	println(callWide(Full{}), keepPartialDescriptor(), callMatcher(simpleMatch{}))
+}

--- a/cl/_testlto/globaldce_interface_method_typeid/in.go
+++ b/cl/_testlto/globaldce_interface_method_typeid/in.go
@@ -1,11 +1,17 @@
 // LITTEST
 package main
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/xgo-dev/llgo/cl/_testlto/globaldce_interface_method_typeid/crossiface"
+)
 
 // SYMBOL-DAG: main{{.*}}Full{{.*}}M
+// SYMBOL-DAG: main{{.*}}Cross{{.*}}M
 // SYMBOL-NOT: main{{.*}}Full{{.*}}N
 // SYMBOL-NOT: main{{.*}}Partial{{.*}}M
+// SYMBOL-NOT: main{{.*}}Cross{{.*}}N
 // SYMBOL-NOT: __typeid_go.method.i.
 
 type Wide interface {
@@ -25,6 +31,14 @@ type Partial struct{}
 
 //go:noinline
 func (Partial) M() int { return 11 }
+
+type Cross struct{}
+
+//go:noinline
+func (Cross) M() int { return 13 }
+
+//go:noinline
+func (Cross) N() int { return 17 }
 
 //go:noinline
 func callWide(v any) int {
@@ -60,5 +74,5 @@ func callMatcher(v any) bool {
 }
 
 func main() {
-	println(callWide(Full{}), keepPartialDescriptor(), callMatcher(simpleMatch{}))
+	println(callWide(Full{}), keepPartialDescriptor(), callMatcher(simpleMatch{}), crossiface.Call(Cross{}))
 }

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -349,13 +349,9 @@ func TestLTOPluginInterfaceMethodTypeIDs(t *testing.T) {
 	const input = `
 target datalayout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 
-@interface.I = internal constant i8 0, !llgo.interface.type !0, !llgo.interface.method !1, !llgo.interface.method !2
-@interface.J = internal constant i8 0, !llgo.interface.type !3, !llgo.interface.method !4
-@interface.K = internal constant i8 0, !llgo.interface.type !8, !llgo.interface.method !9
 @type.A = internal constant [2 x ptr] [ptr @A.M, ptr @A.N], !type !5, !type !6, !vcall_visibility !7
 @type.B = internal constant [1 x ptr] [ptr @B.M], !type !5, !vcall_visibility !7
 @type.C = internal constant [1 x ptr] [ptr @C.N], !type !6, !vcall_visibility !7
-@llvm.compiler.used = appending global [3 x ptr] [ptr @interface.I, ptr @interface.J, ptr @interface.K], section "llvm.metadata"
 
 declare { ptr, i1 } @llvm.type.checked.load(ptr, i32, metadata)
 declare i1 @llvm.type.test(ptr, metadata)
@@ -365,23 +361,20 @@ define internal void @B.M() { ret void }
 define internal void @C.N() { ret void }
 
 define void @entry(ptr %itab.i, ptr %itab.j, ptr %itab.k) {
-  %i = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.i, i32 0, metadata !"go.method.i.I.m0")
-  %j = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.j, i32 0, metadata !"go.method.i.J.m0")
-  %k = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.k, i32 0, metadata !"go.method.i.K.m0")
-  %kt = call i1 @llvm.type.test(ptr %itab.k, metadata !"go.method.i.K.m0")
+  %i = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.i, i32 0, metadata !"go.method.i.I.m0") #0
+  %j = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.j, i32 0, metadata !"go.method.i.J.m0") #1
+  %k = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.k, i32 0, metadata !"go.method.i.K.m0") #2
+  %kt = call i1 @llvm.type.test(ptr %itab.k, metadata !"go.method.i.K.m0") #2
   ret void
 }
 
-!0 = !{i32 1, !"go.method.i.I", i32 2}
-!1 = !{i32 0, !"go.method.i.I.m0", !"go.method.M:func()"}
-!2 = !{i32 1, !"go.method.i.I.m1", !"go.method.N:func()"}
-!3 = !{i32 1, !"go.method.i.J", i32 1}
-!4 = !{i32 0, !"go.method.i.J.m0", !"go.method.M:func()"}
+attributes #0 = { "llgo.interface.call"="1" "llgo.interface.count"="2" "llgo.interface.id"="go.method.i.I" "llgo.interface.index"="0" "llgo.interface.method.0"="go.method.M:func()" "llgo.interface.method.1"="go.method.N:func()" }
+attributes #1 = { "llgo.interface.call"="1" "llgo.interface.count"="1" "llgo.interface.id"="go.method.i.J" "llgo.interface.index"="0" "llgo.interface.method.0"="go.method.M:func()" }
+attributes #2 = { "llgo.interface.call"="1" "llgo.interface.count"="1" "llgo.interface.id"="go.method.i.K" "llgo.interface.index"="0" "llgo.interface.method.0"="go.method.Z:func()" }
+
 !5 = !{i64 0, !"go.method.M:func()"}
 !6 = !{i64 8, !"go.method.N:func()"}
 !7 = !{i64 1}
-!8 = !{i32 1, !"go.method.i.K", i32 1}
-!9 = !{i32 0, !"go.method.i.K.m0", !"go.method.Z:func()"}
 `
 	opt := filepath.Join(llvmenv.New("").BinDir(), "opt")
 	cmd := exec.Command(opt, "-load-pass-plugin="+conf.LTOPlugin.Path,
@@ -408,39 +401,48 @@ define void @entry(ptr %itab.i, ptr %itab.j, ptr %itab.k) {
 			t.Fatalf("%s has %s = %v, want %v\n%s", check.global, check.typeID, got, check.want, ir)
 		}
 	}
-	if strings.Contains(ir, "@llvm.compiler.used") {
-		t.Fatalf("temporary interface declaration preservation was not removed:\n%s", ir)
-	}
 	if !strings.Contains(ir, `metadata !"go.method.Z:func()"`) || strings.Contains(ir, `metadata !"go.method.i.K.m0"`) {
 		t.Fatalf("zero-implementer interface did not use broad fallback:\n%s", ir)
 	}
+	if strings.Contains(ir, `"llgo.interface.`) {
+		t.Fatalf("temporary checked-load interface attributes were not removed:\n%s", ir)
+	}
 }
 
-func TestLTOPluginRejectsMalformedInterfaceMetadata(t *testing.T) {
+func TestLTOPluginRejectsMalformedInterfaceAttributes(t *testing.T) {
 	conf := testltoLTOPluginConf(t, build.ModeGen)
 	tests := []struct {
 		name   string
-		header string
-		method string
+		typeID string
+		attrs  string
 	}{
 		{
-			name:   "wrong integer width",
-			header: `!{i64 1, !"go.method.i.I", i32 1}`,
-			method: `!{i32 0, !"go.method.i.I.m0", !"go.method.M:func()"}`,
+			name:   "malformed method index",
+			typeID: "go.method.i.I.m0",
+			attrs:  `"llgo.interface.call"="1" "llgo.interface.count"="1" "llgo.interface.id"="go.method.i.I" "llgo.interface.index"="x" "llgo.interface.method.0"="go.method.M:func()"`,
 		},
 		{
 			name:   "method key as interface key",
-			header: `!{i32 1, !"go.method.i.I.m0", i32 1}`,
-			method: `!{i32 0, !"go.method.i.I.m0.m0", !"go.method.M:func()"}`,
+			typeID: "go.method.i.I.m0.m0",
+			attrs:  `"llgo.interface.call"="1" "llgo.interface.count"="1" "llgo.interface.id"="go.method.i.I.m0" "llgo.interface.index"="0" "llgo.interface.method.0"="go.method.M:func()"`,
+		},
+		{
+			name:   "checked method mismatch",
+			typeID: "go.method.i.I.m1",
+			attrs:  `"llgo.interface.call"="1" "llgo.interface.count"="2" "llgo.interface.id"="go.method.i.I" "llgo.interface.index"="0" "llgo.interface.method.0"="go.method.M:func()" "llgo.interface.method.1"="go.method.N:func()"`,
 		},
 	}
 	opt := filepath.Join(llvmenv.New("").BinDir(), "opt")
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := `
-@interface.I = internal constant i8 0, !llgo.interface.type !0, !llgo.interface.method !1
-!0 = ` + test.header + `
-!1 = ` + test.method + "\n"
+declare { ptr, i1 } @llvm.type.checked.load(ptr, i32, metadata)
+define void @entry(ptr %itab) {
+  %i = call { ptr, i1 } @llvm.type.checked.load(ptr %itab, i32 0, metadata !"` + test.typeID + `") #0
+  ret void
+}
+attributes #0 = { ` + test.attrs + ` }
+`
 			cmd := exec.Command(opt, "-load-pass-plugin="+conf.LTOPlugin.Path,
 				"-passes=llgo-interface-method-typeids", "-disable-output")
 			cmd.Stdin = strings.NewReader(input)
@@ -448,7 +450,7 @@ func TestLTOPluginRejectsMalformedInterfaceMetadata(t *testing.T) {
 			if err == nil {
 				t.Fatalf("malformed interface metadata was accepted:\n%s", out)
 			}
-			if !strings.Contains(string(out), "invalid interface type-id metadata: unsupported header") {
+			if !strings.Contains(string(out), "invalid interface type-id metadata:") {
 				t.Fatalf("unexpected malformed-metadata diagnostic: %v\n%s", err, out)
 			}
 		})
@@ -467,23 +469,32 @@ func TestLTOPluginFrontendInterfaceMethodTypeIDs(t *testing.T) {
 	ir := pkgs[0].LPkg.String()
 	pkgs[0].LPkg.Prog.Dispose()
 
-	methodDeclRE := regexp.MustCompile(`(?m)^![0-9]+ = !\{i32 0, !"(go\.method\.i\.[^"]+\.m0)", !"go\.method\.M:func\(\) int"\}$`)
-	match := methodDeclRE.FindStringSubmatch(ir)
-	if match == nil {
-		t.Fatalf("frontend did not declare an exact type id for Wide.M:\n%s", ir)
+	methodCallRE := regexp.MustCompile(`(?m)call \{ ptr, i1 \} @llvm\.type\.checked\.load\([^\n]+metadata !"(go\.method\.i\.[^"]+\.m0)"\) #([0-9]+)`)
+	var exactTypeID string
+	for _, match := range methodCallRE.FindAllStringSubmatch(ir, -1) {
+		attrRE := regexp.MustCompile(`(?m)^attributes #` + match[2] + ` = \{ [^\n]*"llgo\.interface\.call"="1"[^\n]*"llgo\.interface\.count"="2"[^\n]*"llgo\.interface\.id"="` + regexp.QuoteMeta(strings.TrimSuffix(match[1], ".m0")) + `"[^\n]*"llgo\.interface\.index"="0"[^\n]*"llgo\.interface\.method\.0"="go\.method\.M:func\(\) int"[^\n]*"llgo\.interface\.method\.1"="go\.method\.N:func\(\) int"[^\n]*\}$`)
+		if attrRE.MatchString(ir) {
+			exactTypeID = match[1]
+			break
+		}
 	}
-	exactTypeID := match[1]
+	if exactTypeID == "" {
+		t.Fatalf("frontend did not attach the Wide declaration to its checked load:\n%s", ir)
+	}
 	for _, want := range []string{
-		`!llgo.interface.type`,
-		`!llgo.interface.method`,
-		`@llvm.compiler.used`,
+		`"llgo.interface.call"="1"`,
 		`call { ptr, i1 } @llvm.type.checked.load`,
 		`metadata !"` + exactTypeID + `"`,
-		`!"go.method.N:func() int"`,
+		`"llgo.interface.method.1"="go.method.N:func() int"`,
 		`verify:func(string, func(string, string) (bool, error)) error`,
 	} {
 		if !strings.Contains(ir, want) {
 			t.Fatalf("frontend IR missing %s:\n%s", want, ir)
+		}
+	}
+	for _, unwanted := range []string{`!llgo.interface.type`, `!llgo.interface.method`} {
+		if strings.Contains(ir, unwanted) {
+			t.Fatalf("frontend retained descriptor-based interface declaration %s:\n%s", unwanted, ir)
 		}
 	}
 	if regexp.MustCompile(`call \{ ptr, i1 \} @llvm\.type\.checked\.load\([^\n]+metadata !"go\.method\.M:func\(\) int"`).MatchString(ir) {

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -199,6 +200,7 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 	conf := build.NewDefaultConf(build.ModeRun)
 	conf.LTO = lto.Full
 	ignore := []string{
+		"./_testlto/globaldce_interface_method_typeid",
 		"./_testlto/globaldce_static_itab_devirt",
 		"./_testlto/globaldce_static_itab_partial_root",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin",
@@ -234,6 +236,7 @@ var testltoSymbolChecks = []string{
 }
 
 var testltoLTOPluginTests = []string{
+	"globaldce_interface_method_typeid",
 	"globaldce_static_itab_devirt",
 	"globaldce_static_itab_partial_root",
 	"globaldce_reflect_type_method_metadata_only",
@@ -323,6 +326,130 @@ func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {
 	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginTests,
 		cltest.WithRunConfig(buildConf),
 	)
+}
+
+func globalHasTypeID(ir, global, typeID string) bool {
+	lineRE := regexp.MustCompile(`(?m)^@` + regexp.QuoteMeta(global) + ` = .*$`)
+	line := lineRE.FindString(ir)
+	if line == "" {
+		return false
+	}
+	refRE := regexp.MustCompile(`!type !([0-9]+)`)
+	for _, match := range refRE.FindAllStringSubmatch(line, -1) {
+		definitionRE := regexp.MustCompile(`(?m)^!` + match[1] + ` = !\{i64 [0-9]+, !"` + regexp.QuoteMeta(typeID) + `"\}$`)
+		if definitionRE.MatchString(ir) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLTOPluginInterfaceMethodTypeIDs(t *testing.T) {
+	conf := testltoLTOPluginConf(t, build.ModeGen)
+	const input = `
+target datalayout = "e-p:64:64-i64:64-n8:16:32:64-S128"
+
+@interface.I = internal constant i8 0, !llgo.interface.type !0, !llgo.interface.method !1, !llgo.interface.method !2
+@interface.J = internal constant i8 0, !llgo.interface.type !3, !llgo.interface.method !4
+@interface.K = internal constant i8 0, !llgo.interface.type !8, !llgo.interface.method !9
+@type.A = internal constant [2 x ptr] [ptr @A.M, ptr @A.N], !type !5, !type !6, !vcall_visibility !7
+@type.B = internal constant [1 x ptr] [ptr @B.M], !type !5, !vcall_visibility !7
+@type.C = internal constant [1 x ptr] [ptr @C.N], !type !6, !vcall_visibility !7
+@llvm.compiler.used = appending global [3 x ptr] [ptr @interface.I, ptr @interface.J, ptr @interface.K], section "llvm.metadata"
+
+declare { ptr, i1 } @llvm.type.checked.load(ptr, i32, metadata)
+declare i1 @llvm.type.test(ptr, metadata)
+define internal void @A.M() { ret void }
+define internal void @A.N() { ret void }
+define internal void @B.M() { ret void }
+define internal void @C.N() { ret void }
+
+define void @entry(ptr %itab.i, ptr %itab.j, ptr %itab.k) {
+  %i = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.i, i32 0, metadata !"go.method.i.I.m0")
+  %j = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.j, i32 0, metadata !"go.method.i.J.m0")
+  %k = call { ptr, i1 } @llvm.type.checked.load(ptr %itab.k, i32 0, metadata !"go.method.i.K.m0")
+  %kt = call i1 @llvm.type.test(ptr %itab.k, metadata !"go.method.i.K.m0")
+  ret void
+}
+
+!0 = !{i32 1, !"go.method.i.I", i32 2}
+!1 = !{i32 0, !"go.method.i.I.m0", !"go.method.M:func()"}
+!2 = !{i32 1, !"go.method.i.I.m1", !"go.method.N:func()"}
+!3 = !{i32 1, !"go.method.i.J", i32 1}
+!4 = !{i32 0, !"go.method.i.J.m0", !"go.method.M:func()"}
+!5 = !{i64 0, !"go.method.M:func()"}
+!6 = !{i64 8, !"go.method.N:func()"}
+!7 = !{i64 1}
+!8 = !{i32 1, !"go.method.i.K", i32 1}
+!9 = !{i32 0, !"go.method.i.K.m0", !"go.method.Z:func()"}
+`
+	opt := filepath.Join(llvmenv.New("").BinDir(), "opt")
+	cmd := exec.Command(opt, "-load-pass-plugin="+conf.LTOPlugin.Path,
+		"-passes=llgo-interface-method-typeids", "-S", "-o", "-")
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run interface method type-id pass: %v\n%s", err, out)
+	}
+	ir := string(out)
+	for _, check := range []struct {
+		global string
+		typeID string
+		want   bool
+	}{
+		{"type.A", "go.method.i.I.m0", true},
+		{"type.B", "go.method.i.I.m0", false},
+		{"type.C", "go.method.i.I.m0", false},
+		{"type.A", "go.method.i.J.m0", true},
+		{"type.B", "go.method.i.J.m0", true},
+		{"type.C", "go.method.i.J.m0", false},
+	} {
+		if got := globalHasTypeID(ir, check.global, check.typeID); got != check.want {
+			t.Fatalf("%s has %s = %v, want %v\n%s", check.global, check.typeID, got, check.want, ir)
+		}
+	}
+	if strings.Contains(ir, "@llvm.compiler.used") {
+		t.Fatalf("temporary interface declaration preservation was not removed:\n%s", ir)
+	}
+	if !strings.Contains(ir, `metadata !"go.method.Z:func()"`) || strings.Contains(ir, `metadata !"go.method.i.K.m0"`) {
+		t.Fatalf("zero-implementer interface did not use broad fallback:\n%s", ir)
+	}
+}
+
+func TestLTOPluginFrontendInterfaceMethodTypeIDs(t *testing.T) {
+	conf := testltoLTOPluginConf(t, build.ModeGen)
+	pkgs, err := build.Do([]string{"./_testlto/globaldce_interface_method_typeid"}, conf)
+	if err != nil {
+		t.Fatalf("generate interface method type-id fixture: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("generate interface method type-id fixture: got %d packages", len(pkgs))
+	}
+	ir := pkgs[0].LPkg.String()
+	pkgs[0].LPkg.Prog.Dispose()
+
+	methodDeclRE := regexp.MustCompile(`(?m)^![0-9]+ = !\{i32 0, !"(go\.method\.i\.[^"]+\.m0)", !"go\.method\.M:func\(\) int"\}$`)
+	match := methodDeclRE.FindStringSubmatch(ir)
+	if match == nil {
+		t.Fatalf("frontend did not declare an exact type id for Wide.M:\n%s", ir)
+	}
+	exactTypeID := match[1]
+	for _, want := range []string{
+		`!llgo.interface.type`,
+		`!llgo.interface.method`,
+		`@llvm.compiler.used`,
+		`call { ptr, i1 } @llvm.type.checked.load`,
+		`metadata !"` + exactTypeID + `"`,
+		`!"go.method.N:func() int"`,
+		`verify:func(string, func(string, string) (bool, error)) error`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("frontend IR missing %s:\n%s", want, ir)
+		}
+	}
+	if regexp.MustCompile(`call \{ ptr, i1 \} @llvm\.type\.checked\.load\([^\n]+metadata !"go\.method\.M:func\(\) int"`).MatchString(ir) {
+		t.Fatalf("frontend retained the signature-wide checked-load type id:\n%s", ir)
+	}
 }
 
 func runTestltoLTOPluginAggregateABI(t *testing.T, fixture string) string {

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -416,6 +416,45 @@ define void @entry(ptr %itab.i, ptr %itab.j, ptr %itab.k) {
 	}
 }
 
+func TestLTOPluginRejectsMalformedInterfaceMetadata(t *testing.T) {
+	conf := testltoLTOPluginConf(t, build.ModeGen)
+	tests := []struct {
+		name   string
+		header string
+		method string
+	}{
+		{
+			name:   "wrong integer width",
+			header: `!{i64 1, !"go.method.i.I", i32 1}`,
+			method: `!{i32 0, !"go.method.i.I.m0", !"go.method.M:func()"}`,
+		},
+		{
+			name:   "method key as interface key",
+			header: `!{i32 1, !"go.method.i.I.m0", i32 1}`,
+			method: `!{i32 0, !"go.method.i.I.m0.m0", !"go.method.M:func()"}`,
+		},
+	}
+	opt := filepath.Join(llvmenv.New("").BinDir(), "opt")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := `
+@interface.I = internal constant i8 0, !llgo.interface.type !0, !llgo.interface.method !1
+!0 = ` + test.header + `
+!1 = ` + test.method + "\n"
+			cmd := exec.Command(opt, "-load-pass-plugin="+conf.LTOPlugin.Path,
+				"-passes=llgo-interface-method-typeids", "-disable-output")
+			cmd.Stdin = strings.NewReader(input)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("malformed interface metadata was accepted:\n%s", out)
+			}
+			if !strings.Contains(string(out), "invalid interface type-id metadata: unsupported header") {
+				t.Fatalf("unexpected malformed-metadata diagnostic: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
 func TestLTOPluginFrontendInterfaceMethodTypeIDs(t *testing.T) {
 	conf := testltoLTOPluginConf(t, build.ModeGen)
 	pkgs, err := build.Do([]string{"./_testlto/globaldce_interface_method_typeid"}, conf)

--- a/ltoplugin/CMakeLists.txt
+++ b/ltoplugin/CMakeLists.txt
@@ -17,7 +17,9 @@ add_definitions(${LLVM_DEFINITIONS})
 
 add_llvm_pass_plugin(LLGOLTOPlugin
   LLGOLTOPlugin.cpp
+  LLGOInterfaceMethodTypeIDPass.cpp
   LLGOReflectMethodByNamePass.cpp
+  LLGOTypeIDExportCleanupPass.cpp
 )
 
 target_compile_features(LLGOLTOPlugin PRIVATE cxx_std_17)

--- a/ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp
+++ b/ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <optional>
 #include <string>
@@ -26,6 +27,8 @@ using namespace llvm;
 
 namespace {
 
+// Keep this metadata protocol in sync with the constants and emitter in
+// ssa/globaldce.go.
 static constexpr char InterfaceTypeMetadata[] = "llgo.interface.type";
 static constexpr char InterfaceMethodMetadata[] = "llgo.interface.method";
 static constexpr char InterfaceTypeIDPrefix[] = "go.method.i.";
@@ -36,7 +39,7 @@ static constexpr char ReflectValueMethodTypeIDPrefix[] =
     "go.method.value.reflect.";
 static constexpr char ReflectTypeMethodTypeIDPrefix[] =
     "go.method.type.reflect.";
-static constexpr uint64_t InterfaceMetadataVersion = 1;
+static constexpr uint32_t InterfaceMetadataVersion = 1;
 
 struct InterfaceMethodDecl {
   unsigned Index = 0;
@@ -45,6 +48,9 @@ struct InterfaceMethodDecl {
 };
 
 struct InterfaceDecl {
+  // Header schema: {i32 version, MDString interface type ID, i32 method count}.
+  // Each method node is:
+  // {i32 index, MDString exact type ID, MDString broad type ID}.
   std::string TypeID;
   std::vector<InterfaceMethodDecl> Methods;
 };
@@ -66,6 +72,14 @@ std::optional<uint64_t> metadataUInt(Metadata *MD) {
   if (!CI || CI->isNegative())
     return std::nullopt;
   return CI->getZExtValue();
+}
+
+std::optional<uint32_t> metadataUInt32(Metadata *MD) {
+  auto *CAM = dyn_cast_or_null<ConstantAsMetadata>(MD);
+  auto *CI = CAM ? dyn_cast<ConstantInt>(CAM->getValue()) : nullptr;
+  if (!CI || CI->isNegative() || CI->getBitWidth() != 32)
+    return std::nullopt;
+  return static_cast<uint32_t>(CI->getZExtValue());
 }
 
 std::optional<StringRef> metadataString(Metadata *MD) {
@@ -102,6 +116,13 @@ bool isReflectMethodTypeID(StringRef TypeID) {
          TypeID.starts_with(ReflectValueMethodTypeIDPrefix) ||
          TypeID == ReflectTypeMethodTypeID ||
          TypeID.starts_with(ReflectTypeMethodTypeIDPrefix);
+}
+
+bool isInterfaceBaseTypeID(StringRef TypeID) {
+  if (!TypeID.starts_with(InterfaceTypeIDPrefix))
+    return false;
+  StringRef Suffix = TypeID.drop_front(StringRef(InterfaceTypeIDPrefix).size());
+  return !Suffix.empty() && !Suffix.contains('.');
 }
 
 [[noreturn]] void invalidMetadata(const Twine &Reason) {
@@ -148,12 +169,11 @@ std::optional<InterfaceDecl> parseInterfaceDeclaration(GlobalVariable &GV,
   if (Header->getNumOperands() != 3)
     invalidMetadata(Twine("malformed header on ") + GV.getName());
 
-  auto Version = metadataUInt(Header->getOperand(0));
+  auto Version = metadataUInt32(Header->getOperand(0));
   auto TypeID = metadataString(Header->getOperand(1));
-  auto MethodCount = metadataUInt(Header->getOperand(2));
+  auto MethodCount = metadataUInt32(Header->getOperand(2));
   if (!Version || *Version != InterfaceMetadataVersion || !TypeID ||
-      !TypeID->starts_with(InterfaceTypeIDPrefix) || !MethodCount ||
-      *MethodCount == 0 || *MethodCount > UINT_MAX)
+      !isInterfaceBaseTypeID(*TypeID) || !MethodCount || *MethodCount == 0)
     invalidMetadata(Twine("unsupported header on ") + GV.getName());
   if (MethodNodes.size() != *MethodCount)
     invalidMetadata(Twine("method count mismatch on ") + GV.getName());
@@ -165,7 +185,7 @@ std::optional<InterfaceDecl> parseInterfaceDeclaration(GlobalVariable &GV,
   for (MDNode *Node : MethodNodes) {
     if (Node->getNumOperands() != 3)
       invalidMetadata(Twine("malformed method on ") + GV.getName());
-    auto Index = metadataUInt(Node->getOperand(0));
+    auto Index = metadataUInt32(Node->getOperand(0));
     auto ExactTypeID = metadataString(Node->getOperand(1));
     auto BroadTypeID = metadataString(Node->getOperand(2));
     if (!Index || *Index >= *MethodCount || !ExactTypeID || !BroadTypeID ||
@@ -173,7 +193,7 @@ std::optional<InterfaceDecl> parseInterfaceDeclaration(GlobalVariable &GV,
         BroadTypeID->starts_with(InterfaceTypeIDPrefix) ||
         isReflectMethodTypeID(*BroadTypeID))
       invalidMetadata(Twine("unsupported method on ") + GV.getName());
-    unsigned I = static_cast<unsigned>(*Index);
+    unsigned I = *Index;
     std::string Expected =
         Decl.TypeID + ".m" + std::to_string(static_cast<uint64_t>(I));
     if (*ExactTypeID != Expected || Seen[I])
@@ -362,8 +382,10 @@ public:
       // interface with at least one closed-world implementer certificate.
       if (Implementers == 0) {
         for (const InterfaceMethodDecl *Method : ActiveMethods) {
-          for (TypeCheckSite Site :
-               TypeChecksByExactTypeID[Method->ExactTypeID]) {
+          auto Sites = TypeChecksByExactTypeID.find(Method->ExactTypeID);
+          if (Sites == TypeChecksByExactTypeID.end())
+            continue;
+          for (TypeCheckSite Site : Sites->second) {
             Site.Call->setArgOperand(
                 Site.TypeIDArg,
                 MetadataAsValue::get(

--- a/ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp
+++ b/ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp
@@ -1,6 +1,5 @@
 #include "LLGOLTOPasses.h"
 
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -13,7 +12,6 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -27,10 +25,13 @@ using namespace llvm;
 
 namespace {
 
-// Keep this metadata protocol in sync with the constants and emitter in
+// Keep this call-attribute protocol in sync with the constants and emitter in
 // ssa/globaldce.go.
-static constexpr char InterfaceTypeMetadata[] = "llgo.interface.type";
-static constexpr char InterfaceMethodMetadata[] = "llgo.interface.method";
+static constexpr char InterfaceCallAttr[] = "llgo.interface.call";
+static constexpr char InterfaceTypeIDAttr[] = "llgo.interface.id";
+static constexpr char InterfaceMethodIndexAttr[] = "llgo.interface.index";
+static constexpr char InterfaceMethodCountAttr[] = "llgo.interface.count";
+static constexpr char InterfaceMethodAttrPrefix[] = "llgo.interface.method.";
 static constexpr char InterfaceTypeIDPrefix[] = "go.method.i.";
 static constexpr char MethodTypeIDPrefix[] = "go.method.";
 static constexpr char ReflectValueMethodTypeID[] = "go.method.value.reflect";
@@ -39,7 +40,7 @@ static constexpr char ReflectValueMethodTypeIDPrefix[] =
     "go.method.value.reflect.";
 static constexpr char ReflectTypeMethodTypeIDPrefix[] =
     "go.method.type.reflect.";
-static constexpr uint32_t InterfaceMetadataVersion = 1;
+static constexpr char InterfaceProtocolVersion[] = "1";
 
 struct InterfaceMethodDecl {
   unsigned Index = 0;
@@ -48,9 +49,9 @@ struct InterfaceMethodDecl {
 };
 
 struct InterfaceDecl {
-  // Header schema: {i32 version, MDString interface type ID, i32 method count}.
-  // Each method node is:
-  // {i32 index, MDString exact type ID, MDString broad type ID}.
+  // Every checked load carries a protocol marker, interface type ID, called
+  // method index, method count, and one broad method type ID per index.
+  // The complete ordered method list makes each checked load self-describing.
   std::string TypeID;
   std::vector<InterfaceMethodDecl> Methods;
 };
@@ -74,12 +75,18 @@ std::optional<uint64_t> metadataUInt(Metadata *MD) {
   return CI->getZExtValue();
 }
 
-std::optional<uint32_t> metadataUInt32(Metadata *MD) {
-  auto *CAM = dyn_cast_or_null<ConstantAsMetadata>(MD);
-  auto *CI = CAM ? dyn_cast<ConstantInt>(CAM->getValue()) : nullptr;
-  if (!CI || CI->isNegative() || CI->getBitWidth() != 32)
+std::optional<StringRef> callStringAttr(CallBase &CB, StringRef Kind) {
+  Attribute Attr = CB.getFnAttr(Kind);
+  if (!Attr.isStringAttribute())
     return std::nullopt;
-  return static_cast<uint32_t>(CI->getZExtValue());
+  return Attr.getValueAsString();
+}
+
+std::optional<uint32_t> parseUInt32(StringRef Value) {
+  uint32_t Result = 0;
+  if (Value.empty() || Value.getAsInteger(10, Result))
+    return std::nullopt;
+  return Result;
 }
 
 std::optional<StringRef> metadataString(Metadata *MD) {
@@ -143,65 +150,53 @@ bool sameDeclaration(const InterfaceDecl &A, const InterfaceDecl &B) {
   return true;
 }
 
-std::optional<InterfaceDecl> parseInterfaceDeclaration(GlobalVariable &GV,
-                                                       unsigned HeaderKind,
-                                                       unsigned MethodKind) {
-  SmallVector<std::pair<unsigned, MDNode *>, 16> Metadata;
-  GV.getAllMetadata(Metadata);
-
-  MDNode *Header = nullptr;
-  SmallVector<MDNode *, 8> MethodNodes;
-  for (auto [Kind, Node] : Metadata) {
-    if (Kind == HeaderKind) {
-      if (Header)
-        invalidMetadata(Twine("duplicate interface header on ") + GV.getName());
-      Header = Node;
-    } else if (Kind == MethodKind) {
-      MethodNodes.push_back(Node);
-    }
-  }
-  if (!Header) {
-    if (!MethodNodes.empty())
-      invalidMetadata(Twine("method declaration without header on ") +
-                      GV.getName());
-    return std::nullopt;
-  }
-  if (Header->getNumOperands() != 3)
-    invalidMetadata(Twine("malformed header on ") + GV.getName());
-
-  auto Version = metadataUInt32(Header->getOperand(0));
-  auto TypeID = metadataString(Header->getOperand(1));
-  auto MethodCount = metadataUInt32(Header->getOperand(2));
-  if (!Version || *Version != InterfaceMetadataVersion || !TypeID ||
-      !isInterfaceBaseTypeID(*TypeID) || !MethodCount || *MethodCount == 0)
-    invalidMetadata(Twine("unsupported header on ") + GV.getName());
-  if (MethodNodes.size() != *MethodCount)
-    invalidMetadata(Twine("method count mismatch on ") + GV.getName());
+InterfaceDecl parseInterfaceCall(CallBase &CB, StringRef CheckedTypeID) {
+  StringRef FunctionName = CB.getFunction()->getName();
+  auto Version = callStringAttr(CB, InterfaceCallAttr);
+  auto TypeID = callStringAttr(CB, InterfaceTypeIDAttr);
+  auto MethodIndexText = callStringAttr(CB, InterfaceMethodIndexAttr);
+  auto MethodCountText = callStringAttr(CB, InterfaceMethodCountAttr);
+  auto MethodIndex =
+      MethodIndexText ? parseUInt32(*MethodIndexText) : std::nullopt;
+  auto MethodCount =
+      MethodCountText ? parseUInt32(*MethodCountText) : std::nullopt;
+  if (!Version || *Version != InterfaceProtocolVersion || !TypeID ||
+      !isInterfaceBaseTypeID(*TypeID) || !MethodIndex || !MethodCount ||
+      *MethodCount == 0 || *MethodIndex >= *MethodCount)
+    invalidMetadata(Twine("unsupported call attributes in ") + FunctionName);
 
   InterfaceDecl Decl;
   Decl.TypeID = TypeID->str();
-  Decl.Methods.resize(static_cast<size_t>(*MethodCount));
-  std::vector<bool> Seen(static_cast<size_t>(*MethodCount), false);
-  for (MDNode *Node : MethodNodes) {
-    if (Node->getNumOperands() != 3)
-      invalidMetadata(Twine("malformed method on ") + GV.getName());
-    auto Index = metadataUInt32(Node->getOperand(0));
-    auto ExactTypeID = metadataString(Node->getOperand(1));
-    auto BroadTypeID = metadataString(Node->getOperand(2));
-    if (!Index || *Index >= *MethodCount || !ExactTypeID || !BroadTypeID ||
-        !BroadTypeID->starts_with(MethodTypeIDPrefix) ||
+  Decl.Methods.reserve(*MethodCount);
+  for (uint32_t I = 0; I < *MethodCount; ++I) {
+    std::string MethodAttr =
+        InterfaceMethodAttrPrefix + std::to_string(static_cast<uint64_t>(I));
+    auto BroadTypeID = callStringAttr(CB, MethodAttr);
+    if (!BroadTypeID || !BroadTypeID->starts_with(MethodTypeIDPrefix) ||
         BroadTypeID->starts_with(InterfaceTypeIDPrefix) ||
         isReflectMethodTypeID(*BroadTypeID))
-      invalidMetadata(Twine("unsupported method on ") + GV.getName());
-    unsigned I = *Index;
-    std::string Expected =
+      invalidMetadata(Twine("unsupported method attributes in ") +
+                      FunctionName);
+    std::string ExactTypeID =
         Decl.TypeID + ".m" + std::to_string(static_cast<uint64_t>(I));
-    if (*ExactTypeID != Expected || Seen[I])
-      invalidMetadata(Twine("inconsistent method on ") + GV.getName());
-    Seen[I] = true;
-    Decl.Methods[I] = {I, ExactTypeID->str(), BroadTypeID->str()};
+    Decl.Methods.push_back(
+        {static_cast<unsigned>(I), std::move(ExactTypeID), BroadTypeID->str()});
   }
+  if (CheckedTypeID != Decl.Methods[*MethodIndex].ExactTypeID)
+    invalidMetadata(Twine("inconsistent checked type id in ") + FunctionName);
   return Decl;
+}
+
+void removeInterfaceCallAttrs(CallBase &CB, unsigned MethodCount) {
+  CB.removeFnAttr(InterfaceCallAttr);
+  CB.removeFnAttr(InterfaceTypeIDAttr);
+  CB.removeFnAttr(InterfaceMethodIndexAttr);
+  CB.removeFnAttr(InterfaceMethodCountAttr);
+  for (unsigned I = 0; I < MethodCount; ++I) {
+    std::string MethodAttr =
+        InterfaceMethodAttrPrefix + std::to_string(static_cast<uint64_t>(I));
+    CB.removeFnAttr(MethodAttr);
+  }
 }
 
 bool collectTypeSlots(GlobalVariable &GV, unsigned TypeKind,
@@ -259,8 +254,10 @@ class LLGOInterfaceMethodTypeIDPass
     : public PassInfoMixin<LLGOInterfaceMethodTypeIDPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &) {
+    bool Changed = false;
     StringSet<> ActiveExactTypeIDs;
     StringMap<SmallVector<TypeCheckSite, 4>> TypeChecksByExactTypeID;
+    StringMap<InterfaceDecl> Declarations;
     for (Function &F : M) {
       for (BasicBlock &BB : F) {
         for (Instruction &I : BB) {
@@ -271,52 +268,43 @@ public:
             TypeID = typeTestTypeID(CB);
             TypeIDArg = 1;
           }
-          if (TypeID && TypeID->starts_with(InterfaceTypeIDPrefix)) {
-            ActiveExactTypeIDs.insert(*TypeID);
-            TypeChecksByExactTypeID[*TypeID].push_back({CB, TypeIDArg});
+          if (!TypeID)
+            continue;
+          bool HasCallInfo = CB->hasFnAttr(InterfaceCallAttr);
+          if (!TypeID->starts_with(InterfaceTypeIDPrefix)) {
+            if (HasCallInfo)
+              invalidMetadata(Twine("attributes on non-interface type id in ") +
+                              F.getName());
+            continue;
           }
+          if (!HasCallInfo)
+            invalidMetadata(Twine("missing call attributes in ") + F.getName());
+
+          InterfaceDecl Parsed = parseInterfaceCall(*CB, *TypeID);
+          removeInterfaceCallAttrs(
+              *CB, static_cast<unsigned>(Parsed.Methods.size()));
+          Changed = true;
+          auto Existing = Declarations.find(Parsed.TypeID);
+          if (Existing == Declarations.end()) {
+            Declarations.try_emplace(Parsed.TypeID, std::move(Parsed));
+          } else if (!sameDeclaration(Existing->second, Parsed)) {
+            invalidMetadata(Twine("conflicting declarations for ") +
+                            Existing->getKey());
+          }
+          ActiveExactTypeIDs.insert(*TypeID);
+          TypeChecksByExactTypeID[*TypeID].push_back({CB, TypeIDArg});
         }
       }
     }
 
-    unsigned HeaderKind = M.getContext().getMDKindID(InterfaceTypeMetadata);
-    unsigned MethodKind = M.getContext().getMDKindID(InterfaceMethodMetadata);
     unsigned TypeKind = M.getContext().getMDKindID("type");
     unsigned VCallVisibilityKind =
         M.getContext().getMDKindID("vcall_visibility");
 
-    StringMap<InterfaceDecl> Declarations;
-    SmallPtrSet<GlobalVariable *, 16> DeclarationGlobals;
-    for (GlobalVariable &GV : M.globals()) {
-      auto Parsed = parseInterfaceDeclaration(GV, HeaderKind, MethodKind);
-      if (!Parsed)
-        continue;
-      DeclarationGlobals.insert(&GV);
-      std::string TypeID = Parsed->TypeID;
-      auto [It, Inserted] =
-          Declarations.try_emplace(TypeID, std::move(*Parsed));
-      if (!Inserted && !sameDeclaration(It->second, *Parsed))
-        invalidMetadata(Twine("conflicting declarations for ") + It->getKey());
-    }
-
-    StringSet<> CoveredExactTypeIDs;
-    for (const auto &Entry : Declarations) {
-      for (const InterfaceMethodDecl &Method : Entry.second.Methods) {
-        if (ActiveExactTypeIDs.contains(Method.ExactTypeID))
-          CoveredExactTypeIDs.insert(Method.ExactTypeID);
-      }
-    }
-    for (const auto &Entry : ActiveExactTypeIDs) {
-      if (!CoveredExactTypeIDs.contains(Entry.getKey()))
-        invalidMetadata(Twine("no declaration for active type id ") +
-                        Entry.getKey());
-    }
-
     std::vector<DescriptorInfo> Descriptors;
     StringMap<SmallVector<unsigned, 8>> DescriptorsByBroadTypeID;
     for (GlobalVariable &GV : M.globals()) {
-      if (DeclarationGlobals.contains(&GV) ||
-          !GV.getMetadata(VCallVisibilityKind))
+      if (!GV.getMetadata(VCallVisibilityKind))
         continue;
       DescriptorInfo Info;
       Info.GV = &GV;
@@ -328,7 +316,6 @@ public:
       Descriptors.push_back(std::move(Info));
     }
 
-    bool Changed = false;
     unsigned AddedTypeIDs = 0;
     unsigned ActiveInterfaces = 0;
     unsigned BroadFallbacks = 0;
@@ -402,19 +389,6 @@ public:
                << Implementers << " implementers for " << ActiveMethods.size()
                << " active methods"
                << (Implementers == 0 ? " (broad fallback)" : "") << "\n";
-    }
-
-    // The frontend preserves declaration descriptors because private metadata
-    // is not an IR use. Once the closed-world mapping has been materialized as
-    // LLVM !type entries, remove only that temporary preservation. Ordinary IR
-    // references still keep descriptors that are needed at runtime.
-    if (!DeclarationGlobals.empty()) {
-      removeFromUsedLists(M, [&](Constant *C) {
-        auto *GV = dyn_cast<GlobalVariable>(C->stripPointerCasts());
-        bool Remove = GV && DeclarationGlobals.contains(GV);
-        Changed |= Remove;
-        return Remove;
-      });
     }
 
     if (std::getenv("LLGO_LTO_PLUGIN_VERBOSE"))

--- a/ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp
+++ b/ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp
@@ -1,0 +1,415 @@
+#include "LLGOLTOPasses.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+
+static constexpr char InterfaceTypeMetadata[] = "llgo.interface.type";
+static constexpr char InterfaceMethodMetadata[] = "llgo.interface.method";
+static constexpr char InterfaceTypeIDPrefix[] = "go.method.i.";
+static constexpr char MethodTypeIDPrefix[] = "go.method.";
+static constexpr char ReflectValueMethodTypeID[] = "go.method.value.reflect";
+static constexpr char ReflectTypeMethodTypeID[] = "go.method.type.reflect";
+static constexpr char ReflectValueMethodTypeIDPrefix[] =
+    "go.method.value.reflect.";
+static constexpr char ReflectTypeMethodTypeIDPrefix[] =
+    "go.method.type.reflect.";
+static constexpr uint64_t InterfaceMetadataVersion = 1;
+
+struct InterfaceMethodDecl {
+  unsigned Index = 0;
+  std::string ExactTypeID;
+  std::string BroadTypeID;
+};
+
+struct InterfaceDecl {
+  std::string TypeID;
+  std::vector<InterfaceMethodDecl> Methods;
+};
+
+struct DescriptorInfo {
+  GlobalVariable *GV = nullptr;
+  StringMap<uint64_t> BroadSlots;
+  StringMap<uint64_t> ExactSlots;
+};
+
+struct TypeCheckSite {
+  CallBase *Call = nullptr;
+  unsigned TypeIDArg = 0;
+};
+
+std::optional<uint64_t> metadataUInt(Metadata *MD) {
+  auto *CAM = dyn_cast_or_null<ConstantAsMetadata>(MD);
+  auto *CI = CAM ? dyn_cast<ConstantInt>(CAM->getValue()) : nullptr;
+  if (!CI || CI->isNegative())
+    return std::nullopt;
+  return CI->getZExtValue();
+}
+
+std::optional<StringRef> metadataString(Metadata *MD) {
+  auto *S = dyn_cast_or_null<MDString>(MD);
+  if (!S)
+    return std::nullopt;
+  return S->getString();
+}
+
+std::optional<StringRef> checkedLoadTypeID(CallBase *CB) {
+  if (!CB || CB->arg_size() < 3)
+    return std::nullopt;
+  Function *Callee = CB->getCalledFunction();
+  if (!Callee || Callee->getIntrinsicID() != Intrinsic::type_checked_load)
+    return std::nullopt;
+  auto *MDValue = dyn_cast<MetadataAsValue>(CB->getArgOperand(2));
+  auto *TypeID = MDValue ? dyn_cast<MDString>(MDValue->getMetadata()) : nullptr;
+  return TypeID ? std::optional<StringRef>(TypeID->getString()) : std::nullopt;
+}
+
+std::optional<StringRef> typeTestTypeID(CallBase *CB) {
+  if (!CB || CB->arg_size() < 2)
+    return std::nullopt;
+  Function *Callee = CB->getCalledFunction();
+  if (!Callee || Callee->getIntrinsicID() != Intrinsic::type_test)
+    return std::nullopt;
+  auto *MDValue = dyn_cast<MetadataAsValue>(CB->getArgOperand(1));
+  auto *TypeID = MDValue ? dyn_cast<MDString>(MDValue->getMetadata()) : nullptr;
+  return TypeID ? std::optional<StringRef>(TypeID->getString()) : std::nullopt;
+}
+
+bool isReflectMethodTypeID(StringRef TypeID) {
+  return TypeID == ReflectValueMethodTypeID ||
+         TypeID.starts_with(ReflectValueMethodTypeIDPrefix) ||
+         TypeID == ReflectTypeMethodTypeID ||
+         TypeID.starts_with(ReflectTypeMethodTypeIDPrefix);
+}
+
+[[noreturn]] void invalidMetadata(const Twine &Reason) {
+  report_fatal_error(
+      Twine("llgo-lto-plugin: invalid interface type-id metadata: ") + Reason);
+}
+
+bool sameDeclaration(const InterfaceDecl &A, const InterfaceDecl &B) {
+  if (A.TypeID != B.TypeID || A.Methods.size() != B.Methods.size())
+    return false;
+  for (unsigned I = 0; I < A.Methods.size(); ++I) {
+    const InterfaceMethodDecl &AM = A.Methods[I];
+    const InterfaceMethodDecl &BM = B.Methods[I];
+    if (AM.Index != BM.Index || AM.ExactTypeID != BM.ExactTypeID ||
+        AM.BroadTypeID != BM.BroadTypeID)
+      return false;
+  }
+  return true;
+}
+
+std::optional<InterfaceDecl> parseInterfaceDeclaration(GlobalVariable &GV,
+                                                       unsigned HeaderKind,
+                                                       unsigned MethodKind) {
+  SmallVector<std::pair<unsigned, MDNode *>, 16> Metadata;
+  GV.getAllMetadata(Metadata);
+
+  MDNode *Header = nullptr;
+  SmallVector<MDNode *, 8> MethodNodes;
+  for (auto [Kind, Node] : Metadata) {
+    if (Kind == HeaderKind) {
+      if (Header)
+        invalidMetadata(Twine("duplicate interface header on ") + GV.getName());
+      Header = Node;
+    } else if (Kind == MethodKind) {
+      MethodNodes.push_back(Node);
+    }
+  }
+  if (!Header) {
+    if (!MethodNodes.empty())
+      invalidMetadata(Twine("method declaration without header on ") +
+                      GV.getName());
+    return std::nullopt;
+  }
+  if (Header->getNumOperands() != 3)
+    invalidMetadata(Twine("malformed header on ") + GV.getName());
+
+  auto Version = metadataUInt(Header->getOperand(0));
+  auto TypeID = metadataString(Header->getOperand(1));
+  auto MethodCount = metadataUInt(Header->getOperand(2));
+  if (!Version || *Version != InterfaceMetadataVersion || !TypeID ||
+      !TypeID->starts_with(InterfaceTypeIDPrefix) || !MethodCount ||
+      *MethodCount == 0 || *MethodCount > UINT_MAX)
+    invalidMetadata(Twine("unsupported header on ") + GV.getName());
+  if (MethodNodes.size() != *MethodCount)
+    invalidMetadata(Twine("method count mismatch on ") + GV.getName());
+
+  InterfaceDecl Decl;
+  Decl.TypeID = TypeID->str();
+  Decl.Methods.resize(static_cast<size_t>(*MethodCount));
+  std::vector<bool> Seen(static_cast<size_t>(*MethodCount), false);
+  for (MDNode *Node : MethodNodes) {
+    if (Node->getNumOperands() != 3)
+      invalidMetadata(Twine("malformed method on ") + GV.getName());
+    auto Index = metadataUInt(Node->getOperand(0));
+    auto ExactTypeID = metadataString(Node->getOperand(1));
+    auto BroadTypeID = metadataString(Node->getOperand(2));
+    if (!Index || *Index >= *MethodCount || !ExactTypeID || !BroadTypeID ||
+        !BroadTypeID->starts_with(MethodTypeIDPrefix) ||
+        BroadTypeID->starts_with(InterfaceTypeIDPrefix) ||
+        isReflectMethodTypeID(*BroadTypeID))
+      invalidMetadata(Twine("unsupported method on ") + GV.getName());
+    unsigned I = static_cast<unsigned>(*Index);
+    std::string Expected =
+        Decl.TypeID + ".m" + std::to_string(static_cast<uint64_t>(I));
+    if (*ExactTypeID != Expected || Seen[I])
+      invalidMetadata(Twine("inconsistent method on ") + GV.getName());
+    Seen[I] = true;
+    Decl.Methods[I] = {I, ExactTypeID->str(), BroadTypeID->str()};
+  }
+  return Decl;
+}
+
+bool collectTypeSlots(GlobalVariable &GV, unsigned TypeKind,
+                      DescriptorInfo &Info) {
+  SmallVector<std::pair<unsigned, MDNode *>, 16> Metadata;
+  GV.getAllMetadata(Metadata);
+  for (auto [Kind, Node] : Metadata) {
+    if (Kind != TypeKind || Node->getNumOperands() < 2)
+      continue;
+    auto Offset = metadataUInt(Node->getOperand(0));
+    auto TypeID = metadataString(Node->getOperand(1));
+    if (!Offset || !TypeID)
+      continue;
+    StringMap<uint64_t> *Slots = nullptr;
+    if (TypeID->starts_with(InterfaceTypeIDPrefix))
+      Slots = &Info.ExactSlots;
+    else if (TypeID->starts_with(MethodTypeIDPrefix) &&
+             !isReflectMethodTypeID(*TypeID))
+      Slots = &Info.BroadSlots;
+    else
+      continue;
+    auto [It, Inserted] = Slots->try_emplace(*TypeID, *Offset);
+    if (!Inserted && It->second != *Offset)
+      invalidMetadata(Twine("type id has multiple offsets on ") + GV.getName());
+  }
+  return !Info.BroadSlots.empty();
+}
+
+bool addExactTypeMetadata(DescriptorInfo &Info,
+                          const InterfaceMethodDecl &Method,
+                          unsigned TypeKind) {
+  auto Broad = Info.BroadSlots.find(Method.BroadTypeID);
+  if (Broad == Info.BroadSlots.end())
+    return false;
+  uint64_t Offset = Broad->second;
+  auto [Existing, Inserted] =
+      Info.ExactSlots.try_emplace(Method.ExactTypeID, Offset);
+  if (!Inserted) {
+    if (Existing->second != Offset)
+      invalidMetadata(Twine("exact type id has multiple offsets on ") +
+                      Info.GV->getName());
+    return false;
+  }
+
+  LLVMContext &Ctx = Info.GV->getContext();
+  Metadata *Ops[] = {
+      ConstantAsMetadata::get(ConstantInt::get(Type::getInt64Ty(Ctx), Offset)),
+      MDString::get(Ctx, Method.ExactTypeID),
+  };
+  Info.GV->addMetadata(TypeKind, *MDNode::get(Ctx, Ops));
+  return true;
+}
+
+class LLGOInterfaceMethodTypeIDPass
+    : public PassInfoMixin<LLGOInterfaceMethodTypeIDPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &) {
+    StringSet<> ActiveExactTypeIDs;
+    StringMap<SmallVector<TypeCheckSite, 4>> TypeChecksByExactTypeID;
+    for (Function &F : M) {
+      for (BasicBlock &BB : F) {
+        for (Instruction &I : BB) {
+          auto *CB = dyn_cast<CallBase>(&I);
+          auto TypeID = checkedLoadTypeID(CB);
+          unsigned TypeIDArg = 2;
+          if (!TypeID) {
+            TypeID = typeTestTypeID(CB);
+            TypeIDArg = 1;
+          }
+          if (TypeID && TypeID->starts_with(InterfaceTypeIDPrefix)) {
+            ActiveExactTypeIDs.insert(*TypeID);
+            TypeChecksByExactTypeID[*TypeID].push_back({CB, TypeIDArg});
+          }
+        }
+      }
+    }
+
+    unsigned HeaderKind = M.getContext().getMDKindID(InterfaceTypeMetadata);
+    unsigned MethodKind = M.getContext().getMDKindID(InterfaceMethodMetadata);
+    unsigned TypeKind = M.getContext().getMDKindID("type");
+    unsigned VCallVisibilityKind =
+        M.getContext().getMDKindID("vcall_visibility");
+
+    StringMap<InterfaceDecl> Declarations;
+    SmallPtrSet<GlobalVariable *, 16> DeclarationGlobals;
+    for (GlobalVariable &GV : M.globals()) {
+      auto Parsed = parseInterfaceDeclaration(GV, HeaderKind, MethodKind);
+      if (!Parsed)
+        continue;
+      DeclarationGlobals.insert(&GV);
+      std::string TypeID = Parsed->TypeID;
+      auto [It, Inserted] =
+          Declarations.try_emplace(TypeID, std::move(*Parsed));
+      if (!Inserted && !sameDeclaration(It->second, *Parsed))
+        invalidMetadata(Twine("conflicting declarations for ") + It->getKey());
+    }
+
+    StringSet<> CoveredExactTypeIDs;
+    for (const auto &Entry : Declarations) {
+      for (const InterfaceMethodDecl &Method : Entry.second.Methods) {
+        if (ActiveExactTypeIDs.contains(Method.ExactTypeID))
+          CoveredExactTypeIDs.insert(Method.ExactTypeID);
+      }
+    }
+    for (const auto &Entry : ActiveExactTypeIDs) {
+      if (!CoveredExactTypeIDs.contains(Entry.getKey()))
+        invalidMetadata(Twine("no declaration for active type id ") +
+                        Entry.getKey());
+    }
+
+    std::vector<DescriptorInfo> Descriptors;
+    StringMap<SmallVector<unsigned, 8>> DescriptorsByBroadTypeID;
+    for (GlobalVariable &GV : M.globals()) {
+      if (DeclarationGlobals.contains(&GV) ||
+          !GV.getMetadata(VCallVisibilityKind))
+        continue;
+      DescriptorInfo Info;
+      Info.GV = &GV;
+      if (!collectTypeSlots(GV, TypeKind, Info))
+        continue;
+      unsigned Index = Descriptors.size();
+      for (const auto &Slot : Info.BroadSlots)
+        DescriptorsByBroadTypeID[Slot.getKey()].push_back(Index);
+      Descriptors.push_back(std::move(Info));
+    }
+
+    bool Changed = false;
+    unsigned AddedTypeIDs = 0;
+    unsigned ActiveInterfaces = 0;
+    unsigned BroadFallbacks = 0;
+    for (const auto &Entry : Declarations) {
+      const InterfaceDecl &Decl = Entry.second;
+      SmallVector<const InterfaceMethodDecl *, 4> ActiveMethods;
+      for (const InterfaceMethodDecl &Method : Decl.Methods) {
+        if (ActiveExactTypeIDs.contains(Method.ExactTypeID))
+          ActiveMethods.push_back(&Method);
+      }
+      if (ActiveMethods.empty())
+        continue;
+      ++ActiveInterfaces;
+
+      const SmallVector<unsigned, 8> *Seed = nullptr;
+      for (const InterfaceMethodDecl &Method : Decl.Methods) {
+        auto It = DescriptorsByBroadTypeID.find(Method.BroadTypeID);
+        if (It == DescriptorsByBroadTypeID.end()) {
+          Seed = nullptr;
+          break;
+        }
+        if (!Seed || It->second.size() < Seed->size())
+          Seed = &It->second;
+      }
+
+      unsigned Implementers = 0;
+      if (Seed) {
+        for (unsigned DescriptorIndex : *Seed) {
+          DescriptorInfo &Info = Descriptors[DescriptorIndex];
+          bool Implements = llvm::all_of(
+              Decl.Methods, [&](const InterfaceMethodDecl &Method) {
+                return Info.BroadSlots.contains(Method.BroadTypeID);
+              });
+          if (!Implements)
+            continue;
+          ++Implementers;
+          for (const InterfaceMethodDecl *Method : ActiveMethods) {
+            if (addExactTypeMetadata(Info, *Method, TypeKind)) {
+              Changed = true;
+              ++AddedTypeIDs;
+            }
+          }
+        }
+      }
+
+      // Some runtime/reflection interfaces are constructed through special
+      // paths that do not materialize a complete concrete descriptor in the
+      // LTO module. An empty proven set is therefore not enough to conclude
+      // that the call is unreachable. Fall back to the old signature-wide
+      // capability for those calls; exact refinement remains enabled for every
+      // interface with at least one closed-world implementer certificate.
+      if (Implementers == 0) {
+        for (const InterfaceMethodDecl *Method : ActiveMethods) {
+          for (TypeCheckSite Site :
+               TypeChecksByExactTypeID[Method->ExactTypeID]) {
+            Site.Call->setArgOperand(
+                Site.TypeIDArg,
+                MetadataAsValue::get(
+                    M.getContext(),
+                    MDString::get(M.getContext(), Method->BroadTypeID)));
+            Changed = true;
+            ++BroadFallbacks;
+          }
+        }
+      }
+
+      if (std::getenv("LLGO_LTO_PLUGIN_VERBOSE"))
+        errs() << "llgo-lto-plugin: interface " << Decl.TypeID << " has "
+               << Implementers << " implementers for " << ActiveMethods.size()
+               << " active methods"
+               << (Implementers == 0 ? " (broad fallback)" : "") << "\n";
+    }
+
+    // The frontend preserves declaration descriptors because private metadata
+    // is not an IR use. Once the closed-world mapping has been materialized as
+    // LLVM !type entries, remove only that temporary preservation. Ordinary IR
+    // references still keep descriptors that are needed at runtime.
+    if (!DeclarationGlobals.empty()) {
+      removeFromUsedLists(M, [&](Constant *C) {
+        auto *GV = dyn_cast<GlobalVariable>(C->stripPointerCasts());
+        bool Remove = GV && DeclarationGlobals.contains(GV);
+        Changed |= Remove;
+        return Remove;
+      });
+    }
+
+    if (std::getenv("LLGO_LTO_PLUGIN_VERBOSE"))
+      errs() << "llgo-lto-plugin: materialized " << AddedTypeIDs
+             << " exact interface method type ids for " << ActiveInterfaces
+             << " active interfaces; " << BroadFallbacks
+             << " type checks used broad fallback\n";
+    return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+};
+
+} // namespace
+
+namespace llgo {
+
+void addLLGOInterfaceMethodTypeIDPass(ModulePassManager &MPM) {
+  MPM.addPass(LLGOInterfaceMethodTypeIDPass());
+}
+
+} // namespace llgo

--- a/ltoplugin/LLGOLTOPasses.h
+++ b/ltoplugin/LLGOLTOPasses.h
@@ -6,10 +6,15 @@
 namespace llgo {
 
 inline constexpr char LLGOPreGlobalDCEPassName[] = "llgo-lto-pre-globaldce";
+inline constexpr char LLGOInterfaceMethodTypeIDPassName[] =
+    "llgo-interface-method-typeids";
 
+void addLLGOInterfaceMethodTypeIDPass(llvm::ModulePassManager &MPM);
 void addLLGOReflectMethodByNamePass(llvm::ModulePassManager &MPM);
+void addLLGOTypeIDExportCleanupPass(llvm::ModulePassManager &MPM);
 
 inline void addLLGOPreGlobalDCEPipeline(llvm::ModulePassManager &MPM) {
+  addLLGOInterfaceMethodTypeIDPass(MPM);
   addLLGOReflectMethodByNamePass(MPM);
 }
 

--- a/ltoplugin/LLGOLTOPlugin.cpp
+++ b/ltoplugin/LLGOLTOPlugin.cpp
@@ -13,15 +13,24 @@ PassPluginLibraryInfo getLLGOLTOPluginInfo() {
             PB.registerPipelineParsingCallback(
                 [](StringRef Name, ModulePassManager &MPM,
                    ArrayRef<PassBuilder::PipelineElement>) {
-                  if (Name != llgo::LLGOPreGlobalDCEPassName)
-                    return false;
-                  llgo::addLLGOPreGlobalDCEPipeline(MPM);
-                  return true;
+                  if (Name == llgo::LLGOInterfaceMethodTypeIDPassName) {
+                    llgo::addLLGOInterfaceMethodTypeIDPass(MPM);
+                    return true;
+                  }
+                  if (Name == llgo::LLGOPreGlobalDCEPassName) {
+                    llgo::addLLGOPreGlobalDCEPipeline(MPM);
+                    return true;
+                  }
+                  return false;
                 });
 
             PB.registerFullLinkTimeOptimizationEarlyEPCallback(
                 [](ModulePassManager &MPM, OptimizationLevel) {
                   llgo::addLLGOPreGlobalDCEPipeline(MPM);
+                });
+            PB.registerFullLinkTimeOptimizationLastEPCallback(
+                [](ModulePassManager &MPM, OptimizationLevel) {
+                  llgo::addLLGOTypeIDExportCleanupPass(MPM);
                 });
           }};
 }

--- a/ltoplugin/LLGOTypeIDExportCleanupPass.cpp
+++ b/ltoplugin/LLGOTypeIDExportCleanupPass.cpp
@@ -1,0 +1,50 @@
+#include "LLGOLTOPasses.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/GlobalAlias.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+
+using namespace llvm;
+
+namespace {
+
+static constexpr char ExactTypeIDExportPrefix[] = "__typeid_go.method.i.";
+
+class LLGOTypeIDExportCleanupPass
+    : public PassInfoMixin<LLGOTypeIDExportCleanupPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &) {
+    // LowerTypeTests exports string type IDs as named aliases even in the
+    // monolithic Full LTO pipeline. At the last Full LTO extension point all
+    // exact LLGo checks have already been lowered, so aliases with no IR uses
+    // are only symbol-table residue. Removing them here leaves the allocated
+    // type-test data and lowered checks untouched.
+    SmallVector<GlobalAlias *, 32> DeadAliases;
+    for (GlobalAlias &Alias : M.aliases()) {
+      if (Alias.getName().starts_with(ExactTypeIDExportPrefix) &&
+          Alias.use_empty())
+        DeadAliases.push_back(&Alias);
+    }
+    for (GlobalAlias *Alias : DeadAliases)
+      Alias->eraseFromParent();
+    if (std::getenv("LLGO_LTO_PLUGIN_VERBOSE"))
+      errs() << "llgo-lto-plugin: removed " << DeadAliases.size()
+             << " unused exact type-id export symbols\n";
+    return DeadAliases.empty() ? PreservedAnalyses::all()
+                               : PreservedAnalyses::none();
+  }
+};
+
+} // namespace
+
+namespace llgo {
+
+void addLLGOTypeIDExportCleanupPass(ModulePassManager &MPM) {
+  MPM.addPass(LLGOTypeIDExportCleanupPass());
+}
+
+} // namespace llgo

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -706,6 +706,15 @@ func (b Builder) abiType(t types.Type) Expr {
 		b.Pkg.setODRLinkage(g.impl, llvm.WeakODRLinkage)
 		if prog.enableGoGlobalDCE {
 			prog.addMethodTypeMetadata(g.impl, prog.Type(typ, InGo), methods)
+			if prog.enableLTOPluginMarker {
+				if intf, ok := types.Unalias(t).(*types.Interface); ok && !intf.Empty() {
+					prog.addInterfaceTypeMetadata(g.impl, intf)
+					// Private metadata is not an IR use. Keep the declaration alive
+					// until the LTO plugin has consumed it; the plugin removes this
+					// preservation before GlobalDCE.
+					pkg.markLLVMUsed(g.impl)
+				}
+			}
 		}
 		prog.abiSymbol[name] = &AbiSymbol{Name: name, PkgPath: pkg.Path(), Raw: t, Typ: g.Type, MSet: mset}
 	}

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -706,15 +706,6 @@ func (b Builder) abiType(t types.Type) Expr {
 		b.Pkg.setODRLinkage(g.impl, llvm.WeakODRLinkage)
 		if prog.enableGoGlobalDCE {
 			prog.addMethodTypeMetadata(g.impl, prog.Type(typ, InGo), methods)
-			if prog.enableLTOPluginMarker {
-				if intf, ok := types.Unalias(t).(*types.Interface); ok && !intf.Empty() {
-					prog.addInterfaceTypeMetadata(g.impl, intf)
-					// Private metadata is not an IR use. Keep the declaration alive
-					// until the LTO plugin has consumed it; the plugin removes this
-					// preservation before GlobalDCE.
-					pkg.markLLVMUsed(g.impl)
-				}
-			}
 		}
 		prog.abiSymbol[name] = &AbiSymbol{Name: name, PkgPath: pkg.Path(), Raw: t, Typ: g.Type, MSet: mset}
 	}

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -1,8 +1,12 @@
 package ssa
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"go/types"
+	"strconv"
 
+	"github.com/xgo-dev/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -22,6 +26,11 @@ const (
 	reflectMethodByNameArgAttr  = "llgo.reflect.methodbyname.name"
 	reflectMethodByNameValue    = "value"
 	reflectMethodByNameType     = "type"
+
+	interfaceTypeMetadata    = "llgo.interface.type"
+	interfaceMethodMetadata  = "llgo.interface.method"
+	interfaceTypeIDPrefix    = "go.method.i."
+	interfaceMetadataVersion = 1
 )
 
 type ReflectMethodCheck struct {
@@ -59,6 +68,14 @@ func methodCapabilityType(t types.Type) types.Type {
 	case *types.Slice:
 		return types.NewSlice(methodCapabilityType(t.Elem()))
 	case *types.Struct:
+		// Interface descriptors are built from ABI-patched types, where a Go
+		// function value is represented as {$f func(...); $data unsafe.Pointer}.
+		// Concrete method descriptors still carry the source-level function type.
+		// Normalize the compiler-only closure struct back to its code signature so
+		// both paths produce the same method capability key.
+		if abi.IsClosure(t) {
+			return methodCapabilityType(t.Field(0).Type())
+		}
 		fields := make([]*types.Var, t.NumFields())
 		tags := make([]string, t.NumFields())
 		for i := range fields {
@@ -125,6 +142,42 @@ func methodCapabilityName(method *types.Func) string {
 		return types.Id(pkg, name)
 	}
 	return name
+}
+
+func (p Program) interfaceCapabilityKey(intf *types.Interface) string {
+	name, _ := p.abi.TypeName(intf)
+	sum := sha256.Sum256([]byte(name))
+	return interfaceTypeIDPrefix + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (p Program) interfaceMethodCapabilityKey(intf *types.Interface, index int) string {
+	return p.interfaceCapabilityKey(intf) + ".m" + strconv.Itoa(index)
+}
+
+// addInterfaceTypeMetadata declares the complete method set of an interface.
+// These are private LLGo markers rather than LLVM type metadata: the LTO
+// plugin consumes them to add exact interface-and-method !type entries only to
+// descriptors that implement every declared method.
+func (p Program) addInterfaceTypeMetadata(global llvm.Value, intf *types.Interface) {
+	if intf == nil || intf.NumMethods() == 0 {
+		return
+	}
+	intf = intf.Complete()
+	intfID := p.interfaceCapabilityKey(intf)
+	int32Type := p.Int32().ll
+	global.AddMetadata(p.ctx.MDKindID(interfaceTypeMetadata), p.ctx.MDNode([]llvm.Metadata{
+		llvm.ConstInt(int32Type, interfaceMetadataVersion, false).ConstantAsMetadata(),
+		p.ctx.MDString(intfID),
+		llvm.ConstInt(int32Type, uint64(intf.NumMethods()), false).ConstantAsMetadata(),
+	}))
+	methodKind := p.ctx.MDKindID(interfaceMethodMetadata)
+	for i := 0; i < intf.NumMethods(); i++ {
+		global.AddMetadata(methodKind, p.ctx.MDNode([]llvm.Metadata{
+			llvm.ConstInt(int32Type, uint64(i), false).ConstantAsMetadata(),
+			p.ctx.MDString(p.interfaceMethodCapabilityKey(intf, i)),
+			p.ctx.MDString(methodCapabilityKey(intf.Method(i))),
+		}))
+	}
 }
 
 func reflectValueMethodNameTypeID(name string) string {

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -27,6 +27,8 @@ const (
 	reflectMethodByNameValue    = "value"
 	reflectMethodByNameType     = "type"
 
+	// Keep this metadata protocol in sync with the constants and schema in
+	// ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp.
 	interfaceTypeMetadata    = "llgo.interface.type"
 	interfaceMethodMetadata  = "llgo.interface.method"
 	interfaceTypeIDPrefix    = "go.method.i."
@@ -151,7 +153,11 @@ func (p Program) interfaceCapabilityKey(intf *types.Interface) string {
 }
 
 func (p Program) interfaceMethodCapabilityKey(intf *types.Interface, index int) string {
-	return p.interfaceCapabilityKey(intf) + ".m" + strconv.Itoa(index)
+	return interfaceMethodCapabilityKeyFromID(p.interfaceCapabilityKey(intf), index)
+}
+
+func interfaceMethodCapabilityKeyFromID(interfaceID string, index int) string {
+	return interfaceID + ".m" + strconv.Itoa(index)
 }
 
 // addInterfaceTypeMetadata declares the complete method set of an interface.
@@ -174,7 +180,7 @@ func (p Program) addInterfaceTypeMetadata(global llvm.Value, intf *types.Interfa
 	for i := 0; i < intf.NumMethods(); i++ {
 		global.AddMetadata(methodKind, p.ctx.MDNode([]llvm.Metadata{
 			llvm.ConstInt(int32Type, uint64(i), false).ConstantAsMetadata(),
-			p.ctx.MDString(p.interfaceMethodCapabilityKey(intf, i)),
+			p.ctx.MDString(interfaceMethodCapabilityKeyFromID(intfID, i)),
 			p.ctx.MDString(methodCapabilityKey(intf.Method(i))),
 		}))
 	}

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -27,12 +27,15 @@ const (
 	reflectMethodByNameValue    = "value"
 	reflectMethodByNameType     = "type"
 
-	// Keep this metadata protocol in sync with the constants and schema in
+	// Keep this call-attribute protocol in sync with the constants and schema in
 	// ltoplugin/LLGOInterfaceMethodTypeIDPass.cpp.
-	interfaceTypeMetadata    = "llgo.interface.type"
-	interfaceMethodMetadata  = "llgo.interface.method"
-	interfaceTypeIDPrefix    = "go.method.i."
-	interfaceMetadataVersion = 1
+	interfaceCallAttr         = "llgo.interface.call"
+	interfaceTypeIDAttr       = "llgo.interface.id"
+	interfaceMethodIndexAttr  = "llgo.interface.index"
+	interfaceMethodCountAttr  = "llgo.interface.count"
+	interfaceMethodAttrPrefix = "llgo.interface.method."
+	interfaceTypeIDPrefix     = "go.method.i."
+	interfaceProtocolVersion  = "1"
 )
 
 type ReflectMethodCheck struct {
@@ -160,32 +163,6 @@ func interfaceMethodCapabilityKeyFromID(interfaceID string, index int) string {
 	return interfaceID + ".m" + strconv.Itoa(index)
 }
 
-// addInterfaceTypeMetadata declares the complete method set of an interface.
-// These are private LLGo markers rather than LLVM type metadata: the LTO
-// plugin consumes them to add exact interface-and-method !type entries only to
-// descriptors that implement every declared method.
-func (p Program) addInterfaceTypeMetadata(global llvm.Value, intf *types.Interface) {
-	if intf == nil || intf.NumMethods() == 0 {
-		return
-	}
-	intf = intf.Complete()
-	intfID := p.interfaceCapabilityKey(intf)
-	int32Type := p.Int32().ll
-	global.AddMetadata(p.ctx.MDKindID(interfaceTypeMetadata), p.ctx.MDNode([]llvm.Metadata{
-		llvm.ConstInt(int32Type, interfaceMetadataVersion, false).ConstantAsMetadata(),
-		p.ctx.MDString(intfID),
-		llvm.ConstInt(int32Type, uint64(intf.NumMethods()), false).ConstantAsMetadata(),
-	}))
-	methodKind := p.ctx.MDKindID(interfaceMethodMetadata)
-	for i := 0; i < intf.NumMethods(); i++ {
-		global.AddMetadata(methodKind, p.ctx.MDNode([]llvm.Metadata{
-			llvm.ConstInt(int32Type, uint64(i), false).ConstantAsMetadata(),
-			p.ctx.MDString(interfaceMethodCapabilityKeyFromID(intfID, i)),
-			p.ctx.MDString(methodCapabilityKey(intf.Method(i))),
-		}))
-	}
-}
-
 func reflectValueMethodNameTypeID(name string) string {
 	return reflectValueMethodTypeID + "." + name
 }
@@ -225,7 +202,7 @@ func (p Program) setVCallVisibilityMetadata(global llvm.Value, vis uint64) {
 	global.AddMetadata(kind, node)
 }
 
-func (p Program) methodCheckedLoad(b llvm.Builder, typedesc llvm.Value, typeID string) llvm.Value {
+func (p Program) methodCheckedLoadWithAttrs(b llvm.Builder, typedesc llvm.Value, typeID string, attrs []llvm.Attribute) llvm.Value {
 	mdVal := p.ctx.MetadataAsValue(p.ctx.MDString(typeID))
 	retTy := p.ctx.StructType([]llvm.Type{p.tyVoidPtr(), p.tyInt1()}, false)
 	res := b.CreateIntrinsic(retTy, llvm.LookupIntrinsicID("llvm.type.checked.load"), []llvm.Value{
@@ -233,9 +210,43 @@ func (p Program) methodCheckedLoad(b llvm.Builder, typedesc llvm.Value, typeID s
 		llvm.ConstInt(p.Int32().ll, 0, false),
 		mdVal,
 	}, "")
+	for _, attr := range attrs {
+		res.AddCallSiteAttribute(-1, attr)
+	}
 	ok := llvm.CreateExtractValue(b, res, 1)
 	b.CreateIntrinsic(p.tyVoid(), llvm.LookupIntrinsicID("llvm.assume"), []llvm.Value{ok}, "")
 	return llvm.CreateExtractValue(b, res, 0)
+}
+
+func (p Program) methodCheckedLoad(b llvm.Builder, typedesc llvm.Value, typeID string) llvm.Value {
+	return p.methodCheckedLoadWithAttrs(b, typedesc, typeID, nil)
+}
+
+// interfaceMethodCheckedLoad makes an exact interface-method check
+// self-describing. The live call carries the complete interface method set, so
+// the LTO plugin does not need to retain or rediscover an interface descriptor.
+func (p Program) interfaceMethodCheckedLoad(b llvm.Builder, typedesc llvm.Value, intf *types.Interface, methodIndex int) llvm.Value {
+	intf = intf.Complete()
+	if !p.enableLTOPluginMarker {
+		return p.methodCheckedLoad(b, typedesc, methodCapabilityKey(intf.Method(methodIndex)))
+	}
+
+	interfaceID := p.interfaceCapabilityKey(intf)
+	attrs := make([]llvm.Attribute, 0, 4+intf.NumMethods())
+	attrs = append(attrs,
+		p.ctx.CreateStringAttribute(interfaceCallAttr, interfaceProtocolVersion),
+		p.ctx.CreateStringAttribute(interfaceTypeIDAttr, interfaceID),
+		p.ctx.CreateStringAttribute(interfaceMethodIndexAttr, strconv.Itoa(methodIndex)),
+		p.ctx.CreateStringAttribute(interfaceMethodCountAttr, strconv.Itoa(intf.NumMethods())),
+	)
+	for i := 0; i < intf.NumMethods(); i++ {
+		attrs = append(attrs, p.ctx.CreateStringAttribute(
+			interfaceMethodAttrPrefix+strconv.Itoa(i), methodCapabilityKey(intf.Method(i)),
+		))
+	}
+	return p.methodCheckedLoadWithAttrs(
+		b, typedesc, interfaceMethodCapabilityKeyFromID(interfaceID, methodIndex), attrs,
+	)
 }
 
 func (b Builder) MarkReflectMethodByNameCall(call llvm.Value, kind string, nameArgIndex int) {

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -176,14 +176,6 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 	tclosure := prog.Type(sig, InGo)
 	i := iMethodOf(rawIntf, method)
 	b.recordUseIfaceMethod(rawIntf, i)
-	methodTypeID := methodCapabilityKey(method)
-	if prog.enableGoGlobalDCE && prog.enableLTOPluginMarker {
-		// Materialize and preserve the structural interface declaration so the
-		// LTO plugin can refine this call from a signature-wide capability to
-		// the exact interface-and-method candidate set.
-		b.abiType(rawIntf)
-		methodTypeID = prog.interfaceMethodCapabilityKey(rawIntf, i)
-	}
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	impl := intf.impl
 	itab := Expr{b.faceItab(impl), prog.VoidPtrPtr()}
@@ -192,7 +184,7 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 	if prog.enableGoGlobalDCE && !recoverToken {
 		fnType := prog.Elem(pfn.Type)
 		fn = Expr{
-			prog.methodCheckedLoad(b.impl, pfn.impl, methodTypeID),
+			prog.interfaceMethodCheckedLoad(b.impl, pfn.impl, rawIntf, i),
 			fnType,
 		}
 	} else {
@@ -202,7 +194,7 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 			// general-purpose pointer. Recover bookkeeping needs the same code
 			// address as ordinary data, so retain the capability check while
 			// carrying the raw itab load into the transient invocation pair.
-			prog.methodCheckedLoad(b.impl, pfn.impl, methodTypeID)
+			prog.interfaceMethodCheckedLoad(b.impl, pfn.impl, rawIntf, i)
 		}
 	}
 	// This is a transient interface invocation pair, not a first-class

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -102,9 +102,10 @@ func (b Builder) staticItab(rawIntf *types.Interface, concrete types.Type, tintf
 	slotKind := prog.ctx.MDKindID("llgo.static.itab.slot")
 	funOffset := uint64(prog.td.ElementOffset(staticType.ll, 3))
 	stride := uint64(prog.td.TypeAllocSize(ptr.ll))
+	interfaceTypeID := prog.interfaceCapabilityKey(rawIntf)
 	for i := range methods {
 		offset := funOffset + uint64(i)*stride
-		typeID := prog.interfaceMethodCapabilityKey(rawIntf, i)
+		typeID := interfaceMethodCapabilityKeyFromID(interfaceTypeID, i)
 		node := prog.ctx.MDNode([]llvm.Metadata{
 			llvm.ConstInt(prog.Int64().ll, offset, false).ConstantAsMetadata(),
 			prog.ctx.MDString(typeID),

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -104,10 +104,10 @@ func (b Builder) staticItab(rawIntf *types.Interface, concrete types.Type, tintf
 	stride := uint64(prog.td.TypeAllocSize(ptr.ll))
 	for i := range methods {
 		offset := funOffset + uint64(i)*stride
-		method := rawIntf.Method(i)
+		typeID := prog.interfaceMethodCapabilityKey(rawIntf, i)
 		node := prog.ctx.MDNode([]llvm.Metadata{
 			llvm.ConstInt(prog.Int64().ll, offset, false).ConstantAsMetadata(),
-			prog.ctx.MDString(methodCapabilityKey(method)),
+			prog.ctx.MDString(typeID),
 		})
 		global.impl.AddMetadata(slotKind, node)
 	}
@@ -175,6 +175,14 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 	tclosure := prog.Type(sig, InGo)
 	i := iMethodOf(rawIntf, method)
 	b.recordUseIfaceMethod(rawIntf, i)
+	methodTypeID := methodCapabilityKey(method)
+	if prog.enableGoGlobalDCE && prog.enableLTOPluginMarker {
+		// Materialize and preserve the structural interface declaration so the
+		// LTO plugin can refine this call from a signature-wide capability to
+		// the exact interface-and-method candidate set.
+		b.abiType(rawIntf)
+		methodTypeID = prog.interfaceMethodCapabilityKey(rawIntf, i)
+	}
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	impl := intf.impl
 	itab := Expr{b.faceItab(impl), prog.VoidPtrPtr()}
@@ -183,7 +191,7 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 	if prog.enableGoGlobalDCE && !recoverToken {
 		fnType := prog.Elem(pfn.Type)
 		fn = Expr{
-			prog.methodCheckedLoad(b.impl, pfn.impl, methodCapabilityKey(method)),
+			prog.methodCheckedLoad(b.impl, pfn.impl, methodTypeID),
 			fnType,
 		}
 	} else {
@@ -193,7 +201,7 @@ func (b Builder) imethod(intf Expr, method *types.Func, recoverToken bool) Expr 
 			// general-purpose pointer. Recover bookkeeping needs the same code
 			// address as ordinary data, so retain the capability check while
 			// carrying the raw itab load into the transient invocation pair.
-			prog.methodCheckedLoad(b.impl, pfn.impl, methodCapabilityKey(method))
+			prog.methodCheckedLoad(b.impl, pfn.impl, methodTypeID)
 		}
 	}
 	// This is a transient interface invocation pair, not a first-class

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -775,9 +775,8 @@ func TestDevLTOGlobalDCEConcreteInterfaceEmitsStaticItabTemplate(t *testing.T) {
 		`!"go.method.M:func()"`,
 		`!"go.method.N:func()"`,
 		`!llgo.static.itab.slot`,
-		`!llgo.interface.type`,
-		`!llgo.interface.method`,
-		`!"` + interfaceTypeID + `"`,
+		`"llgo.interface.call"="1"`,
+		`"llgo.interface.id"="` + interfaceTypeID + `"`,
 		`!"` + prog.interfaceMethodCapabilityKey(intf, 0) + `"`,
 		`!"` + prog.interfaceMethodCapabilityKey(intf, 1) + `"`,
 	} {
@@ -796,6 +795,9 @@ func TestDevLTOGlobalDCEConcreteInterfaceEmitsStaticItabTemplate(t *testing.T) {
 			!strings.Contains(ir, `metadata !"`+typeID+`"`) {
 			t.Fatalf("missing checked load for %s:\n%s", typeID, ir)
 		}
+	}
+	if strings.Contains(ir, `!llgo.interface.type`) || strings.Contains(ir, `!llgo.interface.method`) {
+		t.Fatalf("interface declaration remained attached to a type descriptor:\n%s", ir)
 	}
 }
 
@@ -887,19 +889,41 @@ func TestDevLTOGlobalDCEAddMethodTypeMetadataEarlyReturns(t *testing.T) {
 	}
 }
 
-func TestDevLTOGlobalDCEAddInterfaceTypeMetadataEarlyReturns(t *testing.T) {
+func TestDevLTOGlobalDCEInterfaceMethodCheckedLoadAttributes(t *testing.T) {
 	requireGoGlobalDCE(t)
 
 	prog := NewProgram(nil)
+	prog.EnableLTOPluginMarkers(true)
 	pkg := prog.NewPackage("main", "main")
-	g := pkg.NewVarEx("g", prog.Pointer(prog.Int()))
-
-	prog.addInterfaceTypeMetadata(g.impl, nil)
-	prog.addInterfaceTypeMetadata(g.impl, types.NewInterfaceType(nil, nil).Complete())
+	g := pkg.NewVarEx("itab", prog.Pointer(prog.VoidPtr()))
+	methodSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	methodM := types.NewFunc(token.NoPos, nil, "M", methodSig)
+	methodN := types.NewFunc(token.NoPos, nil, "N", methodSig)
+	intf := types.NewInterfaceType([]*types.Func{methodM, methodN}, nil).Complete()
+	fn := pkg.NewFunc("Use", types.NewSignatureType(nil, nil, nil, nil, nil, false), InGo)
+	b := fn.MakeBody(1)
+	prog.interfaceMethodCheckedLoad(b.impl, g.impl, intf, 1)
+	b.Return()
 
 	ir := pkg.String()
-	if strings.Contains(ir, "!llgo.interface.") {
-		t.Fatalf("early-return paths should not attach interface metadata:\n%s", ir)
+	interfaceID := prog.interfaceCapabilityKey(intf)
+	for _, want := range []string{
+		`metadata !"` + interfaceMethodCapabilityKeyFromID(interfaceID, 1) + `") #`,
+		`"llgo.interface.call"="1"`,
+		`"llgo.interface.id"="` + interfaceID + `"`,
+		`"llgo.interface.index"="1"`,
+		`"llgo.interface.count"="2"`,
+		`"llgo.interface.method.0"="go.method.M:func()"`,
+		`"llgo.interface.method.1"="go.method.N:func()"`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing checked-load interface attribute %s:\n%s", want, ir)
+		}
+	}
+	for _, unwanted := range []string{`!llgo.interface.type`, `!llgo.interface.method`, `@llvm.compiler.used`} {
+		if strings.Contains(ir, unwanted) {
+			t.Fatalf("checked load retained descriptor-based interface declaration %s:\n%s", unwanted, ir)
+		}
 	}
 }
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -435,6 +435,41 @@ func TestDevLTOGlobalDCEMethodCapabilityKeyMatchesInterfaceAndConcreteNames(t *t
 	}
 }
 
+func TestDevLTOGlobalDCEMethodCapabilityKeyNormalizesABIClosure(t *testing.T) {
+	requireGoGlobalDCE(t)
+
+	pkg := types.NewPackage("testing", "testing")
+	callback := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(
+			types.NewVar(token.NoPos, nil, "", types.Typ[types.String]),
+			types.NewVar(token.NoPos, nil, "", types.Typ[types.String]),
+		),
+		types.NewTuple(
+			types.NewVar(token.NoPos, nil, "", types.Typ[types.Bool]),
+			types.NewVar(token.NoPos, nil, "", types.Universe.Lookup("error").Type()),
+		),
+		false)
+	closure := types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, nil, "$f", callback, false),
+		types.NewField(token.NoPos, nil, "$data", types.Typ[types.UnsafePointer], false),
+	}, nil)
+	method := func(param types.Type) *types.Func {
+		return types.NewFunc(token.NoPos, pkg, "verify", types.NewSignatureType(nil, nil, nil,
+			types.NewTuple(
+				types.NewVar(token.NoPos, nil, "", types.Typ[types.String]),
+				types.NewVar(token.NoPos, nil, "", param),
+			),
+			types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Universe.Lookup("error").Type())),
+			false))
+	}
+
+	sourceKey := methodCapabilityKey(method(callback))
+	abiKey := methodCapabilityKey(method(closure))
+	if abiKey != sourceKey {
+		t.Fatalf("ABI closure capability key mismatch: got %q, want %q", abiKey, sourceKey)
+	}
+}
+
 func TestDevLTOGlobalDCEMethodCapabilityKeyQualifiesUnexportedNames(t *testing.T) {
 	requireGoGlobalDCE(t)
 
@@ -688,7 +723,12 @@ func TestDevLTOGlobalDCEConcreteInterfaceEmitsStaticItabTemplate(t *testing.T) {
 	returns := types.NewTuple(types.NewVar(token.NoPos, nil, "", intf))
 	fn := pkg.NewFunc("Make", types.NewSignatureType(nil, nil, nil, nil, returns, false), InGo)
 	b := fn.MakeBody(1)
-	b.Return(b.MakeInterface(prog.Type(intf, InGo), prog.Zero(prog.Type(concrete, InGo))))
+	ifaceValue := b.MakeInterface(prog.Type(intf, InGo), prog.Zero(prog.Type(concrete, InGo)))
+	b.Imethod(ifaceValue, interfaceMethodM)
+	prog.EnableLTOPluginMarkers(false)
+	b.Imethod(ifaceValue, interfaceMethodM)
+	prog.EnableLTOPluginMarkers(true)
+	b.Return(ifaceValue)
 	if _, ok := b.staticItab(intf, concrete, b.abiType(intf), b.abiType(concrete)); !ok {
 		t.Fatal("cached static itab template was not reused")
 	}
@@ -728,12 +768,18 @@ func TestDevLTOGlobalDCEConcreteInterfaceEmitsStaticItabTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	ir := pkg.String()
+	interfaceTypeID := prog.interfaceCapabilityKey(intf)
 	for _, want := range []string{
 		`_llgo_itab$`,
 		`@llvm.compiler.used`,
 		`!"go.method.M:func()"`,
 		`!"go.method.N:func()"`,
 		`!llgo.static.itab.slot`,
+		`!llgo.interface.type`,
+		`!llgo.interface.method`,
+		`!"` + interfaceTypeID + `"`,
+		`!"` + prog.interfaceMethodCapabilityKey(intf, 0) + `"`,
+		`!"` + prog.interfaceMethodCapabilityKey(intf, 1) + `"`,
 	} {
 		if !strings.Contains(ir, want) {
 			t.Fatalf("missing %s in static itab IR:\n%s", want, ir)
@@ -741,6 +787,15 @@ func TestDevLTOGlobalDCEConcreteInterfaceEmitsStaticItabTemplate(t *testing.T) {
 	}
 	if !strings.Contains(ir, `call ptr @"github.com/xgo-dev/llgo/runtime/internal/runtime.NewItab"`) {
 		t.Fatalf("static itab template replaced NewItab before LTO proof:\n%s", ir)
+	}
+	for _, typeID := range []string{
+		prog.interfaceMethodCapabilityKey(intf, 0),
+		methodCapabilityKey(interfaceMethodM),
+	} {
+		if !strings.Contains(ir, `call { ptr, i1 } @llvm.type.checked.load`+"(") ||
+			!strings.Contains(ir, `metadata !"`+typeID+`"`) {
+			t.Fatalf("missing checked load for %s:\n%s", typeID, ir)
+		}
 	}
 }
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -887,6 +887,22 @@ func TestDevLTOGlobalDCEAddMethodTypeMetadataEarlyReturns(t *testing.T) {
 	}
 }
 
+func TestDevLTOGlobalDCEAddInterfaceTypeMetadataEarlyReturns(t *testing.T) {
+	requireGoGlobalDCE(t)
+
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("main", "main")
+	g := pkg.NewVarEx("g", prog.Pointer(prog.Int()))
+
+	prog.addInterfaceTypeMetadata(g.impl, nil)
+	prog.addInterfaceTypeMetadata(g.impl, types.NewInterfaceType(nil, nil).Complete())
+
+	ir := pkg.String()
+	if strings.Contains(ir, "!llgo.interface.") {
+		t.Fatalf("early-return paths should not attach interface metadata:\n%s", ir)
+	}
+}
+
 func TestDevLTOGlobalDCEAddMethodTypeMetadataMarksIFnAndTFnForReflectContexts(t *testing.T) {
 	requireGoGlobalDCE(t)
 


### PR DESCRIPTION
## Summary

- make ordinary interface checked loads use interface-and-method-specific type IDs when the Full LTO plugin is enabled
- attach the complete interface method declaration directly to each checked load as versioned call-site string attributes
- have the LTO plugin materialize exact IDs only on descriptors that implement the complete interface method set, then remove the temporary attributes before the normal optimization pipeline
- avoid materializing or explicitly preserving interface type descriptors solely for plugin analysis
- normalize ABI closure structs back to source-level function signatures when matching method capabilities
- remove unused exact type-ID export aliases at the final Full LTO extension point

Zero-implementer cases retain the previous signature-wide capability as a conservative fallback.

## Validation

On Ubuntu amd64 with LLVM 19 and Go 1.26.5, using a fresh cache after rebasing onto the latest `main`:

- `TestDevLTOGlobalDCE*` across `ssa`, `internal/build`, `internal/crosscompile`, `cmd/internal/flags`, and `internal/cabi`
- `TestRunAndTestFromTestlto/globaldce_*`
- `TestBuildAndCheckSymbolsFromTestlto/globaldce_*`
- all `TestLTOPlugin*` plus the LTO-plugin runtime and symbol suites

The cross-package fixture emits the checked load in a dependency and the concrete descriptor in `main`; Full LTO preserves the call attributes, produces `7 true true 13`, keeps `Cross.M`, and drops `Cross.N`.

Earlier end-to-end validation also covered the full `k8s.io/client-go/util/workqueue` suite, zap startup, `TestArrayWrappers`, and the reflection-backed matcher methods.