### PR TITLE
ci: collect compiler cross-package coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -145,16 +145,6 @@ jobs:
           "${go_test[@]}" -timeout 45m -vet=off \
             -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
 
-          # ssa is covered by both its own tests and the cl fixture runner.
-          # Merge duplicate blocks by summing their atomic counters so the
-          # combined profile remains valid for both Go tooling and Codecov.
-          {
-            echo 'mode: atomic'
-            awk 'FNR > 1 { counts[$1 " " $2] += $3 } END { for (block in counts) print block, counts[block] }' \
-              coverage-main.txt coverage-compiler.txt coverage-test-go.txt \
-              | LC_ALL=C sort
-          } > coverage.txt
-
       - name: Test with embedded emulator env
         env:
           LLGO_EMBED_TESTS: "1"
@@ -169,7 +159,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          files: coverage.txt
+          files: coverage-main.txt,coverage-compiler.txt,coverage-test-go.txt
           disable_search: true
 
   dev-lto-globaldce:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -131,14 +131,29 @@ jobs:
           # for every other package, and disable vet only for that package.
           go list ./... \
             | grep -v '^github.com/xgo-dev/llgo/test/go$' \
+            | grep -v '^github.com/xgo-dev/llgo/cl$' \
             | xargs "${go_test[@]}" -timeout 45m -coverprofile="coverage-main.txt" -covermode=atomic \
                 -bench '^BenchmarkGo126' -benchtime=1x
+
+          # Compiler fixtures owned by cl exercise ssa in-process. Instrument
+          # both packages in this single test binary so coverage follows those
+          # calls without restoring duplicate fixture tests under ssa.
+          "${go_test[@]}" -timeout 45m \
+            -coverpkg=github.com/xgo-dev/llgo/cl,github.com/xgo-dev/llgo/ssa \
+            -coverprofile="coverage-compiler.txt" -covermode=atomic \
+            -bench '^BenchmarkGo126' -benchtime=1x ./cl
           "${go_test[@]}" -timeout 45m -vet=off \
             -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
 
-          head -n 1 coverage-main.txt > coverage.txt
-          tail -n +2 coverage-main.txt >> coverage.txt
-          tail -n +2 coverage-test-go.txt >> coverage.txt
+          # ssa is covered by both its own tests and the cl fixture runner.
+          # Merge duplicate blocks by summing their atomic counters so the
+          # combined profile remains valid for both Go tooling and Codecov.
+          {
+            echo 'mode: atomic'
+            awk 'FNR > 1 { counts[$1 " " $2] += $3 } END { for (block in counts) print block, counts[block] }' \
+              coverage-main.txt coverage-compiler.txt coverage-test-go.txt \
+              | LC_ALL=C sort
+          } > coverage.txt
 
       - name: Test with embedded emulator env
         env:
@@ -154,6 +169,8 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+          files: coverage.txt
+          disable_search: true
 
   dev-lto-globaldce:
     name: Dev LTO GlobalDCE


### PR DESCRIPTION
## Summary

- run the `cl` coverage suite with both `cl` and `ssa` instrumented
- keep `ssa` unit tests in the general package batch, without restoring duplicate compiler fixture entry points
- upload the three explicit coverage profiles and let Codecov merge their package coverage

## Why

#2443 removed duplicate fixture runners from `ssa/cl_test.go`. The fixtures still run under `cl/compile_test.go`, but the existing package-local coverage command does not instrument the `ssa` dependency inside the `cl` test binary. That made executed SSA paths appear uncovered and reduced overall coverage by 2.40 percentage points.

This keeps fixture ownership and execution consolidated while preserving coverage across the `cl` to `ssa` package boundary. A single `-coverpkg=./...` invocation is deliberately avoided: Go copies the selected coverage metadata into every test binary, which substantially increases profile size and test overhead.

## Validation

- `go test -timeout 45m -coverpkg=github.com/xgo-dev/llgo/cl,github.com/xgo-dev/llgo/ssa -coverprofile=/tmp/llgo-cross-full-compiler.cover -covermode=atomic -bench '^BenchmarkGo126' -benchtime=1x ./cl`
- `go test -timeout 45m -coverprofile=/tmp/llgo-cross-full-ssa.cover -covermode=atomic -bench '^BenchmarkGo126' -benchtime=1x ./ssa`
- local union of both profiles: 96.3% across `cl` and `ssa`
- `ssa/python.go`: 92.7% after cross-package union, versus 11.02% in #2443's indirect-change report
- `git diff --check`
