### PR TITLE
ci: consolidate Go compatibility jobs

### DIFF
--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   goroot:
-    name: GOROOT (${{ matrix.lane }}, ${{ matrix.os }}${{ startsWith(matrix.os, 'windows') && format(', {0}', matrix.windows_abi) || '' }}, Go ${{ matrix.go-label }}, shard ${{ matrix.shard-index }}/4)
+    name: GOROOT (${{ matrix.os }}${{ startsWith(matrix.os, 'windows') && format(', {0}', matrix.windows_abi) || '' }}, Go current, shard ${{ matrix.shard-index }}/4)
     timeout-minutes: 180
     env:
       GOPROXY: https://proxy.golang.org,direct
@@ -24,29 +24,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build the runner with current Go, then exercise the current and
-        # previous supported GOROOT corpora. Windows keeps only the current
-        # corpus because ABI coverage is orthogonal to release compatibility.
+        # GOROOT is the compiler's primary compatibility suite, so run its
+        # complete corpus only with the current Go release. Older user-source
+        # releases have focused coverage in the LLGo workflow. Recent shards
+        # take 24-49 minutes each and are not short enough to combine.
         os: [macos-latest, ubuntu-latest, windows-2022]
         windows_abi: [msvc, mingw]
-        toolchain: [go1.26, current]
         shard-index: ["0", "1", "2", "3"]
-        include:
-          - toolchain: go1.26
-            go-version: "1.26.7"
-            go-label: "1.26.7"
-            lane: compatibility
-          - toolchain: current
-            go-version: ""
-            go-label: current
-            lane: primary
         exclude:
           - os: macos-latest
             windows_abi: mingw
           - os: ubuntu-latest
             windows_abi: mingw
-          - os: windows-2022
-            toolchain: go1.26
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -78,11 +67,6 @@ jobs:
           fi
           echo "LLGO_GOROOT_RUNNER=$runner" >> "$GITHUB_ENV"
           echo "LLGO_TEST_LLGO=$llgo" >> "$GITHUB_ENV"
-
-      - name: Set up target Go
-        uses: ./.github/actions/setup-go
-        with:
-          go-version: ${{ matrix.go-version }}
 
       - name: Show toolchain versions
         run: |
@@ -122,15 +106,11 @@ jobs:
         if: always()
         shell: bash
         env:
-          CONFIGURED_GO_VERSION: ${{ matrix.go-version }}
           MATRIX_OS: ${{ matrix.os }}
           WINDOWS_ABI: ${{ matrix.windows_abi }}
           SHARD_INDEX: ${{ matrix.shard-index }}
         run: |
-          GO_VERSION="$CONFIGURED_GO_VERSION"
-          if [[ -z "$GO_VERSION" ]]; then
-            GO_VERSION="$(tr -d '[:space:]' < .go-version)"
-          fi
+          GO_VERSION="$(tr -d '[:space:]' < .go-version)"
           log="$RUNNER_TEMP/goroot.log"
           report_dir="$RUNNER_TEMP/goroot-report"
           mkdir -p "$report_dir"
@@ -186,7 +166,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: goroot-stat-${{ matrix.os }}-${{ matrix.windows_abi }}-${{ matrix.toolchain }}-${{ matrix.shard-index }}
+          name: goroot-stat-${{ matrix.os }}-${{ matrix.windows_abi }}-current-${{ matrix.shard-index }}
           path: ${{ runner.temp }}/goroot-report
           if-no-files-found: error
           retention-days: 7
@@ -214,10 +194,10 @@ jobs:
           find reports -type f -name 'failures-*.tsv' -exec cat {} + >"$failure_tsv"
 
           report_count=$(wc -l <"$summary_tsv" | tr -d ' ')
-          compatibility_version=$(awk -F '\t' '$2 ~ /^1\.26\./ { print $2; exit }' "$summary_tsv")
-          primary_version=$(awk -F '\t' '$2 ~ /^1\.27\./ { print $2; exit }' "$summary_tsv")
-          if [[ -z "$compatibility_version" || -z "$primary_version" ]]; then
-            echo "error: could not determine compatibility and primary Go versions" >&2
+          primary_version=$(awk -F '\t' 'NR == 1 { print $2 }' "$summary_tsv")
+          version_count=$(awk -F '\t' '{ print $2 }' "$summary_tsv" | sort -u | wc -l | tr -d ' ')
+          if [[ -z "$primary_version" || "$version_count" -ne 1 ]]; then
+            echo "error: could not determine the primary Go version" >&2
             exit 1
           fi
           write_row() {
@@ -253,16 +233,12 @@ jobs:
           {
             echo '## GOROOT run summary'
             echo
-            echo "Received $report_count/24 shard reports."
+            echo "Received $report_count/16 shard reports."
             echo
             echo '| Platform / toolchain | Shards | Selected | Observed | Passed | Failed | Skipped |'
             echo '|---|---:|---:|---:|---:|---:|---:|'
-            write_row "Darwin · Go $compatibility_version" darwin/arm64 "$compatibility_version" 4
             write_row "Darwin · Go $primary_version" darwin/arm64 "$primary_version" 4
-            write_row '**Darwin total**' darwin/arm64 '' 8
-            write_row "Linux · Go $compatibility_version" linux/amd64 "$compatibility_version" 4
             write_row "Linux · Go $primary_version" linux/amd64 "$primary_version" 4
-            write_row '**Linux total**' linux/amd64 '' 8
             write_row "Windows MSVC · Go $primary_version" windows-msvc/amd64 "$primary_version" 4
             write_row "Windows MinGW · Go $primary_version" windows-mingw/amd64 "$primary_version" 4
             echo
@@ -279,8 +255,8 @@ jobs:
             fi
           } >>"$GITHUB_STEP_SUMMARY"
 
-          if [[ "$report_count" -ne 24 ]]; then
-            echo "error: expected 24 shard reports, got $report_count" >&2
+          if [[ "$report_count" -ne 16 ]]; then
+            echo "error: expected 16 shard reports, got $report_count" >&2
             exit 1
           fi
           if [[ "$GOROOT_RESULT" != success ]]; then

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -57,6 +57,19 @@ jobs:
           go install ./...
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
+      - name: Test Hello World with go.mod 1.21 through 1.26
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          for mod_version in 1.21 1.22 1.23 1.24 1.25 1.26; do
+            LLGO_HELLO_EMBED=false \
+              dev/with_go_version.sh 1.27 dev/test_helloworld.sh "$mod_version"
+          done
+
+      - name: Test Hello World with go.mod 1.27
+        shell: bash
+        run: dev/with_go_version.sh 1.27 dev/test_helloworld.sh 1.27
+
       - name: Test runtime module compatibility
         if: matrix.os == 'ubuntu-latest'
         run: dev/test_runtime_go_versions.sh
@@ -198,73 +211,18 @@ jobs:
       matrix:
         # LLGo and its checker are always built with .go-version. Each job then
         # selects a real target toolchain and matching alternate module file.
-        # Go 1.20-1.25 use focused compatibility sets; the two supported Go
-        # releases run the complete test tree.
+        # Go 1.20-1.26 share one focused compatibility lane. Go 1.27 is the
+        # primary release and runs the complete test tree on every native
+        # toolchain profile. Its Ubuntu shards remain separate because recent
+        # runs take about 25 minutes each and would exceed 30 minutes combined.
         include:
           - os: ubuntu-latest
             llvm: 19
-            go_version: "1.20"
+            go_version: "1.20-1.26"
             lane: compatibility
             shard_index: "0"
             shard_total: "1"
             check_symbols: true
-          - os: macos-latest
-            llvm: 19
-            go_version: "1.21"
-            lane: compatibility
-            shard_index: "0"
-            shard_total: "1"
-            check_symbols: true
-          - os: ubuntu-latest
-            llvm: 19
-            go_version: "1.22"
-            lane: compatibility
-            shard_index: "0"
-            shard_total: "1"
-            check_symbols: true
-          - os: macos-latest
-            llvm: 19
-            go_version: "1.23"
-            lane: compatibility
-            shard_index: "0"
-            shard_total: "1"
-            check_symbols: true
-          - os: ubuntu-latest
-            llvm: 19
-            go_version: "1.24"
-            lane: compatibility
-            shard_index: "0"
-            shard_total: "1"
-            check_symbols: true
-          - os: macos-latest
-            llvm: 19
-            go_version: "1.25"
-            lane: compatibility
-            shard_index: "0"
-            shard_total: "1"
-            check_symbols: true
-          # In-command package parallelism lets Ubuntu use two shards while
-          # retaining headroom for serial standard-library build-mode checks.
-          - os: ubuntu-latest
-            llvm: 19
-            go_version: "1.26"
-            lane: full
-            shard_index: "0"
-            shard_total: "2"
-            check_symbols: true
-          - os: ubuntu-latest
-            llvm: 19
-            go_version: "1.26"
-            lane: full
-            shard_index: "1"
-            shard_total: "2"
-            check_symbols: true
-          - os: macos-latest
-            llvm: 19
-            go_version: "1.26"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
           - os: ubuntu-latest
             llvm: 19
             go_version: "1.27"
@@ -323,6 +281,7 @@ jobs:
         shell: bash
         run: |
           dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
+          echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
       - name: Check Windows native runtime and FFI
@@ -336,6 +295,8 @@ jobs:
 
       - name: Run versioned LLGo tests
         env:
+          # The multi-version driver gives every target release an isolated
+          # XDG cache, so package reuse stays safe inside the consolidated job.
           LLGO_BUILD_CACHE: "1"
           LLGO_TEST_BENCH_GO126: "1"
           LLGO_TEST_CHECK_SYMBOLS: ${{ matrix.check_symbols && '1' || '0' }}
@@ -355,117 +316,19 @@ jobs:
           export LLGO="$RUNNER_TEMP/llgo-bin/llgo${tool_suffix}"
           export LLGO_TEST_LLGEN="$RUNNER_TEMP/llgo-bin/llgen${tool_suffix}"
           export CHECK_STD_SYMBOLS="$RUNNER_TEMP/llgo-bin/check_std_symbols${tool_suffix}"
-          dev/test_go_version.sh "${{ matrix.go_version }}"
+          if [[ "${{ matrix.lane }}" == compatibility ]]; then
+            dev/test_go_versions.sh 1.20 1.21 1.22 1.23 1.24 1.25 1.26
+          else
+            dev/test_go_version.sh "${{ matrix.go_version }}"
+          fi
 
-  hello:
-    name: hello (${{ matrix.lane }}, ${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go_version }})
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            llvm: 19
-            go_version: "1.20"
-            lane: compatibility
-          - os: ubuntu-latest
-            llvm: 19
-            go_version: "1.27"
-            lane: primary
-          - os: macos-latest
-            llvm: 19
-            go_version: "1.27"
-            lane: primary
-          - os: windows-2022
-            llvm: 19
-            go_version: "1.27"
-            lane: primary
-            windows_abi: msvc
-          - os: windows-2022
-            llvm: 19
-            go_version: "1.27"
-            lane: primary
-            windows_abi: mingw
-    runs-on: ${{matrix.os}}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install dependencies
-        uses: ./.github/actions/setup-deps
-        with:
-          llvm-version: ${{matrix.llvm}}
-          windows-abi: ${{ matrix.windows_abi || 'msvc' }}
-
-      - name: Set up Go for building llgo
-        uses: ./.github/actions/setup-go
-
-      - name: Install llgo
-        shell: bash
-        run: |
-          dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
-          echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
-          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-
-      - name: Test Hello World with go.mod 1.20
-        if: matrix.go_version == '1.20'
+      - name: Test Hello World with Go 1.20
+        if: matrix.lane == 'compatibility'
         uses: ./.github/actions/test-helloworld
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: "1.20"
           embedded: "false"
           mod-version: "1.20"
-
-      - name: Test Hello World with go.mod 1.21
-        if: matrix.os == 'ubuntu-latest' && matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          embedded: "false"
-          mod-version: "1.21"
-
-      - name: Test Hello World with go.mod 1.22
-        if: matrix.os == 'ubuntu-latest' && matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          embedded: "false"
-          mod-version: "1.22"
-
-      - name: Test Hello World with go.mod 1.23
-        if: matrix.os == 'ubuntu-latest' && matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          embedded: "false"
-          mod-version: "1.23"
-
-      - name: Test Hello World with go.mod 1.24
-        if: matrix.os == 'ubuntu-latest' && matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          embedded: "false"
-          mod-version: "1.24"
-
-      - name: Test Hello World with go.mod 1.25
-        if: matrix.os == 'ubuntu-latest' && matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          embedded: "false"
-          mod-version: "1.25"
-
-      - name: Test Hello World with go.mod 1.26
-        if: matrix.os == 'ubuntu-latest' && matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          embedded: "false"
-          mod-version: "1.26"
-
-      - name: Test Hello World with go.mod 1.27
-        if: matrix.go_version == '1.27'
-        uses: ./.github/actions/test-helloworld
-        with:
-          go-version: ${{ matrix.go_version }}
-          mod-version: "1.27"
 
   cross-compile:
     timeout-minutes: 30
@@ -511,14 +374,8 @@ jobs:
           iwasm --stack-size=819200000 --heap-size=800000000 hello.wasm
 
   wasm-runtime:
-    name: wasm-runtime (Go ${{ matrix.go_version }})
+    name: wasm-runtime (Go 1.24 and 1.27)
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - go_version: "1.24"
-          - go_version: "1.27"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -544,5 +401,5 @@ jobs:
         shell: bash
         env:
           LLGO: ${{ runner.temp }}/llgo-bin/llgo
-          LLGO_BUILD_CACHE: "1"
-        run: dev/test_wasm_runtime_go_version.sh "${{ matrix.go_version }}"
+          LLGO_BUILD_CACHE: "off"
+        run: dev/test_wasm_runtime_go_versions.sh 1.24 1.27

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -205,7 +205,7 @@ jobs:
 
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}, Go ${{ matrix.go_version }}, shard ${{ matrix.shard_index }}/${{ matrix.shard_total }})
-    timeout-minutes: ${{ matrix.lane == 'full' && (startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 45 || 40) || 30 }}
+    timeout-minutes: ${{ startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 45 || 40 }}
     strategy:
       fail-fast: false
       matrix:
@@ -295,8 +295,8 @@ jobs:
 
       - name: Run versioned LLGo tests
         env:
-          # The multi-version driver gives every target release an isolated
-          # XDG cache, so package reuse stays safe inside the consolidated job.
+          # The compatibility driver gives every target release an isolated
+          # XDG cache. Full lanes run one target release per runner job.
           LLGO_BUILD_CACHE: "1"
           LLGO_TEST_BENCH_GO126: "1"
           LLGO_TEST_CHECK_SYMBOLS: ${{ matrix.check_symbols && '1' || '0' }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ LLGo is compatible with the C ecosystem through the C **Application Binary Inter
 
 LLGo is compatible with Go 1.20+ source code and supports the complete Go 1.27 language syntax, as well as `cgo`.
 
-Compatibility is checked against applicable upstream [`GOROOT/test`](test/goroot/README.md) cases using pinned Go 1.26 and Go 1.27 toolchains. User projects and packages under `test/` are additionally tested with exact Go 1.20 through Go 1.27 toolchains. Remaining applicable differences are recorded in [`xfail.yaml`](test/goroot/xfail.yaml); gc-specific mechanisms outside LLGo's compatibility goals are documented in [`notapplicable.yaml`](test/goroot/notapplicable.yaml).
+Compiler compatibility is checked against applicable upstream [`GOROOT/test`](test/goroot/README.md) cases using the pinned Go 1.27 toolchain. User projects and packages under `test/` are additionally tested with exact Go 1.20 through Go 1.27 toolchains. Remaining applicable differences are recorded in [`xfail.yaml`](test/goroot/xfail.yaml); gc-specific mechanisms outside LLGo's compatibility goals are documented in [`notapplicable.yaml`](test/goroot/notapplicable.yaml).
 
 ### Runtime
 
@@ -47,7 +47,7 @@ llgo run -tags nogc .
 
 ### Standard libraries
 
-LLGo fully supports the Go standard library on supported native platforms. CI requires compatibility coverage for every public package and exported symbol in the primary Go toolchain, and runs [`test/std`](test/std/README.md) with both supported toolchains.
+LLGo fully supports the Go standard library on supported native platforms. CI requires compatibility coverage for every public package and exported symbol in the primary Go toolchain, and runs focused [`test/std`](test/std/README.md) compatibility sets with each older supported toolchain.
 
 Other targets may not provide every OS service or implementation-specific runtime behavior.
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -66,8 +66,9 @@ Run the complete Go 1.20 through Go 1.27 integration matrix:
 ```
 
 This integration command is intentionally sequential and may take tens of
-minutes locally. CI invokes `test_go_version.sh` in separate versioned jobs
-instead of running the full integration script in one job.
+minutes locally. CI uses the same driver to consolidate the focused Go 1.20
+through Go 1.26 compatibility sets in one job; Go 1.27 runs the complete test
+tree in the primary platform matrix.
 
 The corresponding wasm runtime commands are:
 

--- a/dev/test_go_version.sh
+++ b/dev/test_go_version.sh
@@ -117,7 +117,7 @@ if [[ "${#requested_packages[@]}" -eq 0 ]]; then
 			;;
 		1.25)
 			# Cover every package with Go 1.25-specific symbol checks without
-			# repeating the full test tree reserved for supported releases.
+			# repeating the full test tree reserved for the primary release.
 			requested_packages=(
 				./test/std/crypto
 				./test/std/crypto/ecdsa
@@ -139,6 +139,33 @@ if [[ "${#requested_packages[@]}" -eq 0 ]]; then
 				./test/std/testing/fstest
 				./test/std/testing/synctest
 				./test/std/unicode
+				./test/goroot
+			)
+			;;
+		1.26)
+			# Keep the compatibility lane focused on packages that contain Go
+			# 1.26-specific checks. Go 1.27 owns the complete test matrix.
+			requested_packages=(
+				./test/std/bytes
+				./test/std/crypto
+				./test/std/crypto/ecdh
+				./test/std/crypto/fips140
+				./test/std/crypto/hpke
+				./test/std/crypto/mlkem
+				./test/std/crypto/mlkem/mlkemtest
+				./test/std/crypto/rsa
+				./test/std/crypto/x509
+				./test/std/errors
+				./test/std/go/ast
+				./test/std/go/token
+				./test/std/log/slog
+				./test/std/net
+				./test/std/net/http
+				./test/std/net/netip
+				./test/std/os
+				./test/std/reflect
+				./test/std/testing
+				./test/std/testing/cryptotest
 				./test/goroot
 			)
 			;;

--- a/dev/test_go_versions.sh
+++ b/dev/test_go_versions.sh
@@ -26,9 +26,14 @@ if [[ -z "${llgo_cmd}" || ( "${check_symbols}" == 1 && -z "${check_std_symbols}"
 	fi
 fi
 
+failed_versions=()
 for version in "${versions[@]}"; do
 	echo
 	echo "==== test/ with Go ${version} ===="
+	# LLGo's cache contains target-standard-library objects. Keep one cache per
+	# release so callers can enable package reuse without crossing Go versions.
+	version_cache_dir="${work_dir}/cache/go${version}"
+	mkdir -p "${version_cache_dir}"
 	std_buildmodes="${LLGO_TEST_STD_BUILDMODES:-}"
 	if [[ -z "${std_buildmodes}" ]]; then
 		case "${version}" in
@@ -36,10 +41,20 @@ for version in "${versions[@]}"; do
 			*) std_buildmodes=0 ;;
 		esac
 	fi
-	LLGO="${llgo_cmd}" \
+	if ! XDG_CACHE_HOME="${version_cache_dir}" \
+		LLGO="${llgo_cmd}" \
 		CHECK_STD_SYMBOLS="${check_std_symbols}" \
 		LLGO_TEST_BENCH_GO126="${LLGO_TEST_BENCH_GO126:-1}" \
 		LLGO_TEST_CHECK_SYMBOLS="${check_symbols}" \
 		LLGO_TEST_STD_BUILDMODES="${std_buildmodes}" \
-		dev/test_go_version.sh "${version}"
+		dev/test_go_version.sh "${version}"; then
+		failed_versions+=("${version}")
+	fi
 done
+
+if [[ ${#failed_versions[@]} -ne 0 ]]; then
+	printf 'versioned test failures:' >&2
+	printf ' Go %s' "${failed_versions[@]}" >&2
+	printf '\n' >&2
+	exit 1
+fi

--- a/dev/test_go_versions.sh
+++ b/dev/test_go_versions.sh
@@ -30,8 +30,8 @@ failed_versions=()
 for version in "${versions[@]}"; do
 	echo
 	echo "==== test/ with Go ${version} ===="
-	# LLGo's cache contains target-standard-library objects. Keep one cache per
-	# release so callers can enable package reuse without crossing Go versions.
+	# LLGo's cache contains target-standard-library objects. When callers opt in
+	# with LLGO_BUILD_CACHE=1, keep reuse from crossing Go versions.
 	version_cache_dir="${work_dir}/cache/go${version}"
 	mkdir -p "${version_cache_dir}"
 	std_buildmodes="${LLGO_TEST_STD_BUILDMODES:-}"

--- a/test/README.md
+++ b/test/README.md
@@ -7,10 +7,12 @@ uses a temporary alternate module file whose `go` directive matches the target
 release and sets `GOTOOLCHAIN=local`, so a test cannot silently upgrade or
 downgrade to another toolchain.
 
-Go 1.26 and Go 1.27 run all packages on Linux and macOS, and Go 1.27 also runs
-on both Windows ABI profiles. To limit runner usage, Go 1.20 through Go 1.25
-each run a representative package set, alternating between Linux and macOS.
-Tests for APIs introduced by a newer Go release belong
+Go 1.27 runs all packages on Linux, macOS, and both Windows ABI profiles. To
+limit runner usage, Go 1.20 through Go 1.26 share one sequential Linux job and
+each run a representative package set containing their release-specific
+checks. Platform behavior is covered by the primary Go 1.27 matrix rather than
+forming a Cartesian product of every Go version and platform. Tests for APIs
+introduced by a newer Go release belong
 in files with standard release tags such as `//go:build go1.24`; the selected Go
 toolchain then includes those files automatically. Symbol-coverage checks use
 the same toolchain and tags.
@@ -31,9 +33,10 @@ dev/test_go_version.sh 1.24 ./test/std/bytes ./test/goroot
 dev/test_go_versions.sh
 ```
 
-The complete local matrix is sequential and may take tens of minutes. CI runs
-the versions in separate jobs, with the full Go 1.26 and Go 1.27 package sets
-sharded on Linux.
+The complete local matrix is sequential and may take tens of minutes. CI also
+runs Go 1.20 through Go 1.26 sequentially in one compatibility job, while the
+full Go 1.27 package set is sharded on Linux and runs once on each other native
+toolchain profile.
 
 The runner downloads an exact toolchain when needed, builds llgo itself with
 the `.go-version` toolchain, and leaves the working tree unchanged. Set `LLGO`

--- a/test/std/README.md
+++ b/test/std/README.md
@@ -1,6 +1,6 @@
 # Standard Library Compatibility Tests
 
-This directory contains compatibility tests for the Go standard library on llgo. The tests run with real Go 1.20 through Go 1.27 toolchains and matching module versions, so release tags and available standard-library APIs reflect the version being checked. Go 1.26 and Go 1.27 receive full coverage on Linux and macOS; each earlier version runs a representative, resource-bounded package set on one platform.
+This directory contains compatibility tests for the Go standard library on llgo. The tests run with real Go 1.20 through Go 1.27 toolchains and matching module versions, so release tags and available standard-library APIs reflect the version being checked. Go 1.27 receives full coverage on Linux, macOS, and both Windows ABI profiles; Go 1.20 through Go 1.26 each run a representative, resource-bounded package set in one consolidated Linux job.
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary

- build LLGo and its test tools only with the pinned Go 1.27 toolchain
- consolidate the focused Go 1.20 through Go 1.26 user-code checks into one Ubuntu job while still selecting every exact target toolchain and matching module directive
- keep Go 1.27 as the primary full matrix: two Ubuntu shards, macOS, Windows MSVC, and Windows MinGW
- fold Hello World smoke tests into their matching compiler/compatibility jobs and combine the two short wasm-runtime jobs
- run the scheduled full GOROOT corpus only with Go 1.27; Go 1.26 now follows the same focused compatibility policy as the other older releases

## Coverage and job count

| Area | Before | After |
| --- | ---: | ---: |
| LLGo workflow jobs | 26 | 12 |
| `test/` matrix jobs | 14 | 6 |
| standalone Hello jobs | 5 | 0 |
| wasm-runtime jobs | 2 | 1 |
| scheduled GOROOT shard jobs | 24 | 16 |
| PR checks | 65 | 51 |

## CI result

All 50 executed checks passed; the release-only job was skipped as expected for a pull request.

The event-matched baseline is the final successful #2448 pull-request run. It contains the same code as this PR's base without mixing push-only behavior into the primary comparison.

| Metric | #2448 baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| LLGo workflow runner time | 272.1 min | 206.6 min | -65.5 min (-24.1%) |
| LLGo workflow wall time | 41.4 min | 33.2 min | -8.2 min (-19.8%) |
| Ten core workflows runner time | 525.1 min | 461.6 min | -63.5 min (-12.1%) |
| End-to-end CI wall time | 42.6 min | 36.8 min | -5.9 min (-13.8%) |
| Workflow jobs | 64 | 50 | -14 (-21.9%) |

The current `main` push at base commit `c4941f9ae` gives the same conclusion: LLGo runner time fell from 279.1 to 206.6 minutes (-26.0%), LLGo wall time from 42.6 to 33.2 minutes (-22.1%), and the ten core workflows from 525.5 to 461.6 runner-minutes (-12.2%).

Within the LLGo workflow, the base-main comparison is:

| Area | Base runner time | This PR | Change |
| --- | ---: | ---: | ---: |
| Compiler platform jobs plus Hello jobs | 76.6 min | 56.5 min | -20.1 min (-26.2%) |
| Go 1.20-1.26 compatibility coverage | 65.6 min | 15.45 min | -50.1 min (-76.4%) |
| Go 1.27 full platform matrix | 130.25 min | 130.33 min | +0.08 min (unchanged) |
| wasm runtime | 4.80 min | 2.82 min | -1.98 min (-41.3%) |

The consolidated compatibility job passed in 15m27s. The two Go 1.27 Ubuntu shards passed in 20m20s and 24m39s, or about 45 minutes combined, confirming that they should remain separate.

Primary platform coverage is unchanged: Go 1.27 still builds and tests LLGo on Linux, macOS, Windows MSVC, and Windows MinGW. The removed combinations are the older-Go/platform Cartesian product; Go 1.20 through Go 1.26 remain covered as exact user-code compatibility targets in the consolidated Linux job.

The two Go 1.27 Ubuntu full-test shards remain separate. Their measured combined time in this PR is about 45 minutes. Scheduled GOROOT shards also remain at four per platform because recent shard durations were 24-49 minutes; the new 16-job scheduled matrix has not run yet, so no measured GOROOT time saving is claimed here.

The multi-version driver assigns each target release an isolated XDG cache and continues after an individual version fails, reporting all failed versions at the end.

## Validation

- `actionlint .github/workflows/llgo.yml .github/workflows/goroot.yml`
- `shellcheck -x dev/test_go_version.sh dev/test_go_versions.sh dev/test_wasm_runtime_go_versions.sh dev/test_helloworld.sh`
- `LLGO_BUILD_CACHE=off LLGO_TEST_JOBS=3 dev/test_go_versions.sh 1.20 1.21 1.22 1.23 1.24 1.25 1.26`
  - all seven exact toolchains passed locally in 26m28s
  - peak resident memory: about 2.55 GB
  - this is a conservative no-cache run; the Ubuntu CI job uses an isolated cache per Go release
- verified that the Go 1.26 focused list contains all 20 `test/std` directories with `//go:build go1.26` tests
- injected failures for Go 1.20 and Go 1.21 and verified that both versions ran and were reported together
