### PR TITLE
test: avoid scheduler races in context waits

### DIFF
--- a/test/std/context/context_test.go
+++ b/test/std/context/context_test.go
@@ -7,6 +7,30 @@ import (
 	"time"
 )
 
+func requireDone(t *testing.T, done <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-done:
+	default:
+		t.Fatal(message)
+	}
+}
+
+func waitDone(t *testing.T, done <-chan struct{}, timeout time.Duration, message string) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		// The test goroutine may be descheduled after both channels become
+		// ready. Recheck the success condition so select's random choice does
+		// not turn scheduler latency into a false timeout.
+		requireDone(t, done, message)
+	}
+}
+
 func TestBackground(t *testing.T) {
 	ctx := context.Background()
 	if ctx == nil {
@@ -151,12 +175,7 @@ func TestAfterFunc(t *testing.T) {
 
 	cancel()
 
-	select {
-	case <-called:
-		// OK
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("AfterFunc not called after cancel")
-	}
+	waitDone(t, called, 5*time.Second, "AfterFunc not called after cancel")
 
 	if stop() {
 		t.Error("stop() returned true, want false")
@@ -181,11 +200,7 @@ func TestWithCancelCause(t *testing.T) {
 	testErr := errors.New("test error") // Modified
 	cancel(testErr)
 
-	select {
-	case <-ctx.Done():
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("context not canceled")
-	}
+	requireDone(t, ctx.Done(), "context not canceled")
 
 	if ctx.Err() != context.Canceled {
 		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.Canceled)
@@ -201,11 +216,7 @@ func TestWithDeadline(t *testing.T) {
 	ctx, cancel := context.WithDeadline(parent, time.Now().Add(-time.Hour))
 	defer cancel()
 
-	select {
-	case <-ctx.Done():
-	case <-time.After(10 * time.Millisecond):
-		t.Fatal("context not canceled immediately")
-	}
+	requireDone(t, ctx.Done(), "context not canceled immediately")
 
 	if ctx.Err() != context.DeadlineExceeded {
 		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.DeadlineExceeded)
@@ -222,8 +233,6 @@ func TestWithDeadline(t *testing.T) {
 		// OK
 	}
 
-	select {
-	case <-ctx.Done():
 	// Do not use another deadline-sized timer as the failure bound here.
 	// Delivering a timer callback requires the runtime goroutine to be
 	// scheduled, and on a loaded Windows host or VM even the official Go
@@ -231,9 +240,7 @@ func TestWithDeadline(t *testing.T) {
 	// context cancellation test instead of turning it into a scheduler latency
 	// test; the preceding select still verifies that the 100ms deadline does
 	// not fire during its first 50ms.
-	case <-time.After(time.Second):
-		t.Fatal("context not canceled after deadline")
-	}
+	waitDone(t, ctx.Done(), time.Second, "context not canceled after deadline")
 
 	if ctx.Err() != context.DeadlineExceeded {
 		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.DeadlineExceeded)
@@ -246,11 +253,7 @@ func TestWithDeadlineCause(t *testing.T) {
 	ctx, cancel := context.WithDeadlineCause(parent, time.Now().Add(-time.Hour), testErr)
 	defer cancel()
 
-	select {
-	case <-ctx.Done():
-	case <-time.After(10 * time.Millisecond):
-		t.Fatal("context not canceled immediately")
-	}
+	requireDone(t, ctx.Done(), "context not canceled immediately")
 
 	if ctx.Err() != context.DeadlineExceeded {
 		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.DeadlineExceeded)
@@ -266,11 +269,7 @@ func TestWithTimeoutCause(t *testing.T) {
 	ctx, cancel := context.WithTimeoutCause(parent, -time.Hour, testErr) // Timeout in the past
 	defer cancel()
 
-	select {
-	case <-ctx.Done():
-	case <-time.After(10 * time.Millisecond):
-		t.Fatal("context not canceled immediately")
-	}
+	requireDone(t, ctx.Done(), "context not canceled immediately")
 
 	if ctx.Err() != context.DeadlineExceeded {
 		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.DeadlineExceeded)

--- a/test/std/context/context_test.go
+++ b/test/std/context/context_test.go
@@ -24,9 +24,9 @@ func waitDone(t *testing.T, done <-chan struct{}, timeout time.Duration, message
 	case <-done:
 		return
 	case <-timer.C:
-		// The test goroutine may be descheduled after both channels become
-		// ready. Recheck the success condition so select's random choice does
-		// not turn scheduler latency into a false timeout.
+		// The timeout may be selected just as done becomes ready. Observe done
+		// once more before reporting failure so scheduler latency and select's
+		// choice cannot turn an observable completion into a false timeout.
 		requireDone(t, done, message)
 	}
 }


### PR DESCRIPTION
## Summary

- check already-canceled contexts synchronously instead of racing `Done` against a newly created short timer
- give asynchronous `AfterFunc` delivery a realistic bound and recheck the success channel if the timeout case is selected
- apply the synchronous assertion consistently to cancel and past-deadline cases

This changes tests only; it does not relax or modify `context`, timer, or scheduler semantics.

## Why

The Windows MinGW full-test lane in cpunion/llgo#208 reported `TestAfterFunc` and `TestWithTimeoutCause`, then passed unchanged on rerun. `WithTimeoutCause(parent, -time.Hour, cause)` closes `Done` before returning. In the old assertion, `time.After(10ms)` was created while entering the select; if the test goroutine was descheduled long enough, both channels were ready and Go could legally choose the timeout case. The 100ms asynchronous callback bound had the same scheduler sensitivity.

The immediate cases now verify the stronger contract directly with a nonblocking receive. The asynchronous helper also checks `Done` again before reporting a timeout, so a random select choice cannot produce a false failure.

## Validation

- `go test ./test/std/context -count=100`
- `go test -race ./test/std/context -count=10`
- unchanged failed jobs from [cpunion/llgo#208](https://github.com/cpunion/llgo/pull/208) both passed on rerun: macOS LLGo and Windows MinGW full tests