### PR TITLE
cabi: prove parameter storage reuse

### DIFF
--- a/internal/build/large_array_return_test.go
+++ b/internal/build/large_array_return_test.go
@@ -24,7 +24,7 @@ func TestLargeArrayReturn(t *testing.T) {
 	if len(lines) < 2 {
 		t.Fatalf("output has fewer than two lines: %q", lines)
 	}
-	if got, want := strings.Join(lines[len(lines)-2:], "\n"), "99 0 0 0 98 98 6\n97"; got != want {
+	if got, want := strings.Join(lines[len(lines)-2:], "\n"), "99 0 0 0 98 98 6 1\n97"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 }

--- a/internal/build/testdata/largearrayreturn/main.go
+++ b/internal/build/testdata/largearrayreturn/main.go
@@ -4,12 +4,22 @@ const size = 128*1024 + 1
 
 type params struct{ x, y, z int }
 
+type versionLike struct {
+	major, minor, patch     uint64
+	pre, metadata, original string
+}
+
 func main() {
 	a := f(1, 99)
 	b := g(size-1, 98)
 	c := h(size-1, 98)
 	d := withAggregateParam(params{1, 2, 3})
-	println(a[1], b[1], c[1], a[size-1], b[size-1], c[size-1], d[0])
+	v := versionLike{major: 1, minor: 2, patch: 3, original: "v1.2.3"}.setPrerelease("beta")
+	e := 0
+	if v.pre == "beta" && v.original == "vbeta" {
+		e = 1
+	}
+	println(a[1], b[1], c[1], a[size-1], b[size-1], c[size-1], d[0], e)
 	println(f(1, 97)[1])
 }
 
@@ -36,4 +46,18 @@ func h(i, y int) (a [size]byte) {
 func withAggregateParam(p params) (a [size]byte) {
 	a[0] = byte(p.x + p.y + p.z)
 	return
+}
+
+func (v versionLike) originalVPrefix() string {
+	if v.original != "" && v.original[:1] == "v" {
+		return "v"
+	}
+	return ""
+}
+
+func (v versionLike) setPrerelease(pre string) versionLike {
+	vNext := v
+	vNext.pre = pre
+	vNext.original = v.originalVPrefix() + vNext.pre
+	return vNext
 }

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -576,28 +576,36 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 			// call void @llvm.memset(ptr %2, i8 0, i64 36, i1 false)
 			// store %typ %1, ptr %2, align 4
 			nv = aggregateFromNative(b, ti, loadIndirectParam(b, ti, params[index]))
-			// replace %0 to %2
-			if p.optimize && !ti.hasNativeLayoutConversion() && (ti.ByValAlign == 0 || ti.ByValAlign >= ti.Align) {
-				replaceAllocaInstrs(fn.Param(i), params[index])
+			// Reuse the incoming ABI storage for one proven parameter home.
+			if p.optimize && !ti.hasNativeLayoutConversion() {
+				storageAlign := ti.Align
+				if ti.ByValAlign != 0 {
+					storageAlign = ti.ByValAlign
+				}
+				reuseParamHome(fn.Param(i), params[index], nfn.EntryBasicBlock(), ti.Align, storageAlign)
 			}
 		case AttrWidthType:
 			iptr := llvm.CreateAlloca(b, ti.Type1)
+			storageAlign := max(ti.Align, p.Alignof(ti.Type1))
+			iptr.SetAlignment(storageAlign)
 			b.CreateStore(params[index], iptr)
 			ptr := b.CreateBitCast(iptr, llvm.PointerType(ti.nativeType(), 0), "")
 			nv = aggregateFromNative(b, ti, b.CreateLoad(ti.nativeType(), ptr, ""))
 			if p.optimize && !ti.hasNativeLayoutConversion() {
-				replaceAllocaInstrs(fn.Param(i), ptr)
+				reuseParamHome(fn.Param(i), ptr, nfn.EntryBasicBlock(), ti.Align, storageAlign)
 			}
 		case AttrWidthType2:
 			typ := ctx.StructType([]llvm.Type{ti.Type1, ti.Type2}, false)
 			iptr := llvm.CreateAlloca(b, typ)
+			storageAlign := max(ti.Align, p.Alignof(typ))
+			iptr.SetAlignment(storageAlign)
 			b.CreateStore(params[index], b.CreateStructGEP(typ, iptr, 0, ""))
 			index++
 			b.CreateStore(params[index], b.CreateStructGEP(typ, iptr, 1, ""))
 			ptr := b.CreateBitCast(iptr, llvm.PointerType(ti.nativeType(), 0), "")
 			nv = aggregateFromNative(b, ti, b.CreateLoad(ti.nativeType(), ptr, ""))
 			if p.optimize && !ti.hasNativeLayoutConversion() {
-				replaceAllocaInstrs(fn.Param(i), ptr)
+				reuseParamHome(fn.Param(i), ptr, nfn.EntryBasicBlock(), ti.Align, storageAlign)
 			}
 		case AttrExtract:
 			nsubs := ti.nativeType().StructElementTypesCount()
@@ -851,38 +859,94 @@ func (p *Transformer) callMemcpy(_ llvm.Module, ctx llvm.Context, b llvm.Builder
 	}, "")
 }
 
-func replaceAllocaInstrs(param llvm.Value, nv llvm.Value) {
-	u := param.FirstUse()
-	var storeInstrs []llvm.Value
-	for !u.IsNil() {
-		if user := u.User().IsAStoreInst(); !user.IsNil() && user.Operand(0) == param {
-			storeInstrs = append(storeInstrs, user)
+// reuseParamHome replaces at most one local copy of param with storage. The
+// incoming ABI storage can stand in for one parameter home, but independent
+// copies must remain distinct objects.
+func reuseParamHome(param, storage llvm.Value, entry llvm.BasicBlock, naturalAlign, storageAlign int) {
+	seen := make(map[llvm.Value]bool)
+	for instr := entry.FirstInstruction(); !instr.IsNil(); instr = llvm.NextInstruction(instr) {
+		store := instr.IsAStoreInst()
+		if store.IsNil() || store.Operand(0) != param {
+			continue
 		}
-		u = u.NextUse()
+		alloc := store.Operand(1).IsAAllocaInst()
+		if alloc.IsNil() || seen[alloc] {
+			continue
+		}
+		seen[alloc] = true
+		if canReuseParamHome(alloc, store, entry, param.Type(), naturalAlign, storageAlign) {
+			replaceParamHomeUses(alloc, storage, store)
+			return
+		}
 	}
-	for _, instr := range storeInstrs {
-		if alloc := instr.Operand(1).IsAAllocaInst(); !alloc.IsNil() {
-			skips := make(map[llvm.Value]bool)
-			next := llvm.NextInstruction(alloc)
-			for !next.IsNil() && next != instr {
-				skips[next] = true
-				next = llvm.NextInstruction(next)
-			}
-			var uses []llvm.Value
-			u := alloc.FirstUse()
-			for !u.IsNil() {
-				if v := u.User(); !skips[v] {
-					uses = append(uses, v)
-				}
-				u = u.NextUse()
-			}
-			for _, use := range uses {
-				n := use.OperandsCount()
-				for i := 0; i < n; i++ {
-					if use.Operand(i) == alloc {
-						use.SetOperand(i, nv)
-					}
-				}
+}
+
+func canReuseParamHome(alloc, initStore llvm.Value, entry llvm.BasicBlock, paramType llvm.Type, naturalAlign, storageAlign int) bool {
+	if alloc.InstructionParent() != entry || initStore.InstructionParent() != entry {
+		return false
+	}
+	if alloc.AllocatedType() != paramType {
+		return false
+	}
+	count := alloc.Operand(0).IsAConstantInt()
+	if count.IsNil() || count.ZExtValue() != 1 {
+		return false
+	}
+	allocAlign := alloc.Alignment()
+	if allocAlign == 0 {
+		allocAlign = naturalAlign
+	}
+	if storageAlign < allocAlign {
+		return false
+	}
+
+	// The initialization in the entry block dominates every later block. In
+	// the entry prefix, only a direct memset is harmless: it neither exposes a
+	// pointer that would keep referring to the old object nor observes the
+	// parameter value that begins at initStore.
+	prefix := make(map[llvm.Value]bool)
+	foundInit := false
+	for instr := llvm.NextInstruction(alloc); !instr.IsNil(); instr = llvm.NextInstruction(instr) {
+		if instr == initStore {
+			foundInit = true
+			break
+		}
+		prefix[instr] = true
+	}
+	if !foundInit {
+		return false
+	}
+	for use := alloc.FirstUse(); !use.IsNil(); use = use.NextUse() {
+		user := use.User()
+		if prefix[user] && !isDirectMemset(user, alloc) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDirectMemset(instr, ptr llvm.Value) bool {
+	call := instr.IsACallInst()
+	return !call.IsNil() && call.CalledValue().IntrinsicID() == llvm.LookupIntrinsicID("llvm.memset") && call.Operand(0) == ptr
+}
+
+func replaceParamHomeUses(alloc, storage, initStore llvm.Value) {
+	prefix := make(map[llvm.Value]bool)
+	for instr := llvm.NextInstruction(alloc); !instr.IsNil() && instr != initStore; instr = llvm.NextInstruction(instr) {
+		prefix[instr] = true
+	}
+	var users []llvm.Value
+	for use := alloc.FirstUse(); !use.IsNil(); use = use.NextUse() {
+		user := use.User()
+		if prefix[user] {
+			continue
+		}
+		users = append(users, user)
+	}
+	for _, user := range users {
+		for i, n := 0, user.OperandsCount(); i < n; i++ {
+			if user.Operand(i) == alloc {
+				user.SetOperand(i, storage)
 			}
 		}
 	}

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -1153,3 +1153,234 @@ entry:
 		t.Fatalf("transformed module is invalid: %v\n%s", err, mod.String())
 	}
 }
+
+func TestParamHomeReusePreservesObjectIdentity(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	const testIR = `
+%Aggregate = type { i64, i64, i64 }
+
+declare void @capture(ptr)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg)
+
+define i64 @copy_then_mutate(%Aggregate %value) {
+entry:
+  %mutable = alloca %Aggregate, align 8
+  %original = alloca %Aggregate, align 8
+  store %Aggregate %value, ptr %mutable, align 8
+  %mutable.field = getelementptr inbounds %Aggregate, ptr %mutable, i32 0, i32 1
+  store i64 99, ptr %mutable.field, align 8
+  store %Aggregate %value, ptr %original, align 8
+  %original.field = getelementptr inbounds %Aggregate, ptr %original, i32 0, i32 1
+  %result = load i64, ptr %original.field, align 8
+  ret i64 %result
+}
+
+define i64 @rematerialize_one_copy(%Aggregate %value) {
+entry:
+  %copy = alloca %Aggregate, align 8
+  store %Aggregate %value, ptr %copy, align 8
+  store %Aggregate %value, ptr %copy, align 8
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reuse_after_memset(%Aggregate %value) {
+entry:
+  %copy = alloca %Aggregate, align 8
+  call void @llvm.memset.p0.i64(ptr %copy, i8 0, i64 24, i1 false)
+  store %Aggregate %value, ptr %copy, align 8
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reject_preinit_escape(%Aggregate %value) {
+entry:
+  %copy = alloca %Aggregate, align 8
+  call void @capture(ptr %copy)
+  store %Aggregate %value, ptr %copy, align 8
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reject_conditional_init(%Aggregate %value, i1 %cond) {
+entry:
+  %copy = alloca %Aggregate, align 8
+  br i1 %cond, label %left, label %right
+left:
+  store %Aggregate %value, ptr %copy, align 8
+  br label %done
+right:
+  store %Aggregate %value, ptr %copy, align 8
+  br label %done
+done:
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reject_stronger_alignment(%Aggregate %value) {
+entry:
+  %copy = alloca %Aggregate, align 32
+  store %Aggregate %value, ptr %copy, align 32
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+`
+
+	for _, test := range []struct {
+		name   string
+		goos   string
+		goarch string
+		triple string
+	}{
+		{name: "amd64", goos: "linux", goarch: "amd64", triple: "x86_64-unknown-linux-gnu"},
+		{name: "arm64", goos: "darwin", goarch: "arm64", triple: "arm64-apple-darwin"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := llvm.NewContext()
+			defer ctx.Dispose()
+			path := filepath.Join(t.TempDir(), "param_copies.ll")
+			if err := os.WriteFile(path, []byte(testIR), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			buf, err := llvm.NewMemoryBufferFromFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mod, err := ctx.ParseIR(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer mod.Dispose()
+
+			prog := llssa.NewProgram(&llssa.Target{GOOS: test.goos, GOARCH: test.goarch})
+			defer prog.Dispose()
+			NewTransformer(prog, test.triple, "", true).TransformModule("test", mod)
+
+			got := mod.NamedFunction("copy_then_mutate").String()
+			if strings.Contains(got, "getelementptr inbounds %Aggregate, ptr %mutable") {
+				t.Fatalf("C ABI lowering did not reuse the first proven parameter home:\n%s", got)
+			}
+			if !strings.Contains(got, "getelementptr inbounds %Aggregate, ptr %original") {
+				t.Fatalf("C ABI lowering aliased the independent parameter copy:\n%s", got)
+			}
+			singleCopy := mod.NamedFunction("rematerialize_one_copy").String()
+			if strings.Contains(singleCopy, "getelementptr inbounds %Aggregate, ptr %copy") {
+				t.Fatalf("C ABI lowering did not reuse the indirect parameter for one alloca:\n%s", singleCopy)
+			}
+			memsetCopy := mod.NamedFunction("reuse_after_memset").String()
+			if !strings.Contains(memsetCopy, "call void @llvm.memset.p0.i64(ptr %copy") {
+				t.Fatalf("C ABI lowering moved the pre-initialization memset to the parameter home:\n%s", memsetCopy)
+			}
+			if strings.Contains(memsetCopy, "getelementptr inbounds %Aggregate, ptr %copy") {
+				t.Fatalf("C ABI lowering did not reuse storage after a direct memset:\n%s", memsetCopy)
+			}
+			for _, name := range []string{"reject_preinit_escape", "reject_conditional_init", "reject_stronger_alignment"} {
+				got := mod.NamedFunction(name).String()
+				if !strings.Contains(got, "getelementptr inbounds %Aggregate, ptr %copy") {
+					t.Fatalf("C ABI lowering reused an unproven parameter home in %s:\n%s", name, got)
+				}
+			}
+			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+				t.Fatalf("lowered parameter-copy module is invalid: %v\n%s", err, mod.String())
+			}
+		})
+	}
+}
+
+func TestWidthReturnUsesEvaluatedValue(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	const testIR = `
+%Small = type { i32, i32 }
+%Pair = type { i64, i64 }
+
+define %Small @return_loaded_snapshot(ptr %src) {
+entry:
+  %snapshot = load %Small, ptr %src, align 4
+  store %Small { i32 9, i32 10 }, ptr %src, align 4
+  ret %Small %snapshot
+}
+
+define i32 @width_param_copies(%Small %value) {
+entry:
+  %first = alloca %Small, align 4
+  %second = alloca %Small, align 4
+  store %Small %value, ptr %first, align 4
+  %first.field = getelementptr inbounds %Small, ptr %first, i32 0, i32 0
+  store i32 99, ptr %first.field, align 4
+  store %Small %value, ptr %second, align 4
+  %second.field = getelementptr inbounds %Small, ptr %second, i32 0, i32 0
+  %result = load i32, ptr %second.field, align 4
+  ret i32 %result
+}
+
+define i64 @two_width_param_copies(%Pair %value) {
+entry:
+  %first = alloca %Pair, align 8
+  %second = alloca %Pair, align 8
+  store %Pair %value, ptr %first, align 8
+  %first.field = getelementptr inbounds %Pair, ptr %first, i32 0, i32 0
+  store i64 99, ptr %first.field, align 8
+  store %Pair %value, ptr %second, align 8
+  %second.field = getelementptr inbounds %Pair, ptr %second, i32 0, i32 0
+  %result = load i64, ptr %second.field, align 8
+  ret i64 %result
+}
+`
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	path := filepath.Join(t.TempDir(), "width_return.ll")
+	if err := os.WriteFile(path, []byte(testIR), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Dispose()
+
+	prog := llssa.NewProgram(&llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+	defer prog.Dispose()
+	NewTransformer(prog, "x86_64-unknown-linux-gnu", "", true).TransformModule("test", mod)
+
+	got := mod.NamedFunction("return_loaded_snapshot").String()
+	if !strings.Contains(got, "ret i64") {
+		t.Fatalf("small aggregate return was not width-lowered:\n%s", got)
+	}
+	if strings.Contains(got, "load i64, ptr %src") {
+		t.Fatalf("C ABI lowering re-read a return load's modified source:\n%s", got)
+	}
+	for _, test := range []struct {
+		name string
+		typ  string
+	}{
+		{name: "width_param_copies", typ: "%Small"},
+		{name: "two_width_param_copies", typ: "%Pair"},
+	} {
+		got := mod.NamedFunction(test.name).String()
+		if strings.Contains(got, "getelementptr inbounds "+test.typ+", ptr %first") {
+			t.Fatalf("C ABI lowering did not reuse the first %s parameter home:\n%s", test.name, got)
+		}
+		if !strings.Contains(got, "getelementptr inbounds "+test.typ+", ptr %second") {
+			t.Fatalf("C ABI lowering aliased an independent %s parameter copy:\n%s", test.name, got)
+		}
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("lowered width-return module is invalid: %v\n%s", err, mod.String())
+	}
+}

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -1198,6 +1198,15 @@ entry:
   ret i64 %result
 }
 
+define i64 @reuse_natural_alignment(%Aggregate %value) {
+entry:
+  %copy = alloca %Aggregate
+  store %Aggregate %value, ptr %copy
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field
+  ret i64 %result
+}
+
 define i64 @reject_preinit_escape(%Aggregate %value) {
 entry:
   %copy = alloca %Aggregate, align 8
@@ -1228,6 +1237,33 @@ define i64 @reject_stronger_alignment(%Aggregate %value) {
 entry:
   %copy = alloca %Aggregate, align 32
   store %Aggregate %value, ptr %copy, align 32
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reject_wrong_allocated_type(%Aggregate %value) {
+entry:
+  %copy = alloca i8, align 8
+  store %Aggregate %value, ptr %copy, align 8
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reject_multiple_elements(%Aggregate %value) {
+entry:
+  %copy = alloca %Aggregate, i64 2, align 8
+  store %Aggregate %value, ptr %copy, align 8
+  %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
+  %result = load i64, ptr %copy.field, align 8
+  ret i64 %result
+}
+
+define i64 @reject_dynamic_elements(%Aggregate %value, i64 %count) {
+entry:
+  %copy = alloca %Aggregate, i64 %count, align 8
+  store %Aggregate %value, ptr %copy, align 8
   %copy.field = getelementptr inbounds %Aggregate, ptr %copy, i32 0, i32 1
   %result = load i64, ptr %copy.field, align 8
   ret i64 %result
@@ -1282,7 +1318,18 @@ entry:
 			if strings.Contains(memsetCopy, "getelementptr inbounds %Aggregate, ptr %copy") {
 				t.Fatalf("C ABI lowering did not reuse storage after a direct memset:\n%s", memsetCopy)
 			}
-			for _, name := range []string{"reject_preinit_escape", "reject_conditional_init", "reject_stronger_alignment"} {
+			naturalAlignment := mod.NamedFunction("reuse_natural_alignment").String()
+			if strings.Contains(naturalAlignment, "getelementptr inbounds %Aggregate, ptr %copy") {
+				t.Fatalf("C ABI lowering did not use the alloca type's natural alignment:\n%s", naturalAlignment)
+			}
+			for _, name := range []string{
+				"reject_preinit_escape",
+				"reject_conditional_init",
+				"reject_stronger_alignment",
+				"reject_wrong_allocated_type",
+				"reject_multiple_elements",
+				"reject_dynamic_elements",
+			} {
 				got := mod.NamedFunction(name).String()
 				if !strings.Contains(got, "getelementptr inbounds %Aggregate, ptr %copy") {
 					t.Fatalf("C ABI lowering reused an unproven parameter home in %s:\n%s", name, got)
@@ -1292,6 +1339,66 @@ entry:
 				t.Fatalf("lowered parameter-copy module is invalid: %v\n%s", err, mod.String())
 			}
 		})
+	}
+}
+
+func TestCanReuseParamHomeRequiresEntryBlockOrder(t *testing.T) {
+	const testIR = `
+%Aggregate = type { i64, i64, i64 }
+
+define void @non_entry_alloca(%Aggregate %value) {
+entry:
+  br label %body
+body:
+  %copy = alloca %Aggregate, align 8
+  store %Aggregate %value, ptr %copy, align 8
+  ret void
+}
+
+define void @init_before_alloca(%Aggregate %value) {
+entry:
+  %source = alloca %Aggregate, align 8
+  store %Aggregate %value, ptr %source, align 8
+  %copy = alloca %Aggregate, align 8
+  ret void
+}
+`
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	path := filepath.Join(t.TempDir(), "param_home_order.ll")
+	if err := os.WriteFile(path, []byte(testIR), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Dispose()
+
+	nonEntry := mod.NamedFunction("non_entry_alloca")
+	entry := nonEntry.EntryBasicBlock()
+	body := llvm.NextBasicBlock(entry)
+	alloc := body.FirstInstruction()
+	initStore := llvm.NextInstruction(alloc)
+	if canReuseParamHome(alloc, initStore, entry, nonEntry.Param(0).Type(), 8, 8) {
+		t.Fatal("parameter home outside the entry block was accepted")
+	}
+
+	earlierInit := mod.NamedFunction("init_before_alloca")
+	entry = earlierInit.EntryBasicBlock()
+	initStore = llvm.NextInstruction(entry.FirstInstruction())
+	alloc = llvm.NextInstruction(initStore)
+	alloc.SetAlignment(0)
+	if alloc.Alignment() != 0 {
+		t.Fatalf("failed to clear candidate alloca alignment: got %d", alloc.Alignment())
+	}
+	if canReuseParamHome(alloc, initStore, entry, earlierInit.Param(0).Type(), 8, 8) {
+		t.Fatal("parameter initialization before its candidate alloca was accepted")
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the indirect-parameter alloca-count heuristic with proof-based parameter-home reuse
- reuse at most one entry-block home after checking allocation shape, initialization dominance, pre-initialization uses, and alignment
- apply the same policy to pointer-, one-register-, and two-register-lowered aggregate parameters
- materialize width-lowered returns from the already evaluated SSA value instead of re-reading a load source
- cover independent copies, repeated stores, memset prefixes, escapes, conditional initialization, stronger alignment, and small aggregate returns

## Root cause

`github.com/Masterminds/semver/v3` exposed this when `Version.SetPrerelease` and `Version.SetMetadata` copied a 72-byte value receiver, mutated the copy, and later read the original receiver. The old replacement walked every `store param -> alloca` and redirected every destination to the same ABI storage, collapsing independent objects into one address. A `len(allocas) == 1` guard prevented the reproducer but encoded the symptom rather than the substitution contract.

The new path treats ABI storage as a replacement for at most one proven parameter home. If dominance, pre-initialization aliasing, allocation shape, or alignment cannot be established, it leaves that alloca intact.

## Testing

- `go test ./internal/cabi -count=1`
- `go test ./ssa ./cl -count=1`
- `go test ./internal/build -run ^TestLargeArrayReturnAllABIModes$ -count=1`
- `llgo test -v -count=1 -run ^(TestSetPrerelease|TestSetMetadata)$ .` in `github.com/Masterminds/semver/v3@v3.3.1`

The ABI runtime regression passes in modes 0, 1, and 2. The original semver failures also pass with the compiler built from this head.