### PR TITLE
runtime: preserve pending Unix signals under saturation

### DIFF
--- a/runtime/internal/lib/runtime/_wrap/signal.c
+++ b/runtime/internal/lib/runtime/_wrap/signal.c
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <pthread.h>
 #include <sched.h>
 #include <signal.h>
@@ -14,21 +15,47 @@
 
 _Static_assert(SIGPIPE == 13, "runtime signalPipe assumes SIGPIPE is 13");
 
+#define LLGO_SIGNAL_COUNT 65
+#define LLGO_SIGNAL_WORDS ((LLGO_SIGNAL_COUNT + 31) / 32)
+
+_Static_assert(CHAR_BIT * sizeof(unsigned int) == 32,
+               "signal bitmaps require 32-bit unsigned int");
+#if defined(__clang__) || defined(__GNUC__)
+_Static_assert(__atomic_always_lock_free(sizeof(unsigned int), 0),
+               "signal-handler atomics must be lock-free");
+#endif
+
 static int llgo_signal_pipe[2] = {-1, -1};
 static unsigned int llgo_signal_delivering;
+static unsigned int llgo_signal_pending[LLGO_SIGNAL_WORDS];
+/* Only the dedicated signal reader accesses this snapshot. */
+static unsigned int llgo_signal_received[LLGO_SIGNAL_WORDS];
 
 static void llgo_signal_handler(int signum)
 {
     int saved_errno = errno;
+    unsigned int bit;
+    unsigned int old;
+    const int wake = 1;
 
     /* signalWaitUntilIdle uses this like the Go runtime's sig.delivering:
      * a pipe marker must not overtake a handler that has already entered. */
-    __atomic_add_fetch(&llgo_signal_delivering, 1, __ATOMIC_ACQUIRE);
-    if (llgo_signal_pipe[1] >= 0) {
-        ssize_t ignored = write(llgo_signal_pipe[1], &signum, sizeof(signum));
-        (void)ignored;
+    __atomic_add_fetch(&llgo_signal_delivering, 1, __ATOMIC_SEQ_CST);
+    if (llgo_signal_pipe[1] >= 0 && signum > 0 &&
+        signum < LLGO_SIGNAL_COUNT) {
+        bit = 1U << ((unsigned int)signum & 31U);
+        old = __atomic_fetch_or(&llgo_signal_pending[(unsigned int)signum / 32U],
+                                bit, __ATOMIC_SEQ_CST);
+        if ((old & bit) == 0) {
+            /* EAGAIN is safe: a full pipe already contains a wakeup, while
+             * the per-signal pending bit preserves this distinct signal. */
+            ssize_t count;
+            do {
+                count = write(llgo_signal_pipe[1], &wake, sizeof(wake));
+            } while (count < 0 && errno == EINTR);
+        }
     }
-    __atomic_sub_fetch(&llgo_signal_delivering, 1, __ATOMIC_RELEASE);
+    __atomic_sub_fetch(&llgo_signal_delivering, 1, __ATOMIC_SEQ_CST);
     errno = saved_errno;
 }
 
@@ -155,22 +182,64 @@ int llgo_signal_barrier(void)
     }
 }
 
-int llgo_signal_recv(int fd, int *signum)
+static int llgo_signal_take_received(void)
 {
-    unsigned char *out = (unsigned char *)signum;
-    size_t offset = 0;
+    unsigned int signum;
 
-    if (signum == 0)
-        return EINVAL;
-    while (offset < sizeof(*signum)) {
-        ssize_t count = read(fd, out + offset, sizeof(*signum) - offset);
-        if (count > 0) {
-            offset += (size_t)count;
-            continue;
+    for (signum = 1; signum < LLGO_SIGNAL_COUNT; signum++) {
+        unsigned int bit = 1U << (signum & 31U);
+        unsigned int *word = &llgo_signal_received[signum / 32U];
+
+        if ((*word & bit) != 0) {
+            *word &= ~bit;
+            return (int)signum;
         }
-        if (count < 0 && errno == EINTR)
-            continue;
-        return count == 0 ? EPIPE : errno;
     }
     return 0;
+}
+
+static void llgo_signal_receive_pending(void)
+{
+    unsigned int word;
+
+    for (word = 0; word < LLGO_SIGNAL_WORDS; word++)
+        llgo_signal_received[word] =
+            __atomic_exchange_n(&llgo_signal_pending[word], 0,
+                                __ATOMIC_SEQ_CST);
+}
+
+int llgo_signal_recv(int fd, int *signum)
+{
+    if (signum == 0)
+        return EINVAL;
+
+    for (;;) {
+        int received;
+        int token;
+        unsigned char *out;
+        size_t offset = 0;
+
+        received = llgo_signal_take_received();
+        if (received != 0) {
+            *signum = received;
+            return 0;
+        }
+
+        out = (unsigned char *)&token;
+        while (offset < sizeof(token)) {
+            ssize_t count = read(fd, out + offset, sizeof(token) - offset);
+            if (count > 0) {
+                offset += (size_t)count;
+                continue;
+            }
+            if (count < 0 && errno == EINTR)
+                continue;
+            return count == 0 ? EPIPE : errno;
+        }
+        if (token == 0) {
+            *signum = 0;
+            return 0;
+        }
+        llgo_signal_receive_pending();
+    }
 }

--- a/runtime/internal/lib/runtime/_wrap/signal.c
+++ b/runtime/internal/lib/runtime/_wrap/signal.c
@@ -47,8 +47,9 @@ static void llgo_signal_handler(int signum)
         old = __atomic_fetch_or(&llgo_signal_pending[(unsigned int)signum / 32U],
                                 bit, __ATOMIC_SEQ_CST);
         if ((old & bit) == 0) {
-            /* EAGAIN is safe: a full pipe already contains a wakeup, while
-             * the per-signal pending bit preserves this distinct signal. */
+            /* The pending bit preserves this signal if the nonblocking write
+             * fails. In particular, EAGAIN means the full pipe already
+             * contains a wakeup. */
             ssize_t count;
             do {
                 count = write(llgo_signal_pipe[1], &wake, sizeof(wake));
@@ -210,7 +211,7 @@ static void llgo_signal_receive_pending(void)
 
 int llgo_signal_recv(int fd, int *signum)
 {
-    if (signum == 0)
+    if (signum == NULL)
         return EINVAL;
 
     for (;;) {

--- a/runtime/internal/lib/runtime/signal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_llgo.go
@@ -10,14 +10,20 @@ import (
 	psync "github.com/xgo-dev/llgo/runtime/internal/sync"
 )
 
-// Unix signal handlers write signal numbers to a nonblocking self-pipe. A
-// dedicated runtime goroutine drains that pipe and enters Go code in a normal
-// execution context; the async-signal-safe C handler never calls into Go.
+// Unix signal handlers atomically mark signals pending and write wake tokens to
+// a nonblocking self-pipe. A dedicated runtime goroutine claims the pending
+// signals and enters Go code in a normal execution context; the
+// async-signal-safe C handler never calls into Go.
 
 type sigState struct {
 	active  bool
 	ignored bool
 }
+
+const (
+	signalCount = 65 // max across Unix systems; matches os/signal
+	signalWords = (signalCount + 31) / 32
+)
 
 var (
 	sigInitState uint32
@@ -28,7 +34,8 @@ var (
 	sigMu     psync.Mutex
 	sigCond   psync.Cond
 	sigWaitMu psync.Mutex
-	sigQueue  []uint32
+	sigQueue  [signalWords]uint32
+	sigRecv   [signalWords]uint32
 	sigStates map[uint32]*sigState
 
 	// sigReceiving is true only while the os/signal receive goroutine is
@@ -149,14 +156,26 @@ func signalReadLoop() {
 }
 
 func signalCallback(sig uint32) {
+	if sig == 0 || sig >= signalCount {
+		return
+	}
 	sigMu.Lock()
-	// Every positive pipe entry was written by a handler that was active at
-	// the instant the signal arrived. Preserve it even if Reset or Stop has
-	// since changed sigStates; os/signal keeps stopping channels registered
-	// until signalWaitUntilIdle observes the barrier below.
-	sigQueue = append(sigQueue, sig)
+	// Every positive value was claimed from a pending bit set by a handler that
+	// was active at the instant the signal arrived. Preserve it even if Reset or
+	// Stop has since changed sigStates; os/signal keeps stopping channels
+	// registered until signalWaitUntilIdle observes the barrier below.
+	sigQueue[sig/32] |= 1 << (sig & 31)
 	sigCond.Broadcast()
 	sigMu.Unlock()
+}
+
+func signalBitsEmpty(bits *[signalWords]uint32) bool {
+	for _, word := range bits {
+		if word != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func ensureSignalState(sig uint32) *sigState {
@@ -247,16 +266,25 @@ func signal_ignored(sig uint32) bool {
 func signal_recv() uint32 {
 	ensureSignalInit()
 	sigMu.Lock()
-	for len(sigQueue) == 0 {
-		sigReceiving = true
-		sigCond.Broadcast()
-		sigCond.Wait(&sigMu)
+	for {
+		for sig := uint32(1); sig < signalCount; sig++ {
+			bit := uint32(1) << (sig & 31)
+			if sigRecv[sig/32]&bit != 0 {
+				sigRecv[sig/32] &^= bit
+				sigMu.Unlock()
+				return sig
+			}
+		}
+
+		for signalBitsEmpty(&sigQueue) {
+			sigReceiving = true
+			sigCond.Broadcast()
+			sigCond.Wait(&sigMu)
+		}
+		sigReceiving = false
+		sigRecv = sigQueue
+		sigQueue = [signalWords]uint32{}
 	}
-	sigReceiving = false
-	sig := sigQueue[0]
-	sigQueue = sigQueue[1:]
-	sigMu.Unlock()
-	return sig
 }
 
 func signalWaitUntilIdle() {
@@ -276,7 +304,8 @@ func signalWaitUntilIdle() {
 	}
 
 	sigMu.Lock()
-	for sigBarrierAck < wantAck || len(sigQueue) != 0 || !sigReceiving {
+	for sigBarrierAck < wantAck || !signalBitsEmpty(&sigQueue) ||
+		!signalBitsEmpty(&sigRecv) || !sigReceiving {
 		sigCond.Wait(&sigMu)
 	}
 	sigMu.Unlock()

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -37,7 +37,8 @@ LLGO_STRESS_PROFILE=heavy /tmp/llgo-runtime-stress test \
 ```
 
 The timer suite covers large live heaps, concurrent `Stop`/`Reset` on distinct
-and shared timers, callback bursts, and concurrent sleepers. The signal suite
-covers concurrent handler entry, distinct-signal delivery during a lower-number
-signal storm, concurrent registration churn, repeated `Notify`/`Stop`/`Reset`
-barriers, and timer progress while handlers are busy.
+and shared timers, callback bursts, and concurrent sleepers. The four signal
+tests cover distinct-signal delivery during a lower-number signal storm,
+concurrent registration churn, repeated `Notify`/`Stop`/`Reset` barriers, and
+timer progress while handlers are busy. The flood cases also exercise
+the handler under concurrent delivery pressure.

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -1,0 +1,43 @@
+# Runtime stress tests
+
+These tests exercise timer and Unix signal correctness under loads that are too
+expensive for routine pull-request testing. The leading-underscore directory
+and nested module keep them out of the repository's normal `go test ./...` and
+`llgo test ./test/...` patterns. No push, pull-request, scheduled, or daily
+workflow runs them automatically.
+
+Build LLGo from the revision being tested, then run the suites explicitly:
+
+```sh
+repo=$(git rev-parse --show-toplevel)
+(cd "$repo" && go build -o /tmp/llgo-runtime-stress ./cmd/llgo)
+export LLGO_ROOT="$repo"
+cd "$repo/test/_stress"
+
+go test -race -count=3 -timeout=20m ./runtime/timer
+/tmp/llgo-runtime-stress test -count=3 -timeout=20m ./runtime/timer
+/tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/signal
+```
+
+The signal suite is LLGo-only and targets Unix hosts. The timer suite also runs
+with the standard Go compiler so the harness can be checked independently.
+
+`LLGO_STRESS_PROFILE` controls the load while preserving the same assertions:
+
+- `quick`: one eighth of the default counts, for local iteration.
+- `default` (or unset): the checked-in baseline.
+- `heavy`: twice each default dimension (and potentially more than twice the
+  total work), for deliberate soak runs.
+
+For example:
+
+```sh
+LLGO_STRESS_PROFILE=heavy /tmp/llgo-runtime-stress test \
+  -count=10 -timeout=2h ./runtime/signal
+```
+
+The timer suite covers large live heaps, concurrent `Stop`/`Reset` on distinct
+and shared timers, callback bursts, and concurrent sleepers. The signal suite
+covers concurrent handler entry, distinct-signal delivery during a lower-number
+signal storm, concurrent registration churn, repeated `Notify`/`Stop`/`Reset`
+barriers, and timer progress while handlers are busy.

--- a/test/_stress/go.mod
+++ b/test/_stress/go.mod
@@ -1,0 +1,3 @@
+module github.com/xgo-dev/llgo/test/_stress
+
+go 1.21

--- a/test/_stress/runtime/signal/signal_stress_llgo_test.go
+++ b/test/_stress/runtime/signal/signal_stress_llgo_test.go
@@ -1,0 +1,353 @@
+//go:build llgo && !baremetal && !wasm && !windows && !plan9
+
+package signalstress
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+	_ "unsafe"
+)
+
+//go:linkname cRaise C.raise
+func cRaise(sig int32) int32
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		if count := base / 8; count > 0 {
+			return count
+		}
+		return 1
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+func waitGroup(work *sync.WaitGroup, timeout time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		work.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("workers did not finish within %s", timeout)
+	}
+}
+
+func TestConcurrentRaisePreservesDistinctSignal(t *testing.T) {
+	workers := stressCount(t, 512)
+	perWorker := stressCount(t, 2000)
+	rareRounds := stressCount(t, 64)
+	floodSignal := syscall.SIGCHLD
+	distinctSignal := syscall.SIGWINCH
+	if floodSignal >= distinctSignal {
+		t.Skipf("need a harmless flood signal below %v; got %v", distinctSignal, floodSignal)
+	}
+
+	// Flood a lower-numbered signal so a receiver that repeatedly starts its
+	// global scan at signal 1 can starve the distinct higher-numbered signal.
+	flooded := make(chan os.Signal, 1)
+	distinct := make(chan os.Signal, 1)
+	signal.Notify(flooded, floodSignal)
+	signal.Notify(distinct, distinctSignal)
+
+	start := make(chan struct{})
+	stop := make(chan struct{})
+	var failures atomic.Int64
+	var ready sync.WaitGroup
+	var minimum sync.WaitGroup
+	var work sync.WaitGroup
+	ready.Add(workers)
+	minimum.Add(workers)
+	work.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer work.Done()
+			<-start
+			ready.Done()
+			minimumReported := false
+			defer func() {
+				if !minimumReported {
+					minimum.Done()
+				}
+			}()
+			for n := 0; n < perWorker; n++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if cRaise(int32(floodSignal)) != 0 {
+					failures.Add(1)
+					return
+				}
+			}
+			minimum.Done()
+			minimumReported = true
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if cRaise(int32(floodSignal)) != 0 {
+						failures.Add(1)
+						return
+					}
+				}
+			}
+		}()
+	}
+	close(start)
+
+	var distinctFailure error
+	if err := waitGroup(&ready, 30*time.Second); err != nil {
+		distinctFailure = fmt.Errorf("signal flood did not become ready: %w", err)
+	} else {
+		for round := 0; round < rareRounds; round++ {
+			if cRaise(int32(distinctSignal)) != 0 {
+				distinctFailure = fmt.Errorf("round %d: raise(%v) failed", round, distinctSignal)
+				break
+			}
+			select {
+			case got := <-distinct:
+				if got != distinctSignal {
+					distinctFailure = fmt.Errorf("round %d: got %v, want %v", round, got, distinctSignal)
+				}
+			case <-time.After(10 * time.Second):
+				distinctFailure = fmt.Errorf("round %d: distinct signal starved during flood", round)
+			}
+			if distinctFailure != nil {
+				break
+			}
+		}
+	}
+	var minimumErr error
+	if distinctFailure == nil {
+		minimumErr = waitGroup(&minimum, 5*time.Minute)
+	}
+	close(stop)
+	workErr := waitGroup(&work, 30*time.Second)
+	signal.Stop(distinct)
+	signal.Stop(flooded)
+
+	if workErr != nil {
+		t.Fatal(workErr)
+	}
+	if minimumErr != nil {
+		t.Fatal(minimumErr)
+	}
+	if got := failures.Load(); got != 0 {
+		t.Fatalf("raise(%v) failed in %d workers", floodSignal, got)
+	}
+	if distinctFailure != nil {
+		t.Fatal(distinctFailure)
+	}
+	select {
+	case <-flooded:
+	default:
+		t.Fatal("signal flood delivered no notification")
+	}
+}
+
+func TestNotifyStopResetBarrier(t *testing.T) {
+	rounds := stressCount(t, 2000)
+	for round := 0; round < rounds; round++ {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGWINCH)
+		if cRaise(int32(syscall.SIGWINCH)) != 0 {
+			t.Fatalf("round %d: raise failed", round)
+		}
+		signal.Stop(c)
+		select {
+		case <-c:
+		default:
+			t.Fatalf("round %d: signal sent before Stop was lost", round)
+		}
+		signal.Reset(syscall.SIGWINCH)
+	}
+}
+
+func TestConcurrentNotifyStopDuringSignalFlood(t *testing.T) {
+	raisers := stressCount(t, 64)
+	churners := stressCount(t, 32)
+	roundsPerChurner := stressCount(t, 64)
+	sentinel := make(chan os.Signal, 1)
+	signal.Notify(sentinel, syscall.SIGWINCH)
+
+	raiserStart := make(chan struct{})
+	churnStart := make(chan struct{})
+	abortChurn := make(chan struct{})
+	stop := make(chan struct{})
+	var raiseFailures atomic.Int64
+	var lost atomic.Int64
+	var ready sync.WaitGroup
+	var raiserWork sync.WaitGroup
+	var churnWork sync.WaitGroup
+	ready.Add(raisers)
+	raiserWork.Add(raisers)
+	churnWork.Add(churners)
+	for i := 0; i < raisers; i++ {
+		go func() {
+			defer raiserWork.Done()
+			<-raiserStart
+			ready.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if cRaise(int32(syscall.SIGWINCH)) != 0 {
+						raiseFailures.Add(1)
+						return
+					}
+				}
+			}
+		}()
+	}
+	for i := 0; i < churners; i++ {
+		go func() {
+			defer churnWork.Done()
+			<-churnStart
+			for round := 0; round < roundsPerChurner; round++ {
+				select {
+				case <-abortChurn:
+					return
+				default:
+				}
+				c := make(chan os.Signal, 1)
+				signal.Notify(c, syscall.SIGWINCH)
+				if cRaise(int32(syscall.SIGWINCH)) != 0 {
+					raiseFailures.Add(1)
+					signal.Stop(c)
+					return
+				}
+				signal.Stop(c)
+				select {
+				case <-c:
+				default:
+					lost.Add(1)
+				}
+			}
+		}()
+	}
+	close(raiserStart)
+	readyErr := waitGroup(&ready, 30*time.Second)
+	close(churnStart)
+	churnErr := waitGroup(&churnWork, 5*time.Minute)
+	if churnErr != nil {
+		close(abortChurn)
+		_ = waitGroup(&churnWork, 30*time.Second)
+	}
+	close(stop)
+	raiserErr := waitGroup(&raiserWork, 30*time.Second)
+	signal.Stop(sentinel)
+
+	if readyErr != nil {
+		t.Fatal(readyErr)
+	}
+	if churnErr != nil {
+		t.Fatal(churnErr)
+	}
+	if raiserErr != nil {
+		t.Fatal(raiserErr)
+	}
+	if got := raiseFailures.Load(); got != 0 {
+		t.Fatalf("raise(SIGWINCH) failed %d times", got)
+	}
+	if got := lost.Load(); got != 0 {
+		t.Fatalf("concurrent Notify/Stop lost %d pre-Stop signals", got)
+	}
+	select {
+	case <-sentinel:
+	default:
+		t.Fatal("signal flood delivered no sentinel notification")
+	}
+}
+
+func TestTimerProgressDuringSignalFlood(t *testing.T) {
+	workers := stressCount(t, 64)
+	notified := make(chan os.Signal, 1)
+	signal.Notify(notified, syscall.SIGWINCH)
+
+	start := make(chan struct{})
+	stop := make(chan struct{})
+	var failures atomic.Int64
+	var raises atomic.Int64
+	var ready sync.WaitGroup
+	var work sync.WaitGroup
+	ready.Add(workers)
+	work.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer work.Done()
+			<-start
+			if cRaise(int32(syscall.SIGWINCH)) != 0 {
+				failures.Add(1)
+				ready.Done()
+				return
+			}
+			raises.Add(1)
+			ready.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if cRaise(int32(syscall.SIGWINCH)) != 0 {
+						failures.Add(1)
+						return
+					}
+					raises.Add(1)
+				}
+			}
+		}()
+	}
+	close(start)
+	readyErr := waitGroup(&ready, 30*time.Second)
+	timer := time.NewTimer(20 * time.Millisecond)
+	deadline := time.NewTimer(10 * time.Second)
+	var timerErr error
+	if readyErr == nil {
+		select {
+		case <-timer.C:
+		case <-deadline.C:
+			timerErr = fmt.Errorf("runtime timer made no progress during signal flood")
+		}
+	}
+	timer.Stop()
+	deadline.Stop()
+	close(stop)
+	workErr := waitGroup(&work, 30*time.Second)
+	signal.Stop(notified)
+
+	if readyErr != nil {
+		t.Fatal(readyErr)
+	}
+	if timerErr != nil {
+		t.Fatal(timerErr)
+	}
+	if workErr != nil {
+		t.Fatal(workErr)
+	}
+	if got := failures.Load(); got != 0 {
+		t.Fatalf("raise(SIGWINCH) failed in %d workers", got)
+	}
+	if got := raises.Load(); got < int64(workers) {
+		t.Fatalf("signal flood raised %d signals, want at least %d", got, workers)
+	}
+}

--- a/test/_stress/runtime/timer/timer_stress_test.go
+++ b/test/_stress/runtime/timer/timer_stress_test.go
@@ -1,0 +1,174 @@
+package timerstress
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		if count := base / 8; count > 0 {
+			return count
+		}
+		return 1
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+func waitGroup(work *sync.WaitGroup, timeout time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		work.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("workers did not finish within %s", timeout)
+	}
+}
+
+func TestManyLiveTimersWithConcurrentStopReset(t *testing.T) {
+	live := stressCount(t, 16384)
+	workers := stressCount(t, 512)
+	operations := stressCount(t, 1000)
+
+	var unexpected atomic.Int64
+	timers := make([]*time.Timer, live)
+	for i := range timers {
+		timers[i] = time.AfterFunc(time.Hour, func() {
+			unexpected.Add(1)
+		})
+	}
+	defer func() {
+		for _, timer := range timers {
+			timer.Stop()
+		}
+	}()
+
+	start := make(chan struct{})
+	var work sync.WaitGroup
+	work.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func(seed uint32) {
+			defer work.Done()
+			<-start
+			x := seed
+			for operation := 0; operation < operations; operation++ {
+				x ^= x << 13
+				x ^= x >> 17
+				x ^= x << 5
+				timer := timers[int(x)%len(timers)]
+				if operation&3 == 0 {
+					timer.Stop()
+					timer.Reset(time.Hour)
+				} else {
+					timer.Reset(time.Hour + time.Duration(x&1023)*time.Millisecond)
+				}
+			}
+		}(uint32(worker + 1))
+	}
+
+	fired := make(chan struct{})
+	target := time.AfterFunc(20*time.Millisecond, func() { close(fired) })
+	defer target.Stop()
+	close(start)
+	select {
+	case <-fired:
+	case <-time.After(10 * time.Second):
+		t.Fatal("short timer starved behind concurrent heap operations")
+	}
+	if err := waitGroup(&work, 2*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if got := unexpected.Load(); got != 0 {
+		t.Fatalf("far-future timers fired %d times", got)
+	}
+}
+
+func TestSharedTimerConcurrentStopReset(t *testing.T) {
+	workers := stressCount(t, 512)
+	operations := stressCount(t, 1000)
+
+	var fired atomic.Int64
+	timer := time.AfterFunc(time.Hour, func() { fired.Add(1) })
+	defer timer.Stop()
+	start := make(chan struct{})
+	var work sync.WaitGroup
+	work.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func(worker int) {
+			defer work.Done()
+			<-start
+			for operation := 0; operation < operations; operation++ {
+				if (worker+operation)&1 == 0 {
+					timer.Stop()
+				} else {
+					timer.Reset(time.Hour + time.Duration(operation&1)*time.Second)
+				}
+			}
+		}(worker)
+	}
+	close(start)
+	if err := waitGroup(&work, 2*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	timer.Stop()
+	if got := fired.Load(); got != 0 {
+		t.Fatalf("shared far-future timer fired %d times", got)
+	}
+}
+
+func TestTimerCallbackBurst(t *testing.T) {
+	callbacks := stressCount(t, 1024)
+	delivered := make(chan struct{}, callbacks)
+	for i := 0; i < callbacks; i++ {
+		time.AfterFunc(20*time.Millisecond+time.Duration(i&15)*time.Microsecond, func() {
+			delivered <- struct{}{}
+		})
+	}
+	deadline := time.After(30 * time.Second)
+	for received := 0; received < callbacks; received++ {
+		select {
+		case <-delivered:
+		case <-deadline:
+			t.Fatalf("received %d of %d timer callbacks", received, callbacks)
+		}
+	}
+	select {
+	case <-delivered:
+		t.Fatal("timer callback delivered more than once")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestConcurrentSleep(t *testing.T) {
+	sleepers := stressCount(t, 512)
+	start := make(chan struct{})
+	var work sync.WaitGroup
+	work.Add(sleepers)
+	for i := 0; i < sleepers; i++ {
+		go func() {
+			defer work.Done()
+			<-start
+			time.Sleep(20 * time.Millisecond)
+		}()
+	}
+	close(start)
+	if err := waitGroup(&work, 30*time.Second); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Coalesce Unix signal notifications in a lock-free pending bitmap and use the nonblocking self-pipe only as a wakeup mechanism.
- Atomically snapshot and fairly drain pending signals on the runtime thread, preventing distinct signals from being lost when the pipe is full while keeping the queue bounded.
- Keep the signal-handler path free of mutexes and allocation, including nested delivery of different signals.
- Add opt-in timer and Unix signal stress suites under `test/_stress`; the nested module is excluded from routine root-module tests and CI discovery.

## Correctness

The handler performs only lock-free integer atomics and a nonblocking `write`, retries `EINTR`, and preserves `errno`. Repeated instances of one signal may coalesce, matching Go's notification model, while every distinct pending signal remains represented until the runtime thread snapshots it.
