### PR TITLE
reflect: preserve function type identity in calls

### DIFF
--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -510,6 +510,16 @@ func (t *rtype) Out(i int) Type {
 func toPublicType(typ *abi.Type) Type {
 	if typ.IsClosure() {
 		typ = &toFuncType((*abi.StructType)(unsafe.Pointer(typ))).Type
+	} else if typ.Kind() == abi.Pointer {
+		elem := typ.Elem()
+		if elem == nil || !elem.IsClosure() {
+			return toType(typ)
+		}
+		// A pointer to a function uses a pointer to LLGo's closure struct in
+		// its physical signature. Canonicalize the element before exposing
+		// the reflect.Type, otherwise *NamedFunc from a function parameter is
+		// not identical to PointerTo(TypeOf(NamedFunc)).
+		return PointerTo(toPublicType(elem))
 	}
 	return toType(typ)
 }

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -389,7 +389,14 @@ func (v Value) Addr() Value {
 	// Preserve flagRO instead of using v.flag.ro() so that
 	// v.Addr().Elem() is equivalent to v (#32772)
 	fl := v.flag & flagRO
-	return Value{ptrTo(v.typ()), v.ptr, fl | flag(Pointer)}
+	typ := v.typ()
+	if v.typ_.IsClosure() {
+		// Function values use a closure struct as their physical LLGo
+		// representation. Addr must expose the pointer to the semantic Go
+		// function type, just as Type does, rather than *$closure.
+		typ = v.Type().common()
+	}
+	return Value{ptrTo(typ), v.ptr, fl | flag(Pointer)}
 }
 
 // Bool returns v's underlying value.
@@ -2318,7 +2325,11 @@ func toFFIArg(v Value, typ *abi.Type) unsafe.Pointer {
 		if len(iface.Methods) == 0 {
 			return unsafe.Pointer(&i)
 		}
-		itab := runtime.NewItab(iface, v.typ())
+		// Interface-valued reflect arguments carry the dynamic concrete type
+		// in i. Using v.typ() here instead constructs an itab for the source
+		// interface type itself, leaving method entries invalid when the
+		// reflected callee invokes them.
+		itab := runtime.NewItab(iface, rtypeOf(i))
 		data := struct {
 			itab *runtime.Itab
 			data unsafe.Pointer

--- a/test/go/reflect_call_interface_args_test.go
+++ b/test/go/reflect_call_interface_args_test.go
@@ -1,0 +1,40 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+type reflectCallNamer interface {
+	Name() string
+}
+
+type reflectCallName string
+
+func (n reflectCallName) Name() string { return string(n) }
+
+func reflectCallInterfaceLess(x, y reflectCallNamer) bool {
+	return x.Name() < y.Name()
+}
+
+func reflectCallInterfaceIsNil(x reflectCallNamer) bool { return x == nil }
+
+func TestReflectCallInterfaceSliceElements(t *testing.T) {
+	values := []reflectCallNamer{reflectCallName("b"), reflectCallName("a")}
+	slice := reflect.ValueOf(values)
+	out := reflect.ValueOf(reflectCallInterfaceLess).Call([]reflect.Value{
+		slice.Index(0),
+		slice.Index(1),
+	})
+	if got := out[0].Bool(); got {
+		t.Fatalf("reflected interface call result = %v, want false", got)
+	}
+
+	nilValues := []reflectCallNamer{nil}
+	nilOut := reflect.ValueOf(reflectCallInterfaceIsNil).Call([]reflect.Value{
+		reflect.ValueOf(nilValues).Index(0),
+	})
+	if got := nilOut[0].Bool(); !got {
+		t.Fatalf("reflected nil interface call result = %v, want true", got)
+	}
+}

--- a/test/go/reflect_closure_type_test.go
+++ b/test/go/reflect_closure_type_test.go
@@ -17,8 +17,11 @@ func TestReflectClosureParamTypeString(t *testing.T) {
 }
 
 type reflectClosureFieldHolder struct {
-	F func(int) bool
+	F     func(int) bool
+	Named reflectNamedFunc
 }
+
+type reflectNamedFunc func(int) bool
 
 func TestReflectClosureNestedTypeString(t *testing.T) {
 	field := reflect.TypeOf(reflectClosureFieldHolder{}).Field(0).Type
@@ -34,5 +37,30 @@ func TestReflectClosureNestedTypeString(t *testing.T) {
 	}
 	if got, want := elem.Kind(), reflect.Func; got != want {
 		t.Fatalf("slice element kind = %v, want %v", got, want)
+	}
+}
+
+func TestReflectClosurePointerTypeIdentity(t *testing.T) {
+	holder := &reflectClosureFieldHolder{}
+	holderType := reflect.TypeOf(*holder)
+	holderValue := reflect.ValueOf(holder).Elem()
+
+	plainField := holderType.Field(0).Type
+	plainPointer := reflect.PointerTo(plainField)
+	plainAddr := holderValue.Field(0).Addr().Type()
+	if plainAddr != plainPointer {
+		t.Fatalf("function field address type = %v, want %v", plainAddr, plainPointer)
+	}
+
+	namedParam := reflect.TypeOf(func(*reflectNamedFunc) {}).In(0)
+	namedField := holderType.Field(1).Type
+	namedPointer := reflect.PointerTo(namedField)
+	namedAddr := holderValue.Field(1).Addr().Type()
+	if namedParam != namedPointer || namedAddr != namedPointer {
+		t.Fatalf("named function pointer types differ: parameter=%v field=%v address=%v", namedParam, namedPointer, namedAddr)
+	}
+	types := map[reflect.Type]bool{namedParam: true}
+	if !types[namedPointer] || !types[namedAddr] {
+		t.Fatalf("canonical named function pointer type was not found as a reflect.Type map key")
 	}
 }


### PR DESCRIPTION
## Summary

- canonicalize pointers to LLGo closure types before exposing them as public reflect.Type values
- make Value.Addr on function fields preserve the semantic Go function type
- build reflected non-empty interface arguments from their dynamic concrete type
- add regressions for function-pointer type identity and reflected interface calls

## Motivation

The compatibility dashboard exposed two related representation leaks:

- client-go/rest uses reflect.Type as a map key for named function-pointer fillers. Value.Addr().Type() exposed LLGo's internal pointer-to-closure carrier, so an otherwise identical named function pointer did not compare equal.
- protobuf's cmpopts.SortSlices invokes an interface-typed comparator through reflect.Value.Call. LLGo built the itab from the source interface type instead of the dynamic concrete type, leaving method dispatch invalid.

The changes keep LLGo's physical closure representation internal while preserving Go reflection identity and interface-call semantics.

## Validation

- native and LLGo: TestReflectClosurePointerTypeIdentity
- native and LLGo: TestReflectCallInterfaceSliceElements
- k8s.io/client-go/rest: TestAnonymousAuthConfig
- google.golang.org/protobuf/internal/impl: TestDescriptor
- google.golang.org/protobuf/reflect/protoregistry: TestTypes

Compatibility context: https://xgo-dev.github.io/benchmarks/compatibility.html
