### PR TITLE
runtime: ignore SIGPIPE from ordinary writes

### DIFF
--- a/runtime/internal/lib/runtime/_wrap/signal.c
+++ b/runtime/internal/lib/runtime/_wrap/signal.c
@@ -5,11 +5,14 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <sched.h>
 #include <signal.h>
 #include <stddef.h>
 #include <string.h>
 #include <unistd.h>
+
+_Static_assert(SIGPIPE == 13, "runtime signalPipe assumes SIGPIPE is 13");
 
 static int llgo_signal_pipe[2] = {-1, -1};
 static unsigned int llgo_signal_delivering;
@@ -87,6 +90,46 @@ int llgo_signal_ignore(int signum)
     sigemptyset(&action.sa_mask);
     action.sa_flags = 0;
     return sigaction(signum, &action, 0);
+}
+
+int llgo_signal_ignore_pipe(void)
+{
+    struct sigaction action;
+    struct sigaction previous;
+
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = SIG_IGN;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGPIPE, &action, &previous) != 0)
+        return -errno;
+    return previous.sa_handler == SIG_IGN;
+}
+
+int llgo_signal_raise_pipe(void)
+{
+    return raise(SIGPIPE);
+}
+
+int llgo_signal_die_pipe(void)
+{
+    struct sigaction action;
+    sigset_t mask;
+    int code;
+
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = SIG_DFL;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGPIPE, &action, 0) != 0)
+        return errno;
+
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGPIPE);
+    code = pthread_sigmask(SIG_UNBLOCK, &mask, 0);
+    if (code != 0)
+        return code;
+    if (raise(SIGPIPE) != 0)
+        return errno;
+    return EIO;
 }
 
 /* Place a marker after every signal already written to the pipe. The write

--- a/runtime/internal/lib/runtime/link_darwin_llgo.go
+++ b/runtime/internal/lib/runtime/link_darwin_llgo.go
@@ -71,7 +71,7 @@ func syscall_runtimeUnsetenv(key string) {
 func os_beforeExit(exitCode int) {}
 
 //go:linkname os_sigpipe os.sigpipe
-func os_sigpipe() {}
+func os_sigpipe() { signalPipe() }
 
 //go:linkname c_getpagesize C.getpagesize
 func c_getpagesize() c.Int

--- a/runtime/internal/lib/runtime/link_linux_llgo.go
+++ b/runtime/internal/lib/runtime/link_linux_llgo.go
@@ -62,7 +62,7 @@ func syscall_runtimeUnsetenv(key string) {
 func os_beforeExit(exitCode int) {}
 
 //go:linkname os_sigpipe os.sigpipe
-func os_sigpipe() {}
+func os_sigpipe() { signalPipe() }
 
 //go:linkname os_ignoreSIGSYS os.ignoreSIGSYS
 func os_ignoreSIGSYS() {}

--- a/runtime/internal/lib/runtime/signal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_llgo.go
@@ -23,6 +23,8 @@ var (
 	sigInitState uint32
 	sigReadFD    c.Int
 
+	sigPipeInheritedIgnored bool
+
 	sigMu     psync.Mutex
 	sigCond   psync.Cond
 	sigWaitMu psync.Mutex
@@ -48,11 +50,57 @@ func c_signalDisable(sig c.Int) c.Int
 //go:linkname c_signalIgnore C.llgo_signal_ignore
 func c_signalIgnore(sig c.Int) c.Int
 
+//go:linkname c_signalIgnorePipe C.llgo_signal_ignore_pipe
+func c_signalIgnorePipe() c.Int
+
+//go:linkname c_signalRaisePipe C.llgo_signal_raise_pipe
+func c_signalRaisePipe() c.Int
+
+//go:linkname c_signalDiePipe C.llgo_signal_die_pipe
+func c_signalDiePipe() c.Int
+
 //go:linkname c_signalBarrier C.llgo_signal_barrier
 func c_signalBarrier() c.Int
 
 //go:linkname c_signalRecv C.llgo_signal_recv
 func c_signalRecv(fd c.Int, sig *c.Int) c.Int
+
+func init() {
+	// Go programs turn SIGPIPE from ordinary file descriptors into EPIPE.
+	// Install that process-wide baseline before user goroutines can write.
+	previous := c_signalIgnorePipe()
+	if previous < 0 {
+		panic("runtime: failed to ignore SIGPIPE")
+	}
+	sigPipeInheritedIgnored = previous != 0
+}
+
+// signalPipe implements the explicit SIGPIPE raised by package os after an
+// EPIPE write to stdout or stderr. By contrast, EPIPE on ordinary descriptors
+// never reaches here; those writes rely on the ignored baseline from init.
+func signalPipe() {
+	const sigPipe = 13 // SIGPIPE on the supported Unix hosts.
+
+	ensureSignalInit()
+	sigMu.Lock()
+	defer sigMu.Unlock()
+	st := sigStates[sigPipe]
+	switch {
+	case st == nil && sigPipeInheritedIgnored:
+		return
+	case st != nil && st.ignored:
+		return
+	case st != nil && st.active:
+		if c_signalRaisePipe() != 0 {
+			panic("runtime: failed to raise SIGPIPE")
+		}
+		return
+	default:
+		if c_signalDiePipe() != 0 {
+			panic("runtime: failed to terminate with SIGPIPE")
+		}
+	}
+}
 
 func ensureSignalInit() {
 	const (

--- a/test/go/sigpipe_unix_test.go
+++ b/test/go/sigpipe_unix_test.go
@@ -1,0 +1,60 @@
+//go:build unix
+
+package gotest
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"testing"
+)
+
+func TestBrokenPipeReturnsEPIPE(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := read.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer write.Close()
+
+	if _, err := write.Write([]byte("x")); !errors.Is(err, syscall.EPIPE) {
+		t.Fatalf("write to broken pipe error = %v, want EPIPE", err)
+	}
+}
+
+func TestStdoutBrokenPipeExitsWithSIGPIPE(t *testing.T) {
+	const helperEnv = "LLGO_SIGPIPE_STDOUT_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		// The test parent ignores SIGPIPE and the child inherits that setting.
+		// Exercise Reset so the helper matches a program started with the
+		// default disposition before it writes to stdout.
+		notify := make(chan os.Signal, 1)
+		signal.Notify(notify, syscall.SIGPIPE)
+		signal.Reset(syscall.SIGPIPE)
+		_, _ = os.Stdout.Write([]byte("x"))
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStdoutBrokenPipeExitsWithSIGPIPE$")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stdout.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	err = cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("stdout broken-pipe child error = %v, want signal exit", err)
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGPIPE {
+		t.Fatalf("stdout broken-pipe child status = %v, want SIGPIPE", exitErr.Sys())
+	}
+}


### PR DESCRIPTION
## Summary

- ignore SIGPIPE as the Unix process baseline so writes to ordinary broken pipes return EPIPE
- preserve Go's special stdout/stderr behavior through os.sigpipe
- honor inherited SIGPIPE ignore state and os/signal Notify, Ignore, and Reset transitions
- add regressions for ordinary broken pipes and stdout termination

## Motivation

The client-go remotecommand compatibility test closes an SPDY connection while copy goroutines may still write. LLGo retained the process default SIGPIPE action, so those ordinary writes could terminate the test runner with exit status 141 instead of returning EPIPE.

Go ignores SIGPIPE for ordinary descriptors, while writes to broken stdout or stderr explicitly raise it unless the signal is ignored or handled. This change implements both halves rather than globally suppressing stdout/stderr behavior.

## Validation

- native and LLGo: TestBrokenPipeReturnsEPIPE
- native and LLGo: TestStdoutBrokenPipeExitsWithSIGPIPE
- native and LLGo: full ./test/std/os/signal
- client-go TestSPDYExecutorStream/stdoutBlockTest: 7/10 SIGPIPE exits before, 10/10 passes after
- full client-go TestSPDYExecutorStream: 3/3 passes after the fix

Compatibility context: https://xgo-dev.github.io/benchmarks/compatibility.html
