### PR TITLE
runtime: hide weak keys from conservative GC

### DIFF
--- a/runtime/internal/lib/runtime/weak_llgo.go
+++ b/runtime/internal/lib/runtime/weak_llgo.go
@@ -15,6 +15,17 @@ type weakHandle struct {
 	live uint32
 }
 
+// BDWGC conservatively treats pointer-looking uintptr values as live roots.
+// Keep weak-pointer identities encoded everywhere they outlive the call that
+// registers them, including map keys and weak handles.
+func encodeWeakPointer(p unsafe.Pointer) uintptr {
+	return ^uintptr(p)
+}
+
+func decodeWeakPointer(key uintptr) unsafe.Pointer {
+	return unsafe.Pointer(^key)
+}
+
 var weakState struct {
 	once psync.Once
 	mu   psync.Mutex
@@ -32,7 +43,7 @@ func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
 	}
 	weakState.once.Do(initWeakState)
 
-	key := uintptr(p)
+	key := encodeWeakPointer(p)
 	weakState.mu.Lock()
 	if h := weakState.m[key]; h != nil {
 		weakState.mu.Unlock()
@@ -42,6 +53,8 @@ func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
 	weakState.m[key] = h
 	weakState.mu.Unlock()
 
+	// Keep the cleanup closure limited to encoded identities. Capturing p here
+	// would turn the cleanup itself into a strong reference to the referent.
 	llrt.AddCleanupPtr(p, func() {
 		latomic.StoreUint32(&h.live, 0)
 		weakState.mu.Lock()
@@ -58,7 +71,7 @@ func llgoMakeStrongFromWeak(u unsafe.Pointer) unsafe.Pointer {
 	if h == nil || latomic.LoadUint32(&h.live) == 0 {
 		return nil
 	}
-	return unsafe.Pointer(h.key)
+	return decodeWeakPointer(h.key)
 }
 
 //go:linkname weak_runtime_registerWeakPointer weak.runtime_registerWeakPointer

--- a/test/std/weak/weak_test.go
+++ b/test/std/weak/weak_test.go
@@ -3,6 +3,7 @@ package weak_test
 import (
 	"runtime"
 	"testing"
+	"time"
 	"weak"
 )
 
@@ -52,12 +53,43 @@ func TestPointerGC(t *testing.T) {
 		}
 	}()
 
-	runtime.GC()
-	runtime.GC()
+	deadline := time.Now().Add(3 * time.Second)
+	for wp.Value() != nil && time.Now().Before(deadline) {
+		runtime.Gosched()
+		runtime.GC()
+		time.Sleep(time.Millisecond)
+	}
+	if val := wp.Value(); val != nil {
+		t.Fatalf("weak pointer remained valid after its object became unreachable: %v", *val)
+	}
+}
 
-	val := wp.Value()
-	if val != nil {
-		t.Log("Note: weak pointer still valid after GC (may happen)")
+func TestPointerGCWithCleanup(t *testing.T) {
+	var wp weak.Pointer[int]
+	cleaned := make(chan struct{}, 1)
+
+	func() {
+		x := new(int)
+		*x = 456
+		runtime.AddCleanup(x, func(struct{}) {
+			cleaned <- struct{}{}
+		}, struct{}{})
+		wp = weak.Make(x)
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for wp.Value() != nil && time.Now().Before(deadline) {
+		runtime.Gosched()
+		runtime.GC()
+		time.Sleep(time.Millisecond)
+	}
+	if val := wp.Value(); val != nil {
+		t.Fatalf("weak pointer remained valid after its object became unreachable: %v", *val)
+	}
+	select {
+	case <-cleaned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cleanup did not run after the weak pointer became nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- encode weak-pointer identities before retaining them in the runtime map and weak handle
- decode the identity only when promoting a live weak handle
- make weak collection tests strict and cover interaction with runtime.AddCleanup

## Motivation

LLGo stores weak-pointer identities as uintptr values. BDWGC is conservative and can treat those pointer-looking integers as roots, so the runtime's own weak map and handle kept the referent alive.

Bitwise-complement encoding preserves identity without leaving a value that looks like the original heap pointer in long-lived runtime state.

## Validation

- native: go test ./test/std/weak -count=1
- LLGo: llgo test -count=10 ./test/std/weak

## Scope

This fixes an independent weak-pointer root. The six client-go/transport cleanup failures remain reproducible after this change, so this PR does not claim to close that compatibility gap; a separate retaining-path investigation is still required.

Compatibility context: https://xgo-dev.github.io/benchmarks/compatibility.html
