### PR TITLE
runtime: serialize concurrent finalizer queue access

### DIFF
--- a/runtime/internal/lib/runtime/_wrap/signal.c
+++ b/runtime/internal/lib/runtime/_wrap/signal.c
@@ -26,7 +26,14 @@ _Static_assert(__atomic_always_lock_free(sizeof(unsigned int), 0),
 #endif
 
 static int llgo_signal_pipe[2] = {-1, -1};
+static struct sigaction llgo_signal_default_action;
 static unsigned int llgo_signal_delivering;
+enum {
+    LLGO_SIGNAL_DEFAULT,
+    LLGO_SIGNAL_WANTED,
+    LLGO_SIGNAL_IGNORED,
+};
+static unsigned int llgo_signal_modes[LLGO_SIGNAL_COUNT];
 static unsigned int llgo_signal_pending[LLGO_SIGNAL_WORDS];
 /* Only the dedicated signal reader accesses this snapshot. */
 static unsigned int llgo_signal_received[LLGO_SIGNAL_WORDS];
@@ -43,6 +50,25 @@ static void llgo_signal_handler(int signum)
     __atomic_add_fetch(&llgo_signal_delivering, 1, __ATOMIC_SEQ_CST);
     if (llgo_signal_pipe[1] >= 0 && signum > 0 &&
         signum < LLGO_SIGNAL_COUNT) {
+        unsigned int mode = __atomic_load_n(&llgo_signal_modes[signum],
+                                             __ATOMIC_SEQ_CST);
+
+        if (mode == LLGO_SIGNAL_IGNORED)
+            goto done;
+        if (mode != LLGO_SIGNAL_WANTED) {
+            /* The kernel may select this handler immediately before Stop
+             * restores SIG_DFL, then enter it only after Stop's pipe barrier.
+             * In that case the signal must take its default action rather
+             * than be queued after the stopping channel has been removed. */
+            if (sigaction(signum, &llgo_signal_default_action, 0) != 0)
+                _exit(128 + signum);
+            __atomic_sub_fetch(&llgo_signal_delivering, 1,
+                               __ATOMIC_SEQ_CST);
+            if (raise(signum) != 0)
+                _exit(128 + signum);
+            errno = saved_errno;
+            return;
+        }
         bit = 1U << ((unsigned int)signum & 31U);
         old = __atomic_fetch_or(&llgo_signal_pending[(unsigned int)signum / 32U],
                                 bit, __ATOMIC_SEQ_CST);
@@ -56,6 +82,7 @@ static void llgo_signal_handler(int signum)
             } while (count < 0 && errno == EINTR);
         }
     }
+done:
     __atomic_sub_fetch(&llgo_signal_delivering, 1, __ATOMIC_SEQ_CST);
     errno = saved_errno;
 }
@@ -68,6 +95,11 @@ int llgo_signal_init(void)
         return llgo_signal_pipe[0];
     if (pipe(llgo_signal_pipe) != 0)
         return -errno;
+
+    memset(&llgo_signal_default_action, 0,
+           sizeof(llgo_signal_default_action));
+    llgo_signal_default_action.sa_handler = SIG_DFL;
+    sigemptyset(&llgo_signal_default_action.sa_mask);
 
     flags = fcntl(llgo_signal_pipe[1], F_GETFL, 0);
     if (flags < 0 || fcntl(llgo_signal_pipe[1], F_SETFL,
@@ -90,34 +122,65 @@ fail:
 int llgo_signal_enable(int signum)
 {
     struct sigaction action;
+    unsigned int previous;
+    int code;
+
+    if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT)
+        return EINVAL;
 
     memset(&action, 0, sizeof(action));
     action.sa_handler = llgo_signal_handler;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    return sigaction(signum, &action, 0);
+    previous = __atomic_exchange_n(&llgo_signal_modes[signum],
+                                   LLGO_SIGNAL_WANTED, __ATOMIC_SEQ_CST);
+    if (sigaction(signum, &action, 0) == 0)
+        return 0;
+    code = errno;
+    __atomic_store_n(&llgo_signal_modes[signum], previous,
+                     __ATOMIC_SEQ_CST);
+    return code;
 }
 
 int llgo_signal_disable(int signum)
 {
-    struct sigaction action;
+    unsigned int previous;
+    int code;
 
-    memset(&action, 0, sizeof(action));
-    action.sa_handler = SIG_DFL;
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = 0;
-    return sigaction(signum, &action, 0);
+    if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT)
+        return EINVAL;
+
+    previous = __atomic_exchange_n(&llgo_signal_modes[signum],
+                                   LLGO_SIGNAL_DEFAULT, __ATOMIC_SEQ_CST);
+    if (sigaction(signum, &llgo_signal_default_action, 0) == 0)
+        return 0;
+    code = errno;
+    __atomic_store_n(&llgo_signal_modes[signum], previous,
+                     __ATOMIC_SEQ_CST);
+    return code;
 }
 
 int llgo_signal_ignore(int signum)
 {
     struct sigaction action;
+    unsigned int previous;
+    int code;
+
+    if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT)
+        return EINVAL;
 
     memset(&action, 0, sizeof(action));
     action.sa_handler = SIG_IGN;
     sigemptyset(&action.sa_mask);
     action.sa_flags = 0;
-    return sigaction(signum, &action, 0);
+    previous = __atomic_exchange_n(&llgo_signal_modes[signum],
+                                   LLGO_SIGNAL_IGNORED, __ATOMIC_SEQ_CST);
+    if (sigaction(signum, &action, 0) == 0)
+        return 0;
+    code = errno;
+    __atomic_store_n(&llgo_signal_modes[signum], previous,
+                     __ATOMIC_SEQ_CST);
+    return code;
 }
 
 int llgo_signal_ignore_pipe(void)

--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -50,7 +50,7 @@ type finalizerEntry struct {
 
 var finalizerState struct {
 	once psync.Once
-	mu   psync.Mutex
+	mu   psync.Mutex // protects m, head, and tail
 	m    map[uintptr]*finalizerEntry
 	head *finalizerEntry
 	tail *finalizerEntry
@@ -198,12 +198,15 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 	}
 
 	// Keep the object alive until runFinalizers invokes the Go finalizer.
-	// Do not allocate or lock here; BDWGC calls this while collecting.
 	if state == finalizerInterfaceState {
 		(*finalizerInterfaceArg)(entry.arg).data = ptr
 	} else {
 		entry.arg = ptr
 	}
+	// GC_invoke_finalizers may run on several threads concurrently. It calls
+	// client finalizers without BDWGC's allocation lock, so serialize queue
+	// publication with concurrent drainers.
+	finalizerState.mu.Lock()
 	entry.next = nil
 	if finalizerState.tail == nil {
 		finalizerState.head = entry
@@ -212,6 +215,7 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 		finalizerState.tail.next = entry
 		finalizerState.tail = entry
 	}
+	finalizerState.mu.Unlock()
 }
 
 func restoreFinalizer(ptr unsafe.Pointer, entry *finalizerEntry) {
@@ -227,8 +231,10 @@ func restoreFinalizer(ptr unsafe.Pointer, entry *finalizerEntry) {
 func runFinalizers() {
 	finalizerState.once.Do(initFinalizerState)
 	for {
+		finalizerState.mu.Lock()
 		entry := finalizerState.head
 		if entry == nil {
+			finalizerState.mu.Unlock()
 			return
 		}
 		finalizerState.head = entry.next
@@ -236,7 +242,6 @@ func runFinalizers() {
 			finalizerState.tail = nil
 		}
 		entry.next = nil
-		finalizerState.mu.Lock()
 		if finalizerState.m[entry.key] == entry {
 			delete(finalizerState.m, entry.key)
 		}

--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -197,16 +197,18 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 		return
 	}
 
-	// Keep the object alive until runFinalizers invokes the Go finalizer.
+	// GC_invoke_finalizers may run on several threads concurrently. BDWGC
+	// releases its allocation lock before invoking client finalizers, including
+	// from its default allocation-time path, so serialize queue publication
+	// with concurrent drainers.
+	finalizerState.mu.Lock()
+	// Keep the object alive until runFinalizers invokes the Go finalizer. The
+	// mutex publishes these writes together with the queue entry.
 	if state == finalizerInterfaceState {
 		(*finalizerInterfaceArg)(entry.arg).data = ptr
 	} else {
 		entry.arg = ptr
 	}
-	// GC_invoke_finalizers may run on several threads concurrently. It calls
-	// client finalizers without BDWGC's allocation lock, so serialize queue
-	// publication with concurrent drainers.
-	finalizerState.mu.Lock()
 	entry.next = nil
 	if finalizerState.tail == nil {
 		finalizerState.head = entry
@@ -242,6 +244,8 @@ func runFinalizers() {
 			finalizerState.tail = nil
 		}
 		entry.next = nil
+		// A later SetFinalizer may already have installed a replacement entry
+		// for the same object key; do not delete that newer entry.
 		if finalizerState.m[entry.key] == entry {
 			delete(finalizerState.m, entry.key)
 		}

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -53,10 +53,12 @@ LLGO_STRESS_PROFILE=heavy /tmp/llgo-runtime-stress test \
 ```
 
 The timer suite covers large live heaps, concurrent `Stop`/`Reset` on distinct
-and shared timers, callback bursts, and concurrent sleepers. The four signal
+and shared timers, callback bursts, and concurrent sleepers. The five signal
 tests cover distinct-signal delivery during a lower-number signal storm,
-concurrent registration churn, repeated `Notify`/`Stop`/`Reset` barriers, and
-timer progress while handlers are busy. The flood cases also exercise
-the handler under concurrent delivery pressure. The finalizer suite repeatedly
-publishes large finalizer batches while many goroutines call `runtime.GC`, and
-checks that queued callbacks are neither corrupted nor delivered twice.
+concurrent registration churn, repeated `Notify`/`Stop`/`Reset` barriers,
+fatal-signal arbitration in concurrent helper processes while the final
+receiver stops, and timer progress while handlers are busy. The flood cases
+also exercise the handler under concurrent delivery pressure. The finalizer
+suite repeatedly publishes large finalizer batches while many goroutines call
+`runtime.GC`, and checks that queued callbacks are neither corrupted nor
+delivered twice.

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -1,10 +1,24 @@
 # Runtime stress tests
 
-These tests exercise timer and Unix signal correctness under loads that are too
-expensive for routine pull-request testing. The leading-underscore directory
-and nested module keep them out of the repository's normal `go test ./...` and
+These tests exercise runtime correctness under loads that are too expensive for
+routine pull-request testing. The leading-underscore directory and nested
+module keep them out of the repository's normal `go test ./...` and
 `llgo test ./test/...` patterns. No push, pull-request, scheduled, or daily
 workflow runs them automatically.
+
+## Placement policy
+
+- Keep deterministic, bounded regression coverage that is suitable for every
+  pull request in the normal `test` tree.
+- Put a test here when its useful baseline deliberately requires high
+  concurrency, large live object counts, many repetitions, long timeouts, or a
+  soak profile. A stress test should not be the only regression coverage for a
+  bug when a small routine test is practical.
+- Group runtime suites under `runtime/<subsystem>`. Use
+  `LLGO_STRESS_PROFILE` for scalable counts, give every wait a finite timeout,
+  and document platform or compiler restrictions below.
+- Adding a suite here does not opt it into CI. Run it explicitly against the
+  LLGo revision under test when changing the affected subsystem.
 
 Build LLGo from the revision being tested, then run the suites explicitly:
 
@@ -17,10 +31,12 @@ cd "$repo/test/_stress"
 go test -race -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/signal
+/tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/finalizer
 ```
 
-The signal suite is LLGo-only and targets Unix hosts. The timer suite also runs
-with the standard Go compiler so the harness can be checked independently.
+The signal suite is LLGo-only and targets Unix hosts. The finalizer suite is
+LLGo-only and targets hosted BDWGC builds. The timer suite also runs with the
+standard Go compiler so the harness can be checked independently.
 
 `LLGO_STRESS_PROFILE` controls the load while preserving the same assertions:
 
@@ -41,4 +57,6 @@ and shared timers, callback bursts, and concurrent sleepers. The four signal
 tests cover distinct-signal delivery during a lower-number signal storm,
 concurrent registration churn, repeated `Notify`/`Stop`/`Reset` barriers, and
 timer progress while handlers are busy. The flood cases also exercise
-the handler under concurrent delivery pressure.
+the handler under concurrent delivery pressure. The finalizer suite repeatedly
+publishes large finalizer batches while many goroutines call `runtime.GC`, and
+checks that queued callbacks are neither corrupted nor delivered twice.

--- a/test/_stress/runtime/finalizer/finalizer_stress_llgo_test.go
+++ b/test/_stress/runtime/finalizer/finalizer_stress_llgo_test.go
@@ -1,0 +1,113 @@
+//go:build llgo && !baremetal && !nogc && !wasm
+
+package finalizerstress
+
+import (
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+	_ "unsafe"
+)
+
+type finalizerValue struct {
+	value int
+	pad   [64]byte
+}
+
+//go:linkname getBDWGCFinalizeOnDemand C.GC_get_finalize_on_demand
+func getBDWGCFinalizeOnDemand() int32
+
+//go:linkname setBDWGCFinalizeOnDemand C.GC_set_finalize_on_demand
+func setBDWGCFinalizeOnDemand(enabled int32)
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		if count := base / 8; count > 0 {
+			return count
+		}
+		return 1
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+func TestConcurrentGCFinalizerQueue(t *testing.T) {
+	// Keep finalization inside the concurrent runtime.GC calls below instead
+	// of letting an unrelated allocation drain BDWGC's ready queue first.
+	old := getBDWGCFinalizeOnDemand()
+	setBDWGCFinalizeOnDemand(1)
+	t.Cleanup(func() {
+		setBDWGCFinalizeOnDemand(old)
+	})
+
+	rounds := stressCount(t, 8)
+	objects := stressCount(t, 2048)
+	workers := stressCount(t, 32)
+	for round := 0; round < rounds; round++ {
+		runConcurrentGCFinalizerRound(t, round, objects, workers)
+	}
+}
+
+func runConcurrentGCFinalizerRound(t *testing.T, round, objects, workers int) {
+	t.Helper()
+	finalized := make(chan int, objects)
+	registered := make(chan struct{})
+	go func() {
+		for i := 0; i < objects; i++ {
+			p := &finalizerValue{value: i}
+			runtime.SetFinalizer(p, func(p *finalizerValue) {
+				finalized <- p.value
+			})
+		}
+		close(registered)
+	}()
+	<-registered
+
+	seen := make(map[int]bool, objects)
+	deadline := time.After(30 * time.Second)
+	for len(seen) <= objects/2 {
+		var work sync.WaitGroup
+		work.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer work.Done()
+				runtime.GC()
+			}()
+		}
+		work.Wait()
+
+		for {
+			select {
+			case value := <-finalized:
+				if value < 0 || value >= objects {
+					t.Fatalf("round %d: finalizer got %d, want [0,%d)", round, value, objects)
+				}
+				if seen[value] {
+					t.Fatalf("round %d: finalizer got duplicate value %d", round, value)
+				}
+				seen[value] = true
+			default:
+				goto drained
+			}
+		}
+	drained:
+		if len(seen) > objects/2 {
+			return
+		}
+		runtime.Gosched()
+		select {
+		case <-deadline:
+			t.Fatalf("round %d: only %d/%d concurrent finalizers ran", round, len(seen), objects)
+		default:
+		}
+	}
+}

--- a/test/_stress/runtime/signal/signal_stress_llgo_test.go
+++ b/test/_stress/runtime/signal/signal_stress_llgo_test.go
@@ -3,8 +3,10 @@
 package signalstress
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"sync"
 	"sync/atomic"
@@ -180,6 +182,93 @@ func TestNotifyStopResetBarrier(t *testing.T) {
 		}
 		signal.Reset(syscall.SIGWINCH)
 	}
+}
+
+const atomicStopStressHelperEnv = "LLGO_STRESS_ATOMIC_SIGNAL_STOP"
+
+func TestAtomicStopRace(t *testing.T) {
+	if os.Getenv(atomicStopStressHelperEnv) == "1" {
+		runAtomicStopStressHelper(t, stressCount(t, 128))
+		return
+	}
+
+	// Keep SIGINT from being inherited as ignored by the helper. Each raced
+	// signal must either reach the stopping channel or take the default action.
+	parentSignals := make(chan os.Signal, 1)
+	signal.Notify(parentSignals, syscall.SIGINT)
+	defer signal.Stop(parentSignals)
+
+	helpers := stressCount(t, 64)
+	results := make(chan atomicStopResult, helpers)
+	for helper := 0; helper < helpers; helper++ {
+		go func(helper int) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestAtomicStopRace$")
+			cmd.Env = append(os.Environ(), atomicStopStressHelperEnv+"=1")
+			out, err := cmd.CombinedOutput()
+			results <- atomicStopResult{helper, out, err}
+		}(helper)
+	}
+	for received := 0; received < helpers; received++ {
+		result := <-results
+		if bytes.Contains(result.out, []byte("lost signal")) {
+			t.Errorf("helper %d dropped a signal during Stop:\n%s",
+				result.helper, result.out)
+			continue
+		}
+		if result.err == nil {
+			continue
+		}
+		exitErr, ok := result.err.(*exec.ExitError)
+		if !ok {
+			t.Errorf("helper %d: %v", result.helper, result.err)
+			continue
+		}
+		status, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok || !status.Signaled() || status.Signal() != syscall.SIGINT {
+			t.Errorf("helper %d exited unexpectedly: %v\n%s",
+				result.helper, result.err, result.out)
+		}
+	}
+}
+
+type atomicStopResult struct {
+	helper int
+	out    []byte
+	err    error
+}
+
+func runAtomicStopStressHelper(t *testing.T, tries int) {
+	t.Helper()
+	if signal.Ignored(syscall.SIGINT) {
+		fmt.Println("SIGINT is ignored")
+		os.Exit(2)
+	}
+
+	pid := syscall.Getpid()
+	for try := 0; try < tries; try++ {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT)
+
+		var stopped sync.WaitGroup
+		stopped.Add(1)
+		go func() {
+			defer stopped.Done()
+			signal.Stop(c)
+		}()
+
+		if err := syscall.Kill(pid, syscall.SIGINT); err != nil {
+			fmt.Printf("kill: %v\n", err)
+			os.Exit(2)
+		}
+		select {
+		case <-c:
+		case <-time.After(2 * time.Second):
+			fmt.Printf("lost signal on try %d\n", try)
+			os.Exit(3)
+		}
+		stopped.Wait()
+	}
+	os.Exit(0)
 }
 
 func TestConcurrentNotifyStopDuringSignalFlood(t *testing.T) {

--- a/test/go/finalizer_llgo_test.go
+++ b/test/go/finalizer_llgo_test.go
@@ -118,8 +118,10 @@ func TestRuntimeConcurrentGCFinalizers(t *testing.T) {
 	})
 
 	const (
-		objects = 256
-		workers = 8
+		// Keep the routine regression small. The opt-in high-load variant lives
+		// in test/_stress/runtime/finalizer.
+		objects = 32
+		workers = 4
 	)
 	finalized := make(chan int, objects)
 	registered := make(chan struct{})

--- a/test/go/finalizer_llgo_test.go
+++ b/test/go/finalizer_llgo_test.go
@@ -4,10 +4,16 @@ package gotest
 
 import (
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 	_ "unsafe"
 )
+
+type concurrentFinalizerValue struct {
+	value int
+	pad   [64]byte
+}
 
 //go:linkname getBDWGCFinalizeOnDemand C.GC_get_finalize_on_demand
 func getBDWGCFinalizeOnDemand() int32
@@ -99,5 +105,64 @@ func TestRuntimeGCDrainsBDWGCFinalizersOnDemand(t *testing.T) {
 	}
 	if got := len(finalized); got <= n/2 {
 		t.Fatalf("runtime.GC ran only %d/%d on-demand finalizers", got, n)
+	}
+}
+
+func TestRuntimeConcurrentGCFinalizers(t *testing.T) {
+	// Keep finalization inside the concurrent runtime.GC calls below instead
+	// of letting an unrelated allocation drain BDWGC's ready queue first.
+	old := getBDWGCFinalizeOnDemand()
+	setBDWGCFinalizeOnDemand(1)
+	t.Cleanup(func() {
+		setBDWGCFinalizeOnDemand(old)
+	})
+
+	const (
+		objects = 256
+		workers = 8
+		rounds  = 8
+	)
+	finalized := make(chan int, objects)
+	registered := make(chan struct{})
+	go func() {
+		for i := range objects {
+			p := &concurrentFinalizerValue{value: i}
+			runtime.SetFinalizer(p, func(p *concurrentFinalizerValue) {
+				finalized <- p.value
+			})
+		}
+		close(registered)
+	}()
+	<-registered
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range rounds {
+				runtime.GC()
+			}
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[int]bool)
+	for {
+		select {
+		case value := <-finalized:
+			if value < 0 || value >= objects {
+				t.Fatalf("finalizer got %d, want [0,%d)", value, objects)
+			}
+			if seen[value] {
+				t.Fatalf("finalizer got duplicate value %d", value)
+			}
+			seen[value] = true
+		default:
+			if len(seen) <= objects/2 {
+				t.Fatalf("only %d/%d concurrent finalizers ran", len(seen), objects)
+			}
+			return
+		}
 	}
 }

--- a/test/go/finalizer_llgo_test.go
+++ b/test/go/finalizer_llgo_test.go
@@ -120,7 +120,6 @@ func TestRuntimeConcurrentGCFinalizers(t *testing.T) {
 	const (
 		objects = 256
 		workers = 8
-		rounds  = 8
 	)
 	finalized := make(chan int, objects)
 	registered := make(chan struct{})
@@ -135,34 +134,42 @@ func TestRuntimeConcurrentGCFinalizers(t *testing.T) {
 	}()
 	<-registered
 
-	var wg sync.WaitGroup
-	wg.Add(workers)
-	for range workers {
-		go func() {
-			defer wg.Done()
-			for range rounds {
-				runtime.GC()
-			}
-		}()
-	}
-	wg.Wait()
-
 	seen := make(map[int]bool)
-	for {
-		select {
-		case value := <-finalized:
-			if value < 0 || value >= objects {
-				t.Fatalf("finalizer got %d, want [0,%d)", value, objects)
+	deadline := time.After(3 * time.Second)
+	for len(seen) <= objects/2 {
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for range workers {
+			go func() {
+				defer wg.Done()
+				runtime.GC()
+			}()
+		}
+		wg.Wait()
+
+		for {
+			select {
+			case value := <-finalized:
+				if value < 0 || value >= objects {
+					t.Fatalf("finalizer got %d, want [0,%d)", value, objects)
+				}
+				if seen[value] {
+					t.Fatalf("finalizer got duplicate value %d", value)
+				}
+				seen[value] = true
+			default:
+				goto drained
 			}
-			if seen[value] {
-				t.Fatalf("finalizer got duplicate value %d", value)
-			}
-			seen[value] = true
-		default:
-			if len(seen) <= objects/2 {
-				t.Fatalf("only %d/%d concurrent finalizers ran", len(seen), objects)
-			}
+		}
+	drained:
+		if len(seen) > objects/2 {
 			return
+		}
+		runtime.Gosched()
+		select {
+		case <-deadline:
+			t.Fatalf("only %d/%d concurrent finalizers ran", len(seen), objects)
+		default:
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- serialize publication and draining of the Go finalizer queue with the existing native runtime mutex
- prevent concurrent `runtime.GC` callers from dequeuing and invoking the same finalizer entry twice
- add a regression test that drives finalization from eight concurrent collectors

## Cause

BDWGC permits concurrent `GC_invoke_finalizers` callers and invokes client callbacks without holding its allocation lock. The LLGo queue in `setFinalizerCallback` and `runFinalizers` was unsynchronized. Two drainers could read the same head entry; after the first call cleared `entry.arg`, the second called the same finalizer with a nil argument. The mutex is released before invoking user finalizer code.

## Validation

- macOS arm64: the regression failed before the fix with a nil finalizer argument; 20 consecutive runs pass after the fix
- Windows ARM64 MinGW: the regression failed on its second run before the fix; 20 consecutive runs pass after the fix
- `go test ./test/go -run ^TestRuntimeConcurrentGCFinalizers$ -count=1` (host compile check)