### PR TITLE
windows: qualify remaining GNU/MinGW architectures (R11; depends on #2454)

### DIFF
--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -64,6 +64,8 @@ runs:
           "arm64" { "aarch64" }
           default { throw "Unsupported Windows GNU target architecture: $goArch" }
         }
+        $cc = "clang"
+        $cxx = "clang++"
 
         if ($goArch -eq "386") {
           foreach ($name in @("LLGO_MINGW_TARGET_BIN", "LLGO_MINGW_TARGET_RUNTIME_BIN", "LLGO_MINGW_TARGET_TOOLS", "LLGO_MINGW_TARGET_TRIPLE", "LLGO_MINGW_TARGET_VCPKG_ROOT")) {
@@ -73,6 +75,12 @@ runs:
             }
           }
           $compiler = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang.exe"
+          $compilerXX = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang++.exe"
+          foreach ($path in @($compiler, $compilerXX)) {
+            if (-not (Test-Path $path)) {
+              throw "The standalone llvm-mingw target compiler was not found: $path"
+            }
+          }
           $target = (& $compiler -dumpmachine).Trim()
           if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
             throw "llvm-mingw reports $target, want windows/$goArch GNU"
@@ -84,6 +92,12 @@ runs:
           Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_RUNTIME_BIN
           Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_TOOLS
           Add-Content -Encoding utf8 $env:GITHUB_PATH (Join-Path $env:LLGO_MINGW_TARGET_VCPKG_ROOT "bin")
+          # Keep the wrappers for interactive shells, but let LLGo invoke the
+          # drivers directly. A normal runtime link can exceed cmd.exe's 8191
+          # character limit while remaining below LLGo's 30 KiB response-file
+          # threshold.
+          $cc = $compiler
+          $cxx = $compilerXX
         } else {
           $target = (& clang.exe -dumpmachine).Trim()
           if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
@@ -91,8 +105,8 @@ runs:
           }
         }
 
-        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=clang"
-        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=clang++"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=$cc"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=$cxx"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOOS=windows"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOARCH=$goArch"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_TARGET_ACTIVE=1"

--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -131,6 +131,9 @@ runs:
         # This prevents llvm-mingw's unqualified host tools from shadowing the
         # LLVM installation used to build the LLGo compiler itself.
         echo "$LLGO_MINGW_TARGET_TOOLS" >> "$GITHUB_PATH"
+        echo "CC=$LLGO_MINGW_TARGET_TOOLS/clang" >> "$GITHUB_ENV"
+        echo "CXX=$LLGO_MINGW_TARGET_TOOLS/clang++" >> "$GITHUB_ENV"
+        echo "PKG_CONFIG=$LLGO_MINGW_TARGET_TOOLS/pkg-config" >> "$GITHUB_ENV"
         echo "CGO_ENABLED=1" >> "$GITHUB_ENV"
         echo "GOOS=windows" >> "$GITHUB_ENV"
         echo "GOARCH=${{ inputs.windows-arch }}" >> "$GITHUB_ENV"

--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -96,3 +96,42 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOOS=windows"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOARCH=$goArch"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_TARGET_ACTIVE=1"
+
+    - name: Activate cross-host Windows GNU target
+      if: runner.os != 'Windows' && inputs.windows-abi == 'mingw'
+      shell: bash
+      run: |
+        set -euo pipefail
+        for name in \
+          LLGO_MINGW_TARGET_BIN \
+          LLGO_MINGW_TARGET_RUNTIME_BIN \
+          LLGO_MINGW_TARGET_TOOLS \
+          LLGO_MINGW_TARGET_TRIPLE \
+          LLGO_MINGW_TARGET_VCPKG_ROOT; do
+          if [[ -z "${!name:-}" ]]; then
+            echo "the cross-host llvm-mingw target did not export $name" >&2
+            exit 1
+          fi
+        done
+
+        target="$(${LLGO_MINGW_TARGET_TOOLS}/clang -dumpmachine)"
+        case "${{ inputs.windows-arch }}:$target" in
+          386:i686-*-windows-gnu|386:i686-*-mingw32) ;;
+          amd64:x86_64-*-windows-gnu|amd64:x86_64-*-mingw32) ;;
+          arm64:aarch64-*-windows-gnu|arm64:aarch64-*-mingw32) ;;
+          *)
+            echo "llvm-mingw reports $target for windows/${{ inputs.windows-arch }}" >&2
+            exit 1
+            ;;
+        esac
+
+        # Only expose the target-selecting wrappers. The compiler locates its
+        # own CRT by absolute path, target DLLs cannot run on this Unix host,
+        # and vcpkg contributes link flags through the pkg-config wrapper.
+        # This prevents llvm-mingw's unqualified host tools from shadowing the
+        # LLVM installation used to build the LLGo compiler itself.
+        echo "$LLGO_MINGW_TARGET_TOOLS" >> "$GITHUB_PATH"
+        echo "CGO_ENABLED=1" >> "$GITHUB_ENV"
+        echo "GOOS=windows" >> "$GITHUB_ENV"
+        echo "GOARCH=${{ inputs.windows-arch }}" >> "$GITHUB_ENV"
+        echo "LLGO_WINDOWS_TARGET_ACTIVE=1" >> "$GITHUB_ENV"

--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -52,7 +52,47 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_TARGET_ACTIVE=1"
         Add-Content -Encoding utf8 $env:GITHUB_PATH (Join-Path $env:LLGO_WINDOWS_VCPKG_ROOT "bin")
 
-    - name: Reject unsupported Windows GNU target architecture
-      if: runner.os == 'Windows' && inputs.windows-abi == 'mingw' && inputs.windows-arch != 'amd64'
+    - name: Activate Windows GNU target
+      if: runner.os == 'Windows' && inputs.windows-abi == 'mingw'
       shell: pwsh
-      run: throw "Non-amd64 MinGW qualification belongs to R11"
+      run: |
+        $ErrorActionPreference = "Stop"
+        $goArch = "${{ inputs.windows-arch }}"
+        $targetArch = switch ($goArch) {
+          "386" { "i686" }
+          "amd64" { "x86_64|amd64" }
+          "arm64" { "aarch64" }
+          default { throw "Unsupported Windows GNU target architecture: $goArch" }
+        }
+
+        if ($goArch -eq "386") {
+          foreach ($name in @("LLGO_MINGW_TARGET_BIN", "LLGO_MINGW_TARGET_RUNTIME_BIN", "LLGO_MINGW_TARGET_TOOLS", "LLGO_MINGW_TARGET_TRIPLE", "LLGO_MINGW_TARGET_VCPKG_ROOT")) {
+            $value = [Environment]::GetEnvironmentVariable($name)
+            if (-not $value) {
+              throw "The standalone llvm-mingw target did not export $name"
+            }
+          }
+          $compiler = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang.exe"
+          $target = (& $compiler -dumpmachine).Trim()
+          if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
+            throw "llvm-mingw reports $target, want windows/$goArch GNU"
+          }
+          # GITHUB_PATH prepends entries in reverse write order. Keep the
+          # target-selecting clang/pkg-config wrappers ahead of the bundle's
+          # unqualified x64 host commands for all subsequent steps.
+          Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_BIN
+          Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_RUNTIME_BIN
+          Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_TOOLS
+          Add-Content -Encoding utf8 $env:GITHUB_PATH (Join-Path $env:LLGO_MINGW_TARGET_VCPKG_ROOT "bin")
+        } else {
+          $target = (& clang.exe -dumpmachine).Trim()
+          if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
+            throw "MSYS2 Clang reports $target, want windows/$goArch GNU"
+          }
+        }
+
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=clang"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=clang++"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "GOOS=windows"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "GOARCH=$goArch"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_TARGET_ACTIVE=1"

--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -64,8 +64,6 @@ runs:
           "arm64" { "aarch64" }
           default { throw "Unsupported Windows GNU target architecture: $goArch" }
         }
-        $cc = "clang"
-        $cxx = "clang++"
 
         if ($goArch -eq "386") {
           foreach ($name in @("LLGO_MINGW_TARGET_BIN", "LLGO_MINGW_TARGET_RUNTIME_BIN", "LLGO_MINGW_TARGET_TOOLS", "LLGO_MINGW_TARGET_TRIPLE", "LLGO_MINGW_TARGET_VCPKG_ROOT")) {
@@ -75,12 +73,6 @@ runs:
             }
           }
           $compiler = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang.exe"
-          $compilerXX = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang++.exe"
-          foreach ($path in @($compiler, $compilerXX)) {
-            if (-not (Test-Path $path)) {
-              throw "The standalone llvm-mingw target compiler was not found: $path"
-            }
-          }
           $target = (& $compiler -dumpmachine).Trim()
           if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
             throw "llvm-mingw reports $target, want windows/$goArch GNU"
@@ -92,11 +84,6 @@ runs:
           Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_RUNTIME_BIN
           Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_TOOLS
           Add-Content -Encoding utf8 $env:GITHUB_PATH (Join-Path $env:LLGO_MINGW_TARGET_VCPKG_ROOT "bin")
-          # Keep the wrappers for commands typed by users, but let LLGo invoke
-          # the real drivers directly. cmd.exe limits .cmd command lines to
-          # 8191 characters, which is too short for LLVM's static link flags.
-          $cc = $compiler
-          $cxx = $compilerXX
         } else {
           $target = (& clang.exe -dumpmachine).Trim()
           if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
@@ -104,8 +91,8 @@ runs:
           }
         }
 
-        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=$cc"
-        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=$cxx"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=clang"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=clang++"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOOS=windows"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOARCH=$goArch"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_TARGET_ACTIVE=1"

--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -13,17 +13,60 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Record the installed host compiler when available
+    - name: Record and isolate the host compiler when available
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $ErrorActionPreference = "Stop"
-        # GOROOT and benchmark jobs pass their explicitly built host compiler
-        # by path. Shared test jobs install llgo on PATH and reuse it whenever
-        # a target-native test launches the compiler as a subprocess.
+        # GOROOT exposes its explicitly built compiler through LLGO_TEST_LLGO.
+        # Shared test jobs install llgo on PATH and reuse it whenever a
+        # target-native test launches the compiler as a subprocess.
         $hostCompiler = Get-Command llgo.exe -ErrorAction SilentlyContinue
-        if ($null -ne $hostCompiler) {
-          Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_TEST_COMPILER=$($hostCompiler.Source)"
+        $hostCompilerPath = if ($env:LLGO_TEST_LLGO -and (Test-Path $env:LLGO_TEST_LLGO)) {
+          (Resolve-Path $env:LLGO_TEST_LLGO).Path
+        } elseif ($null -ne $hostCompiler) {
+          $hostCompiler.Source
+        }
+        if ($hostCompilerPath) {
+          if ("${{ inputs.windows-abi }}" -eq "mingw" -and "${{ inputs.windows-arch }}" -eq "386") {
+            $hostBin = Join-Path $env:LLGO_MINGW_HOST_ROOT "bin"
+            $objdump = Join-Path $hostBin "llvm-objdump.exe"
+            if (-not (Test-Path $objdump)) {
+              throw "The MinGW host llvm-objdump is unavailable: $objdump"
+            }
+
+            # The x86 target DLL directories must precede the x64 host on PATH
+            # when generated programs run. Put the host compiler's DLL closure
+            # beside llgo.exe so Windows resolves it before consulting PATH.
+            $compilerDir = Split-Path $hostCompilerPath
+            $queue = [Collections.Generic.Queue[string]]::new()
+            $queue.Enqueue($hostCompilerPath)
+            $copied = @{}
+            while ($queue.Count -ne 0) {
+              $binary = $queue.Dequeue()
+              foreach ($line in (& $objdump -p $binary)) {
+                if ($line -notmatch '^\s*DLL Name:\s*(\S+)\s*$') {
+                  continue
+                }
+                $name = $Matches[1]
+                if ($copied.ContainsKey($name)) {
+                  continue
+                }
+                $source = Join-Path $hostBin $name
+                if (-not (Test-Path $source)) {
+                  continue
+                }
+                $destination = Join-Path $compilerDir $name
+                Copy-Item -LiteralPath $source -Destination $destination -Force
+                $copied[$name] = $true
+                $queue.Enqueue($destination)
+              }
+            }
+            if ($copied.Count -eq 0) {
+              throw "No MinGW host runtime DLLs were discovered for $hostCompilerPath"
+            }
+          }
+          Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_TEST_COMPILER=$hostCompilerPath"
         }
 
     - name: Activate Windows MSVC target

--- a/.github/actions/activate-windows-target/action.yml
+++ b/.github/actions/activate-windows-target/action.yml
@@ -64,6 +64,8 @@ runs:
           "arm64" { "aarch64" }
           default { throw "Unsupported Windows GNU target architecture: $goArch" }
         }
+        $cc = "clang"
+        $cxx = "clang++"
 
         if ($goArch -eq "386") {
           foreach ($name in @("LLGO_MINGW_TARGET_BIN", "LLGO_MINGW_TARGET_RUNTIME_BIN", "LLGO_MINGW_TARGET_TOOLS", "LLGO_MINGW_TARGET_TRIPLE", "LLGO_MINGW_TARGET_VCPKG_ROOT")) {
@@ -73,6 +75,12 @@ runs:
             }
           }
           $compiler = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang.exe"
+          $compilerXX = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang++.exe"
+          foreach ($path in @($compiler, $compilerXX)) {
+            if (-not (Test-Path $path)) {
+              throw "The standalone llvm-mingw target compiler was not found: $path"
+            }
+          }
           $target = (& $compiler -dumpmachine).Trim()
           if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
             throw "llvm-mingw reports $target, want windows/$goArch GNU"
@@ -84,6 +92,11 @@ runs:
           Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_RUNTIME_BIN
           Add-Content -Encoding utf8 $env:GITHUB_PATH $env:LLGO_MINGW_TARGET_TOOLS
           Add-Content -Encoding utf8 $env:GITHUB_PATH (Join-Path $env:LLGO_MINGW_TARGET_VCPKG_ROOT "bin")
+          # Keep the wrappers for commands typed by users, but let LLGo invoke
+          # the real drivers directly. cmd.exe limits .cmd command lines to
+          # 8191 characters, which is too short for LLVM's static link flags.
+          $cc = $compiler
+          $cxx = $compilerXX
         } else {
           $target = (& clang.exe -dumpmachine).Trim()
           if ($target -notmatch "^$targetArch-.*-(windows-gnu|mingw32)$") {
@@ -91,8 +104,8 @@ runs:
           }
         }
 
-        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=clang"
-        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=clang++"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=$cc"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=$cxx"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOOS=windows"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "GOARCH=$goArch"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_TARGET_ACTIVE=1"

--- a/.github/actions/setup-demo-deps/action.yml
+++ b/.github/actions/setup-demo-deps/action.yml
@@ -23,7 +23,7 @@ runs:
         # stdlib path with that installation and cannot import encodings. Keep
         # the MinGW demo environment on the normal latest 3.12 patch.
         python-version: ${{ inputs.windows-abi == 'msvc' && '3.12.7' || '3.12' }}
-        architecture: x64
+        architecture: ${{ inputs.windows-abi == 'mingw' && inputs.windows-arch == 'arm64' && 'arm64' || 'x64' }}
         # setup-python otherwise replaces PKG_CONFIG_PATH, hiding the native
         # vcpkg metadata installed by setup-deps from LLGo's runtime build.
         update-environment: false
@@ -123,6 +123,12 @@ runs:
           $null = Enter-LLGoVisualStudio2022 -GoArch "${{ inputs.windows-arch }}"
         }
         $compiler = (Get-Command clang.exe).Source
+        if ("${{ inputs.windows-abi }}" -eq "mingw" -and "${{ inputs.windows-arch }}" -eq "386") {
+          if (-not $env:LLGO_MINGW_TARGET_BIN) {
+            throw "The standalone llvm-mingw target was not configured"
+          }
+          $compiler = Join-Path $env:LLGO_MINGW_TARGET_BIN "i686-w64-mingw32-clang.exe"
+        }
         $compilerArgs = @()
         if ("${{ inputs.windows-abi }}" -eq "msvc") {
           $compilerArgs = @("--target=$env:LLGO_WINDOWS_TARGET_TRIPLE")
@@ -137,6 +143,14 @@ runs:
         } else {
           if ($compilerTarget -notmatch "-(windows-gnu|mingw32)$") {
             throw "The MinGW profile resolved Clang target $compilerTarget"
+          }
+          $targetArch = switch ("${{ inputs.windows-arch }}") {
+            "386" { "i686" }
+            "amd64" { "x86_64|amd64" }
+            "arm64" { "aarch64" }
+          }
+          if ($compilerTarget -notmatch "^($targetArch)-") {
+            throw "The MinGW profile resolved $compilerTarget for windows/${{ inputs.windows-arch }}"
           }
           $runtimeArgs = @()
           $archive = "libcargs.a"

--- a/.github/actions/setup-demo-deps/action.yml
+++ b/.github/actions/setup-demo-deps/action.yml
@@ -21,9 +21,12 @@ runs:
         # LLVM 19.1.3's MSVC LLDB embeds the 3.12.7 hosted-tool-cache prefix.
         # A newer 3.12 patch is ABI-compatible, but LLDB combines its embedded
         # stdlib path with that installation and cannot import encodings. Keep
-        # the MinGW demo environment on the normal latest 3.12 patch.
+        # the MinGW demo environment on the normal latest 3.12 patch. This is
+        # the host-tools interpreter: use x64 on Windows ARM, where emulation
+        # retains access to wheels that upstream projects do not publish for
+        # native ARM64 Python. The target interpreter is installed below.
         python-version: ${{ inputs.windows-abi == 'msvc' && '3.12.7' || '3.12' }}
-        architecture: ${{ inputs.windows-abi == 'mingw' && inputs.windows-arch == 'arm64' && 'arm64' || 'x64' }}
+        architecture: x64
         # setup-python otherwise replaces PKG_CONFIG_PATH, hiding the native
         # vcpkg metadata installed by setup-deps from LLGo's runtime build.
         update-environment: false

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -31,9 +31,6 @@ runs:
         if ("${{ inputs.windows-arch }}" -notin @("386", "amd64", "arm64")) {
           throw "Unsupported Windows target architecture: ${{ inputs.windows-arch }}"
         }
-        if ("${{ inputs.windows-abi }}" -eq "mingw" -and "${{ inputs.windows-arch }}" -ne "amd64") {
-          throw "The MinGW profile currently supports windows/amd64; other GNU architectures are qualified in R11"
-        }
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_ABI=${{ inputs.windows-abi }}"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_ARCH=${{ inputs.windows-arch }}"
 
@@ -500,7 +497,10 @@ runs:
       id: windows_mingw
       uses: msys2/setup-msys2@v2
       with:
-        msystem: CLANG64
+        # CLANGARM64 supplies an architecture-native LLVM host and target on
+        # the ARM64 runner. The x64 runner keeps CLANG64 as the LLGo host even
+        # when R11 activates a separate llvm-mingw 386 target afterwards.
+        msystem: ${{ inputs.windows-arch == 'arm64' && 'CLANGARM64' || 'CLANG64' }}
         path-type: inherit
         update: true
 
@@ -522,8 +522,20 @@ runs:
             ;;
         esac
 
-        repo=https://repo.msys2.org/mingw/clang64
-        prefix=mingw-w64-clang-x86_64
+        case "${{ inputs.windows-arch }}" in
+          arm64)
+            repo=https://repo.msys2.org/mingw/clangarm64
+            prefix=mingw-w64-clang-aarch64
+            ;;
+          amd64|386)
+            repo=https://repo.msys2.org/mingw/clang64
+            prefix=mingw-w64-clang-x86_64
+            ;;
+          *)
+            echo "unsupported Windows MinGW architecture: ${{ inputs.windows-arch }}" >&2
+            exit 1
+            ;;
+        esac
         packages=(
           "clang-$package_version"
           "clang-libs-$package_version"
@@ -602,7 +614,8 @@ runs:
       run: |
         $ErrorActionPreference = "Stop"
 
-        $mingwRoot = Join-Path $env:MSYS2_LOCATION "clang64"
+        $mingwSubdir = if ("${{ inputs.windows-arch }}" -eq "arm64") { "clangarm64" } else { "clang64" }
+        $mingwRoot = Join-Path $env:MSYS2_LOCATION $mingwSubdir
         $mingwBin = Join-Path $mingwRoot "bin"
         $clang = Join-Path $mingwBin "clang.exe"
         $pkgconf = Join-Path $mingwBin "pkgconf.exe"
@@ -614,8 +627,9 @@ runs:
         }
 
         $target = (& $clang -dumpmachine).Trim()
-        if ($target -notmatch "^(x86_64|amd64)-.*-(windows-gnu|mingw32)$") {
-          throw "MSYS2 Clang defaults to $target, want an x86_64 GNU/MinGW target"
+        $hostTargetArch = if ("${{ inputs.windows-arch }}" -eq "arm64") { "aarch64" } else { "x86_64|amd64" }
+        if ($target -notmatch "^($hostTargetArch)-.*-(windows-gnu|mingw32)$") {
+          throw "MSYS2 Clang defaults to $target, want a matching GNU/MinGW host target"
         }
 
         # Put one self-contained pkg-config command on PATH. Callers do not
@@ -649,10 +663,20 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=clang"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=clang++"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "CGO_ENABLED=1"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_HOST_PC_DIR=$pcDir"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_HOST_PKGCONF=$pkgconf"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_HOST_ROOT=$mingwRoot"
         Add-Content -Encoding utf8 $env:GITHUB_PATH $mingwBin
         # Keep the fixed-search-path wrapper ahead of CLANG64's pkg-config.exe;
         # setup-demo-deps adds profile-local metadata below RUNNER_TEMP.
         Add-Content -Encoding utf8 $env:GITHUB_PATH $nativeTools
+
+    - name: Set up standalone llvm-mingw target
+      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'mingw' && inputs.windows-arch == '386'
+      uses: ./.github/actions/setup-llvm-mingw
+      with:
+        llvm-version: ${{ inputs.llvm-version }}
+        windows-arch: ${{ inputs.windows-arch }}
 
     - name: Install macOS dependencies
       if: runner.os == 'macOS'

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -315,16 +315,16 @@ runs:
         llvm_mingw_root="${LLGO_MINGW_CROSS_ROOT:-$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}}"
         export PATH="$llvm_mingw_root/bin:$PATH"
 
-        # Each target activation persists its compiler wrappers through
-        # GITHUB_ENV. Do not let a preceding Windows target become vcpkg's
-        # macOS/Linux host compiler while the next target is configured.
+        # Do not let target-specific compiler variables from the invoking job
+        # become vcpkg's macOS/Linux host compiler while dependencies are
+        # configured.
         # The MinGW triplet still discovers its target-prefixed drivers from
         # llvm-mingw on PATH.
         unset CC CXX PKG_CONFIG PKG_CONFIG_PATH GOOS GOARCH
 
-        # The three architectures run sequentially in one job. Reuse the
-        # pinned vcpkg checkout and host tool instead of cloning/bootstrapping
-        # it once per target; target build and install roots remain separate.
+        # Keep the pinned checkout and host tool reusable if this composite is
+        # invoked more than once in a job; target build/install roots remain
+        # separate.
         if [[ ! -d "$source_root/.git" ]]; then
           git clone --no-checkout https://github.com/microsoft/vcpkg.git "$source_root"
         fi
@@ -395,8 +395,8 @@ runs:
         mkdir -p "$target_tools"
         printf '#!/usr/bin/env bash\nexec %q "$@"\n' "$compiler" > "$target_tools/clang"
         printf '#!/usr/bin/env bash\nexec %q "$@"\n' "$compiler_xx" > "$target_tools/clang++"
-        # Preserve the Unix host command across sequential architecture
-        # qualifications; a previous target's wrapper may already be on PATH.
+        # Preserve the Unix host command if the composite is invoked again
+        # after a target-selecting wrapper has been added to PATH.
         pkg_config="${LLGO_CROSS_HOST_PKG_CONFIG:-$(command -v pkg-config)}"
         if [[ ! -x "$pkg_config" ]]; then
           echo "the host pkg-config command is unavailable: $pkg_config" >&2

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -17,26 +17,43 @@ runs:
       shell: pwsh
       run: |
         if ("${{ inputs.llvm-version }}" -ne "19") {
-          throw "llvm-mingw 20241217 is paired with LLVM 19, not ${{ inputs.llvm-version }}"
+          throw "llvm-mingw 20250114 is paired with LLVM 19, not ${{ inputs.llvm-version }}"
         }
         if ("${{ inputs.windows-arch }}" -ne "386") {
           throw "The native llvm-mingw target currently qualifies windows/386, not windows/${{ inputs.windows-arch }}"
         }
+
+    - name: Validate cross-host llvm-mingw target
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "${{ inputs.llvm-version }}" != 19 ]]; then
+          echo "llvm-mingw 20250114 is paired with LLVM 19, not ${{ inputs.llvm-version }}" >&2
+          exit 1
+        fi
+        case "${{ inputs.windows-arch }}" in
+          386|amd64|arm64) ;;
+          *)
+            echo "unsupported llvm-mingw target: windows/${{ inputs.windows-arch }}" >&2
+            exit 1
+            ;;
+        esac
 
     - name: Restore llvm-mingw
       if: runner.os == 'Windows'
       id: llvm_mingw_cache
       uses: actions/cache/restore@v4
       with:
-        path: ${{ runner.tool_cache }}\llvm-mingw\20241217\ucrt-x86_64
-        key: llvm-mingw-20241217-ucrt-x86_64-f4f3ad8616c4183ce7b0d72df634400945b41ea9816145fc2430df6003455db7
+        path: ${{ runner.tool_cache }}\llvm-mingw\20250114\ucrt-x86_64
+        key: llvm-mingw-20250114-ucrt-x86_64-9395d95c089611e6cd728c9a07219ffc5ac706e0c719833a2f7e64a706a81541
 
     - name: Install llvm-mingw
       if: runner.os == 'Windows' && steps.llvm_mingw_cache.outputs.cache-hit != 'true'
       shell: pwsh
       env:
-        LLVM_MINGW_VERSION: "20241217"
-        LLVM_MINGW_SHA256: f4f3ad8616c4183ce7b0d72df634400945b41ea9816145fc2430df6003455db7
+        LLVM_MINGW_VERSION: "20250114"
+        LLVM_MINGW_SHA256: 9395d95c089611e6cd728c9a07219ffc5ac706e0c719833a2f7e64a706a81541
       run: |
         $ErrorActionPreference = "Stop"
         $asset = "llvm-mingw-$env:LLVM_MINGW_VERSION-ucrt-x86_64.zip"
@@ -67,8 +84,8 @@ runs:
       if: runner.os == 'Windows' && steps.llvm_mingw_cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: ${{ runner.tool_cache }}\llvm-mingw\20241217\ucrt-x86_64
-        key: llvm-mingw-20241217-ucrt-x86_64-f4f3ad8616c4183ce7b0d72df634400945b41ea9816145fc2430df6003455db7
+        path: ${{ runner.tool_cache }}\llvm-mingw\20250114\ucrt-x86_64
+        key: llvm-mingw-20250114-ucrt-x86_64-9395d95c089611e6cd728c9a07219ffc5ac706e0c719833a2f7e64a706a81541
 
     - name: Restore llvm-mingw target dependencies
       if: runner.os == 'Windows'
@@ -76,7 +93,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ runner.tool_cache }}\llgo-mingw-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}\386
-        key: llgo-llvm-mingw-20241217-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+        key: llgo-llvm-mingw-20250114-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
 
     - name: Build llvm-mingw target dependencies
       if: runner.os == 'Windows' && steps.llvm_mingw_vcpkg_cache.outputs.cache-hit != 'true'
@@ -89,7 +106,7 @@ runs:
         $sourceRoot = Join-Path $env:RUNNER_TEMP "llgo-mingw-vcpkg-source"
         $installRoot = Join-Path $env:RUNNER_TOOL_CACHE "llgo-mingw-vcpkg\$env:VCPKG_MANIFEST_HASH\386"
         $manifestRoot = Join-Path $env:GITHUB_WORKSPACE ".github\windows\vcpkg"
-        $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20241217\ucrt-x86_64"
+        $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20250114\ucrt-x86_64"
         $llvmMingwBin = Join-Path $llvmMingwRoot "bin"
         $llvmMingwRuntimeBin = Join-Path $llvmMingwRoot "i686-w64-mingw32\bin"
         $env:PATH = "$llvmMingwBin;$env:PATH"
@@ -121,7 +138,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ runner.tool_cache }}\llgo-mingw-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}\386
-        key: llgo-llvm-mingw-20241217-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+        key: llgo-llvm-mingw-20250114-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
 
     - name: Configure llvm-mingw target
       if: runner.os == 'Windows'
@@ -130,7 +147,7 @@ runs:
         VCPKG_MANIFEST_HASH: ${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
       run: |
         $ErrorActionPreference = "Stop"
-        $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20241217\ucrt-x86_64"
+        $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20250114\ucrt-x86_64"
         $llvmMingwBin = Join-Path $llvmMingwRoot "bin"
         $llvmMingwRuntimeBin = Join-Path $llvmMingwRoot "i686-w64-mingw32\bin"
         $compiler = Join-Path $llvmMingwBin "i686-w64-mingw32-clang.exe"
@@ -210,3 +227,186 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_TOOLS=$targetTools"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_TRIPLE=i686-w64-windows-gnu"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_VCPKG_ROOT=$vcpkgRoot"
+
+    - name: Restore cross-host llvm-mingw
+      if: runner.os != 'Windows'
+      id: cross_host_llvm_mingw_cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.tool_cache }}/llvm-mingw/20250114/ucrt-${{ runner.os }}-${{ runner.arch }}
+        key: llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ runner.os == 'macOS' && '80b2e7ade71ba2dfe9e8d27fe47ae5738b1fb8d34e057faa2beef3070392f2d6' || 'a16f52dee819797248e6c7d63b8b1e50a92119f45767ecd8e9633d1733b896e2' }}
+
+    - name: Install cross-host llvm-mingw
+      if: runner.os != 'Windows' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        LLVM_MINGW_VERSION: "20250114"
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS/$RUNNER_ARCH" in
+          Linux/X64)
+            asset="llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-20.04-x86_64.tar.xz"
+            sha256=a16f52dee819797248e6c7d63b8b1e50a92119f45767ecd8e9633d1733b896e2
+            ;;
+          macOS/ARM64|macOS/X64)
+            asset="llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-macos-universal.tar.xz"
+            sha256=80b2e7ade71ba2dfe9e8d27fe47ae5738b1fb8d34e057faa2beef3070392f2d6
+            ;;
+          *)
+            echo "llvm-mingw has no qualified $RUNNER_OS/$RUNNER_ARCH host archive" >&2
+            exit 1
+            ;;
+        esac
+
+        archive="$RUNNER_TEMP/$asset"
+        curl --fail --location --retry 5 --retry-all-errors \
+          --output "$archive" \
+          "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${asset}"
+        actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+        if [[ "$actual" != "$sha256" ]]; then
+          echo "llvm-mingw SHA-256 is $actual, want $sha256" >&2
+          exit 1
+        fi
+
+        extract_root="$RUNNER_TEMP/llgo-llvm-mingw-cross-extract"
+        install_root="$RUNNER_TOOL_CACHE/llvm-mingw/${LLVM_MINGW_VERSION}/ucrt-${RUNNER_OS}-${RUNNER_ARCH}"
+        mkdir -p "$extract_root" "$(dirname "$install_root")"
+        tar -xJf "$archive" -C "$extract_root"
+        source_root="$(find "$extract_root" -mindepth 1 -maxdepth 1 -type d \
+          -exec test -x '{}/bin/i686-w64-mingw32-clang' \; -print -quit)"
+        if [[ -z "$source_root" ]]; then
+          echo "the llvm-mingw archive does not contain the i686 target compiler" >&2
+          exit 1
+        fi
+        mv "$source_root" "$install_root"
+
+    - name: Save cross-host llvm-mingw
+      if: runner.os != 'Windows' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.tool_cache }}/llvm-mingw/20250114/ucrt-${{ runner.os }}-${{ runner.arch }}
+        key: llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ runner.os == 'macOS' && '80b2e7ade71ba2dfe9e8d27fe47ae5738b1fb8d34e057faa2beef3070392f2d6' || 'a16f52dee819797248e6c7d63b8b1e50a92119f45767ecd8e9633d1733b896e2' }}
+
+    - name: Restore cross-host target dependencies
+      if: runner.os != 'Windows'
+      id: cross_host_vcpkg_cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.tool_cache }}/llgo-mingw-vcpkg/${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}/${{ runner.os }}-${{ runner.arch }}/${{ inputs.windows-arch }}
+        key: llgo-llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ inputs.windows-arch }}-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+
+    - name: Build cross-host target dependencies
+      if: runner.os != 'Windows' && steps.cross_host_vcpkg_cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        VCPKG_BASELINE: ddd0023b0eee70986e42ed49d9d4afb8098f212e
+        VCPKG_MANIFEST_HASH: ${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+      run: |
+        set -euo pipefail
+        case "${{ inputs.windows-arch }}" in
+          386) triplet=x86-mingw-dynamic ;;
+          amd64) triplet=x64-mingw-dynamic ;;
+          arm64) triplet=arm64-mingw-dynamic ;;
+        esac
+
+        source_root="$RUNNER_TEMP/llgo-mingw-vcpkg-source"
+        install_root="$RUNNER_TOOL_CACHE/llgo-mingw-vcpkg/$VCPKG_MANIFEST_HASH/${RUNNER_OS}-${RUNNER_ARCH}/${{ inputs.windows-arch }}"
+        manifest_root="$GITHUB_WORKSPACE/.github/windows/vcpkg"
+        llvm_mingw_root="$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}"
+        export PATH="$llvm_mingw_root/bin:$PATH"
+
+        # The three architectures run sequentially in one job. Reuse the
+        # pinned vcpkg checkout and host tool instead of cloning/bootstrapping
+        # it once per target; target build and install roots remain separate.
+        if [[ ! -d "$source_root/.git" ]]; then
+          git clone --no-checkout https://github.com/microsoft/vcpkg.git "$source_root"
+        fi
+        git -C "$source_root" checkout --detach "$VCPKG_BASELINE"
+        if [[ ! -x "$source_root/vcpkg" ]]; then
+          "$source_root/bootstrap-vcpkg.sh" -disableMetrics
+        fi
+        "$source_root/vcpkg" install \
+          "--triplet=$triplet" \
+          "--x-manifest-root=$manifest_root" \
+          "--x-install-root=$install_root" \
+          --clean-after-build
+
+    - name: Save cross-host target dependencies
+      if: runner.os != 'Windows' && steps.cross_host_vcpkg_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.tool_cache }}/llgo-mingw-vcpkg/${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}/${{ runner.os }}-${{ runner.arch }}/${{ inputs.windows-arch }}
+        key: llgo-llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ inputs.windows-arch }}-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+
+    - name: Configure cross-host llvm-mingw target
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        VCPKG_MANIFEST_HASH: ${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+      run: |
+        set -euo pipefail
+        case "${{ inputs.windows-arch }}" in
+          386)
+            prefix=i686-w64-mingw32
+            canonical=i686-w64-windows-gnu
+            triplet=x86-mingw-dynamic
+            ;;
+          amd64)
+            prefix=x86_64-w64-mingw32
+            canonical=x86_64-w64-windows-gnu
+            triplet=x64-mingw-dynamic
+            ;;
+          arm64)
+            prefix=aarch64-w64-mingw32
+            canonical=aarch64-w64-windows-gnu
+            triplet=arm64-mingw-dynamic
+            ;;
+        esac
+
+        llvm_mingw_root="$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}"
+        target_bin="$llvm_mingw_root/bin"
+        runtime_bin="$llvm_mingw_root/$prefix/bin"
+        compiler="$target_bin/$prefix-clang"
+        compiler_xx="$target_bin/$prefix-clang++"
+        vcpkg_root="$RUNNER_TOOL_CACHE/llgo-mingw-vcpkg/$VCPKG_MANIFEST_HASH/${RUNNER_OS}-${RUNNER_ARCH}/${{ inputs.windows-arch }}/$triplet"
+        for path in "$compiler" "$compiler_xx" "$runtime_bin" "$vcpkg_root/include/gc/gc.h"; do
+          if [[ ! -e "$path" ]]; then
+            echo "the cross-host windows/${{ inputs.windows-arch }} target is incomplete: $path was not found" >&2
+            exit 1
+          fi
+        done
+        target="$($compiler -dumpmachine)"
+        case "$target" in
+          "$prefix"|"$canonical") ;;
+          *)
+            echo "llvm-mingw reports $target, want $canonical" >&2
+            exit 1
+            ;;
+        esac
+
+        target_tools="$RUNNER_TEMP/llgo-mingw-target-tools-${{ inputs.windows-arch }}"
+        mkdir -p "$target_tools"
+        printf '#!/usr/bin/env bash\nexec %q "$@"\n' "$compiler" > "$target_tools/clang"
+        printf '#!/usr/bin/env bash\nexec %q "$@"\n' "$compiler_xx" > "$target_tools/clang++"
+        # Preserve the Unix host command across sequential architecture
+        # qualifications; a previous target's wrapper may already be on PATH.
+        pkg_config="${LLGO_CROSS_HOST_PKG_CONFIG:-$(command -v pkg-config)}"
+        if [[ ! -x "$pkg_config" ]]; then
+          echo "the host pkg-config command is unavailable: $pkg_config" >&2
+          exit 1
+        fi
+        pkg_config_libdir="$vcpkg_root/lib/pkgconfig:$vcpkg_root/share/pkgconfig"
+        printf '#!/usr/bin/env bash\nPKG_CONFIG_LIBDIR=%q exec %q --dont-define-prefix "$@"\n' \
+          "$pkg_config_libdir" "$pkg_config" > "$target_tools/pkg-config"
+        chmod +x "$target_tools/clang" "$target_tools/clang++" "$target_tools/pkg-config"
+
+        for package in bdw-gc libffi libuv openssl libcjson sqlite3 zlib; do
+          "$target_tools/pkg-config" --modversion "$package"
+        done
+
+        echo "LLGO_MINGW_TARGET_BIN=$target_bin" >> "$GITHUB_ENV"
+        echo "LLGO_MINGW_TARGET_RUNTIME_BIN=$runtime_bin" >> "$GITHUB_ENV"
+        echo "LLGO_MINGW_TARGET_TOOLS=$target_tools" >> "$GITHUB_ENV"
+        echo "LLGO_MINGW_TARGET_TRIPLE=$canonical" >> "$GITHUB_ENV"
+        echo "LLGO_MINGW_TARGET_VCPKG_ROOT=$vcpkg_root" >> "$GITHUB_ENV"
+        echo "LLGO_CROSS_HOST_PKG_CONFIG=$pkg_config" >> "$GITHUB_ENV"

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -108,7 +108,6 @@ runs:
         $manifestRoot = Join-Path $env:GITHUB_WORKSPACE ".github\windows\vcpkg"
         $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20250114\ucrt-x86_64"
         $llvmMingwBin = Join-Path $llvmMingwRoot "bin"
-        $llvmMingwRuntimeBin = Join-Path $llvmMingwRoot "i686-w64-mingw32\bin"
         $env:PATH = "$llvmMingwBin;$env:PATH"
 
         & git clone --no-checkout https://github.com/microsoft/vcpkg.git $sourceRoot
@@ -176,7 +175,7 @@ runs:
 
         $pkgconf = $env:LLGO_MINGW_HOST_PKGCONF
         $hostPC = $env:LLGO_MINGW_HOST_PC_DIR
-        if (-not (Test-Path $pkgconf) -or -not (Test-Path $hostPC)) {
+        if (-not $pkgconf -or -not $hostPC -or -not (Test-Path $pkgconf) -or -not (Test-Path $hostPC)) {
           throw "The CLANG64 host pkg-config profile is unavailable"
         }
         # Only LLVM belongs to the x64 host. Runtime dependencies must resolve

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -229,7 +229,7 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_VCPKG_ROOT=$vcpkgRoot"
 
     - name: Restore cross-host llvm-mingw
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' && env.LLGO_MINGW_CROSS_ROOT == ''
       id: cross_host_llvm_mingw_cache
       uses: actions/cache/restore@v4
       with:
@@ -237,7 +237,7 @@ runs:
         key: llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ runner.os == 'macOS' && '80b2e7ade71ba2dfe9e8d27fe47ae5738b1fb8d34e057faa2beef3070392f2d6' || 'a16f52dee819797248e6c7d63b8b1e50a92119f45767ecd8e9633d1733b896e2' }}
 
     - name: Install cross-host llvm-mingw
-      if: runner.os != 'Windows' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
+      if: runner.os != 'Windows' && env.LLGO_MINGW_CROSS_ROOT == '' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
       shell: bash
       env:
         LLVM_MINGW_VERSION: "20250114"
@@ -281,7 +281,7 @@ runs:
         mv "$source_root" "$install_root"
 
     - name: Save cross-host llvm-mingw
-      if: runner.os != 'Windows' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
+      if: runner.os != 'Windows' && env.LLGO_MINGW_CROSS_ROOT == '' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ${{ runner.tool_cache }}/llvm-mingw/20250114/ucrt-${{ runner.os }}-${{ runner.arch }}
@@ -312,7 +312,7 @@ runs:
         source_root="$RUNNER_TEMP/llgo-mingw-vcpkg-source"
         install_root="$RUNNER_TOOL_CACHE/llgo-mingw-vcpkg/$VCPKG_MANIFEST_HASH/${RUNNER_OS}-${RUNNER_ARCH}/${{ inputs.windows-arch }}"
         manifest_root="$GITHUB_WORKSPACE/.github/windows/vcpkg"
-        llvm_mingw_root="$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}"
+        llvm_mingw_root="${LLGO_MINGW_CROSS_ROOT:-$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}}"
         export PATH="$llvm_mingw_root/bin:$PATH"
 
         # The three architectures run sequentially in one job. Reuse the
@@ -409,4 +409,5 @@ runs:
         echo "LLGO_MINGW_TARGET_TOOLS=$target_tools" >> "$GITHUB_ENV"
         echo "LLGO_MINGW_TARGET_TRIPLE=$canonical" >> "$GITHUB_ENV"
         echo "LLGO_MINGW_TARGET_VCPKG_ROOT=$vcpkg_root" >> "$GITHUB_ENV"
+        echo "LLGO_MINGW_CROSS_ROOT=$llvm_mingw_root" >> "$GITHUB_ENV"
         echo "LLGO_CROSS_HOST_PKG_CONFIG=$pkg_config" >> "$GITHUB_ENV"

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -183,11 +183,16 @@ runs:
         # from the x86 target tree; exposing CLANG64's complete pkg-config
         # directory here would silently select x64 BDWGC/libffi/libuv again.
         $hostLLVMPC = Join-Path $env:RUNNER_TEMP "llgo-mingw-host-pkgconfig"
-        New-Item -ItemType Directory -Force $hostLLVMPC | Out-Null
+        # setup-demo-deps writes target-native cargs and Python metadata here
+        # after this action has configured the target wrapper. Include the
+        # stable directory now so those later files are visible without
+        # exposing any host dependency metadata.
+        $profilePC = Join-Path $env:RUNNER_TEMP "llgo-pkgconfig"
+        New-Item -ItemType Directory -Force $hostLLVMPC, $profilePC | Out-Null
         Copy-Item -LiteralPath (Join-Path $hostPC "llvm-${{ inputs.llvm-version }}.pc") -Destination $hostLLVMPC
         $targetLibPC = Join-Path $vcpkgRoot "lib\pkgconfig"
         $targetSharePC = Join-Path $vcpkgRoot "share\pkgconfig"
-        $pkgConfigLibDir = "$hostLLVMPC;$targetLibPC;$targetSharePC"
+        $pkgConfigLibDir = "$profilePC;$hostLLVMPC;$targetLibPC;$targetSharePC"
         @"
         @echo off
         setlocal

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -363,7 +363,7 @@ runs:
             ;;
         esac
 
-        llvm_mingw_root="$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}"
+        llvm_mingw_root="${LLGO_MINGW_CROSS_ROOT:-$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}}"
         target_bin="$llvm_mingw_root/bin"
         runtime_bin="$llvm_mingw_root/$prefix/bin"
         compiler="$target_bin/$prefix-clang"

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -315,6 +315,13 @@ runs:
         llvm_mingw_root="${LLGO_MINGW_CROSS_ROOT:-$RUNNER_TOOL_CACHE/llvm-mingw/20250114/ucrt-${RUNNER_OS}-${RUNNER_ARCH}}"
         export PATH="$llvm_mingw_root/bin:$PATH"
 
+        # Each target activation persists its compiler wrappers through
+        # GITHUB_ENV. Do not let a preceding Windows target become vcpkg's
+        # macOS/Linux host compiler while the next target is configured.
+        # The MinGW triplet still discovers its target-prefixed drivers from
+        # llvm-mingw on PATH.
+        unset CC CXX PKG_CONFIG PKG_CONFIG_PATH GOOS GOARCH
+
         # The three architectures run sequentially in one job. Reuse the
         # pinned vcpkg checkout and host tool instead of cloning/bootstrapping
         # it once per target; target build and install roots remain separate.

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -132,6 +132,7 @@ runs:
         $ErrorActionPreference = "Stop"
         $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20241217\ucrt-x86_64"
         $llvmMingwBin = Join-Path $llvmMingwRoot "bin"
+        $llvmMingwRuntimeBin = Join-Path $llvmMingwRoot "i686-w64-mingw32\bin"
         $compiler = Join-Path $llvmMingwBin "i686-w64-mingw32-clang.exe"
         $compilerXX = Join-Path $llvmMingwBin "i686-w64-mingw32-clang++.exe"
         $vcpkgRoot = Join-Path $env:RUNNER_TOOL_CACHE "llgo-mingw-vcpkg\$env:VCPKG_MANIFEST_HASH\386\x86-mingw-dynamic"

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -1,0 +1,205 @@
+name: "Set up llvm-mingw target"
+description: "Install a pinned GNU/UCRT target toolchain and architecture-matched dependencies"
+inputs:
+  windows-arch:
+    description: "Windows target GOARCH"
+    required: true
+  llvm-version:
+    description: "LLGo host LLVM major version"
+    required: false
+    default: "19"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate llvm-mingw target
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if ("${{ inputs.llvm-version }}" -ne "19") {
+          throw "llvm-mingw 20241217 is paired with LLVM 19, not ${{ inputs.llvm-version }}"
+        }
+        if ("${{ inputs.windows-arch }}" -ne "386") {
+          throw "The native llvm-mingw target currently qualifies windows/386, not windows/${{ inputs.windows-arch }}"
+        }
+
+    - name: Restore llvm-mingw
+      if: runner.os == 'Windows'
+      id: llvm_mingw_cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.tool_cache }}\llvm-mingw\20241217\ucrt-x86_64
+        key: llvm-mingw-20241217-ucrt-x86_64-f4f3ad8616c4183ce7b0d72df634400945b41ea9816145fc2430df6003455db7
+
+    - name: Install llvm-mingw
+      if: runner.os == 'Windows' && steps.llvm_mingw_cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      env:
+        LLVM_MINGW_VERSION: "20241217"
+        LLVM_MINGW_SHA256: f4f3ad8616c4183ce7b0d72df634400945b41ea9816145fc2430df6003455db7
+      run: |
+        $ErrorActionPreference = "Stop"
+        $asset = "llvm-mingw-$env:LLVM_MINGW_VERSION-ucrt-x86_64.zip"
+        $archive = Join-Path $env:RUNNER_TEMP $asset
+        $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$env:LLVM_MINGW_VERSION/$asset"
+        & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $url
+        if ($LASTEXITCODE -ne 0) {
+          throw "Downloading llvm-mingw failed with exit code $LASTEXITCODE"
+        }
+        $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash
+        if (-not $actual.Equals($env:LLVM_MINGW_SHA256, [StringComparison]::OrdinalIgnoreCase)) {
+          throw "llvm-mingw SHA-256 is $actual, want $env:LLVM_MINGW_SHA256"
+        }
+
+        $extractRoot = Join-Path $env:RUNNER_TEMP "llgo-llvm-mingw-extract"
+        $installRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\$env:LLVM_MINGW_VERSION\ucrt-x86_64"
+        New-Item -ItemType Directory -Force $extractRoot, (Split-Path $installRoot) | Out-Null
+        Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot
+        $source = Get-ChildItem -LiteralPath $extractRoot -Directory |
+          Where-Object { Test-Path (Join-Path $_.FullName "bin\i686-w64-mingw32-clang.exe") } |
+          Select-Object -First 1
+        if (-not $source) {
+          throw "The llvm-mingw archive does not contain the i686 target compiler"
+        }
+        Move-Item -LiteralPath $source.FullName -Destination $installRoot
+
+    - name: Save llvm-mingw
+      if: runner.os == 'Windows' && steps.llvm_mingw_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.tool_cache }}\llvm-mingw\20241217\ucrt-x86_64
+        key: llvm-mingw-20241217-ucrt-x86_64-f4f3ad8616c4183ce7b0d72df634400945b41ea9816145fc2430df6003455db7
+
+    - name: Restore llvm-mingw target dependencies
+      if: runner.os == 'Windows'
+      id: llvm_mingw_vcpkg_cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.tool_cache }}\llgo-mingw-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}\386
+        key: llgo-llvm-mingw-20241217-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+
+    - name: Build llvm-mingw target dependencies
+      if: runner.os == 'Windows' && steps.llvm_mingw_vcpkg_cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      env:
+        VCPKG_BASELINE: ddd0023b0eee70986e42ed49d9d4afb8098f212e
+        VCPKG_MANIFEST_HASH: ${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $sourceRoot = Join-Path $env:RUNNER_TEMP "llgo-mingw-vcpkg-source"
+        $installRoot = Join-Path $env:RUNNER_TOOL_CACHE "llgo-mingw-vcpkg\$env:VCPKG_MANIFEST_HASH\386"
+        $manifestRoot = Join-Path $env:GITHUB_WORKSPACE ".github\windows\vcpkg"
+        $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20241217\ucrt-x86_64"
+        $llvmMingwBin = Join-Path $llvmMingwRoot "bin"
+        $llvmMingwRuntimeBin = Join-Path $llvmMingwRoot "i686-w64-mingw32\bin"
+        $env:PATH = "$llvmMingwBin;$env:PATH"
+
+        & git clone --no-checkout https://github.com/microsoft/vcpkg.git $sourceRoot
+        if ($LASTEXITCODE -ne 0) {
+          throw "Cloning vcpkg failed with exit code $LASTEXITCODE"
+        }
+        & git -C $sourceRoot checkout --detach $env:VCPKG_BASELINE
+        if ($LASTEXITCODE -ne 0) {
+          throw "Checking out vcpkg $env:VCPKG_BASELINE failed with exit code $LASTEXITCODE"
+        }
+        & (Join-Path $sourceRoot "bootstrap-vcpkg.bat") -disableMetrics
+        if ($LASTEXITCODE -ne 0) {
+          throw "Bootstrapping vcpkg failed with exit code $LASTEXITCODE"
+        }
+        & (Join-Path $sourceRoot "vcpkg.exe") install `
+          --triplet=x86-mingw-dynamic `
+          --host-triplet=x64-windows `
+          "--x-manifest-root=$manifestRoot" `
+          "--x-install-root=$installRoot" `
+          --clean-after-build
+        if ($LASTEXITCODE -ne 0) {
+          throw "Installing llvm-mingw 386 dependencies failed with exit code $LASTEXITCODE"
+        }
+
+    - name: Save llvm-mingw target dependencies
+      if: runner.os == 'Windows' && steps.llvm_mingw_vcpkg_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.tool_cache }}\llgo-mingw-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}\386
+        key: llgo-llvm-mingw-20241217-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+
+    - name: Configure llvm-mingw target
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        VCPKG_MANIFEST_HASH: ${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $llvmMingwRoot = Join-Path $env:RUNNER_TOOL_CACHE "llvm-mingw\20241217\ucrt-x86_64"
+        $llvmMingwBin = Join-Path $llvmMingwRoot "bin"
+        $compiler = Join-Path $llvmMingwBin "i686-w64-mingw32-clang.exe"
+        $compilerXX = Join-Path $llvmMingwBin "i686-w64-mingw32-clang++.exe"
+        $vcpkgRoot = Join-Path $env:RUNNER_TOOL_CACHE "llgo-mingw-vcpkg\$env:VCPKG_MANIFEST_HASH\386\x86-mingw-dynamic"
+        foreach ($path in @($compiler, $compilerXX, $llvmMingwRuntimeBin, (Join-Path $vcpkgRoot "include\gc\gc.h"))) {
+          if (-not (Test-Path $path)) {
+            throw "The llvm-mingw 386 target is incomplete: $path was not found"
+          }
+        }
+        $target = (& $compiler -dumpmachine).Trim()
+        if ($target -notmatch '^i686-.*-(windows-gnu|mingw32)$') {
+          throw "llvm-mingw reports $target, want an i686 GNU/MinGW target"
+        }
+
+        $targetTools = Join-Path $env:RUNNER_TEMP "llgo-mingw-target-tools"
+        New-Item -ItemType Directory -Force $targetTools | Out-Null
+        @"
+        @echo off
+        "$compiler" %*
+        "@ | Set-Content -Encoding ascii (Join-Path $targetTools "clang.cmd")
+        @"
+        @echo off
+        "$compilerXX" %*
+        "@ | Set-Content -Encoding ascii (Join-Path $targetTools "clang++.cmd")
+
+        $pkgconf = $env:LLGO_MINGW_HOST_PKGCONF
+        $hostPC = $env:LLGO_MINGW_HOST_PC_DIR
+        if (-not (Test-Path $pkgconf) -or -not (Test-Path $hostPC)) {
+          throw "The CLANG64 host pkg-config profile is unavailable"
+        }
+        $targetLibPC = Join-Path $vcpkgRoot "lib\pkgconfig"
+        $targetSharePC = Join-Path $vcpkgRoot "share\pkgconfig"
+        $pkgConfigLibDir = "$hostPC;$targetLibPC;$targetSharePC"
+        @"
+        @echo off
+        setlocal
+        set "PKG_CONFIG_LIBDIR=$pkgConfigLibDir"
+        "$pkgconf" --dont-define-prefix %*
+        "@ | Set-Content -Encoding ascii (Join-Path $targetTools "pkg-config.cmd")
+
+        $compilerUnix = $compiler.Replace('\', '/')
+        $compilerXXUnix = $compilerXX.Replace('\', '/')
+        $pkgconfUnix = $pkgconf.Replace('\', '/')
+        $pkgConfigLibDirUnix = $pkgConfigLibDir.Replace('\', '/')
+        @"
+        #!/usr/bin/env bash
+        exec "$compilerUnix" "`$@"
+        "@ | Set-Content -Encoding ascii (Join-Path $targetTools "clang")
+        @"
+        #!/usr/bin/env bash
+        exec "$compilerXXUnix" "`$@"
+        "@ | Set-Content -Encoding ascii (Join-Path $targetTools "clang++")
+        @"
+        #!/usr/bin/env bash
+        set -euo pipefail
+        PKG_CONFIG_LIBDIR='$pkgConfigLibDirUnix' exec "$pkgconfUnix" --dont-define-prefix "`$@"
+        "@ | Set-Content -Encoding ascii (Join-Path $targetTools "pkg-config")
+
+        foreach ($package in @("llvm-${{ inputs.llvm-version }}", "bdw-gc", "libffi", "libuv", "openssl", "libcjson", "sqlite3", "zlib")) {
+          $env:PKG_CONFIG_LIBDIR = $pkgConfigLibDir
+          & $pkgconf --dont-define-prefix --modversion $package
+          if ($LASTEXITCODE -ne 0) {
+            throw "llvm-mingw pkg-config metadata for $package is unavailable"
+          }
+        }
+        Remove-Item Env:PKG_CONFIG_LIBDIR -ErrorAction SilentlyContinue
+
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_BIN=$llvmMingwBin"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_RUNTIME_BIN=$llvmMingwRuntimeBin"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_TOOLS=$targetTools"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_TRIPLE=i686-w64-windows-gnu"
+        Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_VCPKG_ROOT=$vcpkgRoot"

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -162,9 +162,15 @@ runs:
         if (-not (Test-Path $pkgconf) -or -not (Test-Path $hostPC)) {
           throw "The CLANG64 host pkg-config profile is unavailable"
         }
+        # Only LLVM belongs to the x64 host. Runtime dependencies must resolve
+        # from the x86 target tree; exposing CLANG64's complete pkg-config
+        # directory here would silently select x64 BDWGC/libffi/libuv again.
+        $hostLLVMPC = Join-Path $env:RUNNER_TEMP "llgo-mingw-host-pkgconfig"
+        New-Item -ItemType Directory -Force $hostLLVMPC | Out-Null
+        Copy-Item -LiteralPath (Join-Path $hostPC "llvm-${{ inputs.llvm-version }}.pc") -Destination $hostLLVMPC
         $targetLibPC = Join-Path $vcpkgRoot "lib\pkgconfig"
         $targetSharePC = Join-Path $vcpkgRoot "share\pkgconfig"
-        $pkgConfigLibDir = "$hostPC;$targetLibPC;$targetSharePC"
+        $pkgConfigLibDir = "$hostLLVMPC;$targetLibPC;$targetSharePC"
         @"
         @echo off
         setlocal

--- a/.github/actions/test-windows-cross/action.yml
+++ b/.github/actions/test-windows-cross/action.yml
@@ -42,10 +42,9 @@ runs:
           echo "LLGo host compiler is not executable: $LLGO_CROSS_COMPILER" >&2
           exit 1
         fi
-        # Make this invocation independent of any target selected by an
-        # earlier architecture step in the same cross-host job. The activation
-        # action exports these target-selecting wrappers so callers do not need
-        # to assemble compiler flags themselves.
+        # Use the target-selecting wrappers exported by activation so callers
+        # do not need to assemble compiler flags and the host compiler cannot
+        # be selected accidentally through PATH.
         export PATH="$LLGO_MINGW_TARGET_TOOLS:$PATH"
         export CC="$LLGO_MINGW_TARGET_TOOLS/clang"
         export CXX="$LLGO_MINGW_TARGET_TOOLS/clang++"

--- a/.github/actions/test-windows-cross/action.yml
+++ b/.github/actions/test-windows-cross/action.yml
@@ -1,0 +1,101 @@
+name: "Test cross-host Windows build"
+description: "Install one Windows GNU target and build representative artifacts without executing them"
+inputs:
+  llgo:
+    description: "Unix-hosted LLGo compiler path"
+    required: true
+  windows-arch:
+    description: "Windows target GOARCH"
+    required: true
+  llvm-version:
+    description: "LLGo host LLVM major version"
+    required: false
+    default: "19"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Windows GNU target
+      uses: ./.github/actions/setup-llvm-mingw
+      with:
+        llvm-version: ${{ inputs.llvm-version }}
+        windows-arch: ${{ inputs.windows-arch }}
+
+    - name: Activate Windows GNU target
+      uses: ./.github/actions/activate-windows-target
+      with:
+        windows-abi: mingw
+        windows-arch: ${{ inputs.windows-arch }}
+
+    - name: Build and inspect Windows GNU artifacts
+      shell: bash
+      env:
+        LLGO_CROSS_COMPILER: ${{ inputs.llgo }}
+        LLGO_CROSS_GOARCH: ${{ inputs.windows-arch }}
+      run: |
+        set -euo pipefail
+        if [[ "$GOOS/$GOARCH" != "windows/$LLGO_CROSS_GOARCH" ]]; then
+          echo "active target is $GOOS/$GOARCH, want windows/$LLGO_CROSS_GOARCH" >&2
+          exit 1
+        fi
+        if [[ ! -x "$LLGO_CROSS_COMPILER" ]]; then
+          echo "LLGo host compiler is not executable: $LLGO_CROSS_COMPILER" >&2
+          exit 1
+        fi
+        # Make this invocation independent of any target selected by an
+        # earlier architecture step in the same cross-host job. Leaving the
+        # Go-compatible compiler overrides unset also exercises LLGo's normal
+        # compiler-target probing path.
+        export PATH="$LLGO_MINGW_TARGET_TOOLS:$PATH"
+        unset CC CXX PKG_CONFIG PKG_CONFIG_PATH
+
+        output_dir="$RUNNER_TEMP/llgo-windows-cross-$LLGO_CROSS_GOARCH"
+        mkdir -p "$output_dir"
+        artifacts=()
+        for package in \
+          windowsempty \
+          windowsruntime \
+          windowsffi \
+          windowsstdlib \
+          windowsnetwork; do
+          output="$output_dir/$package.exe"
+          (
+            cd runtime
+            "$LLGO_CROSS_COMPILER" build -p=2 -o "$output" "./_test/$package"
+          )
+          artifacts+=("$output")
+        done
+
+        # Compile, but do not execute, both the general language suite and the
+        # Windows-specific OS/runtime suite. Native R11 jobs execute the same
+        # surfaces; this lane verifies that no host SDK or ABI leaks into them.
+        for package in go windows; do
+          output="$output_dir/test-$package.exe"
+          "$LLGO_CROSS_COMPILER" test -c -o "$output" "./test/$package"
+          artifacts+=("$output")
+        done
+
+        case "$LLGO_CROSS_GOARCH" in
+          386) machine='IMAGE_FILE_MACHINE_I386' ;;
+          amd64) machine='IMAGE_FILE_MACHINE_AMD64' ;;
+          arm64) machine='IMAGE_FILE_MACHINE_ARM64' ;;
+          *)
+            echo "unsupported Windows target architecture: $LLGO_CROSS_GOARCH" >&2
+            exit 1
+            ;;
+        esac
+        for artifact in "${artifacts[@]}"; do
+          file "$artifact"
+          headers="$(llvm-readobj --file-headers "$artifact")"
+          if ! grep -Fq "$machine" <<<"$headers"; then
+            echo "$artifact is not a windows/$LLGO_CROSS_GOARCH PE/COFF image:" >&2
+            echo "$headers" >&2
+            exit 1
+          fi
+          imports="$(llvm-readobj --coff-imports "$artifact")"
+          if grep -Eqi '(msys-2\.0|cygwin1)\.dll' <<<"$imports"; then
+            echo "$artifact depends on an unsupported POSIX-emulation runtime:" >&2
+            echo "$imports" >&2
+            exit 1
+          fi
+        done

--- a/.github/actions/test-windows-cross/action.yml
+++ b/.github/actions/test-windows-cross/action.yml
@@ -43,11 +43,14 @@ runs:
           exit 1
         fi
         # Make this invocation independent of any target selected by an
-        # earlier architecture step in the same cross-host job. Leaving the
-        # Go-compatible compiler overrides unset also exercises LLGo's normal
-        # compiler-target probing path.
+        # earlier architecture step in the same cross-host job. The activation
+        # action exports these target-selecting wrappers so callers do not need
+        # to assemble compiler flags themselves.
         export PATH="$LLGO_MINGW_TARGET_TOOLS:$PATH"
-        unset CC CXX PKG_CONFIG PKG_CONFIG_PATH
+        export CC="$LLGO_MINGW_TARGET_TOOLS/clang"
+        export CXX="$LLGO_MINGW_TARGET_TOOLS/clang++"
+        export PKG_CONFIG="$LLGO_MINGW_TARGET_TOOLS/pkg-config"
+        unset PKG_CONFIG_PATH
 
         output_dir="$RUNNER_TEMP/llgo-windows-cross-$LLGO_CROSS_GOARCH"
         mkdir -p "$output_dir"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,16 +193,6 @@ jobs:
           windows-abi: ${{ matrix.windows_abi }}
           windows-arch: ${{ matrix.windows_arch }}
 
-      - name: Use direct MinGW 386 drivers for benchmark links
-        if: runner.os == 'Windows' && matrix.windows_abi == 'mingw' && matrix.windows_arch == '386'
-        shell: pwsh
-        run: |
-          # The general target profile keeps command wrappers so unqualified
-          # clang follows GOARCH. Benchmark links include LLVM's complete
-          # static library list, which exceeds cmd.exe's 8191-character limit.
-          Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=$(Join-Path $env:LLGO_MINGW_TARGET_BIN 'i686-w64-mingw32-clang.exe')"
-          Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=$(Join-Path $env:LLGO_MINGW_TARGET_BIN 'i686-w64-mingw32-clang++.exe')"
-
       - name: Measure pull request base
         if: github.event_name == 'pull_request'
         id: measure-base

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,6 +193,16 @@ jobs:
           windows-abi: ${{ matrix.windows_abi }}
           windows-arch: ${{ matrix.windows_arch }}
 
+      - name: Use direct MinGW 386 drivers for benchmark links
+        if: runner.os == 'Windows' && matrix.windows_abi == 'mingw' && matrix.windows_arch == '386'
+        shell: pwsh
+        run: |
+          # The general target profile keeps command wrappers so unqualified
+          # clang follows GOARCH. Benchmark links include LLVM's complete
+          # static library list, which exceeds cmd.exe's 8191-character limit.
+          Add-Content -Encoding utf8 $env:GITHUB_ENV "CC=$(Join-Path $env:LLGO_MINGW_TARGET_BIN 'i686-w64-mingw32-clang.exe')"
+          Add-Content -Encoding utf8 $env:GITHUB_ENV "CXX=$(Join-Path $env:LLGO_MINGW_TARGET_BIN 'i686-w64-mingw32-clang++.exe')"
+
       - name: Measure pull request base
         if: github.event_name == 'pull_request'
         id: measure-base

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,10 +47,24 @@ jobs:
             windows_arch: arm64
             host_go_arch: x64
             timeout: 120
+          - os: windows-11-arm
+            id: windows-mingw-arm64
+            display: Windows MinGW ARM64
+            windows_abi: mingw
+            windows_arch: arm64
+            host_go_arch: arm64
+            timeout: 120
           - os: windows-2022
             id: windows-msvc-386
             display: Windows MSVC 386
             windows_abi: msvc
+            windows_arch: "386"
+            host_go_arch: x64
+            timeout: 90
+          - os: windows-2022
+            id: windows-mingw-386
+            display: Windows MinGW 386
+            windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
             timeout: 90

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -143,6 +143,49 @@ jobs:
             build_host_compiler . .benchmark/llgo.exe
           fi
 
+      - name: Bundle MinGW host compiler runtime
+        if: runner.os == 'Windows' && matrix.windows_abi == 'mingw' && matrix.windows_arch == '386'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $hostBin = Join-Path $env:LLGO_MINGW_HOST_ROOT "bin"
+          $objdump = Join-Path $hostBin "llvm-objdump.exe"
+          if (-not (Test-Path $objdump)) {
+            throw "The MinGW host llvm-objdump is unavailable: $objdump"
+          }
+
+          # Target DLL directories must remain first on PATH when benchmark
+          # programs run. Keep the host compiler architecture-safe without
+          # changing that target environment by placing its DLL closure beside
+          # the prebuilt compiler, which Windows searches before PATH.
+          $queue = [Collections.Generic.Queue[string]]::new()
+          Get-ChildItem "$env:GITHUB_WORKSPACE\.benchmark\*.exe" |
+            ForEach-Object { $queue.Enqueue($_.FullName) }
+          $copied = @{}
+          while ($queue.Count -ne 0) {
+            $binary = $queue.Dequeue()
+            foreach ($line in (& $objdump -p $binary)) {
+              if ($line -notmatch '^\s*DLL Name:\s*(\S+)\s*$') {
+                continue
+              }
+              $name = $Matches[1]
+              if ($copied.ContainsKey($name)) {
+                continue
+              }
+              $source = Join-Path $hostBin $name
+              if (-not (Test-Path $source)) {
+                continue
+              }
+              $destination = Join-Path "$env:GITHUB_WORKSPACE\.benchmark" $name
+              Copy-Item -LiteralPath $source -Destination $destination
+              $copied[$name] = $true
+              $queue.Enqueue($destination)
+            }
+          }
+          if ($copied.Count -eq 0) {
+            throw "No MinGW host runtime DLLs were discovered"
+          }
+
       - name: Activate native Windows target
         if: runner.os == 'Windows' && matrix.windows_arch != 'amd64'
         uses: ./.github/actions/activate-windows-target

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -46,15 +46,7 @@ jobs:
           - os: ubuntu-latest
             windows_arch: "386"
           - os: windows-2022
-            windows_abi: mingw
             windows_arch: arm64
-          - os: windows-2022
-            windows_abi: mingw
-            windows_arch: "386"
-          - os: windows-2022
-            windows_arch: arm64
-          - os: windows-11-arm
-            windows_abi: mingw
           - os: windows-11-arm
             windows_arch: amd64
           - os: windows-11-arm
@@ -73,7 +65,7 @@ jobs:
       - name: Set up Go for building LLGo and the runner
         uses: ./.github/actions/setup-go
         with:
-          architecture: ${{ startsWith(matrix.os, 'windows') && 'x64' || '' }}
+          architecture: ${{ matrix.os == 'windows-11-arm' && matrix.windows_abi == 'mingw' && 'arm64' || startsWith(matrix.os, 'windows') && 'x64' || '' }}
 
       - name: Build LLGo and the GOROOT runner
         shell: bash
@@ -269,14 +261,18 @@ jobs:
           {
             echo '## GOROOT run summary'
             echo
-            echo "Received $report_count/16 shard reports."
+            echo "Received $report_count/32 shard reports."
             echo
             echo '| Platform / toolchain | Shards | Selected | Observed | Passed | Failed | Skipped |'
             echo '|---|---:|---:|---:|---:|---:|---:|'
             write_row "Darwin · Go $primary_version" darwin/arm64 "$primary_version" 4
             write_row "Linux · Go $primary_version" linux/amd64 "$primary_version" 4
             write_row "Windows MSVC · Go $primary_version" windows-msvc/amd64 "$primary_version" 4
+            write_row "Windows MSVC ARM64 · Go $primary_version" windows-msvc/arm64 "$primary_version" 4
+            write_row "Windows MSVC 386 · Go $primary_version" windows-msvc/386 "$primary_version" 4
             write_row "Windows MinGW · Go $primary_version" windows-mingw/amd64 "$primary_version" 4
+            write_row "Windows MinGW ARM64 · Go $primary_version" windows-mingw/arm64 "$primary_version" 4
+            write_row "Windows MinGW 386 · Go $primary_version" windows-mingw/386 "$primary_version" 4
             echo
             echo '_Passed means the runner classification succeeded; expected xfail/not-applicable failures and classified flakes are counted as Passed._'
             echo
@@ -291,8 +287,8 @@ jobs:
             fi
           } >>"$GITHUB_STEP_SUMMARY"
 
-          if [[ "$report_count" -ne 16 ]]; then
-            echo "error: expected 16 shard reports, got $report_count" >&2
+          if [[ "$report_count" -ne 32 ]]; then
+            echo "error: expected 32 shard reports, got $report_count" >&2
             exit 1
           fi
           if [[ "$GOROOT_RESULT" != success ]]; then

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -517,12 +517,13 @@ jobs:
           iwasm --stack-size=819200000 --heap-size=800000000 hello.wasm
 
   windows-gnu-cross:
-    name: windows GNU cross (${{ matrix.os }})
-    timeout-minutes: 180
+    name: windows GNU cross (${{ matrix.os }}, ${{ matrix.windows_arch }})
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-latest]
+        windows_arch: [amd64, arm64, "386"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -547,23 +548,11 @@ jobs:
           # available to the following cross-host builds.
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
-      - name: Test cross-host windows/amd64
+      - name: Test cross-host windows/${{ matrix.windows_arch }}
         uses: ./.github/actions/test-windows-cross
         with:
           llgo: ${{ runner.temp }}/llgo-host
-          windows-arch: amd64
-
-      - name: Test cross-host windows/arm64
-        uses: ./.github/actions/test-windows-cross
-        with:
-          llgo: ${{ runner.temp }}/llgo-host
-          windows-arch: arm64
-
-      - name: Test cross-host windows/386
-        uses: ./.github/actions/test-windows-cross
-        with:
-          llgo: ${{ runner.temp }}/llgo-host
-          windows-arch: "386"
+          windows-arch: ${{ matrix.windows_arch }}
 
   wasm-runtime:
     name: wasm-runtime (Go 1.24 and 1.27)

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -541,8 +541,7 @@ jobs:
       - name: Build Unix host compiler
         shell: bash
         run: |
-          GOWORK="$GITHUB_WORKSPACE/.github/plan9asm.work" \
-            go build -p=2 -o "$RUNNER_TEMP/llgo-host" ./cmd/llgo
+          go build -p=2 -o "$RUNNER_TEMP/llgo-host" ./cmd/llgo
           # This development binary lives outside LLGO_ROOT/bin. Point it at
           # the checkout explicitly so standard-library source patches are
           # available to the following cross-host builds.

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -542,6 +542,10 @@ jobs:
         run: |
           GOWORK="$GITHUB_WORKSPACE/.github/plan9asm.work" \
             go build -p=2 -o "$RUNNER_TEMP/llgo-host" ./cmd/llgo
+          # This development binary lives outside LLGO_ROOT/bin. Point it at
+          # the checkout explicitly so standard-library source patches are
+          # available to the following cross-host builds.
+          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
       - name: Test cross-host windows/amd64
         uses: ./.github/actions/test-windows-cross

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -43,9 +43,19 @@ jobs:
             windows_abi: msvc
             windows_arch: arm64
             host_go_arch: x64
+          - os: windows-11-arm
+            llvm: 19
+            windows_abi: mingw
+            windows_arch: arm64
+            host_go_arch: arm64
           - os: windows-2022
             llvm: 19
             windows_abi: msvc
+            windows_arch: "386"
+            host_go_arch: x64
+          - os: windows-2022
+            llvm: 19
+            windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
     runs-on: ${{matrix.os}}
@@ -210,7 +220,9 @@ jobs:
         run: sudo apt-get install -y lldb-${{matrix.llvm}}
 
       - name: Install MinGW LLDB for integration tests
-        if: ${{ matrix.os == 'windows-2022' && matrix.windows_abi == 'mingw' }}
+        # R12 qualifies debugger behavior for the new GNU architectures. Keep
+        # R11 focused on their language/runtime and C interoperability gates.
+        if: ${{ matrix.os == 'windows-2022' && matrix.windows_abi == 'mingw' && matrix.windows_arch == 'amd64' }}
         shell: msys2 {0}
         env:
           MSYS2_LLDB_PACKAGE_VERSION: "19.1.7-1"
@@ -265,7 +277,7 @@ jobs:
           }
 
       - name: LLDB integration tests (MinGW)
-        if: ${{ matrix.windows_abi == 'mingw' }}
+        if: ${{ matrix.windows_abi == 'mingw' && matrix.windows_arch == 'amd64' }}
         shell: msys2 {0}
         run: |
           # Git Bash prepends its own MinGW runtime DLLs to PATH. Use the
@@ -347,6 +359,15 @@ jobs:
             windows_abi: msvc
             windows_arch: arm64
             host_go_arch: x64
+          - os: windows-11-arm
+            llvm: 19
+            go_version: "1.27"
+            lane: full
+            shard_index: "0"
+            shard_total: "1"
+            windows_abi: mingw
+            windows_arch: arm64
+            host_go_arch: arm64
           - os: windows-2022
             llvm: 19
             go_version: "1.27"
@@ -354,6 +375,15 @@ jobs:
             shard_index: "0"
             shard_total: "1"
             windows_abi: msvc
+            windows_arch: "386"
+            host_go_arch: x64
+          - os: windows-2022
+            llvm: 19
+            go_version: "1.27"
+            lane: full
+            shard_index: "0"
+            shard_total: "1"
+            windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
     runs-on: ${{matrix.os}}

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -186,6 +186,22 @@ jobs:
         shell: bash
         run: |
           echo "Testing ESP32-C3 startup regressions..."
+          if [[ "$RUNNER_OS" == "Windows" && "${{ matrix.windows_abi }}" == "mingw" ]]; then
+            # Native target activation can put an architecture-limited
+            # llvm-mingw bundle first on PATH. Inspect the RISC-V firmware
+            # with the architecture-native host LLVM tools instead; this does
+            # not change the compiler/linker profile selected by LLGo.
+            host_llvm_bin="$(cygpath -u "$LLGO_MINGW_HOST_ROOT")/bin"
+            export LLVM_OBJDUMP="$host_llvm_bin/llvm-objdump.exe"
+            export LLVM_NM="$host_llvm_bin/llvm-nm.exe"
+            export LLVM_READELF="$host_llvm_bin/llvm-readelf.exe"
+            for llvm_tool in "$LLVM_OBJDUMP" "$LLVM_NM" "$LLVM_READELF"; do
+              if [[ ! -x "$llvm_tool" ]]; then
+                echo "required host LLVM inspection tool not found: $llvm_tool" >&2
+                exit 1
+              fi
+            done
+          fi
           # esptool inspects target firmware but runs on the CI host. For a
           # cross-architecture Windows lane, use the x64 host Python so pip
           # can install its native dependencies without cross-building them.

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -516,6 +516,51 @@ jobs:
 
           iwasm --stack-size=819200000 --heap-size=800000000 hello.wasm
 
+  windows-gnu-cross:
+    name: windows GNU cross (${{ matrix.os }})
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install host dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          llvm-version: 19
+
+      - name: Set up Go for building llgo
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: "1.27.0"
+
+      - name: Build Unix host compiler
+        shell: bash
+        run: |
+          GOWORK="$GITHUB_WORKSPACE/.github/plan9asm.work" \
+            go build -p=2 -o "$RUNNER_TEMP/llgo-host" ./cmd/llgo
+
+      - name: Test cross-host windows/amd64
+        uses: ./.github/actions/test-windows-cross
+        with:
+          llgo: ${{ runner.temp }}/llgo-host
+          windows-arch: amd64
+
+      - name: Test cross-host windows/arm64
+        uses: ./.github/actions/test-windows-cross
+        with:
+          llgo: ${{ runner.temp }}/llgo-host
+          windows-arch: arm64
+
+      - name: Test cross-host windows/386
+        uses: ./.github/actions/test-windows-cross
+        with:
+          llgo: ${{ runner.temp }}/llgo-host
+          windows-arch: "386"
+
   wasm-runtime:
     name: wasm-runtime (Go 1.24 and 1.27)
     timeout-minutes: 30

--- a/.github/workflows/test_windows_runtime.ps1
+++ b/.github/workflows/test_windows_runtime.ps1
@@ -24,29 +24,27 @@ New-Item -ItemType Directory $out | Out-Null
 $env:LLGO_ROOT = $root
 $env:LLGO_BUILD_CACHE = "off"
 
-# Each lane executes its selected architecture below. Also compile the raw
-# SyscallN bridge for every Go-supported Windows architecture so a change in
-# one lane cannot silently break assembly selected by another lane.
+# Compile the raw SyscallN bridge with this lane's target compiler. The CI
+# matrix gives every Go-supported Windows architecture its own job, so keeping
+# this probe target-local avoids mixing architecture-specific toolchains.
 $syscallAsm = Join-Path $root "runtime\internal\lib\runtime\_wrap\syscall_windows.S"
 $targetSuffix = if ($Profile -eq "msvc") { "pc-windows-msvc" } else { "w64-windows-gnu" }
-foreach ($syscallTarget in @(
-  @{ Triple = "i686-$targetSuffix"; Symbol = "_llgo_windows_syscall" },
-  @{ Triple = "x86_64-$targetSuffix"; Symbol = "llgo_windows_syscall" },
-  @{ Triple = "aarch64-$targetSuffix"; Symbol = "llgo_windows_syscall" }
-)) {
-  $syscallObj = Join-Path $out ("syscall-{0}.obj" -f $syscallTarget.Triple)
-  & $clangExe "--target=$($syscallTarget.Triple)" -c $syscallAsm -o $syscallObj
-  if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
-  }
-  $symbols = & $llvmNmExe --defined-only $syscallObj | Out-String
-  if (-not $symbols.Contains($syscallTarget.Symbol)) {
-    throw "$($syscallTarget.Triple) bridge is missing $($syscallTarget.Symbol)"
-  }
-  if ($syscallTarget.Triple.StartsWith("i686-") -and
-      $symbols -notmatch '(?m)^00000001 [aA] @feat\.00\r?$') {
-    throw "$($syscallTarget.Triple) bridge is not marked SafeSEH-compatible"
-  }
+$syscallTarget = switch ($GoArch) {
+  "386" { @{ Triple = "i686-$targetSuffix"; Symbol = "_llgo_windows_syscall" } }
+  "amd64" { @{ Triple = "x86_64-$targetSuffix"; Symbol = "llgo_windows_syscall" } }
+  "arm64" { @{ Triple = "aarch64-$targetSuffix"; Symbol = "llgo_windows_syscall" } }
+}
+$syscallObj = Join-Path $out ("syscall-{0}.obj" -f $syscallTarget.Triple)
+& $clangExe "--target=$($syscallTarget.Triple)" -c $syscallAsm -o $syscallObj
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+$symbols = & $llvmNmExe --defined-only $syscallObj | Out-String
+if (-not $symbols.Contains($syscallTarget.Symbol)) {
+  throw "$($syscallTarget.Triple) bridge is missing $($syscallTarget.Symbol)"
+}
+if ($GoArch -eq "386" -and $symbols -notmatch '(?m)^00000001 [aA] @feat\.00\r?$') {
+  throw "$($syscallTarget.Triple) bridge is not marked SafeSEH-compatible"
 }
 
 $runtime = Join-Path $out "windows-runtime-smoke.exe"

--- a/.github/workflows/test_windows_toolchain_profile.ps1
+++ b/.github/workflows/test_windows_toolchain_profile.ps1
@@ -105,7 +105,13 @@ if ($Profile -eq "msvc" -and $env:LLGO_MSYS2_LOCATION) {
 & pkg-config --modversion llvm-19 | Out-Null
 Assert-Success "Reading LLVM metadata through the profile-local pkg-config"
 
-$compilerTarget = (& clang -dumpmachine).Trim()
+$compilerArgs = @()
+if ($Profile -eq "msvc") {
+  # Official LLVM is an x64 host compiler in every MSVC lane. Apply the
+  # activated target explicitly before checking cross-architecture output.
+  $compilerArgs = @("--target=$env:LLGO_WINDOWS_TARGET_TRIPLE")
+}
+$compilerTarget = (& clang @compilerArgs -dumpmachine).Trim()
 Assert-Success "Reading the Clang target"
 $targetPattern = if ($Profile -eq "msvc") { '-windows-msvc$' } else { '-(windows-gnu|mingw32)$' }
 if ($compilerTarget -notmatch $targetPattern) {

--- a/.github/workflows/test_windows_toolchain_profile.ps1
+++ b/.github/workflows/test_windows_toolchain_profile.ps1
@@ -70,17 +70,26 @@ $mainSource.Replace('$Profile', $Profile).Replace('$GoArch', $GoArch) |
   Set-Content -Encoding utf8 (Join-Path $sourceDir "main.go")
 
 $llgo = (Get-Command llgo.exe).Source
-foreach ($tool in @("clang.exe", "clang++.exe", "llvm-config.exe")) {
+foreach ($tool in @("clang", "clang++", "llvm-config")) {
   $path = (Get-Command $tool).Source
   if ($Profile -eq "msvc" -and $path -match '(?i)[\\/](msys64|cygwin)[\\/]') {
     throw "$tool unexpectedly resolves through a POSIX environment: $path"
   }
-  if ($Profile -eq "mingw" -and $path -notmatch '(?i)[\\/]clang64[\\/]') {
-    throw "$tool does not belong to the independent CLANG64 profile: $path"
+  if ($Profile -eq "mingw") {
+    $profilePattern = switch ($GoArch) {
+      "386" {
+        if ($tool -eq "llvm-config") { '(?i)[\\/]clang64[\\/]' } else { '(?i)[\\/]llgo-mingw-target-tools[\\/]' }
+      }
+      "amd64" { '(?i)[\\/]clang64[\\/]' }
+      "arm64" { '(?i)[\\/]clangarm64[\\/]' }
+    }
+    if ($path -notmatch $profilePattern) {
+      throw "$tool does not belong to the windows/$GoArch MinGW profile: $path"
+    }
   }
 }
 $pkgConfig = (Get-Command pkg-config).Source
-if ($pkgConfig -notmatch '(?i)[\\/]llgo-(msvc|mingw)-tools[\\/]pkg-config\.cmd$') {
+if ($pkgConfig -notmatch '(?i)[\\/]llgo-(msvc|mingw)(-target)?-tools[\\/]pkg-config\.cmd$') {
   throw "pkg-config does not resolve to the profile-local command wrapper: $pkgConfig"
 }
 $pkgConfigShell = Join-Path (Split-Path $pkgConfig) "pkg-config"
@@ -96,11 +105,19 @@ if ($Profile -eq "msvc" -and $env:LLGO_MSYS2_LOCATION) {
 & pkg-config --modversion llvm-19 | Out-Null
 Assert-Success "Reading LLVM metadata through the profile-local pkg-config"
 
-$compilerTarget = (& clang.exe -dumpmachine).Trim()
+$compilerTarget = (& clang -dumpmachine).Trim()
 Assert-Success "Reading the Clang target"
 $targetPattern = if ($Profile -eq "msvc") { '-windows-msvc$' } else { '-(windows-gnu|mingw32)$' }
 if ($compilerTarget -notmatch $targetPattern) {
   throw "$Profile Clang reports incompatible target $compilerTarget"
+}
+$targetArch = switch ($GoArch) {
+  "386" { "i686" }
+  "amd64" { "x86_64|amd64" }
+  "arm64" { "aarch64" }
+}
+if ($compilerTarget -notmatch "^($targetArch)-") {
+  throw "$Profile Clang reports $compilerTarget for windows/$GoArch"
 }
 
 $savedCC = $env:CC
@@ -118,15 +135,15 @@ try {
   } finally {
     Pop-Location
   }
-  $targetArch = switch ($GoArch) {
+  $canonicalArch = switch ($GoArch) {
     "386" { "i686" }
     "amd64" { "x86_64" }
     "arm64" { "aarch64" }
   }
   $canonicalTarget = if ($Profile -eq "msvc") {
-    "$targetArch-pc-windows-msvc"
+    "$canonicalArch-pc-windows-msvc"
   } else {
-    "$targetArch-w64-windows-gnu"
+    "$canonicalArch-w64-windows-gnu"
   }
   if ($trace -notmatch [regex]::Escape($canonicalTarget)) {
     throw "Unset CC/CXX did not select the canonical $Profile target:`n$trace"

--- a/_demo/embed/test_esp32c3_startup.sh
+++ b/_demo/embed/test_esp32c3_startup.sh
@@ -38,6 +38,14 @@ TEST_GO="$TEMP_DIR/main.go"
 TEST_ELF="test.elf"
 TEST_BIN="test.bin"
 
+# A native target profile may put architecture-limited LLVM utilities first on
+# PATH. In particular, llvm-mingw's 386 bundle cannot inspect a RISC-V ELF.
+# CI can select host LLVM utilities explicitly while leaving the compiler and
+# linker profile used by LLGo unchanged.
+LLVM_OBJDUMP_CMD="${LLVM_OBJDUMP:-llvm-objdump}"
+LLVM_NM_CMD="${LLVM_NM:-llvm-nm}"
+LLVM_READELF_CMD="${LLVM_READELF:-llvm-readelf}"
+
 cleanup() {
     rm -rf "$TEMP_DIR"
 }
@@ -148,7 +156,7 @@ echo ""
 echo "=== Test 1: Verify newlib startup (calls __libc_init_array) ==="
 
 # Disassemble _start and check for __libc_init_array call
-if llvm-objdump -d "$TEST_ELF" | grep -A50 "<_start>:" | grep "__libc_init_array" > /dev/null; then
+if "$LLVM_OBJDUMP_CMD" -d "$TEST_ELF" | grep -A50 "<_start>:" | grep "__libc_init_array" > /dev/null; then
     echo "✓ PASS: _start calls __libc_init_array"
     echo "        ESP32-C3 uses newlib's standard startup"
 else
@@ -157,7 +165,7 @@ else
     echo ""
     echo "Expected inheritance: esp32c3 → riscv32-nostart → riscv-nostart → riscv-basic"
     echo "Current _start disassembly:"
-    llvm-objdump -d "$TEST_ELF" | grep -A50 "<_start>:" || true
+    "$LLVM_OBJDUMP_CMD" -d "$TEST_ELF" | grep -A50 "<_start>:" || true
     exit 1
 fi
 
@@ -179,7 +187,7 @@ echo "=== Test 2: Verify __init_array_start symbol (ELF) ==="
 #   $3 = __init_array_start (symbol name)
 #
 # We extract $1 and add "0x" prefix: 40380450 → 0x40380450
-INIT_ARRAY_START=$(llvm-nm "$TEST_ELF" | grep "__init_array_start" | awk '{print "0x"$1}')
+INIT_ARRAY_START=$("$LLVM_NM_CMD" "$TEST_ELF" | grep "__init_array_start" | awk '{print "0x"$1}')
 if [ -z "$INIT_ARRAY_START" ]; then
     echo "✗ FAIL: __init_array_start symbol not found"
     exit 1
@@ -188,7 +196,7 @@ fi
 echo "✓ PASS: __init_array_start found at $INIT_ARRAY_START"
 INIT_ADDR_DEC=$((INIT_ARRAY_START))
 
-INIT_ARRAY_INFO=$(llvm-readelf -S "$TEST_ELF" | grep "\.init_array")
+INIT_ARRAY_INFO=$("$LLVM_READELF_CMD" -S "$TEST_ELF" | grep "\.init_array")
 if [ -z "$INIT_ARRAY_INFO" ]; then
     echo "✗ FAIL: .init_array section not found"
     exit 1

--- a/cl/_testgo/defer5/in.go
+++ b/cl/_testgo/defer5/in.go
@@ -32,7 +32,7 @@ func main() {
 	// DARWIN-ARM64: [[SETJMP_RESULT:%[0-9]+]] = call i32 @sigsetjmp(ptr [[DEFER_JMPBUF]], i32 0)
 	// LINUX-AMD64: [[SETJMP_RESULT:%[0-9]+]] = call i32 @__sigsetjmp(ptr [[DEFER_JMPBUF]], i32 0)
 	// WINDOWS-ARM64: [[SETJMP_RESULT:%[0-9]+]] = call i32 @llgo_setjmp(ptr [[DEFER_JMPBUF]])
-	// WINDOWS-AMD64: [[SETJMP_RESULT:%[0-9]+]] = call i32 @_setjmpex(ptr [[DEFER_JMPBUF]], ptr null)
+	// WINDOWS-AMD64: [[SETJMP_RESULT:%[0-9]+]] = call i32 @{{_setjmpex|__intrinsic_setjmpex}}(ptr [[DEFER_JMPBUF]], ptr null)
 	// CHECK-NEXT: [[FIRST_ENTRY:%[0-9]+]] = icmp eq i32 [[SETJMP_RESULT]], 0
 	// CHECK-NEXT: br i1 [[FIRST_ENTRY]], label %{{.*}}, label %{{.*}}
 

--- a/cl/_testlibc/setjmp/in.go
+++ b/cl/_testlibc/setjmp/in.go
@@ -29,7 +29,7 @@ func fprintf(fp unsafe.Pointer, format *int8, __llgo_va_list ...any) int32
 // DARWIN-ARM64-NEXT: [[RET:%[0-9]+]] = call i32 @sigsetjmp(ptr [[JMPBUF]], i32 0)
 // LINUX-AMD64-NEXT: [[RET:%[0-9]+]] = call i32 @__sigsetjmp(ptr [[JMPBUF]], i32 0)
 // WINDOWS-386-NEXT: [[RET:%[0-9]+]] = call i32 @_setjmp3(ptr [[JMPBUF]], i32 0)
-// WINDOWS-AMD64-NEXT: [[RET:%[0-9]+]] = call i32 @_setjmpex(ptr [[JMPBUF]], ptr null)
+// WINDOWS-AMD64-NEXT: [[RET:%[0-9]+]] = call i32 @{{_setjmpex|__intrinsic_setjmpex}}(ptr [[JMPBUF]], ptr null)
 // WINDOWS-ARM64-NEXT: [[RET:%[0-9]+]] = call i32 @llgo_setjmp(ptr [[JMPBUF]])
 // CHECK-NEXT: [[FIRST:%[0-9]+]] = icmp eq i32 [[RET]], 0
 // CHECK-NEXT: br i1 [[FIRST]], label %{{[^,]+}}, label %{{[^ ]+}}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -492,12 +492,12 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
 	nativeInput := crosscompile.NativeToolchainInput{}
-	if usesNativeWindowsToolchain(runtime.GOOS, conf) {
+	if usesWindowsToolchainProfile(runtime.GOOS, conf) {
 		nativeInput, err = parseNativeToolchainInput(commands, conf.LinkOptions)
 		if err != nil {
 			return nil, err
 		}
-		nativeInput.ResolveCrossArch = conf.Mode != ModeGen
+		nativeInput.ResolveWindows = conf.Mode != ModeGen
 	}
 	export, err := crosscompile.UseWithGOARMAndToolchain(conf.Goos, conf.Goarch, conf.GOARM, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel, conf.ltoMode(), conf.goGlobalDCEEnabled(), nativeInput)
 	if err != nil {
@@ -919,12 +919,13 @@ func removeOutFmts(outFmts *OutFmtDetails) {
 	}
 }
 
-func usesNativeWindowsToolchain(hostGOOS string, conf *Config) bool {
-	// Windows can execute a host-architecture LLGo compiler while Clang targets
-	// another Windows architecture (for example, x64 LLGo producing ARM64 or
-	// 386 programs). The selected CC target, not the compiler process's GOARCH,
-	// defines the physical ABI that must be resolved below.
-	return conf.Target == "" && hostGOOS == "windows" && conf.Goos == hostGOOS
+func usesWindowsToolchainProfile(hostGOOS string, conf *Config) bool {
+	// Linked Windows output always needs a coherent compiler, ABI, CRT, and
+	// linker profile. This also covers a Unix-hosted LLGo compiler using an
+	// llvm-mingw toolchain. IR-only generation remains host-independent unless
+	// it runs natively on Windows, preserving golden-test behavior.
+	return conf.Target == "" && conf.Goos == "windows" &&
+		(hostGOOS == "windows" || conf.Mode != ModeGen)
 }
 
 func parseNativeToolchainInput(commands commandEnv, options LinkOptions) (crosscompile.NativeToolchainInput, error) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -493,11 +493,10 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
 	nativeInput := crosscompile.NativeToolchainInput{}
 	if usesWindowsToolchainProfile(runtime.GOOS, conf) {
-		nativeInput, err = parseNativeToolchainInput(commands, conf.LinkOptions)
+		nativeInput, err = parseNativeToolchainInput(commands, conf.LinkOptions, conf.Mode != ModeGen)
 		if err != nil {
 			return nil, err
 		}
-		nativeInput.ResolveWindows = conf.Mode != ModeGen
 	}
 	export, err := crosscompile.UseWithGOARMAndToolchain(conf.Goos, conf.Goarch, conf.GOARM, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel, conf.ltoMode(), conf.goGlobalDCEEnabled(), nativeInput)
 	if err != nil {
@@ -928,8 +927,12 @@ func usesWindowsToolchainProfile(hostGOOS string, conf *Config) bool {
 		(hostGOOS == "windows" || conf.Mode != ModeGen)
 }
 
-func parseNativeToolchainInput(commands commandEnv, options LinkOptions) (crosscompile.NativeToolchainInput, error) {
-	input := crosscompile.NativeToolchainInput{Dir: commands.dir, Environ: slices.Clone(commands.environ)}
+func parseNativeToolchainInput(commands commandEnv, options LinkOptions, resolveWindows bool) (crosscompile.NativeToolchainInput, error) {
+	input := crosscompile.NativeToolchainInput{
+		Dir:            commands.dir,
+		Environ:        slices.Clone(commands.environ),
+		ResolveWindows: resolveWindows,
+	}
 	for _, setting := range []struct {
 		name       string
 		value      string

--- a/internal/build/native_toolchain_test.go
+++ b/internal/build/native_toolchain_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xgo-dev/llgo/internal/crosscompile"
 )
 
-func TestUsesNativeWindowsToolchain(t *testing.T) {
+func TestUsesWindowsToolchainProfile(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		hostOS string
@@ -23,13 +23,16 @@ func TestUsesNativeWindowsToolchain(t *testing.T) {
 	}{
 		{name: "native Windows", hostOS: "windows", conf: Config{Goos: "windows", Goarch: "amd64"}, want: true},
 		{name: "cross-architecture Windows", hostOS: "windows", conf: Config{Goos: "windows", Goarch: "arm64"}, want: true},
+		{name: "cross-host Windows build", hostOS: "darwin", conf: Config{Goos: "windows", Goarch: "arm64", Mode: ModeBuild}, want: true},
+		{name: "cross-host Windows test", hostOS: "linux", conf: Config{Goos: "windows", Goarch: "386", Mode: ModeTest}, want: true},
+		{name: "cross-host Windows IR", hostOS: "darwin", conf: Config{Goos: "windows", Goarch: "arm64", Mode: ModeGen}},
 		{name: "named target", hostOS: "windows", conf: Config{Goos: "windows", Goarch: "amd64", Target: "esp32c3"}},
 		{name: "cross OS", hostOS: "windows", conf: Config{Goos: "linux", Goarch: "amd64"}},
 		{name: "non-Windows host", hostOS: "darwin", conf: Config{Goos: "darwin", Goarch: "arm64"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if got := usesNativeWindowsToolchain(test.hostOS, &test.conf); got != test.want {
-				t.Fatalf("usesNativeWindowsToolchain() = %v, want %v", got, test.want)
+			if got := usesWindowsToolchainProfile(test.hostOS, &test.conf); got != test.want {
+				t.Fatalf("usesWindowsToolchainProfile() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/internal/build/native_toolchain_test.go
+++ b/internal/build/native_toolchain_test.go
@@ -51,12 +51,15 @@ func TestParseNativeToolchainInput(t *testing.T) {
 		ExternalLinker:      `clang "--target=x86_64-pc-windows-msvc"`,
 		ExternalLinkerFlags: `'/debug:dwarf' /incremental:no`,
 	}
-	got, err := parseNativeToolchainInput(commands, options)
+	got, err := parseNativeToolchainInput(commands, options, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Dir != commands.dir || !reflect.DeepEqual(got.Environ, commands.environ) {
 		t.Fatalf("invocation state = dir %q env %q", got.Dir, got.Environ)
+	}
+	if !got.ResolveWindows {
+		t.Fatal("ResolveWindows = false, want true")
 	}
 	for name, values := range map[string]struct {
 		got  []string
@@ -91,7 +94,7 @@ func TestParseNativeToolchainInputErrors(t *testing.T) {
 		{name: "unterminated extldflags", options: LinkOptions{ExternalLinkerFlags: `'/debug`}, wantErr: "could not parse -extldflags"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := parseNativeToolchainInput(commandEnv{environ: test.environ}, test.options)
+			_, err := parseNativeToolchainInput(commandEnv{environ: test.environ}, test.options, false)
 			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("error = %v, want substring %q", err, test.wantErr)
 			}
@@ -103,7 +106,7 @@ func TestParseNativeToolchainInputAcceptsEmptyLinkerFlags(t *testing.T) {
 	got, err := parseNativeToolchainInput(commandEnv{}, LinkOptions{
 		ExternalLinker:      "  ",
 		ExternalLinkerFlags: "\t",
-	})
+	}, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/build/native_toolchain_test.go
+++ b/internal/build/native_toolchain_test.go
@@ -102,6 +102,19 @@ func TestParseNativeToolchainInputErrors(t *testing.T) {
 	}
 }
 
+func TestBuildRejectsMalformedNativeToolchainInput(t *testing.T) {
+	t.Setenv("CC", "'clang")
+	conf := NewDefaultConf(ModeBuild)
+	conf.Goos = "windows"
+	conf.Goarch = "amd64"
+	conf.GOAMD64 = "v1"
+
+	_, err := Build(Invocation{Config: conf, Dir: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "could not parse CC") {
+		t.Fatalf("Build() error = %v, want malformed CC error", err)
+	}
+}
+
 func TestParseNativeToolchainInputAcceptsEmptyLinkerFlags(t *testing.T) {
 	got, err := parseNativeToolchainInput(commandEnv{}, LinkOptions{
 		ExternalLinker:      "  ",

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -457,12 +457,12 @@ func useWithGOARMAndToolchain(goos, goarch, goarm string, wasiThreads, forceEspC
 	targetTriple := llvm.GetTargetTripleWithGOARM(goos, goarch, goarm)
 	llgoRoot := env.LLGoROOT()
 	nativePlatformToolchain := usesNativePlatformToolchain(
-		runtime.GOOS, runtime.GOARCH, goos, goarch, nativeInput.ResolveCrossArch,
+		runtime.GOOS, runtime.GOARCH, goos, goarch, nativeInput.ResolveWindows,
 	)
 
-	// Native Windows resolves its compiler and dependencies as one coherent
-	// profile below. Do not download or reject an unrelated embedded Clang
-	// installation before that profile has a chance to resolve.
+	// Linked Windows output resolves its compiler and dependencies as one
+	// coherent profile below, including when the LLGo host is macOS or Linux.
+	// Do not inspect an unrelated embedded Clang before that profile resolves.
 	var clangRoot string
 	if !(nativePlatformToolchain && goos == "windows") {
 		clangRoot, err = getESPClangRoot(forceEspClang)
@@ -692,9 +692,11 @@ func useWithGOARMAndToolchain(goos, goarch, goarm string, wasiThreads, forceEspC
 	return
 }
 
-func usesNativePlatformToolchain(hostGOOS, hostGOARCH, targetGOOS, targetGOARCH string, resolveCrossArch bool) bool {
-	return hostGOOS == targetGOOS &&
-		(hostGOARCH == targetGOARCH || targetGOOS == "windows" && resolveCrossArch)
+func usesNativePlatformToolchain(hostGOOS, hostGOARCH, targetGOOS, targetGOARCH string, resolveWindows bool) bool {
+	if targetGOOS == "windows" && resolveWindows {
+		return true
+	}
+	return hostGOOS == targetGOOS && hostGOARCH == targetGOARCH
 }
 
 // UseTarget loads configuration from a target name (e.g., "rp2040", "wasi")

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -722,16 +722,18 @@ func TestUsesNativePlatformToolchain(t *testing.T) {
 	for _, test := range []struct {
 		name                                   string
 		hostOS, hostArch, targetOS, targetArch string
-		resolveCrossArch, want                 bool
+		resolveWindows, want                   bool
 	}{
 		{name: "same platform", hostOS: "linux", hostArch: "amd64", targetOS: "linux", targetArch: "amd64", want: true},
-		{name: "Windows linked cross architecture", hostOS: "windows", hostArch: "amd64", targetOS: "windows", targetArch: "arm64", resolveCrossArch: true, want: true},
+		{name: "Windows linked cross architecture", hostOS: "windows", hostArch: "amd64", targetOS: "windows", targetArch: "arm64", resolveWindows: true, want: true},
 		{name: "Windows IR-only cross architecture", hostOS: "windows", hostArch: "amd64", targetOS: "windows", targetArch: "arm64"},
+		{name: "Windows linked cross host", hostOS: "darwin", hostArch: "arm64", targetOS: "windows", targetArch: "386", resolveWindows: true, want: true},
+		{name: "Windows IR-only cross host", hostOS: "linux", hostArch: "amd64", targetOS: "windows", targetArch: "amd64"},
 		{name: "non-Windows cross architecture", hostOS: "darwin", hostArch: "arm64", targetOS: "darwin", targetArch: "amd64"},
 		{name: "cross OS", hostOS: "windows", hostArch: "amd64", targetOS: "linux", targetArch: "amd64"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if got := usesNativePlatformToolchain(test.hostOS, test.hostArch, test.targetOS, test.targetArch, test.resolveCrossArch); got != test.want {
+			if got := usesNativePlatformToolchain(test.hostOS, test.hostArch, test.targetOS, test.targetArch, test.resolveWindows); got != test.want {
 				t.Fatalf("usesNativePlatformToolchain() = %v, want %v", got, test.want)
 			}
 		})

--- a/internal/crosscompile/windows_toolchain.go
+++ b/internal/crosscompile/windows_toolchain.go
@@ -21,11 +21,11 @@ type NativeToolchainInput struct {
 	ExternalFlags  []string
 	Dir            string
 	Environ        []string
-	// ResolveCrossArch selects the host's native Windows toolchain when a
-	// Windows process produces linked output for another Windows architecture.
+	// ResolveWindows selects a Windows native-format toolchain when linked
+	// output is produced for another architecture or from a non-Windows host.
 	// Pure IR generation leaves it false so multi-target golden tests do not
-	// depend on the host compiler's architecture or ABI profile.
-	ResolveCrossArch bool
+	// depend on an installed compiler's architecture or ABI profile.
+	ResolveWindows bool
 }
 
 type toolIdentity struct {
@@ -186,7 +186,7 @@ func requireClangGNUDriver(setting string, command []string, identity toolIdenti
 	if strings.Contains(strings.ToLower(identity.version), "clang") {
 		return nil
 	}
-	return fmt.Errorf("%s %q uses an unsupported driver (%s); native Windows currently requires Clang's GNU-compatible driver", setting, command[0], identity.version)
+	return fmt.Errorf("%s %q uses an unsupported driver (%s); Windows builds currently require Clang's GNU-compatible driver", setting, command[0], identity.version)
 }
 
 func compatibleWindowsToolchains(a, b NativeToolchain) error {

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -19,6 +19,7 @@ package ssa
 import (
 	"go/token"
 	"go/types"
+	"strings"
 	"unsafe"
 
 	"github.com/xgo-dev/llvm"
@@ -159,6 +160,12 @@ func (b Builder) windowsSetjmp(jb Expr) Expr {
 		// LLGo owns Go defer unwinding, and RtlUnwind cannot leave a vectored
 		// exception handler that interrupted generated Go code reliably.
 		name = "_setjmpex"
+		triple := strings.ToLower(prog.target.Spec().Triple)
+		if strings.Contains(triple, "windows-gnu") || strings.Contains(triple, "mingw") {
+			// MinGW exposes the same intrinsic entry point under its GNU CRT
+			// spelling; unlike the setjmp macro this lets LLGo pass a nil frame.
+			name = "__intrinsic_setjmpex"
+		}
 		params = types.NewTuple(
 			ptrParam,
 			types.NewParam(token.NoPos, nil, "", prog.VoidPtr().raw.Type),

--- a/ssa/eh_patch_test.go
+++ b/ssa/eh_patch_test.go
@@ -91,7 +91,7 @@ func TestWindowsSetjmpABI(t *testing.T) {
 	}{
 		{name: "386", arch: "386", setjmp: "@_setjmp3", longjmp: "@longjmp"},
 		{name: "amd64-msvc", arch: "amd64", setjmp: "@_setjmpex", longjmp: "@llgo_longjmp"},
-		{name: "amd64-gnu", arch: "amd64", llvmTarget: "x86_64-w64-windows-gnu", setjmp: "@_setjmpex", longjmp: "@llgo_longjmp"},
+		{name: "amd64-gnu", arch: "amd64", llvmTarget: "x86_64-w64-windows-gnu", setjmp: "@__intrinsic_setjmpex", longjmp: "@llgo_longjmp"},
 		{name: "arm64", arch: "arm64", setjmp: "@llgo_setjmp", longjmp: "@llgo_longjmp"},
 	}
 	for _, test := range tests {
@@ -142,7 +142,7 @@ func TestWindowsDirectSetjmpABI(t *testing.T) {
 	}{
 		{name: "386", arch: "386", setjmp: "@_setjmp3", longjmp: "@longjmp"},
 		{name: "amd64-msvc", arch: "amd64", setjmp: "@_setjmpex", longjmp: "@llgo_longjmp"},
-		{name: "amd64-gnu", arch: "amd64", llvmTarget: "x86_64-w64-windows-gnu", setjmp: "@_setjmpex", longjmp: "@llgo_longjmp"},
+		{name: "amd64-gnu", arch: "amd64", llvmTarget: "x86_64-w64-windows-gnu", setjmp: "@__intrinsic_setjmpex", longjmp: "@llgo_longjmp"},
 		{name: "arm64", arch: "arm64", setjmp: "@llgo_setjmp", longjmp: "@llgo_longjmp"},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/test/go/recover_fault_test.go
+++ b/test/go/recover_fault_test.go
@@ -23,12 +23,17 @@ func faultCopy(dst, src []byte) (n int, err error) {
 }
 
 func TestRecoverAfterFaultPreservesNamedResult(t *testing.T) {
+	if !enterRecoverableFaultTest(t) {
+		return
+	}
+
 	// Automatic GC is orthogonal to this test and can perturb the host's
 	// signal/exception recovery path while the fault is being converted into
 	// a panic. Disable it only around the intentional fault so Go and LLGo run
 	// the same deterministic recovery check.
 	oldGCPercent := debug.SetGCPercent(-1)
 	defer debug.SetGCPercent(oldGCPercent)
+	ensureRecoverableFaultStackHeadroom()
 
 	old := debug.SetPanicOnFault(true)
 	defer debug.SetPanicOnFault(old)

--- a/test/go/recover_fault_unix_check_test.go
+++ b/test/go/recover_fault_unix_check_test.go
@@ -4,4 +4,8 @@ package gotest
 
 import "testing"
 
+func enterRecoverableFaultTest(t *testing.T) bool { return true }
+
+func ensureRecoverableFaultStackHeadroom() {}
+
 func checkRecoveredFaultAddress(t *testing.T, err error, address *byte) {}

--- a/test/go/recover_fault_windows_test.go
+++ b/test/go/recover_fault_windows_test.go
@@ -35,11 +35,11 @@ func enterRecoverableFaultTest(t *testing.T) bool {
 
 	// Keep a possible host Go runtime defect from corrupting the parent test
 	// process. The process-level 0xc0000005 observed in CI may be an instance of
-	// golang/go#81238: Windows exception recovery can use more space below SP
-	// than Go 1.27 reserves on hosts with large XSTATE contexts.
+	// golang/go#81238, where Windows exception recovery can write below a
+	// goroutine stack and corrupt the adjacent heap on some hosts.
 	// The child still has to pass the complete fault/panic/recover assertions;
-	// once the minimum supported Go release contains the upstream fix, revisit
-	// this isolation and the stack-headroom preparation below.
+	// if and when the upstream runtime issue is resolved, revisit this isolation
+	// and the stack-headroom preparation below.
 	cmd := exec.Command(os.Args[0], "-test.run=^TestRecoverAfterFaultPreservesNamedResult$", "-test.v")
 	cmd.Env = append(os.Environ(), recoverableFaultChildEnv+"=1", "GOTRACEBACK=system")
 	if output, err := cmd.CombinedOutput(); err != nil {
@@ -60,9 +60,9 @@ func growRecoverableFaultStack(depth int) {
 
 func ensureRecoverableFaultStackHeadroom() {
 	// Grow and then unwind the goroutine stack before raising the exception.
-	// The 64 one-KiB frames exceed the reported 8 KiB XSTATE-size difference.
-	// This preserves the real protected-page fault while avoiding the specific
-	// near-stack-boundary condition described by golang/go#81238.
+	// About 64 one-KiB frames provide headroom for the host-dependent Windows
+	// exception context suspected in golang/go#81238. This preserves the real
+	// protected-page fault while avoiding the issue's near-stack-boundary setup.
 	growRecoverableFaultStack(64)
 }
 

--- a/test/go/recover_fault_windows_test.go
+++ b/test/go/recover_fault_windows_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"runtime/debug"
 	"runtime/trace"
 	"testing"
 	"unsafe"
@@ -16,6 +17,7 @@ import (
 const (
 	nonNilFaultChildEnv      = "LLGO_TEST_NON_NIL_FAULT"
 	recoverableFaultChildEnv = "LLGO_TEST_RECOVERABLE_FAULT"
+	traceFaultChildEnv       = "LLGO_TEST_TRACE_FAULT"
 )
 
 type traceFaultValue struct {
@@ -28,8 +30,15 @@ func copyTraceFaultValue(x, y *traceFaultValue) {
 }
 
 func enterRecoverableFaultTest(t *testing.T) bool {
+	return enterWindowsFaultTest(
+		t, recoverableFaultChildEnv,
+		"^TestRecoverAfterFaultPreservesNamedResult$",
+	)
+}
+
+func enterWindowsFaultTest(t *testing.T, childEnv, testPattern string) bool {
 	t.Helper()
-	if os.Getenv(recoverableFaultChildEnv) == "1" {
+	if os.Getenv(childEnv) == "1" {
 		return true
 	}
 
@@ -40,10 +49,10 @@ func enterRecoverableFaultTest(t *testing.T) bool {
 	// The child still has to pass the complete fault/panic/recover assertions;
 	// if and when the upstream runtime issue is resolved, revisit this isolation
 	// and the stack-headroom preparation below.
-	cmd := exec.Command(os.Args[0], "-test.run=^TestRecoverAfterFaultPreservesNamedResult$", "-test.v")
-	cmd.Env = append(os.Environ(), recoverableFaultChildEnv+"=1", "GOTRACEBACK=system")
+	cmd := exec.Command(os.Args[0], "-test.run="+testPattern, "-test.v")
+	cmd.Env = append(os.Environ(), childEnv+"=1", "GOTRACEBACK=system")
 	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("recoverable fault child failed: %v\n%s", err, output)
+		t.Fatalf("Windows fault test child failed: %v\n%s", err, output)
 	}
 	return false
 }
@@ -68,10 +77,17 @@ func ensureRecoverableFaultStackHeadroom() {
 
 // Regression test matching GOROOT/test/fixedbugs/issue73748b.go.
 func TestRecoverFaultWhileTracing(t *testing.T) {
+	if !enterWindowsFaultTest(t, traceFaultChildEnv, "^TestRecoverFaultWhileTracing$") {
+		return
+	}
+
+	oldGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGCPercent)
 	if err := trace.Start(io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	defer trace.Stop()
+	ensureRecoverableFaultStackHeadroom()
 
 	var recovered bool
 	func() {

--- a/test/go/recover_fault_windows_test.go
+++ b/test/go/recover_fault_windows_test.go
@@ -7,12 +7,16 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"runtime/trace"
 	"testing"
 	"unsafe"
 )
 
-const nonNilFaultChildEnv = "LLGO_TEST_NON_NIL_FAULT"
+const (
+	nonNilFaultChildEnv      = "LLGO_TEST_NON_NIL_FAULT"
+	recoverableFaultChildEnv = "LLGO_TEST_RECOVERABLE_FAULT"
+)
 
 type traceFaultValue struct {
 	a [16]int
@@ -21,6 +25,45 @@ type traceFaultValue struct {
 //go:noinline
 func copyTraceFaultValue(x, y *traceFaultValue) {
 	*x = *y
+}
+
+func enterRecoverableFaultTest(t *testing.T) bool {
+	t.Helper()
+	if os.Getenv(recoverableFaultChildEnv) == "1" {
+		return true
+	}
+
+	// Keep a possible host Go runtime defect from corrupting the parent test
+	// process. The process-level 0xc0000005 observed in CI may be an instance of
+	// golang/go#81238: Windows exception recovery can use more space below SP
+	// than Go 1.27 reserves on hosts with large XSTATE contexts.
+	// The child still has to pass the complete fault/panic/recover assertions;
+	// once the minimum supported Go release contains the upstream fix, revisit
+	// this isolation and the stack-headroom preparation below.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRecoverAfterFaultPreservesNamedResult$", "-test.v")
+	cmd.Env = append(os.Environ(), recoverableFaultChildEnv+"=1", "GOTRACEBACK=system")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("recoverable fault child failed: %v\n%s", err, output)
+	}
+	return false
+}
+
+//go:noinline
+func growRecoverableFaultStack(depth int) {
+	var frame [1024]byte
+	frame[0] = byte(depth)
+	if depth != 0 {
+		growRecoverableFaultStack(depth - 1)
+	}
+	runtime.KeepAlive(&frame)
+}
+
+func ensureRecoverableFaultStackHeadroom() {
+	// Grow and then unwind the goroutine stack before raising the exception.
+	// The 64 one-KiB frames exceed the reported 8 KiB XSTATE-size difference.
+	// This preserves the real protected-page fault while avoiding the specific
+	// near-stack-boundary condition described by golang/go#81238.
+	growRecoverableFaultStack(64)
 }
 
 // Regression test matching GOROOT/test/fixedbugs/issue73748b.go.


### PR DESCRIPTION
Depends on https://github.com/xgo-dev/llgo/pull/2454.

Part of https://github.com/xgo-dev/llgo/issues/2325.

This PR completes GNU/MinGW architecture qualification beyond the independent amd64 profile merged in R9:

- Windows ARM64 uses the architecture-native MSYS2 CLANGARM64 LLVM 19, UCRT, and dependency packages on the native ARM64 runner.
- Windows 386 keeps the x64 LLGo host compiler separate from a pinned LLVM 19 llvm-mingw/UCRT target and x86-mingw vcpkg dependency tree; it does not rely on the obsolete MSYS2 MINGW32 environment.
- macOS and Linux hosts use pinned llvm-mingw archives to compile and inspect Windows 386, amd64, and arm64 GNU/UCRT artifacts. Each target architecture runs in an isolated matrix job.
- Toolchain activation keeps `GOOS`/`GOARCH` authoritative, derives the GNU ABI from the compiler target triple, and isolates host LLVM metadata, target pkg-config metadata, and target runtime DLLs.
- Cross-host activation exports target-selecting compiler and pkg-config wrappers, so callers do not need to construct target flags or environment variables themselves.
- MinGW amd64 uses the CRT `__intrinsic_setjmpex` spelling while preserving the MSVC `_setjmpex` path and LLGo panic/defer context restoration.
- Native LLGo, language/runtime tests, benchmarks, scheduled GOROOT matrices, and artifact dependency audits gain architecture-matched GNU lanes. Debugger and final packaging qualification remain follow-up work.

The branch is rebased directly onto the current #2454 head. The temporary foreign-thread and finalizer commits formerly carried by the integration branch have been removed because their upstream fixes are already present or merged; this PR contains only R11 changes after R10.

Validation:

- the branch has the current #2454 head as its exact merge base;
- the fresh xgo-dev run for `18c06352a` completed with 67 successful checks; only the PR-inapplicable release-publish job was skipped;
- native MSVC/MinGW amd64, 386, and ARM64 language/runtime, standard-library, GOROOT, demo, benchmark, coverage, and dependency-audit lanes passed;
- Codecov patch coverage passed;
- the Windows regressions retain both real hardware-fault paths: protected-memory access with complete panic/recover assertions and nil fault while tracing. Both passed 100 consecutive Go 1.27 runs on a Windows 11 ARM64 VM. Child-process isolation, stack headroom, and temporary automatic-GC suppression are documented as a possible workaround for golang/go#81238, not as a proven diagnosis, and must be revisited after the upstream compiler/runtime fix reaches LLGo's minimum Go version.
