### PR TITLE
runtime: keep SIGPROF handler active during signal updates

### DIFF
--- a/runtime/internal/lib/runtime/_wrap/profile.c
+++ b/runtime/internal/lib/runtime/_wrap/profile.c
@@ -29,6 +29,14 @@
 #define LLGO_PROF_SAMPLES 2048
 #define LLGO_PROF_MAX_FP_STRIDE (1u << 20)
 
+/* Raw ABI shared with LLGO_SIGNAL_* in signal.c and signalMode* in
+ * signal_llgo.go. Keep the numeric values synchronized. */
+enum {
+    LLGO_PROF_SIGNAL_DEFAULT = 0,
+    LLGO_PROF_SIGNAL_WANTED = 1,
+    LLGO_PROF_SIGNAL_IGNORED = 2,
+};
+
 struct llgo_prof_sample {
     uint32_t n;
     uintptr_t pc[LLGO_PROF_STACK];
@@ -46,10 +54,14 @@ static int llgo_prof_previous_valid;
 static sigjmp_buf llgo_prof_fault_jmp;
 static volatile uintptr_t llgo_prof_fault_owner;
 static volatile int llgo_prof_fault_active;
+/* The Go cpuProfileStateMu serializes these control-plane fields. They are
+ * never read from the asynchronous profiling handler. */
 static int llgo_prof_previous_signal_mode;
 static int llgo_prof_desired_signal_mode;
 static int llgo_prof_signal_mode_updated;
 
+/* begin reports a previous mode or negative errno. The remaining helpers
+ * report zero or positive errno, matching the ordinary signal helpers. */
 extern int llgo_signal_profile_begin(int signum);
 extern int llgo_signal_profile_abort(int signum, int mode);
 extern int llgo_signal_profile_finish(int signum, int mode);
@@ -166,28 +178,31 @@ static int llgo_prof_install_signal(void)
     return sigaction(SIGPROF, &sa, 0);
 }
 
-static void llgo_prof_restore_signal(void)
+static int llgo_prof_restore_signal(void)
 {
     struct sigaction current;
+    int code;
     int mode;
     int updated = llgo_prof_signal_mode_updated;
 
     mode = updated ? llgo_prof_desired_signal_mode
                    : llgo_prof_previous_signal_mode;
-    llgo_signal_profile_finish(SIGPROF, mode);
+    code = llgo_signal_profile_finish(SIGPROF, mode);
     llgo_prof_signal_mode_updated = 0;
+    if (code != 0)
+        return code;
     if (sigaction(SIGPROF, 0, &current) != 0)
-        return;
+        return errno;
     /* Do not overwrite a handler installed by foreign code that did not use
      * the coordinated os/signal path. */
     if (!llgo_prof_action_is_ours(&current))
-        return;
-    if (updated) {
-        llgo_signal_profile_restore(SIGPROF, mode);
-        return;
-    }
-    if (llgo_prof_previous_valid)
-        sigaction(SIGPROF, &llgo_prof_previous_action, 0);
+        return 0;
+    if (updated)
+        return llgo_signal_profile_restore(SIGPROF, mode);
+    if (llgo_prof_previous_valid &&
+        sigaction(SIGPROF, &llgo_prof_previous_action, 0) != 0)
+        return errno;
+    return 0;
 }
 
 static void llgo_prof_signal(int sig, siginfo_t *info, void *uctx)
@@ -317,18 +332,22 @@ int llgo_cpu_profile_start(int hz)
 #endif
 }
 
-void llgo_cpu_profile_stop(void)
+int llgo_cpu_profile_stop(void)
 {
 #if defined(__APPLE__) || defined(__linux__)
     struct itimerval timer;
+    int code;
     int saved_errno = errno;
     llgo_prof_ring_lock_wait();
     memset(&timer, 0, sizeof(timer));
     setitimer(ITIMER_PROF, &timer, 0);
     __atomic_store_n(&llgo_prof_active, 0, __ATOMIC_RELEASE);
-    llgo_prof_restore_signal();
+    code = llgo_prof_restore_signal();
     llgo_prof_ring_unlock();
     errno = saved_errno;
+    return code;
+#else
+    return 0;
 #endif
 }
 
@@ -343,7 +362,8 @@ int llgo_cpu_profile_update_signal(int mode)
 #if defined(__APPLE__) || defined(__linux__)
     if (!__atomic_load_n(&llgo_prof_active, __ATOMIC_RELAXED))
         return 0;
-    if (mode < 0 || mode > 2)
+    if (mode < LLGO_PROF_SIGNAL_DEFAULT ||
+        mode > LLGO_PROF_SIGNAL_IGNORED)
         return -EINVAL;
     llgo_prof_desired_signal_mode = mode;
     llgo_prof_signal_mode_updated = 1;

--- a/runtime/internal/lib/runtime/_wrap/profile.c
+++ b/runtime/internal/lib/runtime/_wrap/profile.c
@@ -46,6 +46,14 @@ static int llgo_prof_previous_valid;
 static sigjmp_buf llgo_prof_fault_jmp;
 static volatile uintptr_t llgo_prof_fault_owner;
 static volatile int llgo_prof_fault_active;
+static int llgo_prof_previous_signal_mode;
+static int llgo_prof_desired_signal_mode;
+static int llgo_prof_signal_mode_updated;
+
+extern int llgo_signal_profile_begin(int signum);
+extern int llgo_signal_profile_abort(int signum, int mode);
+extern int llgo_signal_profile_finish(int signum, int mode);
+extern int llgo_signal_profile_restore(int signum, int mode);
 #endif
 
 static int llgo_prof_ring_try_lock(void)
@@ -161,12 +169,24 @@ static int llgo_prof_install_signal(void)
 static void llgo_prof_restore_signal(void)
 {
     struct sigaction current;
+    int mode;
+    int updated = llgo_prof_signal_mode_updated;
 
-    if (!llgo_prof_previous_valid || sigaction(SIGPROF, 0, &current) != 0)
+    mode = updated ? llgo_prof_desired_signal_mode
+                   : llgo_prof_previous_signal_mode;
+    llgo_signal_profile_finish(SIGPROF, mode);
+    llgo_prof_signal_mode_updated = 0;
+    if (sigaction(SIGPROF, 0, &current) != 0)
         return;
     /* Do not overwrite a handler installed by foreign code that did not use
-     * the coordinated os/signal path below. */
-    if (llgo_prof_action_is_ours(&current))
+     * the coordinated os/signal path. */
+    if (!llgo_prof_action_is_ours(&current))
+        return;
+    if (updated) {
+        llgo_signal_profile_restore(SIGPROF, mode);
+        return;
+    }
+    if (llgo_prof_previous_valid)
         sigaction(SIGPROF, &llgo_prof_previous_action, 0);
 }
 
@@ -255,13 +275,22 @@ int llgo_cpu_profile_start(int hz)
         errno = saved_errno;
         return 0;
     }
+    llgo_prof_previous_signal_mode = llgo_signal_profile_begin(SIGPROF);
+    if (llgo_prof_previous_signal_mode < 0) {
+        llgo_prof_ring_unlock();
+        errno = saved_errno;
+        return -1;
+    }
     if (llgo_prof_install_signal() != 0) {
+        llgo_signal_profile_abort(SIGPROF,
+                                  llgo_prof_previous_signal_mode);
         llgo_prof_ring_unlock();
         errno = saved_errno;
         return -1;
     }
     llgo_prof_read_index = 0;
     llgo_prof_write_index = 0;
+    llgo_prof_signal_mode_updated = 0;
     __atomic_store_n(&llgo_prof_lost, 0, __ATOMIC_RELAXED);
     __atomic_store_n(&llgo_prof_active, 1, __ATOMIC_RELEASE);
 
@@ -300,6 +329,28 @@ void llgo_cpu_profile_stop(void)
     llgo_prof_restore_signal();
     llgo_prof_ring_unlock();
     errno = saved_errno;
+#endif
+}
+
+/* os/signal must record its desired SIGPROF state without replacing the
+ * active profiler handler or changing the live handler mode. Installing
+ * SIG_DFL even briefly can terminate the process when a timer signal arrives
+ * between that install and the profiler refresh. Exposing DEFAULT to an old
+ * os/signal handler that the kernel selected before profiling began has the
+ * same problem. The Go control plane serializes this with start and stop. */
+int llgo_cpu_profile_update_signal(int mode)
+{
+#if defined(__APPLE__) || defined(__linux__)
+    if (!__atomic_load_n(&llgo_prof_active, __ATOMIC_RELAXED))
+        return 0;
+    if (mode < 0 || mode > 2)
+        return -EINVAL;
+    llgo_prof_desired_signal_mode = mode;
+    llgo_prof_signal_mode_updated = 1;
+    return 1;
+#else
+    (void)mode;
+    return 0;
 #endif
 }
 

--- a/runtime/internal/lib/runtime/_wrap/profile_windows.c
+++ b/runtime/internal/lib/runtime/_wrap/profile_windows.c
@@ -390,13 +390,13 @@ int llgo_cpu_profile_start(int hz)
 #endif
 }
 
-void llgo_cpu_profile_stop(void)
+int llgo_cpu_profile_stop(void)
 {
     llgo_handle thread;
     llgo_handle event;
 
     if (!__atomic_exchange_n(&llgo_prof_active, 0, __ATOMIC_ACQ_REL))
-        return;
+        return 0;
     thread = llgo_prof_thread;
     event = llgo_prof_stop_event;
     if (event != 0)
@@ -409,6 +409,7 @@ void llgo_cpu_profile_stop(void)
         CloseHandle(event);
     llgo_prof_thread = 0;
     llgo_prof_stop_event = 0;
+    return 0;
 }
 
 int llgo_cpu_profile_refresh_signal(void) { return 0; }

--- a/runtime/internal/lib/runtime/_wrap/signal.c
+++ b/runtime/internal/lib/runtime/_wrap/signal.c
@@ -28,6 +28,8 @@ _Static_assert(__atomic_always_lock_free(sizeof(unsigned int), 0),
 static int llgo_signal_pipe[2] = {-1, -1};
 static struct sigaction llgo_signal_default_action;
 static unsigned int llgo_signal_delivering;
+/* Raw ABI shared with LLGO_PROF_SIGNAL_* in profile.c and signalMode* in
+ * signal_llgo.go. Keep the numeric values synchronized. */
 enum {
     LLGO_SIGNAL_DEFAULT,
     LLGO_SIGNAL_WANTED,

--- a/runtime/internal/lib/runtime/_wrap/signal.c
+++ b/runtime/internal/lib/runtime/_wrap/signal.c
@@ -38,6 +38,23 @@ static unsigned int llgo_signal_pending[LLGO_SIGNAL_WORDS];
 /* Only the dedicated signal reader accesses this snapshot. */
 static unsigned int llgo_signal_received[LLGO_SIGNAL_WORDS];
 
+static void llgo_signal_handler(int signum);
+
+static void llgo_signal_wanted_action(struct sigaction *action)
+{
+    memset(action, 0, sizeof(*action));
+    action->sa_handler = llgo_signal_handler;
+    sigemptyset(&action->sa_mask);
+    action->sa_flags = SA_RESTART;
+}
+
+static void llgo_signal_ignored_action(struct sigaction *action)
+{
+    memset(action, 0, sizeof(*action));
+    action->sa_handler = SIG_IGN;
+    sigemptyset(&action->sa_mask);
+}
+
 static void llgo_signal_handler(int signum)
 {
     int saved_errno = errno;
@@ -128,10 +145,7 @@ int llgo_signal_enable(int signum)
     if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT)
         return EINVAL;
 
-    memset(&action, 0, sizeof(action));
-    action.sa_handler = llgo_signal_handler;
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = SA_RESTART;
+    llgo_signal_wanted_action(&action);
     previous = __atomic_exchange_n(&llgo_signal_modes[signum],
                                    LLGO_SIGNAL_WANTED, __ATOMIC_SEQ_CST);
     if (sigaction(signum, &action, 0) == 0)
@@ -169,10 +183,7 @@ int llgo_signal_ignore(int signum)
     if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT)
         return EINVAL;
 
-    memset(&action, 0, sizeof(action));
-    action.sa_handler = SIG_IGN;
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = 0;
+    llgo_signal_ignored_action(&action);
     previous = __atomic_exchange_n(&llgo_signal_modes[signum],
                                    LLGO_SIGNAL_IGNORED, __ATOMIC_SEQ_CST);
     if (sigaction(signum, &action, 0) == 0)
@@ -181,6 +192,64 @@ int llgo_signal_ignore(int signum)
     __atomic_store_n(&llgo_signal_modes[signum], previous,
                      __ATOMIC_SEQ_CST);
     return code;
+}
+
+/* CPU profiling owns the native SIGPROF disposition while active. Keep the
+ * live os/signal handler mode ignored for that whole interval: a handler the
+ * kernel selected just before profiling began may enter late and must not
+ * forward a timer signal to SIG_DFL. */
+int llgo_signal_profile_begin(int signum)
+{
+    if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT)
+        return -EINVAL;
+    return (int)__atomic_exchange_n(&llgo_signal_modes[signum],
+                                    LLGO_SIGNAL_IGNORED,
+                                    __ATOMIC_SEQ_CST);
+}
+
+/* Restore the exact live mode when profiling failed before its handler or
+ * timer became active. Unlike a completed Stop, this path has no pending
+ * profiling signal that requires DEFAULT to be normalized to IGNORED. */
+int llgo_signal_profile_abort(int signum, int mode)
+{
+    if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT ||
+        mode < LLGO_SIGNAL_DEFAULT || mode > LLGO_SIGNAL_IGNORED)
+        return EINVAL;
+    __atomic_store_n(&llgo_signal_modes[signum], (unsigned int)mode,
+                     __ATOMIC_SEQ_CST);
+    return 0;
+}
+
+int llgo_signal_profile_finish(int signum, int mode)
+{
+    unsigned int live_mode;
+
+    if (signum <= 0 || signum >= LLGO_SIGNAL_COUNT ||
+        mode < LLGO_SIGNAL_DEFAULT || mode > LLGO_SIGNAL_IGNORED)
+        return EINVAL;
+    live_mode = mode == LLGO_SIGNAL_WANTED ? LLGO_SIGNAL_WANTED
+                                           : LLGO_SIGNAL_IGNORED;
+    __atomic_store_n(&llgo_signal_modes[signum], live_mode,
+                     __ATOMIC_SEQ_CST);
+    return 0;
+}
+
+/* Apply the os/signal state requested while profiling was active. Default is
+ * restored as ignore, matching the Go runtime's protection against a final
+ * pending profiling signal. */
+int llgo_signal_profile_restore(int signum, int mode)
+{
+    struct sigaction action;
+
+    if (llgo_signal_profile_finish(signum, mode) != 0)
+        return EINVAL;
+    if (mode == LLGO_SIGNAL_WANTED)
+        llgo_signal_wanted_action(&action);
+    else
+        llgo_signal_ignored_action(&action);
+    if (sigaction(signum, &action, 0) == 0)
+        return 0;
+    return errno;
 }
 
 int llgo_signal_ignore_pipe(void)

--- a/runtime/internal/lib/runtime/cpuprof_signal_update_unix_llgo.go
+++ b/runtime/internal/lib/runtime/cpuprof_signal_update_unix_llgo.go
@@ -1,0 +1,22 @@
+//go:build !baremetal && !wasm && (darwin || linux) && (amd64 || arm64)
+
+package runtime
+
+import _ "unsafe"
+
+//go:linkname c_cpuProfileUpdateSignal C.llgo_cpu_profile_update_signal
+func c_cpuProfileUpdateSignal(mode int32) int32
+
+func cpuProfileSignalUpdate(sig uint32, mode int32) (handled bool, code int) {
+	if sig != cpuProfileSignal {
+		return false, 0
+	}
+	result := c_cpuProfileUpdateSignal(mode)
+	if result == 0 {
+		return false, 0
+	}
+	if result < 0 {
+		return true, int(-result)
+	}
+	return true, 0
+}

--- a/runtime/internal/lib/runtime/cpuprof_sigprof_llgo.go
+++ b/runtime/internal/lib/runtime/cpuprof_sigprof_llgo.go
@@ -22,7 +22,7 @@ const (
 func c_cpuProfileStart(hz int32) int32
 
 //go:linkname c_cpuProfileStop C.llgo_cpu_profile_stop
-func c_cpuProfileStop()
+func c_cpuProfileStop() int32
 
 //go:linkname c_cpuProfileDrain C.llgo_cpu_profile_drain
 func c_cpuProfileDrain(pcs, lengths unsafe.Pointer, maxRecords, maxStack int32, lost *uint64, empty *int32) int32
@@ -93,7 +93,9 @@ func SetCPUProfileRate(hz int) {
 
 	if hz == 0 {
 		if latomic.LoadInt32(&cpuProfileRate) != 0 {
-			c_cpuProfileStop()
+			if c_cpuProfileStop() != 0 {
+				print("runtime: failed to restore CPU profiling signal handler.\n")
+			}
 			latomic.StoreInt32(&cpuProfileRate, 0)
 		}
 		return

--- a/runtime/internal/lib/runtime/cpuprof_stub_llgo.go
+++ b/runtime/internal/lib/runtime/cpuprof_stub_llgo.go
@@ -7,3 +7,7 @@ func SetCPUProfileRate(hz int) {}
 func cpuProfileSignalLock(sig uint32) bool { return false }
 
 func cpuProfileSignalUnlock(locked bool) {}
+
+func cpuProfileSignalUpdate(sig uint32, mode int32) (handled bool, code int) {
+	return false, 0
+}

--- a/runtime/internal/lib/runtime/signal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_llgo.go
@@ -25,6 +25,12 @@ const (
 	signalWords = (signalCount + 31) / 32
 )
 
+const (
+	signalModeDefault int32 = iota
+	signalModeWanted
+	signalModeIgnored
+)
+
 var (
 	sigInitState uint32
 	sigReadFD    c.Int
@@ -190,7 +196,13 @@ func ensureSignalState(sig uint32) *sigState {
 func setSignalHandler(sig uint32, enabled bool) c.Int {
 	locked := cpuProfileSignalLock(sig)
 	var code c.Int
+	mode := signalModeDefault
 	if enabled {
+		mode = signalModeWanted
+	}
+	if handled, updateCode := cpuProfileSignalUpdate(sig, mode); handled {
+		code = c.Int(updateCode)
+	} else if enabled {
 		code = c_signalEnable(c.Int(sig))
 	} else {
 		code = c_signalDisable(c.Int(sig))
@@ -201,7 +213,12 @@ func setSignalHandler(sig uint32, enabled bool) c.Int {
 
 func setSignalIgnored(sig uint32) c.Int {
 	locked := cpuProfileSignalLock(sig)
-	code := c_signalIgnore(c.Int(sig))
+	var code c.Int
+	if handled, updateCode := cpuProfileSignalUpdate(sig, signalModeIgnored); handled {
+		code = c.Int(updateCode)
+	} else {
+		code = c_signalIgnore(c.Int(sig))
+	}
 	cpuProfileSignalUnlock(locked)
 	return code
 }

--- a/runtime/internal/lib/runtime/signal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_llgo.go
@@ -26,6 +26,8 @@ const (
 )
 
 const (
+	// Raw ABI shared with LLGO_SIGNAL_* in _wrap/signal.c and
+	// LLGO_PROF_SIGNAL_* in _wrap/profile.c. Keep the values synchronized.
 	signalModeDefault int32 = iota
 	signalModeWanted
 	signalModeIgnored

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -31,10 +31,12 @@ cd "$repo/test/_stress"
 go test -race -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/signal
+/tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/cpuprof
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/finalizer
 ```
 
-The signal suite is LLGo-only and targets Unix hosts. The finalizer suite is
+The signal suite is LLGo-only and targets Unix hosts. The CPU profile suite is
+LLGo-only and targets supported Darwin and Linux hosts. The finalizer suite is
 LLGo-only and targets hosted BDWGC builds. The timer suite also runs with the
 standard Go compiler so the harness can be checked independently.
 
@@ -58,7 +60,9 @@ tests cover distinct-signal delivery during a lower-number signal storm,
 concurrent registration churn, repeated `Notify`/`Stop`/`Reset` barriers,
 fatal-signal arbitration in concurrent helper processes while the final
 receiver stops, and timer progress while handlers are busy. The flood cases
-also exercise the handler under concurrent delivery pressure. The finalizer
-suite repeatedly publishes large finalizer batches while many goroutines call
+also exercise the handler under concurrent delivery pressure. The CPU profile
+suite changes the logical SIGPROF mode under a continuous signal flood to
+regress fatal native-handler replacement windows. The finalizer suite
+repeatedly publishes large finalizer batches while many goroutines call
 `runtime.GC`, and checks that queued callbacks are neither corrupted nor
 delivered twice.

--- a/test/_stress/runtime/cpuprof/cpuprof_stress_llgo_test.go
+++ b/test/_stress/runtime/cpuprof/cpuprof_stress_llgo_test.go
@@ -1,0 +1,155 @@
+//go:build llgo && !baremetal && !wasm && (darwin || linux) && (amd64 || arm64)
+
+package cpuprofstress
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime/pprof"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		if count := base / 8; count > 0 {
+			return count
+		}
+		return 1
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+const modeChurnHelperEnv = "LLGO_STRESS_SIGPROF_MODE_CHURN"
+
+func TestSIGPROFModeChurnWhileProfiling(t *testing.T) {
+	if os.Getenv(modeChurnHelperEnv) != "1" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestSIGPROFModeChurnWhileProfiling$", "-test.v")
+		cmd.Env = append(os.Environ(), modeChurnHelperEnv+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("SIGPROF mode-churn child failed: %v\n%s", err, output)
+		}
+		return
+	}
+
+	notified := make(chan os.Signal, 1)
+	signal.Notify(notified, syscall.SIGPROF)
+	t.Cleanup(func() {
+		signal.Stop(notified)
+		signal.Reset(syscall.SIGPROF)
+	})
+	raisers := stressCount(t, 8)
+	rounds := stressCount(t, 2000)
+	pid := syscall.Getpid()
+	stop := make(chan struct{})
+	var failures atomic.Int64
+	var work sync.WaitGroup
+	work.Add(raisers)
+	for worker := 0; worker < raisers; worker++ {
+		go func() {
+			defer work.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if syscall.Kill(pid, syscall.SIGPROF) != nil {
+						failures.Add(1)
+						return
+					}
+				}
+			}
+		}()
+	}
+	done := make(chan struct{})
+	go func() {
+		work.Wait()
+		close(done)
+	}()
+	stopped := false
+	stopRaisers := func() bool {
+		if !stopped {
+			close(stop)
+			stopped = true
+		}
+		select {
+		case <-done:
+			return true
+		case <-time.After(30 * time.Second):
+			return false
+		}
+	}
+
+	select {
+	case got := <-notified:
+		if got != syscall.SIGPROF {
+			if !stopRaisers() {
+				t.Fatal("SIGPROF raisers did not stop within 30s")
+			}
+			t.Fatalf("got initial signal %v, want SIGPROF", got)
+		}
+	case <-time.After(30 * time.Second):
+		if !stopRaisers() {
+			t.Fatal("SIGPROF raisers did not stop within 30s")
+		}
+		t.Fatal("signal flood did not deliver an initial SIGPROF")
+	}
+
+	var profile bytes.Buffer
+	if err := pprof.StartCPUProfile(&profile); err != nil {
+		if !stopRaisers() {
+			t.Fatal("SIGPROF raisers did not stop within 30s")
+		}
+		t.Fatalf("StartCPUProfile: %v", err)
+	}
+	t.Cleanup(pprof.StopCPUProfile)
+	t.Cleanup(func() {
+		if !stopRaisers() {
+			t.Error("SIGPROF raisers did not stop within 30s")
+		}
+	})
+
+	var stateFailure string
+	for round := 0; round < rounds; round++ {
+		signal.Notify(notified, syscall.SIGPROF)
+		signal.Stop(notified)
+		signal.Ignore(syscall.SIGPROF)
+		if !signal.Ignored(syscall.SIGPROF) {
+			stateFailure = fmt.Sprintf("round %d: SIGPROF is not ignored", round)
+			break
+		}
+		signal.Reset(syscall.SIGPROF)
+		if signal.Ignored(syscall.SIGPROF) {
+			stateFailure = fmt.Sprintf("round %d: SIGPROF is still ignored after Reset", round)
+			break
+		}
+	}
+	if !stopRaisers() {
+		t.Fatal("SIGPROF raisers did not stop within 30s")
+	}
+	if stateFailure != "" {
+		t.Fatal(stateFailure)
+	}
+	if got := failures.Load(); got != 0 {
+		t.Fatalf("kill(SIGPROF) failed in %d workers", got)
+	}
+
+	pprof.StopCPUProfile()
+	if profile.Len() == 0 {
+		t.Fatal("CPU profile is empty")
+	}
+}

--- a/test/_stress/runtime/cpuprof/cpuprof_stress_llgo_test.go
+++ b/test/_stress/runtime/cpuprof/cpuprof_stress_llgo_test.go
@@ -36,6 +36,8 @@ func stressCount(t *testing.T, base int) int {
 
 const modeChurnHelperEnv = "LLGO_STRESS_SIGPROF_MODE_CHURN"
 
+const raiserStopTimeout = 30 * time.Second
+
 func TestSIGPROFModeChurnWhileProfiling(t *testing.T) {
 	if os.Getenv(modeChurnHelperEnv) != "1" {
 		cmd := exec.Command(os.Args[0], "-test.run=^TestSIGPROFModeChurnWhileProfiling$", "-test.v")
@@ -89,42 +91,44 @@ func TestSIGPROFModeChurnWhileProfiling(t *testing.T) {
 		select {
 		case <-done:
 			return true
-		case <-time.After(30 * time.Second):
+		case <-time.After(raiserStopTimeout):
 			return false
+		}
+	}
+	requireRaisersStopped := func() {
+		t.Helper()
+		if !stopRaisers() {
+			t.Fatalf("SIGPROF raisers did not stop within %s", raiserStopTimeout)
 		}
 	}
 
 	select {
 	case got := <-notified:
 		if got != syscall.SIGPROF {
-			if !stopRaisers() {
-				t.Fatal("SIGPROF raisers did not stop within 30s")
-			}
+			requireRaisersStopped()
 			t.Fatalf("got initial signal %v, want SIGPROF", got)
 		}
-	case <-time.After(30 * time.Second):
-		if !stopRaisers() {
-			t.Fatal("SIGPROF raisers did not stop within 30s")
-		}
+	case <-time.After(raiserStopTimeout):
+		requireRaisersStopped()
 		t.Fatal("signal flood did not deliver an initial SIGPROF")
 	}
 
 	var profile bytes.Buffer
 	if err := pprof.StartCPUProfile(&profile); err != nil {
-		if !stopRaisers() {
-			t.Fatal("SIGPROF raisers did not stop within 30s")
-		}
+		requireRaisersStopped()
 		t.Fatalf("StartCPUProfile: %v", err)
 	}
 	t.Cleanup(pprof.StopCPUProfile)
 	t.Cleanup(func() {
 		if !stopRaisers() {
-			t.Error("SIGPROF raisers did not stop within 30s")
+			t.Errorf("SIGPROF raisers did not stop within %s", raiserStopTimeout)
 		}
 	})
 
 	var stateFailure string
 	for round := 0; round < rounds; round++ {
+		// Exercise the native WANTED -> DEFAULT edge before the independent
+		// IGNORED -> DEFAULT edge in every round.
 		signal.Notify(notified, syscall.SIGPROF)
 		signal.Stop(notified)
 		signal.Ignore(syscall.SIGPROF)
@@ -138,9 +142,7 @@ func TestSIGPROFModeChurnWhileProfiling(t *testing.T) {
 			break
 		}
 	}
-	if !stopRaisers() {
-		t.Fatal("SIGPROF raisers did not stop within 30s")
-	}
+	requireRaisersStopped()
 	if stateFailure != "" {
 		t.Fatal(stateFailure)
 	}


### PR DESCRIPTION
Fixes the macOS `test/go` flake seen in https://github.com/xgo-dev/llgo/actions/runs/33388520899/job/99476512530.

While CPU profiling was active, `os/signal.Reset(SIGPROF)` briefly installed `SIG_DFL` before the profiler refreshed its handler. A timer signal delivered in that window terminated the test process, which LLGo reported only as `exit code -1`. A handler selected before profiling could hit the same problem if it entered late and observed the updated default mode.

This change keeps the live SIGPROF mode ignored and leaves the profiler handler installed for the full profiling interval. Logical `Notify`, `Stop`, `Ignore`, and `Reset` changes are recorded separately and applied when profiling stops. It also preserves a foreign handler installed while profiling, restores the exact live mode if profiler installation fails, and reports a failure to restore the native handler at Stop.

## Why the coordination is needed

Go 1.20 through 1.27 use the same simpler design in `runtime/signal_unix.go`:

- the runtime owns SIGPROF through its unified signal handler;
- native `sigenable`, `sigdisable`, and `sigignore` return immediately for SIGPROF, so `os/signal` only changes logical bitmaps;
- when profiling starts, a previous `SIG_DFL` disposition is normalized to `SIG_IGN` before installing the runtime handler, protecting against pending signals and late handler entry;
- the implementation explicitly does not try to support external SIGPROF handler replacement while profiling.

LLGo currently has separate native handlers for CPU profiling and `os/signal`, and it preserves the existing behavior that `os/signal` can own SIGPROF outside profiling. Keeping that behavior requires three distinct states: the profiler's native handler, the logical mode requested for restoration after Stop, and a safe live mode observed by a previously selected LLGo signal handler. Removing only one of these states would reopen either the temporary `SIG_DFL` window or the late-handler race.

Adopting Go's permanently unified SIGPROF handler would reduce the coordination code, but it would also change LLGo's existing `os/signal` behavior and tests. That is an architectural change and is intentionally outside this focused fix.

## Stress coverage

A child-isolated suite under `test/_stress/runtime/cpuprof` starts a process-directed SIGPROF flood before profiling, then repeatedly churns all `os/signal` modes. The stress-test documentation includes the explicit command, load profiles, platform scope, and placement policy. It remains opt-in and is not part of routine CI.