### PR TITLE
ci: simplify and accelerate workflows

### DIFF
--- a/.github/actions/setup-demo-deps/action.yml
+++ b/.github/actions/setup-demo-deps/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Python 3.12 on Windows
       if: runner.os == 'Windows'
       id: windows_python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         # LLVM 19.1.3's MSVC LLDB embeds the 3.12.7 hosted-tool-cache prefix.
         # A newer 3.12 patch is ABI-compatible, but LLDB combines its embedded
@@ -34,7 +34,7 @@ runs:
     - name: Set up target Python 3.12 on Windows
       if: runner.os == 'Windows' && inputs.windows-arch != 'amd64'
       id: windows_target_python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         # The target library ABI is stable across Python 3.12 patch releases.
         # Reuse the runner's native architecture build when available instead
@@ -46,7 +46,7 @@ runs:
     - name: Set up LLDB Python 3.10 on Windows 386
       if: runner.os == 'Windows' && inputs.windows-arch == '386'
       id: windows_lldb_python_386
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         # LLVM's official 19.1.7 Win32 LLDB links python310.dll. Keep this
         # debugger runtime separate from the target Python 3.12 demo library.
@@ -57,7 +57,7 @@ runs:
     - name: Set up LLDB Python 3.11 on Windows ARM64
       if: runner.os == 'Windows' && inputs.windows-arch == 'arm64'
       id: windows_lldb_python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         # LLVM's official 19.1.7 Windows-on-Arm LLDB links python311.dll.
         # 3.11.9 is the final ARM64 artifact in actions/python-versions.

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -669,10 +669,22 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
-        brew update
-        
+        brew_install_missing() {
+          local formula
+          local missing=()
+          for formula in "$@"; do
+            if ! brew list --versions "${formula}" >/dev/null; then
+              missing+=("${formula}")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            brew install "${missing[@]}"
+          fi
+        }
+
         # Install LLVM if requested
         if [[ "${{ inputs.install-llvm }}" == "true" ]]; then
           llvm_formula="llvm@${{inputs.llvm-version}}"
@@ -690,7 +702,7 @@ runs:
             esac
           done < <(brew list --formula)
 
-          brew install "${llvm_formula}" "${lld_formula}"
+          brew_install_missing "${llvm_formula}" "${lld_formula}"
           brew link --force --overwrite "${llvm_formula}" "${lld_formula}"
           llvm_bin="$(brew --prefix "${llvm_formula}")/bin"
           lld_bin="$(brew --prefix "${lld_formula}")/bin"
@@ -707,7 +719,7 @@ runs:
         fi
         
         # Install common dependencies
-        brew install bdw-gc openssl libffi libuv
+        brew_install_missing bdw-gc openssl libffi libuv
         brew link --overwrite libffi
 
         # Install optional deps for demos.
@@ -717,9 +729,9 @@ runs:
           cjson       # for github.com/goplus/lib/c/cjson
           sqlite      # for github.com/goplus/lib/c/sqlite
         )
-        brew install "${opt_deps[@]}"
+        brew_install_missing "${opt_deps[@]}"
         
-        brew install python@3.12 || true # for github.com/goplus/lib/py
+        brew_install_missing python@3.12 || true # for github.com/goplus/lib/py
         brew link --overwrite python@3.12
 
     - name: Install Ubuntu dependencies

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -672,6 +672,12 @@ runs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
+        # Refresh formula and tap metadata once, but keep usable formulae from
+        # the runner image. A plain `brew install` upgrades outdated formulae;
+        # that can fail when a newly published version temporarily has no
+        # bottle for Intel macOS.
+        brew update
+
         brew_install_missing() {
           local formula
           local missing=()

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -731,8 +731,10 @@ runs:
         )
         brew_install_missing "${opt_deps[@]}"
         
-        brew_install_missing python@3.12 || true # for github.com/goplus/lib/py
-        brew link --overwrite python@3.12
+        # Python is optional and is used only by github.com/goplus/lib/py.
+        if brew_install_missing python@3.12; then
+          brew link --overwrite python@3.12 || true
+        fi
 
     - name: Install Ubuntu dependencies
       if: runner.os == 'Linux'

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -665,6 +665,13 @@ runs:
         llvm-version: ${{ inputs.llvm-version }}
         windows-arch: ${{ inputs.windows-arch }}
 
+    - name: Refresh Homebrew metadata on Apple Silicon
+      if: runner.os == 'macOS' && runner.arch == 'ARM64'
+      shell: bash
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+      run: brew update
+
     - name: Install macOS dependencies
       if: runner.os == 'macOS'
       shell: bash
@@ -672,12 +679,9 @@ runs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
-        # Refresh formula and tap metadata once, but keep usable formulae from
-        # the runner image. A plain `brew install` upgrades outdated formulae;
-        # that can fail when a newly published version temporarily has no
-        # bottle for Intel macOS.
-        brew update
-
+        # Intel macOS is a Homebrew Tier 3 configuration and newly published
+        # formulae may have no Intel bottle. Keep its runner-image metadata and
+        # installed formulae; Apple Silicon refreshes metadata in the step above.
         brew_install_missing() {
           local formula
           local missing=()

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -37,10 +37,12 @@ runs:
     - name: Cache full-target Windows LLVM
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'
       id: windows_llvm_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}\llgo-llvm\LLVM-19.1.3-Windows-X64
-        key: llgo-llvm-19.1.3-full-target-windows-x64-1077267ca353a1e236055ed4b57d6a404d09c40b01bd27dc882870395cdc1aae
+        # Configuration later installs the selected compiler-rt builtins into
+        # this tree, so each target architecture must own an immutable cache.
+        key: llgo-llvm-19.1.3-full-target-windows-${{ inputs.windows-arch }}-1077267ca353a1e236055ed4b57d6a404d09c40b01bd27dc882870395cdc1aae
 
     - name: Install full-target Windows LLVM
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc' && steps.windows_llvm_cache.outputs.cache-hit != 'true'
@@ -98,17 +100,10 @@ runs:
         Move-Item -LiteralPath $extractedRoot.FullName -Destination $installRoot
         Remove-Item -LiteralPath $archive, $tar.FullName
 
-    - name: Save full-target Windows LLVM
-      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc' && steps.windows_llvm_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}\llgo-llvm\LLVM-19.1.3-Windows-X64
-        key: llgo-llvm-19.1.3-full-target-windows-x64-1077267ca353a1e236055ed4b57d6a404d09c40b01bd27dc882870395cdc1aae
-
     - name: Cache target-native Windows LLVM support
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-arch != 'amd64'
       id: windows_target_llvm_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}\llgo-compiler-rt\19.1.7\${{ inputs.windows-arch }}
         key: ${{ inputs.windows-arch == 'arm64' && 'llgo-compiler-rt-19.1.7-windows-arm64-08d871c9a20caf0987ede1a4e44d489e28854c9f2fff3da98b486891f4856e05-native-lldb-v1' || 'llgo-compiler-rt-19.1.7-windows-386-3d7044fa307d3183e4ee2a98e12dd0523ced58f1d1c95c5e057694fb75beb51a-native-lldb-v1' }}
@@ -180,17 +175,10 @@ runs:
           }
         }
 
-    - name: Save target-native Windows LLVM support
-      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-arch != 'amd64' && steps.windows_target_llvm_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}\llgo-compiler-rt\19.1.7\${{ inputs.windows-arch }}
-        key: ${{ inputs.windows-arch == 'arm64' && 'llgo-compiler-rt-19.1.7-windows-arm64-08d871c9a20caf0987ede1a4e44d489e28854c9f2fff3da98b486891f4856e05-native-lldb-v1' || 'llgo-compiler-rt-19.1.7-windows-386-3d7044fa307d3183e4ee2a98e12dd0523ced58f1d1c95c5e057694fb75beb51a-native-lldb-v1' }}
-
     - name: Cache Windows MSVC dependencies
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'
       id: windows_vcpkg_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}\llgo-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
         key: llgo-vcpkg-${{ inputs.windows-arch }}-windows-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
@@ -234,13 +222,6 @@ runs:
         if ($LASTEXITCODE -ne 0) {
           throw "Installing vcpkg dependencies failed with exit code $LASTEXITCODE"
         }
-
-    - name: Save Windows MSVC dependencies
-      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc' && steps.windows_vcpkg_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}\llgo-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
-        key: llgo-vcpkg-${{ inputs.windows-arch }}-windows-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
 
     - name: Configure standalone Windows LLVM, SDK, and dependencies
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'

--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -20,13 +20,24 @@ runs:
         sudo apt-get update
         sudo apt-get install -y libsdl2-2.0-0 libslirp0
 
+    - name: Cache ESP QEMU toolchains
+      id: esp_qemu_cache
+      uses: actions/cache@v6
+      with:
+        path: .cache/qemu
+        key: esp-qemu-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/install-esp-qemu.sh') }}
+
     - name: Install ESP QEMU toolchains
+      if: steps.esp_qemu_cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         chmod +x .github/workflows/install-esp-qemu.sh
-        QEMU_DIR=".cache/qemu"
-        .github/workflows/install-esp-qemu.sh "$QEMU_DIR"
-        qemu_bin="${PWD}/${QEMU_DIR}/bin"
+        .github/workflows/install-esp-qemu.sh .cache/qemu
+
+    - name: Add ESP QEMU to PATH
+      shell: bash
+      run: |
+        qemu_bin="${PWD}/.cache/qemu/bin"
         if [[ "$RUNNER_OS" == Windows ]]; then
           # Git Bash understands /d/... paths, but LLGo launches QEMU through
           # Windows CreateProcess and therefore needs a native path.

--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -8,10 +8,10 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
-        brew update
-        brew install sdl2
+        brew list --versions sdl2 >/dev/null || brew install sdl2
 
     - name: Install Ubuntu embedded dependencies
       if: runner.os == 'Linux'

--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -4,6 +4,13 @@ description: "Install dependencies required for embedded QEMU tests"
 runs:
   using: "composite"
   steps:
+    - name: Refresh Homebrew metadata on Apple Silicon
+      if: runner.os == 'macOS' && runner.arch == 'ARM64'
+      shell: bash
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+      run: brew update
+
     - name: Install macOS embedded dependencies
       if: runner.os == 'macOS'
       shell: bash
@@ -11,10 +18,8 @@ runs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
-        # Refresh metadata explicitly, then preserve a usable runner-provided
-        # SDL installation instead of upgrading it as an incidental side
-        # effect of dependency setup.
-        brew update
+        # Preserve runner-provided packages on Intel, where Homebrew no longer
+        # guarantees bottles. Apple Silicon refreshes metadata in the step above.
         brew list --versions sdl2 >/dev/null || brew install sdl2
 
     - name: Install Ubuntu embedded dependencies

--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -11,6 +11,10 @@ runs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
+        # Refresh metadata explicitly, then preserve a usable runner-provided
+        # SDL installation instead of upgrading it as an incidental side
+        # effect of dependency setup.
+        brew update
         brew list --versions sdl2 >/dev/null || brew install sdl2
 
     - name: Install Ubuntu embedded dependencies

--- a/.github/actions/setup-goreleaser/action.yml
+++ b/.github/actions/setup-goreleaser/action.yml
@@ -19,16 +19,16 @@ runs:
       uses: ./.github/actions/setup-go
     - name: Restore Linux sysroot cache
       id: cache-linux-sysroot
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: .sysroot/linux.tar.gz
         key: ${{ inputs.linux-cache-key }}
     - name: Populate Linux sysroot
       run: tar -xzvf .sysroot/linux.tar.gz -C .sysroot
       shell: bash
-    - name: Restore ESP Clang cache
+    - name: Cache ESP Clang
       id: cache-esp-clang
-      uses: actions/cache/restore@v5
+      uses: actions/cache@v6
       with:
         path: ${{ inputs.esp-clang-cache-path }}
         key: esp-clang-${{ hashFiles('.github/workflows/download_esp_clang.sh') }}
@@ -36,12 +36,6 @@ runs:
       if: steps.cache-esp-clang.outputs.cache-hit != 'true'
       run: bash .github/workflows/download_esp_clang.sh
       shell: bash
-    - name: Save ESP Clang cache
-      if: steps.cache-esp-clang.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
-      with:
-        path: ${{ inputs.esp-clang-cache-path }}
-        key: esp-clang-${{ hashFiles('.github/workflows/download_esp_clang.sh') }}
     - name: Check file
       run: tree .sysroot
       shell: bash

--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -40,10 +40,10 @@ runs:
             ;;
         esac
 
-    - name: Restore llvm-mingw
+    - name: Cache llvm-mingw
       if: runner.os == 'Windows'
       id: llvm_mingw_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}\llvm-mingw\20250114\ucrt-x86_64
         key: llvm-mingw-20250114-ucrt-x86_64-9395d95c089611e6cd728c9a07219ffc5ac706e0c719833a2f7e64a706a81541
@@ -80,17 +80,10 @@ runs:
         }
         Move-Item -LiteralPath $source.FullName -Destination $installRoot
 
-    - name: Save llvm-mingw
-      if: runner.os == 'Windows' && steps.llvm_mingw_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}\llvm-mingw\20250114\ucrt-x86_64
-        key: llvm-mingw-20250114-ucrt-x86_64-9395d95c089611e6cd728c9a07219ffc5ac706e0c719833a2f7e64a706a81541
-
-    - name: Restore llvm-mingw target dependencies
+    - name: Cache llvm-mingw target dependencies
       if: runner.os == 'Windows'
       id: llvm_mingw_vcpkg_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}\llgo-mingw-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}\386
         key: llgo-llvm-mingw-20250114-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
@@ -131,13 +124,6 @@ runs:
         if ($LASTEXITCODE -ne 0) {
           throw "Installing llvm-mingw 386 dependencies failed with exit code $LASTEXITCODE"
         }
-
-    - name: Save llvm-mingw target dependencies
-      if: runner.os == 'Windows' && steps.llvm_mingw_vcpkg_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}\llgo-mingw-vcpkg\${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}\386
-        key: llgo-llvm-mingw-20250114-ucrt-386-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
 
     - name: Configure llvm-mingw target
       if: runner.os == 'Windows'
@@ -232,10 +218,10 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_TRIPLE=i686-w64-windows-gnu"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_MINGW_TARGET_VCPKG_ROOT=$vcpkgRoot"
 
-    - name: Restore cross-host llvm-mingw
+    - name: Cache cross-host llvm-mingw
       if: runner.os != 'Windows' && env.LLGO_MINGW_CROSS_ROOT == ''
       id: cross_host_llvm_mingw_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}/llvm-mingw/20250114/ucrt-${{ runner.os }}-${{ runner.arch }}
         key: llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ runner.os == 'macOS' && '80b2e7ade71ba2dfe9e8d27fe47ae5738b1fb8d34e057faa2beef3070392f2d6' || 'a16f52dee819797248e6c7d63b8b1e50a92119f45767ecd8e9633d1733b896e2' }}
@@ -284,17 +270,10 @@ runs:
         fi
         mv "$source_root" "$install_root"
 
-    - name: Save cross-host llvm-mingw
-      if: runner.os != 'Windows' && env.LLGO_MINGW_CROSS_ROOT == '' && steps.cross_host_llvm_mingw_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}/llvm-mingw/20250114/ucrt-${{ runner.os }}-${{ runner.arch }}
-        key: llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ runner.os == 'macOS' && '80b2e7ade71ba2dfe9e8d27fe47ae5738b1fb8d34e057faa2beef3070392f2d6' || 'a16f52dee819797248e6c7d63b8b1e50a92119f45767ecd8e9633d1733b896e2' }}
-
-    - name: Restore cross-host target dependencies
+    - name: Cache cross-host target dependencies
       if: runner.os != 'Windows'
       id: cross_host_vcpkg_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}/llgo-mingw-vcpkg/${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}/${{ runner.os }}-${{ runner.arch }}/${{ inputs.windows-arch }}
         key: llgo-llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ inputs.windows-arch }}-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
@@ -341,13 +320,6 @@ runs:
           "--x-manifest-root=$manifest_root" \
           "--x-install-root=$install_root" \
           --clean-after-build
-
-    - name: Save cross-host target dependencies
-      if: runner.os != 'Windows' && steps.cross_host_vcpkg_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.tool_cache }}/llgo-mingw-vcpkg/${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}/${{ runner.os }}-${{ runner.arch }}/${{ inputs.windows-arch }}
-        key: llgo-llvm-mingw-20250114-ucrt-${{ runner.os }}-${{ runner.arch }}-${{ inputs.windows-arch }}-${{ hashFiles('.github/windows/vcpkg/vcpkg.json') }}
 
     - name: Configure cross-host llvm-mingw target
       if: runner.os != 'Windows'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -47,16 +47,22 @@ jobs:
           source doc/_readme/scripts/run.sh
 
   local_install:
-    name: local install (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
+    name: local ${{ matrix.install_mode == 'full' && 'full ' || '' }}install (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
     timeout-minutes: 30
     strategy:
       matrix:
+        install_mode: [default, full]
+        platform: [macos, ubuntu, windows-msvc, windows-mingw]
         include:
-          - os: macos-latest
-          - os: ubuntu-latest
-          - os: windows-2022
+          - platform: macos
+            os: macos-latest
+          - platform: ubuntu
+            os: ubuntu-latest
+          - platform: windows-msvc
+            os: windows-2022
             windows_abi: msvc
-          - os: windows-2022
+          - platform: windows-mingw
+            os: windows-2022
             windows_abi: mingw
     runs-on: ${{matrix.os}}
     steps:
@@ -74,10 +80,14 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         if: startsWith(matrix.os, 'ubuntu')
+        shell: bash
         run: |
           set -e
           set -x
           source doc/_readme/scripts/install_ubuntu.sh
+          if [[ "${{ matrix.install_mode }}" == "full" ]]; then
+            echo "PATH=/usr/lib/llvm-19/bin:$PATH" >> "$GITHUB_ENV"
+          fi
 
       - name: Set up Python 3.12 on Windows
         if: startsWith(matrix.os, 'windows')
@@ -111,84 +121,12 @@ jobs:
               command git "$@"
             fi
           }
-          source doc/_readme/scripts/install_llgo.sh
-          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-
-      - name: Test doc code blocks
-        shell: bash
-        run: |
-          set -e
-          set -x
-          source doc/_readme/scripts/run.sh
-
-  local_install_full:
-    name: local full install (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-          - os: ubuntu-latest
-          - os: windows-2022
-            windows_abi: msvc
-          - os: windows-2022
-            windows_abi: mingw
-    runs-on: ${{matrix.os}}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: ./.github/actions/setup-go
-
-      - name: Install dependencies on macOS
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          set -e
-          set -x
-          source doc/_readme/scripts/install_macos.sh
-
-      - name: Install dependencies on Ubuntu
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          set -e
-          set -x
-          source doc/_readme/scripts/install_ubuntu.sh
-          echo "PATH=/usr/lib/llvm-19/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Set up Python 3.12 on Windows
-        if: startsWith(matrix.os, 'windows')
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies on Windows
-        if: startsWith(matrix.os, 'windows')
-        uses: ./.github/actions/setup-deps
-        with:
-          windows-abi: ${{ matrix.windows_abi || 'msvc' }}
-
-      - name: Install llgo with tools
-        shell: bash
-        run: |
-          set -e
-          set -x
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            python_lib=$(python -c 'import os, sys; print(os.path.join(sys.base_prefix, "libs", f"python{sys.version_info.major}{sys.version_info.minor}"))')
-            export LLGO_LIB_PYTHON="$python_lib"
-            export LLGO_STDIO_NOBUF=1
-            echo "LLGO_LIB_PYTHON=$LLGO_LIB_PYTHON" >> "$GITHUB_ENV"
-            echo "LLGO_STDIO_NOBUF=$LLGO_STDIO_NOBUF" >> "$GITHUB_ENV"
+          if [[ "${{ matrix.install_mode }}" == "full" ]]; then
+            source doc/_readme/scripts/install_full.sh
+          else
+            source doc/_readme/scripts/install_llgo.sh
           fi
-          git() {
-            if [ "$1" = "clone" ]; then
-              # do nothing because we already have the branch
-              cd ..
-            else
-              command git "$@"
-            fi
-          }
-          source doc/_readme/scripts/install_full.sh
-          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
       - name: Test doc code blocks
         shell: bash

--- a/.github/workflows/install-esp-qemu.sh
+++ b/.github/workflows/install-esp-qemu.sh
@@ -50,6 +50,41 @@ PACKAGES=(
   "qemu-xtensa-softmmu-${VERSION}-${PLATFORM}.tar.xz"
 )
 
+# SHA-256 values published with the pinned Espressif QEMU release. Keep the
+# order aligned with PACKAGES (riscv32, then xtensa).
+case "$PLATFORM" in
+  aarch64-apple-darwin)
+    SHA256S=(
+      "234690b6fa7c1d5dfe3dbb2bdd0c2810755e7c98999a9f21c389a6046b7eb76d"
+      "aa92e337461d482f5d9f31cd8efc0bd67b3de8fcfcfb567289cb43a59c184651"
+    )
+    ;;
+  aarch64-linux-gnu)
+    SHA256S=(
+      "f907a54313058f8a9681d2f48257d518950ff98bcd5a319194b4bee7c10cf223"
+      "317f6e0fd1dba0886d8110709823d909593ef29438822a14f81ebe19d72ce7cd"
+    )
+    ;;
+  x86_64-apple-darwin)
+    SHA256S=(
+      "820028ee7cd2dd8fe8cd8ca5519ab6e792d15fea9367c4525cf63c0f707c0b1f"
+      "00b9dbc2124cf7633cb86f264fbc524226ad4001bce68bbdba43c9bdc4eb026e"
+    )
+    ;;
+  x86_64-linux-gnu)
+    SHA256S=(
+      "373b37a68bae3ef441ead24a7bfc950fcbfc274cbdd2b628fc6915f179eb1d8e"
+      "588bfaccd0f929650655d10a580f020c6ba9c131712d8fa519280081b8d126eb"
+    )
+    ;;
+  x86_64-w64-mingw32)
+    SHA256S=(
+      "9474015f24d27acb7516955ec932e5307226bd9d6652cdc870793ed36010ab73"
+      "ef550b912726997f3c1ff4a4fb13c1569e2b692efdc5c9f9c3c926a8f7c540fa"
+    )
+    ;;
+esac
+
 echo "Detected platform: $PLATFORM"
 echo "Installing to: ${INSTALL_DIR}"
 
@@ -57,10 +92,26 @@ echo "Installing to: ${INSTALL_DIR}"
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 
-for filename in "${PACKAGES[@]}"; do
+for index in "${!PACKAGES[@]}"; do
+  filename="${PACKAGES[$index]}"
+  archive="${INSTALL_DIR}/${filename}"
   url="https://github.com/espressif/qemu/releases/download/${RELEASE_TAG}/${filename}"
   echo "Downloading: $url"
-  curl -fsSL "$url" | tar -xJ -C "$INSTALL_DIR" --strip-components=1
+  curl -fsSL -o "$archive" "$url"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256="$(sha256sum "$archive")"
+  else
+    actual_sha256="$(shasum -a 256 "$archive")"
+  fi
+  actual_sha256="${actual_sha256%% *}"
+  if [[ "$actual_sha256" != "${SHA256S[$index]}" ]]; then
+    echo "SHA-256 mismatch for ${filename}" >&2
+    echo "expected: ${SHA256S[$index]}" >&2
+    echo "actual:   ${actual_sha256}" >&2
+    exit 1
+  fi
+  tar -xJf "$archive" -C "$INSTALL_DIR" --strip-components=1
+  rm -f "$archive"
 done
 
 if [[ "$PLATFORM" == "x86_64-w64-mingw32" ]]; then

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -504,7 +504,9 @@ jobs:
           windows-arch: ${{ matrix.windows_arch }}
 
       - name: Check Windows native runtime and FFI
-        if: runner.os == 'Windows'
+        # This check is profile-wide rather than package-specific. Run it once
+        # on the first shard instead of duplicating it in every shard.
+        if: runner.os == 'Windows' && matrix.shard_index == '0'
         shell: pwsh
         run: |
           $llgo = Join-Path $env:RUNNER_TEMP 'llgo-bin\llgo.exe'
@@ -543,7 +545,9 @@ jobs:
           fi
 
       - name: Check std symbol coverage
-        if: runner.os == 'Windows' && matrix.windows_arch != 'amd64'
+        # Balance the other profile-wide check onto shard 1 when the profile
+        # is split; unsharded profiles retain their existing coverage.
+        if: runner.os == 'Windows' && matrix.windows_arch != 'amd64' && (matrix.shard_total == '1' || matrix.shard_index == '1')
         shell: bash
         run: bash doc/_readme/scripts/check_std_cover.sh
 

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -370,8 +370,10 @@ jobs:
         # selects a real target toolchain and matching alternate module file.
         # Go 1.20-1.26 share one focused compatibility lane. Go 1.27 is the
         # primary release and runs the complete test tree on every native
-        # toolchain profile. Its Ubuntu shards remain separate because recent
-        # runs take about 25 minutes each and would exceed 30 minutes combined.
+        # toolchain profile. Ubuntu remains split because each shard takes
+        # about 25 minutes. Four recent full runs put Windows ARM64 MSVC at
+        # 45-48 minutes, so it is the only other profile split here; the next
+        # slowest profiles stay below 35 minutes and avoid duplicate setup.
         include:
           - os: ubuntu-latest
             llvm: 19
@@ -426,7 +428,16 @@ jobs:
             go_version: "1.27"
             lane: full
             shard_index: "0"
-            shard_total: "1"
+            shard_total: "2"
+            windows_abi: msvc
+            windows_arch: arm64
+            host_go_arch: x64
+          - os: windows-11-arm
+            llvm: 19
+            go_version: "1.27"
+            lane: full
+            shard_index: "1"
+            shard_total: "2"
             windows_abi: msvc
             windows_arch: arm64
             host_go_arch: x64

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Cache Linux sysroot
+      - name: Check Linux sysroot cache
         id: cache-linux-sysroot
         uses: actions/cache@v6
         with:
@@ -56,6 +56,14 @@ jobs:
       - name: Create Linux sysroot tarball
         if: steps.cache-linux-sysroot.outputs.cache-hit != 'true'
         run: tar -czvf .sysroot/linux.tar.gz -C .sysroot linux
+      # Keep the producer lookup-only so a hit does not download this large
+      # archive merely to discard it. A miss therefore needs an explicit save.
+      - name: Save Linux sysroot cache
+        if: steps.cache-linux-sysroot.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: .sysroot/linux.tar.gz
+          key: ${{ needs.setup.outputs.linux-cache-key }}
   build:
     runs-on: ubuntu-latest
     needs: [setup, populate-linux-sysroot]

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,9 +38,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Check Linux sysroot cache
+      - name: Cache Linux sysroot
         id: cache-linux-sysroot
-        uses: actions/cache/restore@v5
+        uses: actions/cache@v6
         with:
           path: .sysroot/linux.tar.gz
           key: ${{ needs.setup.outputs.linux-cache-key }}
@@ -56,12 +56,6 @@ jobs:
       - name: Create Linux sysroot tarball
         if: steps.cache-linux-sysroot.outputs.cache-hit != 'true'
         run: tar -czvf .sysroot/linux.tar.gz -C .sysroot linux
-      - name: Save Linux sysroot cache
-        if: steps.cache-linux-sysroot.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: .sysroot/linux.tar.gz
-          key: ${{ needs.setup.outputs.linux-cache-key }}
   build:
     runs-on: ubuntu-latest
     needs: [setup, populate-linux-sysroot]


### PR DESCRIPTION
## Purpose

Simplify the R12-era workflows, reduce repeated dependency work, and shorten the only native test job that consistently exceeds 40 minutes without sharding the profiles that stay below 35 minutes.

Based on the merged R12 work in https://github.com/xgo-dev/llgo/pull/2465.

## Decisions

### MSYS2

`msys2/setup-msys2@v2` is already used for the `CLANG64`, `CLANGARM64`, and MSYS host-shell environments, and its built-in package cache is enabled by default. This PR does not move the pinned LLVM 19.1.7 and old-libxml2 ABI installation into `install` or `pacboy`: those inputs resolve the rolling MSYS2 repository before the manual pins are applied and can introduce newer runtime libraries. Deprecated `MINGW32` and `MINGW64` environments are not required by the supported R12 profiles.

### Caches and actions

- collapse eight safe restore/save pairs into unified `actions/cache@v6` steps;
- cache ESP QEMU downloads by host OS, host architecture, and installer-script hash;
- update Windows Python setup to `actions/setup-python@v7`;
- key the mutable full Windows LLVM tree by target architecture, so amd64, i386, and ARM64 builtins cannot race through one immutable cache key;
- keep target-native compiler-rt/LLDB and vcpkg caches target-specific;
- refresh Homebrew formula and tap metadata on Apple Silicon while only installing missing formulae; keep Intel macOS on its runner-image metadata and dependencies because Homebrew no longer guarantees Intel bottles.

Large ESP Clang, WASI, and sysroot inputs remain narrowly cached where already bounded. Unpinned Python demo packages and Go build outputs are not newly cached because their invalidation and size would make the hit rate or storage tradeoff unclear.

### Matrices and sharding

- represent the eight default/full documentation install combinations as one two-axis matrix while preserving their existing check names;
- split Windows ARM64 MSVC full tests into two 100-package shards;
- execute profile-wide Windows runtime/FFI and std-symbol checks exactly once across the two shards;
- leave every other native profile unsharded because four R12 measurements put them below 35 minutes, while ARM64 MSVC alone took 45-48 minutes.

## Measured comparison

The warm-cache fork run at `4a2cb1322` is compared with the successful upstream R12 head `9f0a5af09`. These are single-run measurements on GitHub-hosted runners, so small differences should be treated as normal variance. The current head refreshes Homebrew metadata only on Apple Silicon and keeps Intel macOS on its runner-image metadata; final macOS and release timings will be refreshed after its CI completes.

| Scope | R12 | This PR | Change |
| --- | ---: | ---: | ---: |
| Docs total runner time | 28.60 min | 28.37 min | -0.8% |
| LLGo total runner time | 466.18 min | 435.82 min | -6.5% |
| Release Build total runner time | 23.87 min | 19.72 min | -17.4% |
| Build Cache total runner time | 22.57 min | 20.67 min | -8.4% |
| Combined total above | 541.22 min | 504.58 min | -6.8% |
| ARM64 MSVC critical path | 45m07s | 32m15s | -28.5% |
| ARM64 MSVC total runner time | 45m07s | 61m20s | +35.9% |

The ARM64 profile intentionally spends 16m13s more aggregate runner time to remove the sole 45-48 minute critical-path outlier. The two final shards complete in 29m05s and 32m15s. Sharding shorter profiles would repeat setup without a comparable reliability or latency benefit.

A cold-cache probe also verified that each target writes its own full LLVM cache; the final run restored `llgo-llvm-19.1.3-full-target-windows-arm64-...` exactly. ESP QEMU likewise restored its host-specific key and skipped installation.

## Contributor-side validation

- [x] I created a pull request from this same branch in my fork and its CI passed: https://github.com/cpunion/llgo/pull/217

All 67 runnable checks passed on predecessor head `4a2cb1322`; the release-only job was correctly skipped for a pull request. Current head `47984a395` is running with the architecture-specific Homebrew refresh policy. Previous LLGo run: https://github.com/cpunion/llgo/actions/runs/33441249158.

