### PR TITLE
test: isolate early Windows exception probes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,6 +84,16 @@ jobs:
           # one ordinary package run does not prove mutual exclusion.
           go test -count=20 -timeout=10m -run 'Lock' ./internal/crosscompile
 
+          # These tests recover runtime faults before the protected-memory
+          # checks that exposed corruption on some hosted amd64 runners. Stress
+          # the shared Windows exception-stack preparation independently of the
+          # much larger coverage command below.
+          go test -count=100 -timeout=10m \
+            -ldflags='-linkmode=external -extldflags=-lsynchronization' \
+            -coverprofile="$RUNNER_TEMP/windows-exception-stress.txt" -covermode=atomic \
+            -run '^(TestMapUpdateRHSNilDerefOrder|TestMapUpdateAppendRHSOrder|TestMultipleAssignmentMapUpdateBeforeNilStore|TestMultipleAssignmentOrderBeforeLaterPanic|TestBinOpIntegerDivideByZeroPanics|TestBinOpIntegerRemainderByZeroPanics)$' \
+            ./test/go
+
           # The runtime is a nested module and is therefore outside ./....
           # These host-side FFI tests still need native Windows coverage.
           (

--- a/test/go/assignment_order_test.go
+++ b/test/go/assignment_order_test.go
@@ -3,6 +3,10 @@ package gotest
 import "testing"
 
 func TestMapUpdateRHSNilDerefOrder(t *testing.T) {
+	if !enterWindowsExceptionTest(t) {
+		return
+	}
+
 	var sink bool
 
 	tests := []struct {
@@ -88,6 +92,10 @@ func TestMapUpdateRHSNilDerefOrder(t *testing.T) {
 }
 
 func TestMapUpdateAppendRHSOrder(t *testing.T) {
+	if !enterWindowsExceptionTest(t) {
+		return
+	}
+
 	var sink bool
 
 	tests := []struct {
@@ -139,6 +147,10 @@ func TestMapUpdateAppendRHSOrder(t *testing.T) {
 // Mirrors fixedbugs/issue23017: LHS addresses are evaluated before stores,
 // then stores proceed left-to-right even when a later store panics.
 func TestMultipleAssignmentMapUpdateBeforeNilStore(t *testing.T) {
+	if !enterWindowsExceptionTest(t) {
+		return
+	}
+
 	m := map[int]int{}
 	var p *int
 
@@ -154,6 +166,10 @@ func TestMultipleAssignmentMapUpdateBeforeNilStore(t *testing.T) {
 }
 
 func TestMultipleAssignmentOrderBeforeLaterPanic(t *testing.T) {
+	if !enterWindowsExceptionTest(t) {
+		return
+	}
+
 	t.Run("slice index", func(t *testing.T) {
 		m := map[int]int{}
 		p := []int{}
@@ -266,6 +282,7 @@ func TestMultipleAssignmentAddressUsesPreAssignmentValue(t *testing.T) {
 
 func expectPanic(t *testing.T, f func()) {
 	t.Helper()
+	ensureWindowsExceptionStackHeadroom()
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected panic")

--- a/test/go/binop_test.go
+++ b/test/go/binop_test.go
@@ -740,6 +740,11 @@ func TestBinOpSignedMinIntDivisionOverflow(t *testing.T) {
 }
 
 func TestBinOpIntegerDivideByZeroPanics(t *testing.T) {
+	if !enterWindowsExceptionTest(t) {
+		return
+	}
+
+	ensureWindowsExceptionStackHeadroom()
 	defer func() {
 		if recover() == nil {
 			t.Fatal("division by zero did not panic")
@@ -750,6 +755,11 @@ func TestBinOpIntegerDivideByZeroPanics(t *testing.T) {
 }
 
 func TestBinOpIntegerRemainderByZeroPanics(t *testing.T) {
+	if !enterWindowsExceptionTest(t) {
+		return
+	}
+
+	ensureWindowsExceptionStackHeadroom()
 	defer func() {
 		if recover() == nil {
 			t.Fatal("remainder by zero did not panic")

--- a/test/go/recover_fault_test.go
+++ b/test/go/recover_fault_test.go
@@ -33,7 +33,7 @@ func TestRecoverAfterFaultPreservesNamedResult(t *testing.T) {
 	// the same deterministic recovery check.
 	oldGCPercent := debug.SetGCPercent(-1)
 	defer debug.SetGCPercent(oldGCPercent)
-	ensureRecoverableFaultStackHeadroom()
+	ensureWindowsExceptionStackHeadroom()
 
 	old := debug.SetPanicOnFault(true)
 	defer debug.SetPanicOnFault(old)

--- a/test/go/recover_fault_unix_check_test.go
+++ b/test/go/recover_fault_unix_check_test.go
@@ -6,6 +6,4 @@ import "testing"
 
 func enterRecoverableFaultTest(t *testing.T) bool { return true }
 
-func ensureRecoverableFaultStackHeadroom() {}
-
 func checkRecoveredFaultAddress(t *testing.T, err error, address *byte) {}

--- a/test/go/recover_fault_windows_test.go
+++ b/test/go/recover_fault_windows_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 	"runtime/debug"
 	"runtime/trace"
 	"testing"
@@ -57,24 +56,6 @@ func enterWindowsFaultTest(t *testing.T, childEnv, testPattern string) bool {
 	return false
 }
 
-//go:noinline
-func growRecoverableFaultStack(depth int) {
-	var frame [1024]byte
-	frame[0] = byte(depth)
-	if depth != 0 {
-		growRecoverableFaultStack(depth - 1)
-	}
-	runtime.KeepAlive(&frame)
-}
-
-func ensureRecoverableFaultStackHeadroom() {
-	// Grow and then unwind the goroutine stack before raising the exception.
-	// About 64 one-KiB frames provide headroom for the host-dependent Windows
-	// exception context suspected in golang/go#81238. This preserves the real
-	// protected-page fault while avoiding the issue's near-stack-boundary setup.
-	growRecoverableFaultStack(64)
-}
-
 // Regression test matching GOROOT/test/fixedbugs/issue73748b.go.
 func TestRecoverFaultWhileTracing(t *testing.T) {
 	if !enterWindowsFaultTest(t, traceFaultChildEnv, "^TestRecoverFaultWhileTracing$") {
@@ -87,7 +68,7 @@ func TestRecoverFaultWhileTracing(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer trace.Stop()
-	ensureRecoverableFaultStackHeadroom()
+	ensureWindowsExceptionStackHeadroom()
 
 	var recovered bool
 	func() {

--- a/test/go/windows_exception_stack_other_test.go
+++ b/test/go/windows_exception_stack_other_test.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package gotest
+
+import "testing"
+
+func enterWindowsExceptionTest(t *testing.T) bool { return true }
+
+func ensureWindowsExceptionStackHeadroom() {}

--- a/test/go/windows_exception_stack_windows_test.go
+++ b/test/go/windows_exception_stack_windows_test.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package gotest
+
+import (
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+const recoverableWindowsExceptionChildEnv = "LLGO_TEST_WINDOWS_EXCEPTION_CHILD"
+
+func enterWindowsExceptionTest(t *testing.T) bool {
+	t.Helper()
+	return enterWindowsFaultTest(
+		t,
+		recoverableWindowsExceptionChildEnv,
+		"^"+regexp.QuoteMeta(t.Name())+"$",
+	)
+}
+
+//go:noinline
+func growWindowsExceptionStack(depth int) {
+	var frame [1024]byte
+	frame[0] = byte(depth)
+	if depth != 0 {
+		growWindowsExceptionStack(depth - 1)
+	}
+	runtime.KeepAlive(&frame)
+}
+
+func ensureWindowsExceptionStackHeadroom() {
+	// Grow and then unwind the current goroutine stack before recovering a
+	// hardware exception. About 64 one-KiB frames provide headroom for the
+	// host-dependent Windows exception context suspected in golang/go#81238.
+	// Without that headroom, exception dispatch can write below stack.lo and
+	// corrupt unrelated heap state on some AMX-capable hosted runners.
+	growWindowsExceptionStack(64)
+}


### PR DESCRIPTION
## Summary

- move the Windows exception stack-headroom workaround into a shared test helper
- run the recovered runtime-fault probes that precede the protected-memory checks in isolated child processes
- stress those probes 100 times under Windows external linking and atomic coverage

## Diagnosis

The latest PR #2455 MinGW job terminated the native `test/go` binary with `0xc0000005` before it could report a test name: https://github.com/xgo-dev/llgo/actions/runs/33528051544/job/99923840484

An earlier run of the same job failed at the same package-startup boundary with `fatal error: concurrent map writes` in `testing.(*common).Helper`, first observed by `TestBoundsCheckBeforeWiderByteLoad`: https://github.com/xgo-dev/llgo/actions/runs/33486618449/job/99788080318

`testing.Helper` serializes that map with its mutex, so the failure points to earlier process memory corruption rather than a race in `protectedMemory`. The tests that run immediately before it intentionally trigger and recover nil dereferences and arithmetic runtime faults. On affected Windows hosts, this is consistent with the still-open golang/go#81238 exception-dispatch corruption: https://github.com/golang/go/issues/81238

The upstream diagnosis remains provisional here. The change does not skip the fault paths or assertions: the child must still pass each complete test. Stack headroom is prepared on the goroutine that actually raises the exception, and child isolation prevents delayed corruption from reaching the rest of `test/go`.

## Validation

- `go test -count=100 -run <affected tests> ./test/go`
- `go test -count=10 -run ^TestRecoverAfterFaultPreservesNamedResult$ ./test/go`
- `go test ./test/go`
- Windows amd64 normal and atomic-coverage cross-compilation of `./test/go`
- workflow YAML parse and `git diff --check`

`go test ./...` passed the touched package and the rest of the repository except the unrelated local-only `TestWasmRuntimeSourcePatchTypeChecks`: Go 1.27 rejected its overlay because the local GOROOT is beneath GOMODCACHE. The branch does not modify `internal/build`; GitHub CI provides the authoritative clean-toolchain result.