### PR TITLE
build: make LLGoFiles safe across compiler processes

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1178,8 +1178,9 @@ type context struct {
 	llvmVersion  string
 
 	// go list derived file lists (SFiles, etc.)
-	sfilesCache  map[string][]string // pkg.ID -> absolute .s/.S file paths
-	sfilesFrozen bool
+	sfilesCache    map[string][]string // pkg.ID -> absolute .s/.S file paths
+	sfilesFrozen   bool
+	llgoFilesCache map[*packages.Package][]llgoFileInput
 
 	// plan9asm package policy parsed from env.
 	plan9asmOnce  sync.Once
@@ -3267,27 +3268,48 @@ func WasmRuntime() string {
 }
 
 func concatPkgLinkFiles(ctx *context, pkg *packages.Package, verbose bool) (parts []string) {
-	llgoPkgLinkFiles(ctx, pkg, func(linkFile string) {
-		parts = append(parts, linkFile)
-	}, verbose)
+	for _, input := range llgoPkgFileInputs(ctx, pkg) {
+		clFile(ctx, input.compilerArgs, input.path, pkg.ExportFile, pkg.PkgPath, func(linkFile string) {
+			parts = append(parts, linkFile)
+		}, verbose)
+	}
 	return
 }
 
+type llgoFileInput struct {
+	path         string
+	compilerArgs []string
+}
+
 // const LLGoFiles = "file1; file2; ..."
-func llgoPkgLinkFiles(ctx *context, pkg *packages.Package, procFile func(linkFile string), verbose bool) {
-	if o := pkg.Types.Scope().Lookup("LLGoFiles"); o != nil {
-		val := o.(*types.Const).Val()
-		if val.Kind() == constant.String {
-			clFiles(ctx, constant.StringVal(val), pkg, procFile, verbose)
+func llgoPkgFileInputs(ctx *context, pkg *packages.Package) []llgoFileInput {
+	if inputs, ok := ctx.llgoFilesCache[pkg]; ok {
+		return inputs
+	}
+	if ctx.llgoFilesCache == nil {
+		ctx.llgoFilesCache = make(map[*packages.Package][]llgoFileInput)
+	}
+
+	var inputs []llgoFileInput
+	if pkg.Types != nil {
+		if object, ok := pkg.Types.Scope().Lookup("LLGoFiles").(*types.Const); ok {
+			value := object.Val()
+			if value.Kind() == constant.String {
+				inputs = parseLLGoFileInputs(ctx, constant.StringVal(value), pkg)
+			}
 		}
 	}
+	ctx.llgoFilesCache[pkg] = inputs
+	return inputs
 }
 
 // files = "file1; file2; ..."
 // files = "$(pkg-config --cflags xxx): file1; file2; ..."
-func clFiles(ctx *context, files string, pkg *packages.Package, procFile func(linkFile string), verbose bool) {
+func parseLLGoFileInputs(ctx *context, files string, pkg *packages.Package) []llgoFileInput {
+	if len(pkg.GoFiles) == 0 {
+		return nil
+	}
 	dir := filepath.Dir(pkg.GoFiles[0])
-	expFile := pkg.ExportFile
 	args := make([]string, 0, 16)
 	if strings.HasPrefix(files, "$") { // has cflags
 		if pos := strings.IndexByte(files, ':'); pos > 0 {
@@ -3296,10 +3318,18 @@ func clFiles(ctx *context, files string, pkg *packages.Package, procFile func(li
 			args = append(args, cflags...)
 		}
 	}
+	var inputs []llgoFileInput
 	for _, file := range strings.Split(files, ";") {
-		cFile := filepath.Join(dir, strings.TrimSpace(file))
-		clFile(ctx, args, cFile, expFile, pkg.PkgPath, procFile, verbose)
+		file = strings.TrimSpace(file)
+		if file == "" {
+			continue
+		}
+		inputs = append(inputs, llgoFileInput{
+			path:         filepath.Join(dir, file),
+			compilerArgs: slices.Clone(args),
+		})
 	}
+	return inputs
 }
 
 func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, procFile func(linkFile string), verbose bool) {
@@ -3315,28 +3345,38 @@ func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, procFil
 	// If GenLL is enabled, first emit .ll for debugging, then compile to .o
 	printCmds := ctx.shouldPrintCommands(verbose)
 	if ctx.buildConf.GenLL {
-		llFile := baseName + ".ll"
+		llFile, err := genLLGoFileOutput(cFile, ".ll")
+		check(err)
+		defer os.Remove(llFile)
 		llArgs := append(slices.Clone(args), "-emit-llvm", "-S", "-o", llFile, "-c", cFile)
 		if printCmds {
 			fmt.Fprintf(os.Stderr, "# compiling %s for pkg: %s\n", llFile, pkgPath)
 			fmt.Fprintln(os.Stderr, "clang", llArgs)
 		}
 		cmd := ctx.compilerForSource(cFile)
-		err := cmd.Compile(llArgs...)
-		check(err)
+		check(cmd.Compile(llArgs...))
+		check(os.Chmod(llFile, 0o644))
+		check(copyFileAtomic(llFile, baseName+".ll"))
 	}
 
 	// Always compile to .o for linking
-	objFile := baseName + ".o"
+	objFile, err := genLLGoFileOutput(cFile, ".o")
+	check(err)
 	objArgs := append(args, "-o", objFile, "-c", cFile)
 	if printCmds {
 		fmt.Fprintf(os.Stderr, "# compiling %s for pkg: %s\n", objFile, pkgPath)
 		fmt.Fprintln(os.Stderr, "clang", objArgs)
 	}
 	cmd := ctx.compilerForSource(cFile)
-	err := cmd.Compile(objArgs...)
-	check(err)
+	if err := cmd.Compile(objArgs...); err != nil {
+		os.Remove(objFile)
+		check(err)
+	}
 	procFile(objFile)
+}
+
+func genLLGoFileOutput(source, ext string) (string, error) {
+	return genTempOutputFile("llgofile-"+filepath.Base(source), ext)
 }
 
 func (c *context) compilerForSource(path string) *clang.Cmd {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1182,7 +1182,7 @@ type context struct {
 	sfilesFrozen      bool
 	llgoFilesCache    map[*packages.Package][]llgoFileInput
 	llgoFilesFrozen   bool
-	llgoFileHashCache map[string]string // absolute path -> content digest
+	llgoFileHashCache map[llgoFileHashKey]string
 
 	// plan9asm package policy parsed from env.
 	plan9asmOnce  sync.Once
@@ -3316,6 +3316,11 @@ type llgoFileInput struct {
 	compilerArgs []string
 }
 
+type llgoFileHashKey struct {
+	path         string
+	compilerArgs string
+}
+
 // const LLGoFiles = "file1; file2; ..."
 func llgoPkgFileInputs(ctx *context, pkg *packages.Package) ([]llgoFileInput, error) {
 	if ctx.llgoFilesCache == nil {
@@ -3375,13 +3380,7 @@ func parseLLGoFileInputs(ctx *context, files string, pkg *packages.Package) []ll
 
 func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, verbose bool) (string, error) {
 	baseName := expFile + filepath.Base(cFile)
-	ext := filepath.Ext(cFile)
-	args = append(slices.Clone(args), debugInfoCompilerArgs(ctx.buildConf, &ctx.crossCompile)...)
-
-	// default clang++ will use c++ to compile c file,will cause symbol be mangled
-	if ext == ".c" {
-		args = append(args, "-x", "c")
-	}
+	args = llgoFileCompilerArgs(ctx, args, cFile)
 
 	// If GenLL is enabled, first emit .ll for debugging, then compile to .o
 	printCmds := ctx.shouldPrintCommands(verbose)
@@ -3425,6 +3424,20 @@ func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, verbose
 		return "", fmt.Errorf("compile %s: %w", cFile, err)
 	}
 	return objFile, nil
+}
+
+// llgoFileCompilerArgs returns the source-specific arguments shared by the
+// fingerprint preprocessor pass and the object compilation pass. Keeping this
+// in one place prevents cache keys from drifting away from compilation.
+func llgoFileCompilerArgs(ctx *context, args []string, source string) []string {
+	args = append(slices.Clone(args), debugInfoCompilerArgs(ctx.buildConf, &ctx.crossCompile)...)
+
+	// A configured C++ driver would otherwise treat a .c input as C++ and
+	// mangle its symbols.
+	if filepath.Ext(source) == ".c" {
+		args = append(args, "-x", "c")
+	}
+	return args
 }
 
 func removeFiles(files []string) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1178,9 +1178,11 @@ type context struct {
 	llvmVersion  string
 
 	// go list derived file lists (SFiles, etc.)
-	sfilesCache    map[string][]string // pkg.ID -> absolute .s/.S file paths
-	sfilesFrozen   bool
-	llgoFilesCache map[*packages.Package][]llgoFileInput
+	sfilesCache       map[string][]string // pkg.ID -> absolute .s/.S file paths
+	sfilesFrozen      bool
+	llgoFilesCache    map[*packages.Package][]llgoFileInput
+	llgoFilesFrozen   bool
+	llgoFileHashCache map[string]string // absolute path -> content digest
 
 	// plan9asm package policy parsed from env.
 	plan9asmOnce  sync.Once
@@ -1379,6 +1381,7 @@ func normalizeToArchive(ctx *context, aPkg *aPackage, verbose bool) error {
 		return fmt.Errorf("create archive for %s: %w", aPkg.PkgPath, err)
 	}
 
+	aPkg.cleanupTemporaryObjFiles()
 	aPkg.ObjFiles = nil
 	aPkg.ArchiveFile = archivePath
 	return nil
@@ -2470,8 +2473,12 @@ func compilePackageModule(ctx *context, aPkg *aPackage, externs []string, verbos
 	if err != nil {
 		return fmt.Errorf("build cgo of %v failed: %v", pkgPath, err)
 	}
-	aPkg.ObjFiles = append(aPkg.ObjFiles, cgoLLFiles...)
-	aPkg.ObjFiles = append(aPkg.ObjFiles, concatPkgLinkFiles(ctx, pkg, printCmds)...)
+	aPkg.appendTemporaryObjFiles(cgoLLFiles...)
+	llgoFiles, err := concatPkgLinkFiles(ctx, pkg, printCmds)
+	if err != nil {
+		return fmt.Errorf("build LLGoFiles of %v failed: %w", pkgPath, err)
+	}
+	aPkg.appendTemporaryObjFiles(llgoFiles...)
 	if aliasObjs, err := buildGoCgoAliasObjects(ctx, pkgPath, aPkg.Package.Syntax, printCmds); err != nil {
 		return err
 	} else {
@@ -2484,8 +2491,12 @@ func compilePackageModule(ctx *context, aPkg *aPackage, externs []string, verbos
 		if e != nil {
 			return fmt.Errorf("build cgo of %v failed: %v", pkgPath, e)
 		}
-		aPkg.ObjFiles = append(aPkg.ObjFiles, altLLFiles...)
-		aPkg.ObjFiles = append(aPkg.ObjFiles, concatPkgLinkFiles(ctx, aPkg.AltPkg.Package, printCmds)...)
+		aPkg.appendTemporaryObjFiles(altLLFiles...)
+		altLLGoFiles, err := concatPkgLinkFiles(ctx, aPkg.AltPkg.Package, printCmds)
+		if err != nil {
+			return fmt.Errorf("build alternate LLGoFiles of %v failed: %w", pkgPath, err)
+		}
+		aPkg.appendTemporaryObjFiles(altLLGoFiles...)
 		if aliasObjs, err := buildGoCgoAliasObjects(ctx, pkgPath, aPkg.AltPkg.Syntax, printCmds); err != nil {
 			return err
 		} else {
@@ -2840,17 +2851,30 @@ type aPackage struct {
 	NeedRt     bool
 	NeedPyInit bool
 
-	LinkArgs    []string
-	ObjFiles    []string               // file-backed archive members: .o or .ll
-	ObjBuffers  []packageArchiveBuffer // LLVM-produced in-memory archive members
-	ArchiveFile string                 // archive file: .a (output of archiver, used for linking)
-	Meta        *meta.PackageMeta
-	rewriteVars map[string]string
+	LinkArgs     []string
+	ObjFiles     []string               // file-backed archive members: .o or .ll
+	ObjBuffers   []packageArchiveBuffer // LLVM-produced in-memory archive members
+	ArchiveFile  string                 // archive file: .a (output of archiver, used for linking)
+	Meta         *meta.PackageMeta
+	rewriteVars  map[string]string
+	tempObjFiles []string // process-private C/C++/assembly objects consumed by ArchiveFile
 
 	// Cache related fields
 	Fingerprint string // fingerprint digest
 	Manifest    string // manifest text content
 	CacheHit    bool   // whether cache was hit
+}
+
+func (p *aPackage) appendTemporaryObjFiles(files ...string) {
+	p.ObjFiles = append(p.ObjFiles, files...)
+	p.tempObjFiles = append(p.tempObjFiles, files...)
+}
+
+func (p *aPackage) cleanupTemporaryObjFiles() {
+	for _, file := range p.tempObjFiles {
+		_ = os.Remove(file)
+	}
+	p.tempObjFiles = nil
 }
 
 type Package = *aPackage
@@ -3267,13 +3291,24 @@ func WasmRuntime() string {
 	return defaultEnv(llgoWasmRuntime, defaultWasmRuntime)
 }
 
-func concatPkgLinkFiles(ctx *context, pkg *packages.Package, verbose bool) (parts []string) {
-	for _, input := range llgoPkgFileInputs(ctx, pkg) {
-		clFile(ctx, input.compilerArgs, input.path, pkg.ExportFile, pkg.PkgPath, func(linkFile string) {
-			parts = append(parts, linkFile)
-		}, verbose)
+func concatPkgLinkFiles(ctx *context, pkg *packages.Package, verbose bool) (parts []string, err error) {
+	inputs, err := llgoPkgFileInputs(ctx, pkg)
+	if err != nil {
+		return nil, err
 	}
-	return
+	defer func() {
+		if err != nil {
+			removeFiles(parts)
+		}
+	}()
+	for _, input := range inputs {
+		linkFile, compileErr := clFile(ctx, input.compilerArgs, input.path, pkg.ExportFile, pkg.PkgPath, verbose)
+		if compileErr != nil {
+			return parts, compileErr
+		}
+		parts = append(parts, linkFile)
+	}
+	return parts, nil
 }
 
 type llgoFileInput struct {
@@ -3282,12 +3317,18 @@ type llgoFileInput struct {
 }
 
 // const LLGoFiles = "file1; file2; ..."
-func llgoPkgFileInputs(ctx *context, pkg *packages.Package) []llgoFileInput {
-	if inputs, ok := ctx.llgoFilesCache[pkg]; ok {
-		return inputs
-	}
+func llgoPkgFileInputs(ctx *context, pkg *packages.Package) ([]llgoFileInput, error) {
 	if ctx.llgoFilesCache == nil {
+		if ctx.llgoFilesFrozen {
+			return nil, fmt.Errorf("package %s LLGoFiles were not prepared before backend execution", pkg.PkgPath)
+		}
 		ctx.llgoFilesCache = make(map[*packages.Package][]llgoFileInput)
+	}
+	if inputs, ok := ctx.llgoFilesCache[pkg]; ok {
+		return inputs, nil
+	}
+	if ctx.llgoFilesFrozen {
+		return nil, fmt.Errorf("package %s LLGoFiles were not prepared before backend execution", pkg.PkgPath)
 	}
 
 	var inputs []llgoFileInput
@@ -3300,7 +3341,7 @@ func llgoPkgFileInputs(ctx *context, pkg *packages.Package) []llgoFileInput {
 		}
 	}
 	ctx.llgoFilesCache[pkg] = inputs
-	return inputs
+	return inputs, nil
 }
 
 // files = "file1; file2; ..."
@@ -3332,7 +3373,7 @@ func parseLLGoFileInputs(ctx *context, files string, pkg *packages.Package) []ll
 	return inputs
 }
 
-func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, procFile func(linkFile string), verbose bool) {
+func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, verbose bool) (string, error) {
 	baseName := expFile + filepath.Base(cFile)
 	ext := filepath.Ext(cFile)
 	args = append(slices.Clone(args), debugInfoCompilerArgs(ctx.buildConf, &ctx.crossCompile)...)
@@ -3346,7 +3387,9 @@ func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, procFil
 	printCmds := ctx.shouldPrintCommands(verbose)
 	if ctx.buildConf.GenLL {
 		llFile, err := genLLGoFileOutput(cFile, ".ll")
-		check(err)
+		if err != nil {
+			return "", fmt.Errorf("create temporary LLVM IR output for %s: %w", cFile, err)
+		}
 		defer os.Remove(llFile)
 		llArgs := append(slices.Clone(args), "-emit-llvm", "-S", "-o", llFile, "-c", cFile)
 		if printCmds {
@@ -3354,14 +3397,23 @@ func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, procFil
 			fmt.Fprintln(os.Stderr, "clang", llArgs)
 		}
 		cmd := ctx.compilerForSource(cFile)
-		check(cmd.Compile(llArgs...))
-		check(os.Chmod(llFile, 0o644))
-		check(copyFileAtomic(llFile, baseName+".ll"))
+		if err := cmd.Compile(llArgs...); err != nil {
+			return "", fmt.Errorf("compile %s to LLVM IR: %w", cFile, err)
+		}
+		published := baseName + ".ll"
+		if err := copyFileAtomic(llFile, published); err != nil {
+			return "", fmt.Errorf("publish LLVM IR for %s: %w", cFile, err)
+		}
+		if err := os.Chmod(published, 0o644); err != nil {
+			return "", fmt.Errorf("set LLVM IR permissions for %s: %w", cFile, err)
+		}
 	}
 
 	// Always compile to .o for linking
 	objFile, err := genLLGoFileOutput(cFile, ".o")
-	check(err)
+	if err != nil {
+		return "", fmt.Errorf("create temporary object output for %s: %w", cFile, err)
+	}
 	objArgs := append(args, "-o", objFile, "-c", cFile)
 	if printCmds {
 		fmt.Fprintf(os.Stderr, "# compiling %s for pkg: %s\n", objFile, pkgPath)
@@ -3369,10 +3421,16 @@ func clFile(ctx *context, args []string, cFile, expFile, pkgPath string, procFil
 	}
 	cmd := ctx.compilerForSource(cFile)
 	if err := cmd.Compile(objArgs...); err != nil {
-		os.Remove(objFile)
-		check(err)
+		_ = os.Remove(objFile)
+		return "", fmt.Errorf("compile %s: %w", cFile, err)
 	}
-	procFile(objFile)
+	return objFile, nil
+}
+
+func removeFiles(files []string) {
+	for _, file := range files {
+		_ = os.Remove(file)
+	}
 }
 
 func genLLGoFileOutput(source, ext string) (string, error) {

--- a/internal/build/cgo.go
+++ b/internal/build/cgo.go
@@ -67,6 +67,12 @@ static void* _Cmalloc(size_t size) {
 var cgoExternRE = regexp.MustCompile(`^(_cgo_[^_]+_(C2func|Cfunc|Cmacro)_)(.*)$`)
 
 func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, verbose bool) (llfiles, cgoLdflags []string, err error) {
+	defer func() {
+		if err != nil {
+			removeFiles(llfiles)
+			llfiles = nil
+		}
+	}()
 	buildCtx := build.Default
 	if ctx.buildConf.Goos != "" {
 		buildCtx.GOOS = ctx.buildConf.Goos
@@ -116,9 +122,11 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 		if src.isCXX {
 			args = append(args, cxxflags...)
 		}
-		clFile(ctx, args, src.path, pkg.ExportFile, pkg.PkgPath, func(linkFile string) {
-			llfiles = append(llfiles, linkFile)
-		}, verbose)
+		linkFile, compileErr := clFile(ctx, args, src.path, pkg.ExportFile, pkg.PkgPath, verbose)
+		if compileErr != nil {
+			return nil, nil, compileErr
+		}
+		llfiles = append(llfiles, linkFile)
 	}
 	cgoSymbols := collectCgoSymbols(externs)
 	for _, preamble := range preambles {
@@ -136,9 +144,11 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 		if err = os.WriteFile(tmpName, []byte(code+"\n\n"+externDecls), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write temp file: %v", err)
 		}
-		clFile(ctx, cflags, tmpName, pkg.ExportFile, pkg.PkgPath, func(linkFile string) {
-			llfiles = append(llfiles, linkFile)
-		}, verbose)
+		linkFile, compileErr := clFile(ctx, cflags, tmpName, pkg.ExportFile, pkg.PkgPath, verbose)
+		if compileErr != nil {
+			return nil, nil, compileErr
+		}
+		llfiles = append(llfiles, linkFile)
 	}
 	for _, ldflag := range ldflags {
 		cgoLdflags = append(cgoLdflags, safesplit.SplitPkgConfigFlags(ldflag)...)

--- a/internal/build/cgo_test.go
+++ b/internal/build/cgo_test.go
@@ -338,6 +338,79 @@ import "unsafe"
 	}
 }
 
+func buildCgoTestFile(t *testing.T, dir, preamble string) (*ast.File, *aPackage, *context) {
+	t.Helper()
+	src := "package demo\n\n/*\n" + preamble + "\n*/\nimport \"unsafe\"\n"
+	goFile := filepath.Join(dir, "demo.go")
+	if err := os.WriteFile(goFile, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, goFile, src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := &aPackage{Package: &packages.Package{
+		Fset:       fset,
+		PkgPath:    "example.com/demo",
+		ExportFile: filepath.Join(dir, "demo.a"),
+	}}
+	ctx := &context{
+		conf:      &packages.Config{},
+		buildConf: &Config{Goos: runtime.GOOS, Goarch: runtime.GOARCH},
+		commands: commandEnv{
+			dir:     dir,
+			environ: os.Environ(),
+		},
+	}
+	return file, pkg, ctx
+}
+
+func TestBuildCgoCompilesSourcesAndPreambles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "extra.c"), []byte("int extra_value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file, pkg, ctx := buildCgoTestFile(t, dir, "int preamble_value = 2;")
+	objects, _, err := buildCgo(ctx, pkg, []*ast.File{file}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeFiles(objects)
+	if len(objects) != 2 {
+		t.Fatalf("buildCgo objects = %v, want source and preamble objects", objects)
+	}
+	for _, object := range objects {
+		if _, err := os.Stat(object); err != nil {
+			t.Fatalf("compiled object %q: %v", object, err)
+		}
+	}
+}
+
+func TestBuildCgoReportsSourceAndPreambleCompileErrors(t *testing.T) {
+	t.Run("source", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "broken.c"), []byte("this is not C;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		file, pkg, ctx := buildCgoTestFile(t, dir, "")
+		if _, _, err := buildCgo(ctx, pkg, []*ast.File{file}, nil, false); err == nil {
+			t.Fatal("buildCgo unexpectedly compiled an invalid C source")
+		}
+	})
+
+	t.Run("preamble assembly", func(t *testing.T) {
+		dir := t.TempDir()
+		// Clang accepts this during the syntax and preprocessor probes used to
+		// discover cgo symbols, but its assembler rejects the directive when
+		// clFile performs the real object compilation.
+		file, pkg, ctx := buildCgoTestFile(t, dir, `__asm__(".llgo_invalid_directive");`)
+		if _, _, err := buildCgo(ctx, pkg, []*ast.File{file}, nil, false); err == nil {
+			t.Fatal("buildCgo unexpectedly compiled an invalid preamble directive")
+		}
+	})
+}
+
 func TestParseCgoCollectsCXXFiles(t *testing.T) {
 	dir := t.TempDir()
 	src := `package demo

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -229,11 +229,19 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 		m.pkg.OtherFiles = otherList
 	}
 
-	llgoInputs := append([]llgoFileInput(nil), llgoPkgFileInputs(c, p)...)
-	if pkg.AltPkg != nil {
-		llgoInputs = append(llgoInputs, llgoPkgFileInputs(c, pkg.AltPkg.Package)...)
+	llgoInputs, err := llgoPkgFileInputs(c, p)
+	if err != nil {
+		return fmt.Errorf("list LLGoFiles: %w", err)
 	}
-	llgoFiles, err := digestLLGoFileInputs(llgoInputs, c.buildConf.Overlay)
+	llgoInputs = append([]llgoFileInput(nil), llgoInputs...)
+	if pkg.AltPkg != nil {
+		altInputs, err := llgoPkgFileInputs(c, pkg.AltPkg.Package)
+		if err != nil {
+			return fmt.Errorf("list alternate LLGoFiles: %w", err)
+		}
+		llgoInputs = append(llgoInputs, altInputs...)
+	}
+	llgoFiles, err := digestLLGoFileInputs(c, llgoInputs, c.buildConf.Overlay)
 	if err != nil {
 		return fmt.Errorf("digest LLGoFiles: %w", err)
 	}

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -229,6 +229,16 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 		m.pkg.OtherFiles = otherList
 	}
 
+	llgoInputs := append([]llgoFileInput(nil), llgoPkgFileInputs(c, p)...)
+	if pkg.AltPkg != nil {
+		llgoInputs = append(llgoInputs, llgoPkgFileInputs(c, pkg.AltPkg.Package)...)
+	}
+	llgoFiles, err := digestLLGoFileInputs(llgoInputs, c.buildConf.Overlay)
+	if err != nil {
+		return fmt.Errorf("digest LLGoFiles: %w", err)
+	}
+	m.pkg.LLGoFiles = llgoFiles
+
 	// Rewrite vars
 	if len(pkg.rewriteVars) > 0 {
 		rewrites := make(map[string]string, len(pkg.rewriteVars))

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -229,23 +229,28 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 		m.pkg.OtherFiles = otherList
 	}
 
-	llgoInputs, err := llgoPkgFileInputs(c, p)
-	if err != nil {
-		return fmt.Errorf("list LLGoFiles: %w", err)
-	}
-	llgoInputs = append([]llgoFileInput(nil), llgoInputs...)
-	if pkg.AltPkg != nil {
-		altInputs, err := llgoPkgFileInputs(c, pkg.AltPkg.Package)
+	// ModeGen returns the in-memory Go LLVM module before C/C++/assembly
+	// LLGoFiles are compiled or archived, so it must not require the target
+	// native compiler merely to fingerprint unused link inputs.
+	if c.mode != ModeGen {
+		llgoInputs, err := llgoPkgFileInputs(c, p)
 		if err != nil {
-			return fmt.Errorf("list alternate LLGoFiles: %w", err)
+			return fmt.Errorf("list LLGoFiles: %w", err)
 		}
-		llgoInputs = append(llgoInputs, altInputs...)
+		llgoInputs = append([]llgoFileInput(nil), llgoInputs...)
+		if pkg.AltPkg != nil {
+			altInputs, err := llgoPkgFileInputs(c, pkg.AltPkg.Package)
+			if err != nil {
+				return fmt.Errorf("list alternate LLGoFiles: %w", err)
+			}
+			llgoInputs = append(llgoInputs, altInputs...)
+		}
+		llgoFiles, err := digestLLGoFileInputs(c, llgoInputs, c.buildConf.Overlay)
+		if err != nil {
+			return fmt.Errorf("digest LLGoFiles: %w", err)
+		}
+		m.pkg.LLGoFiles = llgoFiles
 	}
-	llgoFiles, err := digestLLGoFileInputs(c, llgoInputs, c.buildConf.Overlay)
-	if err != nil {
-		return fmt.Errorf("digest LLGoFiles: %w", err)
-	}
-	m.pkg.LLGoFiles = llgoFiles
 
 	// Rewrite vars
 	if len(pkg.rewriteVars) > 0 {

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -172,11 +172,13 @@ type packageSection struct {
 	GoFiles     []fileDigest     `yaml:"go_files,omitempty"`
 	AltGoFiles  []fileDigest     `yaml:"alt_go_files,omitempty"`
 	OtherFiles  []fileDigest     `yaml:"other_files,omitempty"`
+	LLGoFiles   []llgoFileDigest `yaml:"llgo_files,omitempty"`
 	RewriteVars orderedStringMap `yaml:"rewrite_vars,omitempty"`
 }
 
 func (s *packageSection) empty() bool {
-	return s.PkgPath == "" && s.PkgID == "" && len(s.GoFiles) == 0 && len(s.AltGoFiles) == 0 && len(s.OtherFiles) == 0 && len(s.RewriteVars) == 0
+	return s.PkgPath == "" && s.PkgID == "" && len(s.GoFiles) == 0 && len(s.AltGoFiles) == 0 &&
+		len(s.OtherFiles) == 0 && len(s.LLGoFiles) == 0 && len(s.RewriteVars) == 0
 }
 
 // manifestBuilder builds manifest text with sorted sections.
@@ -297,6 +299,44 @@ type fileDigest struct {
 	Size        int64  `yaml:"size"`
 	ModTime     int64  `yaml:"mtime"`
 	OverlayHash string `yaml:"overlay_hash,omitempty"`
+}
+
+// llgoFileDigest records the content and per-file flags of an LLGoFiles input.
+// These files are declared through a Go constant, so go list does not include
+// them in OtherFiles and file metadata alone cannot safely key their objects.
+type llgoFileDigest struct {
+	Path         string   `yaml:"path"`
+	ContentHash  string   `yaml:"content_hash"`
+	CompilerArgs []string `yaml:"compiler_args,omitempty"`
+}
+
+func digestLLGoFileInputs(inputs []llgoFileInput, overlay map[string][]byte) ([]llgoFileDigest, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	digests := make([]llgoFileDigest, 0, len(inputs))
+	for _, input := range inputs {
+		content, ok := overlay[input.path]
+		if !ok {
+			var err error
+			content, err = os.ReadFile(input.path)
+			if err != nil {
+				return nil, fmt.Errorf("read file %q: %w", input.path, err)
+			}
+		}
+		digests = append(digests, llgoFileDigest{
+			Path:         input.path,
+			ContentHash:  digestBytes(content),
+			CompilerArgs: append([]string(nil), input.compilerArgs...),
+		})
+	}
+	sort.Slice(digests, func(i, j int) bool {
+		if digests[i].Path != digests[j].Path {
+			return digests[i].Path < digests[j].Path
+		}
+		return strings.Join(digests[i].CompilerArgs, "\x00") < strings.Join(digests[j].CompilerArgs, "\x00")
+	})
+	return digests, nil
 }
 
 // digestFiles calculates digests for multiple files.

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -310,23 +310,31 @@ type llgoFileDigest struct {
 	CompilerArgs []string `yaml:"compiler_args,omitempty"`
 }
 
-func digestLLGoFileInputs(inputs []llgoFileInput, overlay map[string][]byte) ([]llgoFileDigest, error) {
+func digestLLGoFileInputs(ctx *context, inputs []llgoFileInput, overlay map[string][]byte) ([]llgoFileDigest, error) {
 	if len(inputs) == 0 {
 		return nil, nil
 	}
+	if ctx.llgoFileHashCache == nil {
+		ctx.llgoFileHashCache = make(map[string]string)
+	}
 	digests := make([]llgoFileDigest, 0, len(inputs))
 	for _, input := range inputs {
-		content, ok := overlay[input.path]
+		contentHash, ok := ctx.llgoFileHashCache[input.path]
 		if !ok {
-			var err error
-			content, err = os.ReadFile(input.path)
-			if err != nil {
-				return nil, fmt.Errorf("read file %q: %w", input.path, err)
+			content, overlaid := overlay[input.path]
+			if !overlaid {
+				var err error
+				content, err = os.ReadFile(input.path)
+				if err != nil {
+					return nil, fmt.Errorf("read file %q: %w", input.path, err)
+				}
 			}
+			contentHash = digestBytes(content)
+			ctx.llgoFileHashCache[input.path] = contentHash
 		}
 		digests = append(digests, llgoFileDigest{
 			Path:         input.path,
-			ContentHash:  digestBytes(content),
+			ContentHash:  contentHash,
 			CompilerArgs: append([]string(nil), input.compilerArgs...),
 		})
 	}

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -301,13 +302,14 @@ type fileDigest struct {
 	OverlayHash string `yaml:"overlay_hash,omitempty"`
 }
 
-// llgoFileDigest records the content and per-file flags of an LLGoFiles input.
-// These files are declared through a Go constant, so go list does not include
-// them in OtherFiles and file metadata alone cannot safely key their objects.
+// llgoFileDigest records the preprocessed content and per-file flags of an
+// LLGoFiles input. These files are declared through a Go constant, so go list
+// does not include either them or their local includes in OtherFiles.
 type llgoFileDigest struct {
-	Path         string   `yaml:"path"`
-	ContentHash  string   `yaml:"content_hash"`
-	CompilerArgs []string `yaml:"compiler_args,omitempty"`
+	Path             string   `yaml:"path"`
+	PreprocessedHash string   `yaml:"preprocessed_hash"`
+	OverlayHash      string   `yaml:"overlay_hash,omitempty"`
+	CompilerArgs     []string `yaml:"compiler_args,omitempty"`
 }
 
 func digestLLGoFileInputs(ctx *context, inputs []llgoFileInput, overlay map[string][]byte) ([]llgoFileDigest, error) {
@@ -315,27 +317,36 @@ func digestLLGoFileInputs(ctx *context, inputs []llgoFileInput, overlay map[stri
 		return nil, nil
 	}
 	if ctx.llgoFileHashCache == nil {
-		ctx.llgoFileHashCache = make(map[string]string)
+		ctx.llgoFileHashCache = make(map[llgoFileHashKey]string)
 	}
 	digests := make([]llgoFileDigest, 0, len(inputs))
 	for _, input := range inputs {
-		contentHash, ok := ctx.llgoFileHashCache[input.path]
+		compilerArgs := llgoFileCompilerArgs(ctx, input.compilerArgs, input.path)
+		cacheKey := llgoFileHashKey{
+			path:         input.path,
+			compilerArgs: strings.Join(compilerArgs, "\x00"),
+		}
+		preprocessedHash, ok := ctx.llgoFileHashCache[cacheKey]
 		if !ok {
-			content, overlaid := overlay[input.path]
-			if !overlaid {
-				var err error
-				content, err = os.ReadFile(input.path)
-				if err != nil {
-					return nil, fmt.Errorf("read file %q: %w", input.path, err)
-				}
+			hash := sha256.New()
+			cmd := ctx.compilerForSource(input.path)
+			cmd.Stdout = hash
+			preprocessArgs := append(slices.Clone(compilerArgs), "-E", input.path)
+			if err := cmd.Compile(preprocessArgs...); err != nil {
+				return nil, fmt.Errorf("preprocess file %q: %w", input.path, err)
 			}
-			contentHash = digestBytes(content)
-			ctx.llgoFileHashCache[input.path] = contentHash
+			preprocessedHash = hex.EncodeToString(hash.Sum(nil))
+			ctx.llgoFileHashCache[cacheKey] = preprocessedHash
+		}
+		overlayHash := ""
+		if content, ok := overlay[input.path]; ok {
+			overlayHash = digestBytes(content)
 		}
 		digests = append(digests, llgoFileDigest{
-			Path:         input.path,
-			ContentHash:  contentHash,
-			CompilerArgs: append([]string(nil), input.compilerArgs...),
+			Path:             input.path,
+			PreprocessedHash: preprocessedHash,
+			OverlayHash:      overlayHash,
+			CompilerArgs:     append([]string(nil), input.compilerArgs...),
 		})
 	}
 	sort.Slice(digests, func(i, j int) bool {

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -185,8 +186,16 @@ func TestLLGoFileCompilationLifecycle(t *testing.T) {
 		defer os.Remove(published)
 		if info, err := os.Stat(published); err != nil {
 			t.Fatal(err)
-		} else if info.Mode().Perm() != 0o644 {
-			t.Fatalf("published LLVM IR mode = %o, want 644", info.Mode().Perm())
+		} else {
+			wantMode := os.FileMode(0o644)
+			if runtime.GOOS == "windows" {
+				// Windows records only the read-only attribute, so os.Stat reports
+				// every writable regular file as 0666 even after Chmod(0644).
+				wantMode = 0o666
+			}
+			if got := info.Mode().Perm(); got != wantMode {
+				t.Fatalf("published LLVM IR mode = %o, want %o", got, wantMode)
+			}
 		}
 	})
 

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -182,6 +182,19 @@ func TestLLGoFilesFingerprintUsesIncludedContent(t *testing.T) {
 	}
 }
 
+func TestModeGenFingerprintSkipsLLGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	pkg := llgoFilesTestPackage(t, dir, "missing.c")
+	ctx := &context{mode: ModeGen, buildConf: &Config{Mode: ModeGen}}
+	manifest := newManifestBuilder()
+	if err := ctx.collectPackageInputs(manifest, &aPackage{Package: pkg}); err != nil {
+		t.Fatalf("ModeGen fingerprint required an unused LLGoFiles compiler: %v", err)
+	}
+	if manifest.pkg.LLGoFiles != nil {
+		t.Fatalf("ModeGen LLGoFiles manifest = %#v, want nil", manifest.pkg.LLGoFiles)
+	}
+}
+
 func TestLLGoFileOutputsAreProcessPrivate(t *testing.T) {
 	first, err := genLLGoFileOutput("wrap.c", ".o")
 	if err != nil {

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -1,0 +1,125 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import (
+	"go/constant"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/xgo-dev/llgo/internal/packages"
+)
+
+func llgoFilesTestPackage(t *testing.T, dir, value string) *packages.Package {
+	t.Helper()
+	goFile := filepath.Join(dir, "package.go")
+	if err := os.WriteFile(goFile, []byte("package fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	typesPkg := types.NewPackage("example.com/fixture", "fixture")
+	typesPkg.Scope().Insert(types.NewConst(token.NoPos, typesPkg, "LLGoFiles", types.Typ[types.UntypedString], constant.MakeString(value)))
+	return &packages.Package{
+		ID:         "example.com/fixture",
+		PkgPath:    "example.com/fixture",
+		GoFiles:    []string{goFile},
+		ExportFile: filepath.Join(dir, "fixture.a"),
+		Types:      typesPkg,
+	}
+}
+
+func TestLLGoFileInputsResolvePathsAndFlags(t *testing.T) {
+	dir := t.TempDir()
+	pkg := llgoFilesTestPackage(t, dir, "$LLGO_TEST_CFLAGS: wrap.c; wrap.S")
+	ctx := &context{commands: commandEnv{environ: []string{"LLGO_TEST_CFLAGS=-DVALUE=1"}}}
+	inputs := llgoPkgFileInputs(ctx, pkg)
+	if len(inputs) != 2 {
+		t.Fatalf("LLGoFiles inputs = %#v, want two files", inputs)
+	}
+	for i, name := range []string{"wrap.c", "wrap.S"} {
+		if got, want := inputs[i].path, filepath.Join(dir, name); got != want {
+			t.Errorf("input %d path = %q, want %q", i, got, want)
+		}
+		if got, want := inputs[i].compilerArgs, []string{"-DVALUE=1"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("input %d compiler args = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestLLGoFilesFingerprintUsesContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wrap.c")
+	if err := os.WriteFile(path, []byte("int value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkg := llgoFilesTestPackage(t, dir, "wrap.c")
+	ctx := &context{buildConf: &Config{}}
+
+	fingerprint := func() (string, llgoFileDigest) {
+		manifest := newManifestBuilder()
+		if err := ctx.collectPackageInputs(manifest, &aPackage{Package: pkg}); err != nil {
+			t.Fatal(err)
+		}
+		if len(manifest.pkg.LLGoFiles) != 1 {
+			t.Fatalf("manifest LLGoFiles = %#v, want one file", manifest.pkg.LLGoFiles)
+		}
+		return manifest.Fingerprint(), manifest.pkg.LLGoFiles[0]
+	}
+
+	before, beforeFile := fingerprint()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("int value = 2;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Preserve size and modification time to prove that content, rather than
+	// the metadata used for ordinary Go inputs, invalidates the package cache.
+	if err := os.Chtimes(path, time.Unix(0, info.ModTime().UnixNano()), time.Unix(0, info.ModTime().UnixNano())); err != nil {
+		t.Fatal(err)
+	}
+	after, afterFile := fingerprint()
+	if before == after {
+		t.Fatal("LLGoFiles content change did not change the package fingerprint")
+	}
+	if beforeFile.ContentHash == afterFile.ContentHash {
+		t.Fatal("LLGoFiles content change did not change its content hash")
+	}
+}
+
+func TestLLGoFileOutputsAreProcessPrivate(t *testing.T) {
+	first, err := genLLGoFileOutput("wrap.c", ".o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(first)
+	second, err := genLLGoFileOutput("wrap.c", ".o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(second)
+	if first == second {
+		t.Fatalf("two LLGoFiles compilations selected the same object path %q", first)
+	}
+}

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -52,7 +52,10 @@ func TestLLGoFileInputsResolvePathsAndFlags(t *testing.T) {
 	dir := t.TempDir()
 	pkg := llgoFilesTestPackage(t, dir, "$LLGO_TEST_CFLAGS: wrap.c; ; wrap.S")
 	ctx := &context{commands: commandEnv{environ: []string{"LLGO_TEST_CFLAGS=-DVALUE=1"}}}
-	inputs := llgoPkgFileInputs(ctx, pkg)
+	inputs, err := llgoPkgFileInputs(ctx, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(inputs) != 2 {
 		t.Fatalf("LLGoFiles inputs = %#v, want two files", inputs)
 	}
@@ -65,8 +68,30 @@ func TestLLGoFileInputsResolvePathsAndFlags(t *testing.T) {
 		}
 	}
 	pkg.GoFiles = nil
-	if inputs := llgoPkgFileInputs(&context{}, pkg); len(inputs) != 0 {
+	inputs, err = llgoPkgFileInputs(&context{}, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 0 {
 		t.Fatalf("LLGoFiles inputs without a package source directory = %#v, want none", inputs)
+	}
+}
+
+func TestLLGoFileInputsFrozenCache(t *testing.T) {
+	pkg := llgoFilesTestPackage(t, t.TempDir(), "wrap.c")
+	ctx := &context{llgoFilesFrozen: true}
+	if _, err := llgoPkgFileInputs(ctx, pkg); err == nil {
+		t.Fatal("frozen LLGoFiles cache miss unexpectedly succeeded")
+	}
+
+	want := []llgoFileInput{{path: "cached.c"}}
+	ctx.llgoFilesCache = map[*packages.Package][]llgoFileInput{pkg: want}
+	got, err := llgoPkgFileInputs(ctx, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("frozen LLGoFiles cache hit = %#v, want %#v", got, want)
 	}
 }
 
@@ -77,9 +102,7 @@ func TestLLGoFilesFingerprintUsesContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	pkg := llgoFilesTestPackage(t, dir, "wrap.c")
-	ctx := &context{buildConf: &Config{}}
-
-	fingerprint := func() (string, llgoFileDigest) {
+	fingerprint := func(ctx *context) (string, llgoFileDigest) {
 		manifest := newManifestBuilder()
 		if err := ctx.collectPackageInputs(manifest, &aPackage{Package: pkg}); err != nil {
 			t.Fatal(err)
@@ -90,7 +113,7 @@ func TestLLGoFilesFingerprintUsesContent(t *testing.T) {
 		return manifest.Fingerprint(), manifest.pkg.LLGoFiles[0]
 	}
 
-	before, beforeFile := fingerprint()
+	before, beforeFile := fingerprint(&context{buildConf: &Config{}})
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +126,7 @@ func TestLLGoFilesFingerprintUsesContent(t *testing.T) {
 	if err := os.Chtimes(path, time.Unix(0, info.ModTime().UnixNano()), time.Unix(0, info.ModTime().UnixNano())); err != nil {
 		t.Fatal(err)
 	}
-	after, afterFile := fingerprint()
+	after, afterFile := fingerprint(&context{buildConf: &Config{}})
 	if before == after {
 		t.Fatal("LLGoFiles content change did not change the package fingerprint")
 	}
@@ -128,13 +151,36 @@ func TestLLGoFileOutputsAreProcessPrivate(t *testing.T) {
 	}
 }
 
+func TestCleanupTemporaryObjFilesPreservesOtherMembers(t *testing.T) {
+	dir := t.TempDir()
+	temporary := filepath.Join(dir, "temporary.o")
+	stable := filepath.Join(dir, "stable.o")
+	for _, path := range []string{temporary, stable} {
+		if err := os.WriteFile(path, []byte("object"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pkg := &aPackage{ObjFiles: []string{temporary, stable}, tempObjFiles: []string{temporary}}
+	pkg.cleanupTemporaryObjFiles()
+	if _, err := os.Stat(temporary); !os.IsNotExist(err) {
+		t.Fatalf("temporary object still exists: %v", err)
+	}
+	if _, err := os.Stat(stable); err != nil {
+		t.Fatalf("stable archive member was removed: %v", err)
+	}
+	if pkg.tempObjFiles != nil {
+		t.Fatalf("temporary object tracking = %#v, want nil", pkg.tempObjFiles)
+	}
+}
+
 func TestDigestLLGoFileInputsEdges(t *testing.T) {
-	if digests, err := digestLLGoFileInputs(nil, nil); err != nil || digests != nil {
+	ctx := &context{}
+	if digests, err := digestLLGoFileInputs(ctx, nil, nil); err != nil || digests != nil {
 		t.Fatalf("empty digests = %#v, %v; want nil, nil", digests, err)
 	}
 
 	path := filepath.Join(t.TempDir(), "overlay.c")
-	digests, err := digestLLGoFileInputs([]llgoFileInput{
+	digests, err := digestLLGoFileInputs(ctx, []llgoFileInput{
 		{path: path, compilerArgs: []string{"-DZ=1"}},
 		{path: path, compilerArgs: []string{"-DA=1"}},
 	}, map[string][]byte{path: []byte("overlay content")})
@@ -147,7 +193,30 @@ func TestDigestLLGoFileInputsEdges(t *testing.T) {
 	}
 
 	missing := filepath.Join(t.TempDir(), "missing.c")
-	if _, err := digestLLGoFileInputs([]llgoFileInput{{path: missing}}, nil); err == nil {
+	if _, err := digestLLGoFileInputs(ctx, []llgoFileInput{{path: missing}}, nil); err == nil {
 		t.Fatal("digesting a missing LLGoFiles input unexpectedly succeeded")
+	}
+}
+
+func TestDigestLLGoFileInputsMemoizesContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cached.c")
+	if err := os.WriteFile(path, []byte("int value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &context{}
+	inputs := []llgoFileInput{{path: path}}
+	first, err := digestLLGoFileInputs(ctx, inputs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := digestLLGoFileInputs(ctx, inputs, nil)
+	if err != nil {
+		t.Fatalf("memoized digest re-read removed input: %v", err)
+	}
+	if !reflect.DeepEqual(second, first) {
+		t.Fatalf("memoized digest = %#v, want %#v", second, first)
 	}
 }

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -50,7 +50,7 @@ func llgoFilesTestPackage(t *testing.T, dir, value string) *packages.Package {
 
 func TestLLGoFileInputsResolvePathsAndFlags(t *testing.T) {
 	dir := t.TempDir()
-	pkg := llgoFilesTestPackage(t, dir, "$LLGO_TEST_CFLAGS: wrap.c; wrap.S")
+	pkg := llgoFilesTestPackage(t, dir, "$LLGO_TEST_CFLAGS: wrap.c; ; wrap.S")
 	ctx := &context{commands: commandEnv{environ: []string{"LLGO_TEST_CFLAGS=-DVALUE=1"}}}
 	inputs := llgoPkgFileInputs(ctx, pkg)
 	if len(inputs) != 2 {
@@ -63,6 +63,10 @@ func TestLLGoFileInputsResolvePathsAndFlags(t *testing.T) {
 		if got, want := inputs[i].compilerArgs, []string{"-DVALUE=1"}; !reflect.DeepEqual(got, want) {
 			t.Errorf("input %d compiler args = %q, want %q", i, got, want)
 		}
+	}
+	pkg.GoFiles = nil
+	if inputs := llgoPkgFileInputs(&context{}, pkg); len(inputs) != 0 {
+		t.Fatalf("LLGoFiles inputs without a package source directory = %#v, want none", inputs)
 	}
 }
 
@@ -121,5 +125,29 @@ func TestLLGoFileOutputsAreProcessPrivate(t *testing.T) {
 	defer os.Remove(second)
 	if first == second {
 		t.Fatalf("two LLGoFiles compilations selected the same object path %q", first)
+	}
+}
+
+func TestDigestLLGoFileInputsEdges(t *testing.T) {
+	if digests, err := digestLLGoFileInputs(nil, nil); err != nil || digests != nil {
+		t.Fatalf("empty digests = %#v, %v; want nil, nil", digests, err)
+	}
+
+	path := filepath.Join(t.TempDir(), "overlay.c")
+	digests, err := digestLLGoFileInputs([]llgoFileInput{
+		{path: path, compilerArgs: []string{"-DZ=1"}},
+		{path: path, compilerArgs: []string{"-DA=1"}},
+	}, map[string][]byte{path: []byte("overlay content")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(digests) != 2 || !reflect.DeepEqual(digests[0].CompilerArgs, []string{"-DA=1"}) ||
+		digests[0].ContentHash != digestBytes([]byte("overlay content")) {
+		t.Fatalf("overlay digests = %#v", digests)
+	}
+
+	missing := filepath.Join(t.TempDir(), "missing.c")
+	if _, err := digestLLGoFileInputs([]llgoFileInput{{path: missing}}, nil); err == nil {
+		t.Fatal("digesting a missing LLGoFiles input unexpectedly succeeded")
 	}
 }

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,6 +94,11 @@ func TestLLGoFileInputsFrozenCache(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("frozen LLGoFiles cache hit = %#v, want %#v", got, want)
 	}
+
+	other := llgoFilesTestPackage(t, t.TempDir(), "other.c")
+	if _, err := llgoPkgFileInputs(ctx, other); err == nil {
+		t.Fatal("nonempty frozen LLGoFiles cache miss unexpectedly succeeded")
+	}
 }
 
 func TestLLGoFilesFingerprintUsesContent(t *testing.T) {
@@ -149,6 +155,170 @@ func TestLLGoFileOutputsAreProcessPrivate(t *testing.T) {
 	if first == second {
 		t.Fatalf("two LLGoFiles compilations selected the same object path %q", first)
 	}
+}
+
+func llgoFilesBuildContext(dir string, genLL bool) *context {
+	return &context{
+		conf:      &packages.Config{},
+		buildConf: &Config{GenLL: genLL},
+		commands: commandEnv{
+			dir:     dir,
+			environ: os.Environ(),
+		},
+	}
+}
+
+func TestLLGoFileCompilationLifecycle(t *testing.T) {
+	t.Run("GenLL success", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "wrap.c")
+		if err := os.WriteFile(source, []byte("int answer(void) { return 42; }\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		exportFile := filepath.Join(dir, "fixture.a")
+		object, err := clFile(llgoFilesBuildContext(dir, true), nil, source, exportFile, "example.com/fixture", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(object)
+		published := exportFile + filepath.Base(source) + ".ll"
+		defer os.Remove(published)
+		if info, err := os.Stat(published); err != nil {
+			t.Fatal(err)
+		} else if info.Mode().Perm() != 0o644 {
+			t.Fatalf("published LLVM IR mode = %o, want 644", info.Mode().Perm())
+		}
+	})
+
+	t.Run("temporary output errors", func(t *testing.T) {
+		blocker := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(blocker, []byte("block"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+			t.Setenv(key, blocker)
+		}
+		for _, tt := range []struct {
+			name   string
+			genLL  bool
+			needle string
+		}{
+			{name: "LLVM IR", genLL: true, needle: "temporary LLVM IR output"},
+			{name: "object", needle: "temporary object output"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := llgoFilesBuildContext("", tt.genLL)
+				if _, err := clFile(ctx, nil, "wrap.c", "fixture.a", "example.com/fixture", false); err == nil || !strings.Contains(err.Error(), tt.needle) {
+					t.Fatalf("clFile error = %v, want %q", err, tt.needle)
+				}
+			})
+		}
+	})
+
+	t.Run("LLVM IR compile error", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "broken.c")
+		if err := os.WriteFile(source, []byte("this is not C;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := clFile(llgoFilesBuildContext(dir, true), nil, source, filepath.Join(dir, "fixture.a"), "example.com/fixture", false); err == nil || !strings.Contains(err.Error(), "to LLVM IR") {
+			t.Fatalf("clFile error = %v, want LLVM IR compile error", err)
+		}
+	})
+
+	t.Run("LLVM IR publish error", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "wrap.c")
+		if err := os.WriteFile(source, []byte("int answer(void) { return 42; }\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		blocker := filepath.Join(dir, "not-a-directory")
+		if err := os.WriteFile(blocker, []byte("block"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := clFile(llgoFilesBuildContext(dir, true), nil, source, blocker+string(os.PathSeparator), "example.com/fixture", false); err == nil || !strings.Contains(err.Error(), "publish LLVM IR") {
+			t.Fatalf("clFile error = %v, want publish error", err)
+		}
+	})
+
+	t.Run("object compile error", func(t *testing.T) {
+		dir := t.TempDir()
+		source := filepath.Join(dir, "broken.c")
+		if err := os.WriteFile(source, []byte("this is not C;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := clFile(llgoFilesBuildContext(dir, false), nil, source, filepath.Join(dir, "fixture.a"), "example.com/fixture", false); err == nil || !strings.Contains(err.Error(), "compile ") {
+			t.Fatalf("clFile error = %v, want object compile error", err)
+		}
+	})
+}
+
+func TestConcatPkgLinkFilesCleansPartialOutputs(t *testing.T) {
+	dir := t.TempDir()
+	valid := filepath.Join(dir, "valid.c")
+	if err := os.WriteFile(valid, []byte("int answer(void) { return 42; }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkg := llgoFilesTestPackage(t, dir, "valid.c;missing.c")
+	ctx := llgoFilesBuildContext(dir, false)
+	ctx.llgoFilesCache = map[*packages.Package][]llgoFileInput{
+		pkg: {
+			{path: valid},
+			{path: filepath.Join(dir, "missing.c")},
+		},
+	}
+	parts, err := concatPkgLinkFiles(ctx, pkg, false)
+	if err == nil {
+		t.Fatal("concatPkgLinkFiles unexpectedly succeeded")
+	}
+	if len(parts) != 1 {
+		t.Fatalf("partial outputs = %v, want one compiled object", parts)
+	}
+	if _, statErr := os.Stat(parts[0]); !os.IsNotExist(statErr) {
+		t.Fatalf("partial object was not removed: %v", statErr)
+	}
+
+	frozen := &context{llgoFilesFrozen: true}
+	if _, err := concatPkgLinkFiles(frozen, pkg, false); err == nil {
+		t.Fatal("concatPkgLinkFiles accepted an unprepared frozen cache")
+	}
+}
+
+func TestCollectPackageInputsReportsLLGoFilesErrors(t *testing.T) {
+	t.Run("primary list", func(t *testing.T) {
+		pkg := llgoFilesTestPackage(t, t.TempDir(), "wrap.c")
+		ctx := &context{buildConf: &Config{}, llgoFilesFrozen: true}
+		err := ctx.collectPackageInputs(newManifestBuilder(), &aPackage{Package: pkg})
+		if err == nil || !strings.Contains(err.Error(), "list LLGoFiles") {
+			t.Fatalf("collectPackageInputs error = %v, want primary list error", err)
+		}
+	})
+
+	t.Run("alternate list", func(t *testing.T) {
+		pkg := llgoFilesTestPackage(t, t.TempDir(), "wrap.c")
+		alt := llgoFilesTestPackage(t, t.TempDir(), "alt.c")
+		ctx := &context{
+			buildConf:       &Config{},
+			llgoFilesCache:  map[*packages.Package][]llgoFileInput{pkg: nil},
+			llgoFilesFrozen: true,
+		}
+		err := ctx.collectPackageInputs(newManifestBuilder(), &aPackage{
+			Package: pkg,
+			AltPkg:  &packages.Cached{Package: alt},
+		})
+		if err == nil || !strings.Contains(err.Error(), "list alternate LLGoFiles") {
+			t.Fatalf("collectPackageInputs error = %v, want alternate list error", err)
+		}
+	})
+
+	t.Run("digest", func(t *testing.T) {
+		pkg := llgoFilesTestPackage(t, t.TempDir(), "missing.c")
+		ctx := &context{buildConf: &Config{}}
+		err := ctx.collectPackageInputs(newManifestBuilder(), &aPackage{Package: pkg})
+		if err == nil || !strings.Contains(err.Error(), "digest LLGoFiles") {
+			t.Fatalf("collectPackageInputs error = %v, want digest error", err)
+		}
+	})
 }
 
 func TestCleanupTemporaryObjFilesPreservesOtherMembers(t *testing.T) {

--- a/internal/build/llgofiles_test.go
+++ b/internal/build/llgofiles_test.go
@@ -137,8 +137,48 @@ func TestLLGoFilesFingerprintUsesContent(t *testing.T) {
 	if before == after {
 		t.Fatal("LLGoFiles content change did not change the package fingerprint")
 	}
-	if beforeFile.ContentHash == afterFile.ContentHash {
-		t.Fatal("LLGoFiles content change did not change its content hash")
+	if beforeFile.PreprocessedHash == afterFile.PreprocessedHash {
+		t.Fatal("LLGoFiles content change did not change its preprocessed hash")
+	}
+}
+
+func TestLLGoFilesFingerprintUsesIncludedContent(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "wrap.c")
+	header := filepath.Join(dir, "value.h")
+	if err := os.WriteFile(source, []byte("#include \"value.h\"\nint value = VALUE;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(header, []byte("#define VALUE 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkg := llgoFilesTestPackage(t, dir, "wrap.c")
+	fingerprint := func() (string, llgoFileDigest) {
+		ctx := &context{buildConf: &Config{}}
+		manifest := newManifestBuilder()
+		if err := ctx.collectPackageInputs(manifest, &aPackage{Package: pkg}); err != nil {
+			t.Fatal(err)
+		}
+		return manifest.Fingerprint(), manifest.pkg.LLGoFiles[0]
+	}
+
+	before, beforeFile := fingerprint()
+	info, err := os.Stat(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(header, []byte("#define VALUE 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(header, time.Unix(0, info.ModTime().UnixNano()), time.Unix(0, info.ModTime().UnixNano())); err != nil {
+		t.Fatal(err)
+	}
+	after, afterFile := fingerprint()
+	if before == after {
+		t.Fatal("included LLGoFiles content change did not change the package fingerprint")
+	}
+	if beforeFile.PreprocessedHash == afterFile.PreprocessedHash {
+		t.Fatal("included LLGoFiles content change did not change its preprocessed hash")
 	}
 }
 
@@ -353,12 +393,15 @@ func TestCleanupTemporaryObjFilesPreservesOtherMembers(t *testing.T) {
 }
 
 func TestDigestLLGoFileInputsEdges(t *testing.T) {
-	ctx := &context{}
+	ctx := &context{buildConf: &Config{}}
 	if digests, err := digestLLGoFileInputs(ctx, nil, nil); err != nil || digests != nil {
 		t.Fatalf("empty digests = %#v, %v; want nil, nil", digests, err)
 	}
 
 	path := filepath.Join(t.TempDir(), "overlay.c")
+	if err := os.WriteFile(path, []byte("int value;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	digests, err := digestLLGoFileInputs(ctx, []llgoFileInput{
 		{path: path, compilerArgs: []string{"-DZ=1"}},
 		{path: path, compilerArgs: []string{"-DA=1"}},
@@ -367,7 +410,7 @@ func TestDigestLLGoFileInputsEdges(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(digests) != 2 || !reflect.DeepEqual(digests[0].CompilerArgs, []string{"-DA=1"}) ||
-		digests[0].ContentHash != digestBytes([]byte("overlay content")) {
+		digests[0].OverlayHash != digestBytes([]byte("overlay content")) {
 		t.Fatalf("overlay digests = %#v", digests)
 	}
 
@@ -382,7 +425,7 @@ func TestDigestLLGoFileInputsMemoizesContent(t *testing.T) {
 	if err := os.WriteFile(path, []byte("int value = 1;\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ctx := &context{}
+	ctx := &context{buildConf: &Config{}}
 	inputs := []llgoFileInput{{path: path}}
 	first, err := digestLLGoFileInputs(ctx, inputs, nil)
 	if err != nil {

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -296,6 +296,7 @@ func (ctx *context) newBackendTask(session backendSession) *context {
 		buildTrace:      ctx.buildTrace,
 		sfilesCache:     ctx.sfilesCache,
 		sfilesFrozen:    true,
+		llgoFilesCache:  ctx.llgoFilesCache,
 		plan9asmReady:   true,
 		plan9asmMode:    ctx.plan9asmMode,
 		plan9asmPkgs:    ctx.plan9asmPkgs,

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -148,6 +148,7 @@ func tracePackageBuild(ctx *context, task *packageBuildTask, verbose, isolated, 
 }
 
 func buildPackage(ctx *context, task *packageBuildTask, verbose, isolated bool) error {
+	defer task.pkg.cleanupTemporaryObjFiles()
 	var err error
 	if isolated {
 		err = ctx.executeIsolatedPackage(task, verbose)
@@ -273,8 +274,9 @@ func (ctx *context) executeIsolatedPackage(task *packageBuildTask, verbose bool)
 }
 
 func (ctx *context) newBackendTask(session backendSession) *context {
-	// preparePackageBuilds populated every task's SFiles entry before workers start.
-	// Backend tasks share that map read-only; a frozen miss returns an error.
+	// preparePackageBuilds populated every task's SFiles and LLGoFiles entries
+	// before workers start. Backend tasks share those maps read-only; a frozen
+	// miss returns an error instead of mutating coordinator state concurrently.
 	return &context{
 		conf:            ctx.conf,
 		progSSA:         ctx.progSSA,
@@ -297,6 +299,7 @@ func (ctx *context) newBackendTask(session backendSession) *context {
 		sfilesCache:     ctx.sfilesCache,
 		sfilesFrozen:    true,
 		llgoFilesCache:  ctx.llgoFilesCache,
+		llgoFilesFrozen: true,
 		plan9asmReady:   true,
 		plan9asmMode:    ctx.plan9asmMode,
 		plan9asmPkgs:    ctx.plan9asmPkgs,

--- a/internal/build/package_build_test.go
+++ b/internal/build/package_build_test.go
@@ -557,6 +557,7 @@ func TestNewBackendTaskUsesPackageLocalState(t *testing.T) {
 		commands:        commandEnv{dir: t.TempDir()},
 		frontendOptions: cl.Options{Debug: true},
 		sfilesCache:     map[string][]string{"example.com/p": {"asm.s"}},
+		llgoFilesCache:  make(map[*packages.Package][]llgoFileInput),
 		plan9asmReady:   true,
 		plan9asmMode:    plan9asmEnvSelected,
 		plan9asmPkgs:    map[string]bool{"example.com/p": true},
@@ -569,9 +570,15 @@ func TestNewBackendTaskUsesPackageLocalState(t *testing.T) {
 	if task.buildConf != coordinator.buildConf || task.conf != coordinator.conf {
 		t.Fatal("backend task did not retain immutable build inputs")
 	}
-	if !task.sfilesFrozen || !task.plan9asmReady || task.plan9asmMode != plan9asmEnvSelected {
+	if !task.sfilesFrozen || !task.llgoFilesFrozen || !task.plan9asmReady || task.plan9asmMode != plan9asmEnvSelected {
 		t.Fatalf("backend task state = %+v", task)
 	}
+	probe := &packages.Package{ID: "example.com/probe"}
+	task.llgoFilesCache[probe] = nil
+	if _, ok := coordinator.llgoFilesCache[probe]; !ok {
+		t.Fatal("backend task did not retain the prepared LLGoFiles cache")
+	}
+	delete(task.llgoFilesCache, probe)
 	if !task.frontendOptions.Debug || task.commands.dir != coordinator.commands.dir {
 		t.Fatal("backend task lost invocation settings")
 	}


### PR DESCRIPTION
* #2483

## Summary

- compile each `LLGoFiles` C, C++, or assembly input to a process-private temporary object instead of a shared path beside the Go export file\n- clean process-private objects after archiving or on failure, while preserving stable archive members\n- freeze the prepared LLGoFiles input map before concurrent backend execution and report any missed preparation as an error
- atomically publish the stable debug IR copy used by `-gen-llfiles`
- add the resolved `LLGoFiles` paths, SHA-256 content hashes, and per-file compiler arguments to package cache manifests
- reuse resolved inputs and memoized content hashes so helper commands and source reads are not repeated in backend workers\n- return contextual C/C++/assembly compilation errors instead of relying on panic recovery

## Why

`LLGoFiles` inputs are commonly stored below `_wrap/`, so `go list` does not report them in `OtherFiles`. Their content was therefore absent from the LLGo package fingerprint. The generated object path was also derived only from `pkg.ExportFile` and the source basename. Two independent LLGo processes sharing `GOCACHE` could concurrently truncate, write, and archive the same object. This can produce incomplete archives and late link errors such as a missing `llgo_windows_syscall` symbol.

This is independent of #2234: that PR removes its own child-process fan-out, while this PR makes the underlying `LLGoFiles` compilation safe for any independent LLGo processes.

## Validation

- `go test ./internal/build -count=1`
- `go test -race ./internal/build -run TestLLGo -count=1`
- `go test ./... -run ^$ -count=1`
- launched two independent cold LLGo builds concurrently with the same compiler binary and fresh shared `GOCACHE`; both linked and ran successfully
- built a cached non-main package returning `41` from an `LLGoFiles` C file, changed only that C content to return `42`, and confirmed the package rebuilt and the second executable returned `42`
