### PR TITLE
ci: configure a writable GOPATH

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -12,6 +12,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # setup-go creates GOPATH/bin, but some hosted images export an unwritable
+    # system path such as /opt/go. Keep the Go workspace private to each job.
+    - name: Configure writable GOPATH
+      shell: bash
+      env:
+        LLGO_CI_GOPATH: ${{ runner.temp }}/go
+      run: echo "GOPATH=${LLGO_CI_GOPATH}" >> "$GITHUB_ENV"
+
     - name: Set up the LLGo build toolchain
       if: inputs.go-version == ''
       uses: actions/setup-go@v7


### PR DESCRIPTION
## Summary

- configure a per-job writable `GOPATH` before invoking `actions/setup-go`
- prevent setup-go from failing when a hosted runner exports an unwritable system path such as `/opt/go`
- apply the same Go workspace location to every CI workflow through the shared setup action

## Validation

- `git diff --check`
- parsed `.github/actions/setup-go/action.yml` as YAML
- confirmed the same runner class succeeds after overriding `GOPATH` to a writable path
