### PR TITLE
runtime: avoid reentrant finalizer callback deadlocks

### DIFF
--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -48,16 +48,20 @@ type finalizerEntry struct {
 	explicitEnv bool
 }
 
+// BDWGC may invoke a callback during an allocation made while mu is held, so
+// the callback queue must use an independent lock.
 var finalizerState struct {
-	once psync.Once
-	mu   psync.Mutex // protects m, head, and tail
-	m    map[uintptr]*finalizerEntry
-	head *finalizerEntry
-	tail *finalizerEntry
+	once    psync.Once
+	mu      psync.Mutex // protects m
+	queueMu psync.Mutex // protects head and tail
+	m       map[uintptr]*finalizerEntry
+	head    *finalizerEntry
+	tail    *finalizerEntry
 }
 
 func initFinalizerState() {
 	finalizerState.mu.Init(nil)
+	finalizerState.queueMu.Init(nil)
 	finalizerState.m = make(map[uintptr]*finalizerEntry)
 }
 
@@ -201,7 +205,7 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 	// releases its allocation lock before invoking client finalizers, including
 	// from its default allocation-time path, so serialize queue publication
 	// with concurrent drainers.
-	finalizerState.mu.Lock()
+	finalizerState.queueMu.Lock()
 	// Keep the object alive until runFinalizers invokes the Go finalizer. The
 	// mutex publishes these writes together with the queue entry.
 	if state == finalizerInterfaceState {
@@ -217,7 +221,7 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 		finalizerState.tail.next = entry
 		finalizerState.tail = entry
 	}
-	finalizerState.mu.Unlock()
+	finalizerState.queueMu.Unlock()
 }
 
 func restoreFinalizer(ptr unsafe.Pointer, entry *finalizerEntry) {
@@ -233,10 +237,10 @@ func restoreFinalizer(ptr unsafe.Pointer, entry *finalizerEntry) {
 func runFinalizers() {
 	finalizerState.once.Do(initFinalizerState)
 	for {
-		finalizerState.mu.Lock()
+		finalizerState.queueMu.Lock()
 		entry := finalizerState.head
 		if entry == nil {
-			finalizerState.mu.Unlock()
+			finalizerState.queueMu.Unlock()
 			return
 		}
 		finalizerState.head = entry.next
@@ -244,8 +248,11 @@ func runFinalizers() {
 			finalizerState.tail = nil
 		}
 		entry.next = nil
+		finalizerState.queueMu.Unlock()
+
 		// A later SetFinalizer may already have installed a replacement entry
 		// for the same object key; do not delete that newer entry.
+		finalizerState.mu.Lock()
 		if finalizerState.m[entry.key] == entry {
 			delete(finalizerState.m, entry.key)
 		}

--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -48,19 +48,17 @@ type finalizerEntry struct {
 	explicitEnv bool
 }
 
-// BDWGC may invoke a callback during an allocation made while mu is held, so
-// the callback queue must use an independent lock.
 var finalizerState struct {
-	once    psync.Once
-	mu      psync.Mutex // protects m
-	queueMu psync.Mutex // protects head and tail
-	m       map[uintptr]*finalizerEntry
-	head    *finalizerEntry
-	tail    *finalizerEntry
+	once       psync.Once
+	registryMu psync.Mutex // protects m
+	queueMu    psync.Mutex // protects queue state and callback argument publication
+	m          map[uintptr]*finalizerEntry
+	head       *finalizerEntry
+	tail       *finalizerEntry
 }
 
 func initFinalizerState() {
-	finalizerState.mu.Init(nil)
+	finalizerState.registryMu.Init(nil)
 	finalizerState.queueMu.Init(nil)
 	finalizerState.m = make(map[uintptr]*finalizerEntry)
 }
@@ -81,13 +79,13 @@ func SetFinalizer(obj any, finalizer any) {
 	finalizerState.once.Do(initFinalizerState)
 	key := hideFinalizerPtr(objPtr)
 
-	finalizerState.mu.Lock()
+	finalizerState.registryMu.Lock()
 	if old := finalizerState.m[key]; old != nil {
 		atomic.Store(&old.state, finalizerStopped)
 		delete(finalizerState.m, key)
 		restoreFinalizer(objPtr, old)
 	}
-	finalizerState.mu.Unlock()
+	finalizerState.registryMu.Unlock()
 
 	finalizerFace := (*eface)(unsafe.Pointer(&finalizer))
 	if finalizerFace._type == nil {
@@ -124,9 +122,9 @@ func SetFinalizer(obj any, finalizer any) {
 	entry.prevFn = oldFn
 	entry.prevCb = oldCb
 
-	finalizerState.mu.Lock()
+	finalizerState.registryMu.Lock()
 	finalizerState.m[key] = entry
-	finalizerState.mu.Unlock()
+	finalizerState.registryMu.Unlock()
 }
 
 func prepareFinalizerArgument(objType, argType *abi.Type) (*ffi.Type, unsafe.Pointer, bool) {
@@ -205,6 +203,8 @@ func setFinalizerCallback(ptr unsafe.Pointer, cb unsafe.Pointer) {
 	// releases its allocation lock before invoking client finalizers, including
 	// from its default allocation-time path, so serialize queue publication
 	// with concurrent drainers.
+	// Do not acquire registryMu here: this callback may run during an allocation
+	// made while registryMu is held.
 	finalizerState.queueMu.Lock()
 	// Keep the object alive until runFinalizers invokes the Go finalizer. The
 	// mutex publishes these writes together with the queue entry.
@@ -252,16 +252,18 @@ func runFinalizers() {
 
 		// A later SetFinalizer may already have installed a replacement entry
 		// for the same object key; do not delete that newer entry.
-		finalizerState.mu.Lock()
+		finalizerState.registryMu.Lock()
 		if finalizerState.m[entry.key] == entry {
 			delete(finalizerState.m, entry.key)
 		}
-		finalizerState.mu.Unlock()
+		finalizerState.registryMu.Unlock()
 
 		state := atomic.Load(&entry.state)
 		if state != finalizerStopped {
 			callFinalizer(entry, state == finalizerInterfaceState)
 		}
+		// A finalizerEntry is registered and dequeued at most once, so no
+		// callback can race this release of its retained argument.
 		entry.arg = nil
 	}
 }


### PR DESCRIPTION
## Problem

`runtime.SetFinalizer` and the BDWGC callback queue currently share one mutex. BDWGC may invoke a ready callback from an allocation while `SetFinalizer` holds that mutex, so the callback tries to acquire the same non-recursive lock. In `os/exec`, this can leave `Cmd.Start` blocked before its wait goroutine is created and leave the child as a zombie.

This was observed in the compatibility jobs as intermittent `test/goroot` timeouts. Native Linux reproductions stopped inside `runtime.SetFinalizer -> GC_malloc -> GC_invoke_finalizers -> setFinalizerCallback`.

## Fix

- keep the registration map under its existing mutex
- protect callback queue publication and removal with a separate mutex
- release the queue mutex before touching the registration map, so the two locks are never held together

This preserves concurrent finalizer queue serialization while making allocation-time callbacks independent of registration.

## Validation

- macOS arm64: finalizer tests, 5 repetitions
- macOS arm64: concurrent finalizer stress
- macOS arm64: `TestRunProgramTimeout`, 200 repetitions
- Linux arm64: concurrent finalizer stress
- Linux arm64: four concurrent `TestRunProgramTimeout` processes, 1000 repetitions each (4000 total)
- Linux amd64: four concurrent `TestRunProgramTimeout` processes, 1000 repetitions each (4000 total)

Before this fix, the same four-process stress hung 1/4 workers on Linux arm64 and 2/4 workers on Linux amd64. After the fix, all workers completed.
