### PR TITLE
build: pipeline multi-package tests through a DAG

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -531,7 +531,6 @@ jobs:
           LLGO_BUILD_CACHE: "1"
           LLGO_TEST_BENCH_GO126: "1"
           LLGO_TEST_CHECK_SYMBOLS: ${{ matrix.check_symbols && '1' || '0' }}
-          LLGO_TEST_JOBS: ${{ startsWith(matrix.os, 'windows') && '2' || startsWith(matrix.os, 'macos') && '3' || '4' }}
           LLGO_TEST_STD_BUILDMODES: ${{ matrix.std_buildmodes && '1' || '0' }}
           SHARD_INDEX: ${{ matrix.shard_index }}
           SHARD_TOTAL: ${{ matrix.shard_total }}

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -236,8 +236,8 @@ func AddBuildFlags(fs *flag.FlagSet) {
 }
 
 // AddBuildTraceFlag adds the build-scheduler trace flag. It is intentionally
-// separate from AddBuildFlags because only "llgo build" owns a single trace
-// output file; test and run may coordinate multiple child invocations.
+// separate from AddBuildFlags for commands that execute one traced build
+// invocation, currently "llgo build" and "llgo test".
 func AddBuildTraceFlag(fs *flag.FlagSet) {
 	BuildTrace = ""
 	fs.StringVar(&BuildTrace, "debug-trace", "", "Write a Chrome/Perfetto build-scheduler trace to file")

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -27,6 +27,7 @@ func init() {
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddCompilerVerboseFlag(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
+	flags.AddBuildTraceFlag(&Cmd.Flag)
 	flags.AddBuildModeFlags(&Cmd.Flag)
 	flags.AddTestFlags(&Cmd.Flag)
 	flags.AddTestBinaryFlags(&Cmd.Flag)
@@ -48,6 +49,7 @@ func runCmd(cmd *base.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}
+	conf.BuildTrace = flags.BuildTrace
 	if err := flags.ApplyGoBuildFlags(conf, goBuildFlags.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)

--- a/cmd/internal/test/test_test.go
+++ b/cmd/internal/test/test_test.go
@@ -10,12 +10,14 @@ import (
 )
 
 func TestBuildFlagsWiring(t *testing.T) {
-	if goBuildFlags.Flag != &Cmd.Flag || Cmd.Flag.Lookup("ldflags") == nil || Cmd.Flag.Lookup("buildmode") == nil {
+	if goBuildFlags.Flag != &Cmd.Flag || Cmd.Flag.Lookup("ldflags") == nil ||
+		Cmd.Flag.Lookup("buildmode") == nil || Cmd.Flag.Lookup("debug-trace") == nil {
 		t.Fatal("test build flags are not bound to the test command")
 	}
 }
 
 func resetTestFlags() {
+	flags.BuildTrace = ""
 	flags.Verbose = false
 	flags.TestRun = ""
 	flags.TestBench = ""

--- a/dev/test_go_version.sh
+++ b/dev/test_go_version.sh
@@ -190,7 +190,10 @@ echo "LLGo: ${llgo_cmd}"
 echo "Shard: ${shard_index}/${shard_total}; packages: ${#selected[@]}"
 printf '  %s\n' "${selected[@]}"
 
-test_flags=(-p="${LLGO_TEST_JOBS:-4}" -timeout="${LLGO_TEST_TIMEOUT:-20m}" -modfile="${modfile}")
+test_flags=(-timeout="${LLGO_TEST_TIMEOUT:-20m}" -modfile="${modfile}")
+if [[ -n "${LLGO_TEST_JOBS:-}" ]]; then
+	test_flags=(-p="${LLGO_TEST_JOBS}" "${test_flags[@]}")
+fi
 if [[ "${LLGO_TEST_COMPILE_ONLY:-}" == 1 ]]; then
 	test_flags+=(-run='^$')
 fi

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -37,6 +37,7 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
 
 	"github.com/xgo-dev/llgo/cl"
 	llabi "github.com/xgo-dev/llgo/internal/abi"
@@ -808,6 +809,7 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 		return nil, err
 	}
 	buildSSAPkgs(ctx, append(append(altEntries, pkgEntries...), depEntries...))
+	recordPackageSSAInstructions(ctx)
 	callerSpan := buildTrace.startCoordinator("precompute caller tracking", nil)
 	ctx.callerTracking.Precompute(ctx.progSSA.AllPackages())
 	callerSpan.done()
@@ -1604,14 +1606,25 @@ func buildAllPkgs(ctx *context, pkgs []*aPackage, verbose bool) ([]*aPackage, er
 	// Resolve the lazy Plan 9 policy before workers start.
 	_ = ctx.plan9asmEnabled("")
 
-	// Build non-runtime packages first, so we know whether runtime is actually needed.
+	// Host links always include runtime, so put ordinary and runtime packages in
+	// the same cost-ordered worker pool. This avoids making runtime wait behind
+	// the longest ordinary backend without adding another scheduling boundary.
+	if ctx.buildConf.Target == "" {
+		normalTasks = append(normalTasks, runtimeTasks...)
+		if err := buildPackageGroup(ctx, normalTasks, verbose); err != nil {
+			return nil, err
+		}
+		return pkgs, nil
+	}
+
+	// Cross builds still defer all runtime preparation until ordinary package
+	// results show it is needed; unused target runtimes must remain untouched.
 	if err := buildPackageGroup(ctx, normalTasks, verbose); err != nil {
 		return nil, err
 	}
 	needRuntime, needPyInit := packageRuntimeNeeds(normalTasks)
 
-	// Only build runtime packages when required (or host build with empty Target).
-	if needRuntime || needPyInit || ctx.buildConf.Target == "" {
+	if needRuntime || needPyInit {
 		if err := buildPackageGroup(ctx, runtimeTasks, verbose); err != nil {
 			return nil, err
 		}
@@ -3109,10 +3122,11 @@ func prepareLocalVariables(prog llssa.Program, groups ...[]*packages.Package) er
 }
 
 type ssaBuildEntry struct {
-	id       string
-	pkg      *ssa.Package
-	syntax   []*ast.File
-	fixOrder bool
+	id         string
+	pkg        *ssa.Package
+	syntax     []*ast.File
+	fixOrder   bool
+	complexity int64
 }
 
 func registerAltSSAPkgs(prog *ssa.Program, patches cl.Patches, alts []*packages.Package, conf *Config, verbose bool) []ssaBuildEntry {
@@ -3148,9 +3162,10 @@ type aPackage struct {
 	AltPkg *packages.Cached
 	LPkg   llssa.Package
 
-	NeedRt       bool
-	NeedPyInit   bool
-	linkSnapshot *packageLinkSnapshot
+	NeedRt          bool
+	NeedPyInit      bool
+	ssaInstructions int64
+	linkSnapshot    *packageLinkSnapshot
 
 	LinkArgs     []string
 	ObjFiles     []string               // file-backed archive members: .o or .ll
@@ -3239,6 +3254,9 @@ func buildSSAPkgs(ctx *context, entries []ssaBuildEntry) {
 	if len(entries) == 0 {
 		return
 	}
+	rankSpan := ctx.buildTrace.startCoordinator("rank SSA packages", map[string]any{
+		"entries": len(entries),
+	})
 	unique := make([]ssaBuildEntry, 0, len(entries))
 	index := make(map[*ssa.Package]int, len(entries))
 	for _, entry := range entries {
@@ -3250,8 +3268,21 @@ func buildSSAPkgs(ctx *context, entries []ssaBuildEntry) {
 			continue
 		}
 		index[entry.pkg] = len(unique)
+		entry.complexity = syntaxNodeCount(entry.syntax)
 		unique = append(unique, entry)
 	}
+	slices.SortStableFunc(unique, func(left, right ssaBuildEntry) int {
+		switch {
+		case left.complexity > right.complexity:
+			return -1
+		case left.complexity < right.complexity:
+			return 1
+		default:
+			return 0
+		}
+	})
+	rankSpan.setArg("packages", len(unique))
+	rankSpan.done()
 	jobs := make(chan ssaBuildEntry, len(unique))
 	var wg sync.WaitGroup
 	for range min(ctx.buildConf.parallelism(), len(unique)) {
@@ -3262,6 +3293,7 @@ func buildSSAPkgs(ctx *context, entries []ssaBuildEntry) {
 				pkgPath := entry.pkg.Pkg.Path()
 				traceSpan := ctx.buildTrace.startWorker("ssa", pkgPath)
 				traceSpan.setArg("package_id", entry.id)
+				traceSpan.setArg("syntax_nodes", entry.complexity)
 				func() {
 					defer traceSpan.done()
 					entry.pkg.Build()
@@ -3282,6 +3314,52 @@ func buildSSAPkgs(ctx *context, entries []ssaBuildEntry) {
 		}
 	}
 	repairSpan.done()
+}
+
+func syntaxNodeCount(files []*ast.File) (nodes int64) {
+	for _, file := range files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			if node != nil {
+				nodes++
+			}
+			return true
+		})
+	}
+	return
+}
+
+// recordPackageSSAInstructions makes backend ordering a single linear pass
+// over the SSA that was already built. It includes methods, wrappers, and
+// closures without repeating a whole-program reachability scan per package.
+func recordPackageSSAInstructions(ctx *context) {
+	if ctx == nil || ctx.progSSA == nil {
+		return
+	}
+	span := ctx.buildTrace.startCoordinator("count SSA instructions", nil)
+	defer span.done()
+	counts := make(map[*ssa.Package]int64)
+	var total int64
+	for fn := range ssautil.AllFunctions(ctx.progSSA) {
+		if fn == nil || fn.Pkg == nil {
+			continue
+		}
+		for _, block := range fn.Blocks {
+			instructions := int64(len(block.Instrs))
+			counts[fn.Pkg] += instructions
+			total += instructions
+		}
+	}
+	for _, pkg := range ctx.pkgs {
+		if pkg == nil {
+			continue
+		}
+		pkg.ssaInstructions = counts[pkg.SSA]
+		if pkg.AltPkg != nil && pkg.AltPkg.Types != nil {
+			pkg.ssaInstructions += counts[ctx.progSSA.Package(pkg.AltPkg.Types)]
+		}
+	}
+	span.setArg("packages", len(counts))
+	span.setArg("instructions", total)
 }
 
 func formatPackageError(err packages.Error, noColumn bool) string {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -174,9 +174,8 @@ type Config struct {
 	// go/packages. Callers use internal/goflags to parse supported compiler and
 	// linker semantics into typed Config fields before calling Do.
 	GoBuildFlags []string
-	// BuildParallelism is the package-build and test-run concurrency requested
-	// by Go's -p build flag. The two phases do not overlap. Zero uses the Go
-	// default, GOMAXPROCS.
+	// BuildParallelism is the package-build, test-link, and test-run concurrency
+	// requested by Go's -p build flag. Zero uses the Go default, GOMAXPROCS.
 	BuildParallelism int
 	// BuildTrace is an optional Chrome Trace Event JSON output path. Relative
 	// paths are resolved from the build invocation directory.
@@ -813,6 +812,41 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 
 	allPkgs := append([]*aPackage{}, pkgs...)
 	allPkgs = append(allPkgs, depPkgs...)
+	var nativeTestRoots []*packages.Package
+	if mode == ModeTest && !inv.compileOnly {
+		for _, pkg := range initial {
+			if needLink(pkg, mode) {
+				nativeTestRoots = append(nativeTestRoots, pkg)
+			}
+		}
+	}
+	if canUseNativeTestDAG(ctx, len(nativeTestRoots)) {
+		dagResult, buildErr := runNativeTestDAG(ctx, allPkgs, nativeTestRoots, conf, verbose)
+		fallback = nil
+		ctx.disposeBackendPrograms()
+		var errs []error
+		if buildErr != nil {
+			errs = append(errs, buildErr)
+		}
+		for index, result := range dagResult.links {
+			if result.err == nil {
+				continue
+			}
+			if inv.disableMultiFallback {
+				errs = append(errs, result.err)
+			} else {
+				errs = append(errs, fmt.Errorf("%s: %w", nativeTestRoots[index].PkgPath, result.err))
+			}
+		}
+		ctx.testFail = dagResult.tests.failed
+		if dagResult.tests.skipped != 0 {
+			fmt.Fprintf(os.Stderr, "FAIL\t%d package(s) skipped by -failfast\n", dagResult.tests.skipped)
+		}
+		if ctx.testFail {
+			mockable.Exit(1)
+		}
+		return allPkgs, errors.Join(errs...)
+	}
 	allPkgs, err = buildAllPkgs(ctx, allPkgs, verbose)
 	if err != nil {
 		return nil, err
@@ -827,10 +861,6 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 		return nil, fmt.Errorf("initial package not found")
 	}
 
-	// buildAllPkgs has already used the existing bounded package scheduler.
-	// Test-main linking still uses coordinator-owned state, so keep links
-	// sequential and collect only the finished native binaries for concurrent
-	// execution below.
 	linkMultiple := mode == ModeBuild && len(initial) > 1
 	var linkErrs []error
 	var testPrograms []testProgram
@@ -876,76 +906,132 @@ func useShadowStack(goarch string) bool {
 	return goarch == "wasm" || isEnvOn(llgoShadowStack, false)
 }
 
+type initialPackageLink struct {
+	pkg           *packages.Package
+	allPkgs       []*aPackage
+	conf          *Config
+	outFmts       *OutFmtDetails
+	plan          *mainLinkPlan
+	discardOutput bool
+}
+
 func linkInitialPackage(ctx *context, pkg *packages.Package, allPkgs []*aPackage, conf *Config, verbose, discardOutput bool) (*testProgram, error) {
+	link, err := prepareInitialPackageLink(ctx, pkg, allPkgs, conf, verbose, discardOutput)
+	if err != nil {
+		return nil, err
+	}
+	return executeInitialPackageLink(ctx, link, verbose, false)
+}
+
+func prepareInitialPackageLink(ctx *context, pkg *packages.Package, allPkgs []*aPackage, conf *Config, verbose, discardOutput bool) (*initialPackageLink, error) {
 	name := defaultExecutableName(pkg.PkgPath)
 	outFmts, err := buildOutFmts(name, conf, len(ctx.initial) > 1, &ctx.crossCompile)
 	if err != nil {
 		return nil, err
 	}
-	if discardOutput {
-		defer removeOutFmts(outFmts)
-	}
 	resolveOutputs(ctx.commands.dir, outFmts)
-	linkSpan := ctx.buildTrace.startCoordinator("link "+pkg.PkgPath, map[string]any{
+	prepareSpan := ctx.buildTrace.startCoordinator("prepare link "+pkg.PkgPath, map[string]any{
 		"package": pkg.PkgPath,
 		"output":  outFmts.Out,
 	})
-	err = linkMainPkg(ctx, pkg, allPkgs, outFmts.Out, verbose)
-	linkSpan.done()
+	plan, err := prepareMainLink(ctx, pkg, allPkgs, outFmts.Out, verbose)
+	prepareSpan.done()
+	if err != nil {
+		if discardOutput {
+			removeOutFmts(outFmts)
+		}
+		return nil, err
+	}
+	return &initialPackageLink{
+		pkg: pkg, allPkgs: allPkgs, conf: conf, outFmts: outFmts, plan: plan,
+		discardOutput: discardOutput,
+	}, nil
+}
+
+func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, worker bool) (*testProgram, error) {
+	if link.discardOutput {
+		defer removeOutFmts(link.outFmts)
+	}
+	var linkSpan *buildTraceSpan
+	if worker {
+		linkSpan = ctx.buildTrace.startWorker("link", link.pkg.PkgPath)
+	} else {
+		linkSpan = ctx.buildTrace.startCoordinator("link "+link.pkg.PkgPath, map[string]any{
+			"package": link.pkg.PkgPath,
+			"output":  link.outFmts.Out,
+		})
+	}
+	linkCtx := newLinkExecutionContext(ctx, link.plan)
+	err := func() error {
+		defer linkSpan.done()
+		if err := executeMainLink(linkCtx, link.plan, verbose); err != nil {
+			return err
+		}
+		if err := finalizeRuntimePCLN(linkCtx, link.outFmts, verbose); err != nil {
+			return err
+		}
+		return finalizeDarwinSizeExecutable(linkCtx, link.outFmts.Out, verbose)
+	}()
 	if err != nil {
 		return nil, err
 	}
-	if err := finalizeRuntimePCLN(ctx, outFmts, verbose); err != nil {
-		return nil, err
-	}
-	if err := finalizeDarwinSizeExecutable(ctx, outFmts.Out, verbose); err != nil {
-		return nil, err
-	}
-	if conf.Mode == ModeBuild && conf.SizeReport {
-		if err := reportBinarySize(outFmts.Out, conf.SizeFormat, conf.SizeLevel, allPkgs); err != nil {
+	if link.conf.Mode == ModeBuild && link.conf.SizeReport {
+		if err := reportBinarySize(link.outFmts.Out, link.conf.SizeFormat, link.conf.SizeLevel, link.allPkgs); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: size report failed: %v\n", err)
 		}
 	}
-	if ctx.buildConf.BuildMode == BuildModeCArchive || ctx.buildConf.BuildMode == BuildModeCShared {
-		libname := strings.TrimSuffix(filepath.Base(outFmts.Out), conf.AppExt)
-		headerPath := filepath.Join(filepath.Dir(outFmts.Out), libname) + ".h"
-		return nil, header.GenHeaderFile(ctx.prog, cHeaderPackages(allPkgs), libname, headerPath, verbose)
+	if linkCtx.buildConf.BuildMode == BuildModeCArchive || linkCtx.buildConf.BuildMode == BuildModeCShared {
+		libname := strings.TrimSuffix(filepath.Base(link.outFmts.Out), link.conf.AppExt)
+		headerPath := filepath.Join(filepath.Dir(link.outFmts.Out), libname) + ".h"
+		return nil, header.GenHeaderFile(linkCtx.prog, cHeaderPackages(link.allPkgs), libname, headerPath, verbose)
 	}
 
-	envMap := outFmts.ToEnvMap()
-	if conf.Target != "" {
-		if err := firmware.ConvertFormats(ctx.crossCompile.BinaryFormat, ctx.crossCompile.FormatDetail, envMap); err != nil {
+	envMap := link.outFmts.ToEnvMap()
+	if link.conf.Target != "" {
+		if err := firmware.ConvertFormats(linkCtx.crossCompile.BinaryFormat, linkCtx.crossCompile.FormatDetail, envMap); err != nil {
 			return nil, err
 		}
 	}
-	switch conf.Mode {
+	switch link.conf.Mode {
 	case ModeInstall:
-		if conf.Target != "" {
-			return nil, flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose)
+		if link.conf.Target != "" {
+			return nil, flash.FlashDevice(linkCtx.crossCompile.Device, envMap, linkCtx.buildConf.Port, verbose)
 		}
 	case ModeRun, ModeTest, ModeCmpTest:
-		if conf.Target == "" {
-			if conf.Mode == ModeTest {
+		if link.conf.Target == "" {
+			if link.conf.Mode == ModeTest {
 				return &testProgram{
-					app:     outFmts.Out,
-					pkgDir:  pkg.Dir,
-					pkgName: strings.TrimSuffix(pkg.PkgPath, ".test"),
+					app:     link.outFmts.Out,
+					pkgDir:  link.pkg.Dir,
+					pkgName: strings.TrimSuffix(link.pkg.PkgPath, ".test"),
 				}, nil
 			}
-			return nil, runNative(ctx, outFmts.Out, pkg.Dir, pkg.PkgPath, conf, conf.Mode)
+			return nil, runNative(linkCtx, link.outFmts.Out, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode)
 		}
-		if conf.Emulator {
-			return nil, runInEmulator(ctx.commands, ctx.crossCompile.Emulator, envMap, pkg.Dir, pkg.PkgPath, conf, conf.Mode, verbose)
+		if link.conf.Emulator {
+			return nil, runInEmulator(linkCtx.commands, linkCtx.crossCompile.Emulator, envMap, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode, verbose)
 		}
-		if err := flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose); err != nil {
+		if err := flash.FlashDevice(linkCtx.crossCompile.Device, envMap, linkCtx.buildConf.Port, verbose); err != nil {
 			return nil, err
 		}
 		return nil, monitor.Monitor(monitor.MonitorConfig{
-			Port: ctx.buildConf.Port, Target: conf.Target, Executable: outFmts.Out,
-			BaudRate: conf.BaudRate, SerialPort: ctx.crossCompile.Device.SerialPort,
+			Port: linkCtx.buildConf.Port, Target: link.conf.Target, Executable: link.outFmts.Out,
+			BaudRate: link.conf.BaudRate, SerialPort: linkCtx.crossCompile.Device.SerialPort,
 		}, verbose)
 	}
 	return nil, nil
+}
+
+func newLinkExecutionContext(ctx *context, plan *mainLinkPlan) *context {
+	return &context{
+		prog:                 ctx.prog,
+		mode:                 ctx.mode,
+		buildConf:            ctx.buildConf,
+		crossCompile:         ctx.crossCompile,
+		commands:             ctx.commands,
+		pclnExternal:         plan.pclnExternal,
+		stripDarwinLTOLocals: plan.stripDarwinLTOLocals,
+	}
 }
 
 func removeOutFmts(outFmts *OutFmtDetails) {
@@ -1732,7 +1818,23 @@ func rewritePrebuiltFuncTab(ctx *context, out string, verbose bool) {
 	}
 }
 
+type mainLinkPlan struct {
+	outputPath           string
+	linkInputs           []string
+	linkArgs             []string
+	pclnExternal         *pclnmap.Data
+	stripDarwinLTOLocals bool
+}
+
 func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPath string, verbose bool) error {
+	plan, err := prepareMainLink(ctx, pkg, pkgs, outputPath, verbose)
+	if err != nil {
+		return err
+	}
+	return executeMainLink(ctx, plan, verbose)
+}
+
+func prepareMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPath string, verbose bool) (*mainLinkPlan, error) {
 	ctx.pclnExternal = nil
 	ctx.stripDarwinLTOLocals = false
 	needRuntime := false
@@ -1796,11 +1898,11 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	}
 	packageInits, err := linkedPackageInitNames(pkg, linkedOrder)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	cExports, err := linkedCExports(ctx, linkedOrder)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	entryPkg := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
 		rtInit:        needRuntime,
@@ -1821,19 +1923,19 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	}
 	if ctx.buildConf.deadcodeDropEnabled() {
 		if err := applyDeadcodeDropOverrides(linkedOrder, entryPkg, needRuntime, verbose); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	entryObjFile, err := exportObject(ctx, "entry_main", entryPkg.ExportFile, entryPkg.LPkg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	linkInputs := []string{entryObjFile}
 
 	// Compile extra files from target configuration
 	extraObjFiles, err := compileExtraFiles(ctx, verbose)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	linkInputs = append(linkInputs, extraObjFiles...)
 	linkInputs = append(linkInputs, archiveInputs...)
@@ -1846,15 +1948,28 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	linkArgs = append(linkArgs, darwinSymbols.linkerArgs...)
 	ctx.stripDarwinLTOLocals = darwinSymbols.stripLTOLocals
 
-	linkOutput, err := prepareWasmLinkOutput(ctx.buildConf, &ctx.crossCompile, outputPath)
+	return &mainLinkPlan{
+		outputPath:           outputPath,
+		linkInputs:           linkInputs,
+		linkArgs:             linkArgs,
+		pclnExternal:         ctx.pclnExternal,
+		stripDarwinLTOLocals: darwinSymbols.stripLTOLocals,
+	}, nil
+}
+
+func executeMainLink(ctx *context, plan *mainLinkPlan, verbose bool) error {
+	if plan == nil {
+		return errors.New("missing main link plan")
+	}
+	linkOutput, err := prepareWasmLinkOutput(ctx.buildConf, &ctx.crossCompile, plan.outputPath)
 	if err != nil {
 		return err
 	}
-	defer cleanupWasmLinkOutput(linkOutput, outputPath)
-	if err := linkObjFiles(ctx, linkOutput, linkInputs, linkArgs, verbose); err != nil {
+	defer cleanupWasmLinkOutput(linkOutput, plan.outputPath)
+	if err := linkObjFiles(ctx, linkOutput, plan.linkInputs, plan.linkArgs, verbose); err != nil {
 		return err
 	}
-	return publishWasmLinkOutput(ctx, linkOutput, outputPath, verbose)
+	return publishWasmLinkOutput(ctx, linkOutput, plan.outputPath, verbose)
 }
 
 func fullRpathArgs(toolchain crosscompile.NativeToolchain, linkArgs []string) (rpathArgs []string) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -121,6 +121,8 @@ type OutFmtDetails struct {
 	Img  string // Image output file path (.img)
 	Uf2  string // UF2 output file path (.uf2)
 	Zip  string // ZIP/DFU output file path (.zip)
+
+	tempDir string // LLGo-owned directory removed with implicit test outputs
 }
 
 // ModuleHook observes a package module immediately after it is generated and
@@ -930,7 +932,7 @@ func prepareInitialPackageLink(ctx *context, pkg *packages.Package, allPkgs []*a
 		return nil, err
 	}
 	if err := buildInitialPackageEntry(ctx, link, verbose, false); err != nil {
-		if discardOutput {
+		if discardOutput || link.outFmts.tempDir != "" {
 			removeOutFmts(link.outFmts)
 		}
 		return nil, err
@@ -952,7 +954,7 @@ func planInitialPackageLink(ctx *context, pkg *packages.Package, allPkgs []*aPac
 	preparation, err := planMainLink(ctx, pkg, allPkgs)
 	prepareSpan.done()
 	if err != nil {
-		if discardOutput {
+		if discardOutput || outFmts.tempDir != "" {
 			removeOutFmts(outFmts)
 		}
 		return nil, err
@@ -998,9 +1000,12 @@ func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, 
 	// completed roots do not retain their metadata while other tests run.
 	plan := link.plan
 	link.plan = nil
-	if link.discardOutput {
-		defer removeOutFmts(link.outFmts)
-	}
+	cleanupTemp := link.outFmts.tempDir != ""
+	defer func() {
+		if link.discardOutput || cleanupTemp {
+			removeOutFmts(link.outFmts)
+		}
+	}()
 	var linkSpan *buildTraceSpan
 	if worker {
 		linkSpan = ctx.buildTrace.startWorker("link", link.pkg.PkgPath)
@@ -1049,11 +1054,16 @@ func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, 
 	case ModeRun, ModeTest, ModeCmpTest:
 		if link.conf.Target == "" {
 			if link.conf.Mode == ModeTest {
-				return &testProgram{
+				program := &testProgram{
 					app:     link.outFmts.Out,
 					pkgDir:  link.pkg.Dir,
 					pkgName: strings.TrimSuffix(link.pkg.PkgPath, ".test"),
-				}, nil
+				}
+				if cleanupTemp {
+					program.temporaryOutputs = link.outFmts
+					cleanupTemp = false // runNativeTest now owns the temporary output.
+				}
+				return program, nil
 			}
 			return nil, runNative(linkCtx, link.outFmts.Out, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode)
 		}
@@ -1084,6 +1094,15 @@ func newLinkExecutionContext(ctx *context, plan *mainLinkPlan) *context {
 }
 
 func removeOutFmts(outFmts *OutFmtDetails) {
+	if outFmts == nil {
+		return
+	}
+	if outFmts.tempDir != "" {
+		// tempDir comes only from os.MkdirTemp in buildOutFmts and contains all
+		// intermediate sidecars as well as the final test executable.
+		_ = os.RemoveAll(outFmts.tempDir)
+		return
+	}
 	for _, output := range []string{
 		outFmts.Out, outFmts.PCLN, outFmts.Bin, outFmts.Hex,
 		outFmts.Img, outFmts.Uf2, outFmts.Zip,
@@ -1351,7 +1370,14 @@ func (c *context) backendAbiTypes(pkgs []Package) []llssa.AbiTypeInfo {
 	seen := make(map[llssa.Program]none)
 	var infos []llssa.AbiTypeInfo
 	for _, pkg := range pkgs {
-		if pkg == nil || pkg.LPkg == nil {
+		if pkg == nil {
+			continue
+		}
+		if pkg.linkSnapshot != nil {
+			infos = append(infos, pkg.linkSnapshot.abiTypes...)
+			continue
+		}
+		if pkg.LPkg == nil {
 			continue
 		}
 		prog := pkg.LPkg.Prog
@@ -1876,9 +1902,10 @@ type mainLinkPlan struct {
 }
 
 // mainLinkPreparation separates shared package inspection from entry-module
-// emission. planMainLink runs on the coordinator because linkedOrder contains
-// LLVM-owned packages shared by several roots. Every other field is a Go-owned
-// snapshot and must remain safe to consume after those Programs are disposed.
+// emission. planMainLink runs on the coordinator because linkedOrder may still
+// contain packages owned by the shared coordinator Program. Every other field
+// is a Go-owned snapshot and must remain safe to consume after isolated package
+// Programs are disposed.
 // linkedOrder is kept only for the coordinator-only dead-code-drop path; the
 // native test DAG is disabled when that mode is active, so its workers must
 // never dereference linkedOrder.
@@ -1906,9 +1933,9 @@ func prepareMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage, outp
 	return buildMainLink(ctx, pkg, preparation, outputPath, verbose)
 }
 
-// planMainLink snapshots all package-owned state needed to generate an entry
-// module. Native test DAG callers must invoke it as a coordinator node before
-// releasing the linked package Programs.
+// planMainLink combines package-owned snapshots into the state needed to
+// generate one entry module. Native test DAG callers invoke it on the
+// coordinator; isolated package Programs may already have been disposed.
 func planMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage) (*mainLinkPreparation, error) {
 	needRuntime := false
 	needPyInit := false
@@ -1940,12 +1967,22 @@ func planMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage) (*mainL
 		need1, need2 := aPkg.isNeedRuntimeOrPyInit()
 		needRuntime = needRuntime || need1
 		needPyInit = needPyInit || need2
-		needAbiInit |= aPkg.LPkg.NeedAbiInit
-		for k, _ := range aPkg.LPkg.MethodByIndex {
-			methodByIndex[k] = none{}
-		}
-		for k, _ := range aPkg.LPkg.MethodByName {
-			methodByName[k] = none{}
+		if snapshot := aPkg.linkSnapshot; snapshot != nil {
+			needAbiInit |= snapshot.needAbiInit
+			for k := range snapshot.methodByIndex {
+				methodByIndex[k] = none{}
+			}
+			for k := range snapshot.methodByName {
+				methodByName[k] = none{}
+			}
+		} else {
+			needAbiInit |= aPkg.LPkg.NeedAbiInit
+			for k := range aPkg.LPkg.MethodByIndex {
+				methodByIndex[k] = none{}
+			}
+			for k := range aPkg.LPkg.MethodByName {
+				methodByName[k] = none{}
+			}
 		}
 
 		linkArgs = append(linkArgs, aPkg.LinkArgs...)
@@ -2192,7 +2229,16 @@ func linkedModuleGlobals(pkgs []Package) map[string]none {
 	}
 	seen := make(map[string]none)
 	for _, pkg := range pkgs {
-		if pkg == nil || pkg.LPkg == nil {
+		if pkg == nil {
+			continue
+		}
+		if pkg.linkSnapshot != nil {
+			for name := range pkg.linkSnapshot.abiSymbols {
+				seen[name] = none{}
+			}
+			continue
+		}
+		if pkg.LPkg == nil {
 			continue
 		}
 		for g := pkg.LPkg.Module().FirstGlobal(); !g.IsNil(); g = gllvm.NextGlobal(g) {
@@ -3102,8 +3148,9 @@ type aPackage struct {
 	AltPkg *packages.Cached
 	LPkg   llssa.Package
 
-	NeedRt     bool
-	NeedPyInit bool
+	NeedRt       bool
+	NeedPyInit   bool
+	linkSnapshot *packageLinkSnapshot
 
 	LinkArgs     []string
 	ObjFiles     []string               // file-backed archive members: .o or .ll

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -911,6 +911,7 @@ type initialPackageLink struct {
 	allPkgs       []*aPackage
 	conf          *Config
 	outFmts       *OutFmtDetails
+	preparation   *mainLinkPreparation
 	plan          *mainLinkPlan
 	discardOutput bool
 }
@@ -924,17 +925,31 @@ func linkInitialPackage(ctx *context, pkg *packages.Package, allPkgs []*aPackage
 }
 
 func prepareInitialPackageLink(ctx *context, pkg *packages.Package, allPkgs []*aPackage, conf *Config, verbose, discardOutput bool) (*initialPackageLink, error) {
+	link, err := planInitialPackageLink(ctx, pkg, allPkgs, conf, discardOutput)
+	if err != nil {
+		return nil, err
+	}
+	if err := buildInitialPackageEntry(ctx, link, verbose, false); err != nil {
+		if discardOutput {
+			removeOutFmts(link.outFmts)
+		}
+		return nil, err
+	}
+	return link, nil
+}
+
+func planInitialPackageLink(ctx *context, pkg *packages.Package, allPkgs []*aPackage, conf *Config, discardOutput bool) (*initialPackageLink, error) {
 	name := defaultExecutableName(pkg.PkgPath)
 	outFmts, err := buildOutFmts(name, conf, len(ctx.initial) > 1, &ctx.crossCompile)
 	if err != nil {
 		return nil, err
 	}
 	resolveOutputs(ctx.commands.dir, outFmts)
-	prepareSpan := ctx.buildTrace.startCoordinator("prepare link "+pkg.PkgPath, map[string]any{
+	prepareSpan := ctx.buildTrace.startCoordinator("plan link "+pkg.PkgPath, map[string]any{
 		"package": pkg.PkgPath,
 		"output":  outFmts.Out,
 	})
-	plan, err := prepareMainLink(ctx, pkg, allPkgs, outFmts.Out, verbose)
+	preparation, err := planMainLink(ctx, pkg, allPkgs)
 	prepareSpan.done()
 	if err != nil {
 		if discardOutput {
@@ -943,12 +958,46 @@ func prepareInitialPackageLink(ctx *context, pkg *packages.Package, allPkgs []*a
 		return nil, err
 	}
 	return &initialPackageLink{
-		pkg: pkg, allPkgs: allPkgs, conf: conf, outFmts: outFmts, plan: plan,
+		pkg: pkg, allPkgs: allPkgs, conf: conf, outFmts: outFmts, preparation: preparation,
 		discardOutput: discardOutput,
 	}, nil
 }
 
+func buildInitialPackageEntry(ctx *context, link *initialPackageLink, verbose, worker bool) error {
+	// The preparation can contain full-program PCLN snapshots. Transfer it to
+	// this phase so the DAG does not retain one snapshot per root during tests.
+	preparation := link.preparation
+	link.preparation = nil
+	entryCtx := ctx
+	var entrySpan *buildTraceSpan
+	if worker {
+		if ctx.buildConf.deadcodeDropEnabled() {
+			return errors.New("parallel entry generation does not support dead-code drop")
+		}
+		session := ctx.newBackendSession()
+		defer session.prog.Dispose()
+		entryCtx = ctx.newBackendTask(session)
+		entrySpan = ctx.buildTrace.startWorker("entry-object", link.pkg.PkgPath)
+		entrySpan.setArg("output", link.outFmts.Out)
+	} else {
+		entrySpan = ctx.buildTrace.startCoordinator("entry object "+link.pkg.PkgPath, map[string]any{
+			"package": link.pkg.PkgPath,
+			"output":  link.outFmts.Out,
+		})
+	}
+	plan, err := buildMainLink(entryCtx, link.pkg, preparation, link.outFmts.Out, verbose)
+	entrySpan.done()
+	if err == nil {
+		link.plan = plan
+	}
+	return err
+}
+
 func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, worker bool) (*testProgram, error) {
+	// PCLN finalization is the last consumer of the link plan. Keep it local so
+	// completed roots do not retain their metadata while other tests run.
+	plan := link.plan
+	link.plan = nil
 	if link.discardOutput {
 		defer removeOutFmts(link.outFmts)
 	}
@@ -961,10 +1010,10 @@ func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, 
 			"output":  link.outFmts.Out,
 		})
 	}
-	linkCtx := newLinkExecutionContext(ctx, link.plan)
+	linkCtx := newLinkExecutionContext(ctx, plan)
 	err := func() error {
 		defer linkSpan.done()
-		if err := executeMainLink(linkCtx, link.plan, verbose); err != nil {
+		if err := executeMainLink(linkCtx, plan, verbose); err != nil {
 			return err
 		}
 		if err := finalizeRuntimePCLN(linkCtx, link.outFmts, verbose); err != nil {
@@ -1294,10 +1343,10 @@ type context struct {
 	buildTrace *buildTracer
 }
 
-// backendAbiTypes returns Go-owned type identities from isolated Programs in
-// stable linked-package order. The Programs remain alive while the entry
-// module recreates target-local declarations, but no LLVM value crosses a
-// Context boundary.
+// backendAbiTypes snapshots Go-owned type identities from isolated Programs
+// in stable linked-package order. Entry generation may consume the result in
+// another Program after the source Programs have been disposed; no LLVM value
+// may cross that ownership boundary.
 func (c *context) backendAbiTypes(pkgs []Package) []llssa.AbiTypeInfo {
 	seen := make(map[llssa.Program]none)
 	var infos []llssa.AbiTypeInfo
@@ -1826,6 +1875,21 @@ type mainLinkPlan struct {
 	stripDarwinLTOLocals bool
 }
 
+// mainLinkPreparation separates shared package inspection from entry-module
+// emission. planMainLink runs on the coordinator because linkedOrder contains
+// LLVM-owned packages shared by several roots. Every other field is a Go-owned
+// snapshot and must remain safe to consume after those Programs are disposed.
+// linkedOrder is kept only for the coordinator-only dead-code-drop path; the
+// native test DAG is disabled when that mode is active, so its workers must
+// never dereference linkedOrder.
+type mainLinkPreparation struct {
+	linkedOrder          []*aPackage
+	archiveInputs        []string
+	linkArgs             []string
+	gen                  genConfig
+	stripDarwinLTOLocals bool
+}
+
 func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPath string, verbose bool) error {
 	plan, err := prepareMainLink(ctx, pkg, pkgs, outputPath, verbose)
 	if err != nil {
@@ -1835,8 +1899,17 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 }
 
 func prepareMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPath string, verbose bool) (*mainLinkPlan, error) {
-	ctx.pclnExternal = nil
-	ctx.stripDarwinLTOLocals = false
+	preparation, err := planMainLink(ctx, pkg, pkgs)
+	if err != nil {
+		return nil, err
+	}
+	return buildMainLink(ctx, pkg, preparation, outputPath, verbose)
+}
+
+// planMainLink snapshots all package-owned state needed to generate an entry
+// module. Native test DAG callers must invoke it as a coordinator node before
+// releasing the linked package Programs.
+func planMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage) (*mainLinkPreparation, error) {
 	needRuntime := false
 	needPyInit := false
 	var needAbiInit int
@@ -1904,7 +1977,7 @@ func prepareMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage, outp
 	if err != nil {
 		return nil, err
 	}
-	entryPkg := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
+	gen := genConfig{
 		rtInit:        needRuntime,
 		pyInit:        needPyInit,
 		abiInit:       needAbiInit,
@@ -1916,13 +1989,40 @@ func prepareMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage, outp
 		funcInfo:      funcInfo,
 		pcLineInfo:    pcLineInfo,
 		cExports:      cExports,
-	})
+	}
+
+	if IsFullRpathEnabled() {
+		linkArgs = append(linkArgs, fullRpathArgs(ctx.crossCompile.Toolchain, linkArgs)...)
+	}
+	linkArgs = append(linkArgs, cSharedExportArgs(ctx, linkedOrder)...)
+	darwinSymbols := planDarwinSizeSymbols(ctx, linkedOrder, linkArgs)
+	linkArgs = append(linkArgs, darwinSymbols.linkerArgs...)
+
+	return &mainLinkPreparation{
+		linkedOrder:          linkedOrder,
+		archiveInputs:        archiveInputs,
+		linkArgs:             linkArgs,
+		gen:                  gen,
+		stripDarwinLTOLocals: darwinSymbols.stripLTOLocals,
+	}, nil
+}
+
+// buildMainLink consumes the LLVM-free portion of preparation. It may run in
+// an isolated backend Program after the package Programs have been released.
+func buildMainLink(ctx *context, pkg *packages.Package, preparation *mainLinkPreparation, outputPath string, verbose bool) (*mainLinkPlan, error) {
+	if preparation == nil {
+		return nil, errors.New("missing main link preparation")
+	}
+	ctx.pclnExternal = nil
+	ctx.stripDarwinLTOLocals = false
+	entryPkg := genMainModule(ctx, llssa.PkgRuntime, pkg, &preparation.gen)
+	cExports := preparation.gen.cExports
 	if len(cExports) != 0 {
 		llabi.LowerLargeAggregates(ctx.prog.TargetData(), entryPkg.LPkg.Module())
 		ctx.cTransformer.TransformModule(entryPkg.LPkg.Path(), entryPkg.LPkg.Module())
 	}
 	if ctx.buildConf.deadcodeDropEnabled() {
-		if err := applyDeadcodeDropOverrides(linkedOrder, entryPkg, needRuntime, verbose); err != nil {
+		if err := applyDeadcodeDropOverrides(preparation.linkedOrder, entryPkg, preparation.gen.rtInit, verbose); err != nil {
 			return nil, err
 		}
 	}
@@ -1938,22 +2038,15 @@ func prepareMainLink(ctx *context, pkg *packages.Package, pkgs []*aPackage, outp
 		return nil, err
 	}
 	linkInputs = append(linkInputs, extraObjFiles...)
-	linkInputs = append(linkInputs, archiveInputs...)
-
-	if IsFullRpathEnabled() {
-		linkArgs = append(linkArgs, fullRpathArgs(ctx.crossCompile.Toolchain, linkArgs)...)
-	}
-	linkArgs = append(linkArgs, cSharedExportArgs(ctx, linkedOrder)...)
-	darwinSymbols := planDarwinSizeSymbols(ctx, linkedOrder, linkArgs)
-	linkArgs = append(linkArgs, darwinSymbols.linkerArgs...)
-	ctx.stripDarwinLTOLocals = darwinSymbols.stripLTOLocals
+	linkInputs = append(linkInputs, preparation.archiveInputs...)
+	ctx.stripDarwinLTOLocals = preparation.stripDarwinLTOLocals
 
 	return &mainLinkPlan{
 		outputPath:           outputPath,
 		linkInputs:           linkInputs,
-		linkArgs:             linkArgs,
+		linkArgs:             preparation.linkArgs,
 		pclnExternal:         ctx.pclnExternal,
-		stripDarwinLTOLocals: darwinSymbols.stripLTOLocals,
+		stripDarwinLTOLocals: preparation.stripDarwinLTOLocals,
 	}, nil
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1038,6 +1038,13 @@ func TestIsFuncInfoEnabled(t *testing.T) {
 }
 
 func TestLinkedModuleGlobalsSkipsDeclarations(t *testing.T) {
+	if got := linkedModuleGlobals(nil); got != nil {
+		t.Fatalf("empty linked globals = %#v, want nil", got)
+	}
+	if got := linkedModuleGlobals([]Package{&aPackage{}}); len(got) != 0 {
+		t.Fatalf("backend-free linked globals = %#v, want empty", got)
+	}
+
 	prog := llssa.NewProgram(nil)
 	lpkg := prog.NewPackage("example.com/p", "example.com/p")
 	mod := lpkg.Module()

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1142,6 +1142,23 @@ func TestExtest(t *testing.T) {
 	}
 }
 
+func TestExtestNativeTestDAG(t *testing.T) {
+	mockRun([]string{"../../cl/_testgo/runextest/..."}, &Config{Mode: ModeTest, BuildParallelism: 2})
+}
+
+func TestExtestNativeTestDAGFailFast(t *testing.T) {
+	mockRun([]string{"../../cl/_testgo/runextest/..."}, &Config{
+		Mode:              ModeTest,
+		BuildParallelism:  2,
+		RunArgs:           []string{"-test.not-a-real-flag"},
+		TestRunSequential: true,
+		TestFailFast:      true,
+	})
+	if got := mockable.ExitCode(); got != 1 {
+		t.Fatalf("mocked exit code = %d, want 1", got)
+	}
+}
+
 func TestCmpTest(t *testing.T) {
 	mockRun([]string{"../../cl/_testgo/runtest"}, &Config{Mode: ModeCmpTest})
 }

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -2065,6 +2065,21 @@ func TestDevLTOGlobalDCEDefaultsToFullLTO(t *testing.T) {
 	}
 }
 
+func TestDevLTOGlobalDCERejectsParallelDeadcodeEntry(t *testing.T) {
+	if !buildenv.Dev {
+		t.Skip("deadcode drop requires a development build")
+	}
+	ctx := &context{buildConf: &Config{DeadcodeDrop: true}}
+	link := &initialPackageLink{preparation: &mainLinkPreparation{}}
+	if err := buildInitialPackageEntry(ctx, link, false, true); err == nil ||
+		!strings.Contains(err.Error(), "does not support dead-code drop") {
+		t.Fatalf("parallel deadcode entry error = %v", err)
+	}
+	if link.preparation != nil {
+		t.Fatal("failed entry retained its consumed preparation")
+	}
+}
+
 func TestDeadcodeDropEnabled(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/build/funcinfo_table.go
+++ b/internal/build/funcinfo_table.go
@@ -82,10 +82,16 @@ type funcInfoSymbolIndexRecord struct {
 func collectFuncInfo(pkgs []Package) []funcInfoRecord {
 	seen := make(map[string]funcInfoRecord)
 	for _, pkg := range pkgs {
-		if pkg == nil || pkg.LPkg == nil {
+		if pkg == nil {
 			continue
 		}
-		for _, rec := range readFuncInfo(pkg.LPkg.Module()) {
+		var records []funcInfoRecord
+		if pkg.linkSnapshot != nil {
+			records = pkg.linkSnapshot.funcInfo
+		} else if pkg.LPkg != nil {
+			records = readFuncInfo(pkg.LPkg.Module())
+		}
+		for _, rec := range records {
 			if rec.symbol == "" {
 				continue
 			}
@@ -111,10 +117,16 @@ func collectPCLineInfo(pkgs []Package) []pcLineRecord {
 	var out []pcLineRecord
 	seen := make(map[uint64]none)
 	for _, pkg := range pkgs {
-		if pkg == nil || pkg.LPkg == nil {
+		if pkg == nil {
 			continue
 		}
-		for _, rec := range readPCLineInfo(pkg.LPkg.Module()) {
+		var records []pcLineRecord
+		if pkg.linkSnapshot != nil {
+			records = pkg.linkSnapshot.pcLineInfo
+		} else if pkg.LPkg != nil {
+			records = readPCLineInfo(pkg.LPkg.Module())
+		}
+		for _, rec := range records {
 			if rec.id == 0 || rec.symbol == "" {
 				continue
 			}

--- a/internal/build/macho_size.go
+++ b/internal/build/macho_size.go
@@ -106,8 +106,13 @@ func mainPackageHasExports(pkgs []*aPackage) bool {
 		// package. Runtime and standard-library //export callbacks are static
 		// implementation links and must not turn every Go symbol into a dyld
 		// export.
-		if pkg != nil && pkg.Package != nil && pkg.Name == "main" && hasLocalCExports(pkg.LPkg) {
-			return true
+		if pkg != nil && pkg.Package != nil && pkg.Name == "main" {
+			if pkg.linkSnapshot != nil && pkg.linkSnapshot.hasLocalExports {
+				return true
+			}
+			if pkg.LPkg != nil && hasLocalCExports(pkg.LPkg) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -7,6 +7,7 @@ import (
 	"go/constant"
 	"go/token"
 	"go/types"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -262,6 +263,31 @@ func TestLinkMainPkgRejectsPackageInitCycle(t *testing.T) {
 	}
 	if err := linkMainPkg(ctx, cycle, nil, "", false); err == nil || !strings.Contains(err.Error(), "contains a cycle") {
 		t.Fatalf("linkMainPkg cycle error = %v, want cycle error", err)
+	}
+}
+
+func TestPrepareMainLinkBuildsEntryPlan(t *testing.T) {
+	llvm.InitializeAllTargets()
+	prog := llssa.NewProgram(nil)
+	defer prog.Dispose()
+	ctx := &context{
+		prog: prog,
+		buildConf: &Config{
+			BuildMode: BuildModeExe,
+			Goos:      runtime.GOOS,
+			Goarch:    runtime.GOARCH,
+		},
+		pkgs:    make(map[*packages.Package]Package),
+		pkgByID: make(map[string]Package),
+	}
+	pkg := &packages.Package{ID: "example.com/main", PkgPath: "example.com/main"}
+	plan, err := prepareMainLink(ctx, pkg, nil, "main.out", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeFiles(plan.linkInputs)
+	if plan.outputPath != "main.out" || len(plan.linkInputs) == 0 {
+		t.Fatalf("link plan = %+v", plan)
 	}
 }
 

--- a/internal/build/outputs.go
+++ b/internal/build/outputs.go
@@ -182,10 +182,23 @@ func buildOutFmts(pkgName string, conf *Config, multiPkg bool, crossCompile *cro
 
 	// Determine base name and directory
 	baseName, dir := determineBaseNameAndDir(pkgName, conf, multiPkg)
+	if conf.Target == "" && conf.Mode == ModeTest && !conf.CompileOnly && conf.OutFile == "" {
+		// codesign examines an executable's parent directory while deciding
+		// whether it belongs to a bundle. Keep each implicit test binary in a
+		// small LLGo-owned directory instead of making every link scan the shared
+		// system temp directory. The directory is removed after the test runs.
+		var err error
+		details.tempDir, err = os.MkdirTemp("", "llgo-test-*")
+		if err != nil {
+			return nil, err
+		}
+		dir = details.tempDir
+	}
 
 	// Build output path
 	outputPath, err := buildOutputPath(baseName, dir, conf, multiPkg, conf.AppExt)
 	if err != nil {
+		removeOutFmts(details)
 		return nil, err
 	}
 	details.Out = outputPath

--- a/internal/build/outputs_test.go
+++ b/internal/build/outputs_test.go
@@ -4,6 +4,7 @@
 package build
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,27 @@ import (
 	"github.com/xgo-dev/llgo/internal/crosscompile"
 	"github.com/xgo-dev/llgo/internal/flash"
 )
+
+func TestBuildOutFmtsIsolatesImplicitNativeTestOutput(t *testing.T) {
+	details, err := buildOutFmts("example.test", &Config{
+		Mode: ModeTest, BuildMode: BuildModeExe,
+	}, false, &crosscompile.Export{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { removeOutFmts(details) })
+	if details.tempDir == "" || filepath.Dir(details.Out) != details.tempDir {
+		t.Fatalf("output %q is not isolated in temp directory %q", details.Out, details.tempDir)
+	}
+	if err := os.WriteFile(filepath.Join(details.tempDir, ".link-sidecar"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tempDir := details.tempDir
+	removeOutFmts(details)
+	if _, err := os.Stat(tempDir); !os.IsNotExist(err) {
+		t.Fatalf("temporary output directory still exists: %v", err)
+	}
+}
 
 func TestWebAssemblyTargetDefaultExtension(t *testing.T) {
 	for _, target := range []string{"emscripten", "emscripten-memory64", "wasm"} {

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -283,6 +283,21 @@ func (ctx *context) executeIsolatedPackage(task *packageBuildTask, verbose bool)
 	return nil
 }
 
+// disposeBackendPackage releases an isolated package Program after the last
+// coordinator link plan has copied its whole-program metadata. Entry-module
+// workers consume only that Go-owned snapshot, object paths, and link args.
+func (ctx *context) disposeBackendPackage(pkg *aPackage) {
+	if pkg == nil || pkg.LPkg == nil {
+		return
+	}
+	prog := pkg.LPkg.Prog
+	if prog == nil || prog == ctx.prog {
+		return
+	}
+	pkg.LPkg = nil
+	prog.Dispose()
+}
+
 func (ctx *context) newBackendTask(session backendSession) *context {
 	// preparePackageBuilds populated every task's SFiles and LLGoFiles entries
 	// before workers start. Backend tasks share those maps read-only; a frozen

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -94,13 +94,28 @@ func buildPackageGroup(ctx *context, tasks []*packageBuildTask, verbose bool) er
 	if len(tasks) == 0 {
 		return nil
 	}
+	isolated, err := preparePackageGroup(ctx, tasks, verbose)
+	if err != nil {
+		return err
+	}
+	return runBoundedPackageJobs(ctx.buildConf.parallelism(), isolated, func(index int) error {
+		return tracePackageBuild(ctx, tasks[index], verbose, true, true)
+	})
+}
+
+// preparePackageGroup completes coordinator-only preparation and package
+// builds, returning the indexes whose isolated backends may run concurrently.
+func preparePackageGroup(ctx *context, tasks []*packageBuildTask, verbose bool) ([]int, error) {
+	if len(tasks) == 0 {
+		return nil, nil
+	}
 	prepareSpan := ctx.buildTrace.startCoordinator("prepare packages", map[string]any{
 		"count":   len(tasks),
 		"runtime": tasks[0].isRuntime(),
 	})
 	if err := preparePackageBuilds(ctx, tasks, verbose); err != nil {
 		prepareSpan.done()
-		return err
+		return nil, err
 	}
 	prepareSpan.done()
 
@@ -116,15 +131,10 @@ func buildPackageGroup(ctx *context, tasks []*packageBuildTask, verbose bool) er
 			continue
 		}
 		if err := tracePackageBuild(ctx, task, verbose, task.isolated, false); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	if err := runBoundedPackageJobs(ctx.buildConf.parallelism(), isolated, func(index int) error {
-		return tracePackageBuild(ctx, tasks[index], verbose, true, true)
-	}); err != nil {
-		return err
-	}
-	return nil
+	return isolated, nil
 }
 
 func tracePackageBuild(ctx *context, task *packageBuildTask, verbose, isolated, worker bool) (err error) {

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -120,7 +120,7 @@ func buildPackageGroup(ctx *context, tasks []*packageBuildTask, verbose bool) er
 }
 
 // preparePackageGroup completes coordinator-only preparation and package
-// builds, returning the indexes whose isolated backends may run concurrently.
+// builds, returning the indexes whose backends are eligible for worker execution.
 func preparePackageGroup(ctx *context, tasks []*packageBuildTask, verbose bool) ([]int, error) {
 	if len(tasks) == 0 {
 		return nil, nil

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/xgo-dev/llgo/cl"
@@ -41,21 +42,45 @@ type packageLinkSnapshot struct {
 }
 
 type packageBuildTask struct {
-	pkg       *aPackage
-	kind      int
-	kindParam string
-	skip      bool
-	isolated  bool
-	parallel  bool
+	pkg             *aPackage
+	kind            int
+	kindParam       string
+	ssaInstructions int64
+	skip            bool
+	isolated        bool
+	parallel        bool
 }
 
 func newPackageBuildTask(pkg *aPackage) *packageBuildTask {
 	kind, kindParam := cl.PkgKindOf(pkg.Types)
 	return &packageBuildTask{
-		pkg:       pkg,
-		kind:      kind,
-		kindParam: kindParam,
+		pkg:             pkg,
+		kind:            kind,
+		kindParam:       kindParam,
+		ssaInstructions: pkg.ssaInstructions,
 	}
+}
+
+func (task *packageBuildTask) estimatedBackendCost() int64 {
+	if task.skip || task.pkg.CacheHit {
+		return 0
+	}
+	return task.ssaInstructions
+}
+
+func sortPackageIndexesByEstimatedCost(tasks []*packageBuildTask, indexes []int) {
+	slices.SortStableFunc(indexes, func(left, right int) int {
+		leftCost := tasks[left].estimatedBackendCost()
+		rightCost := tasks[right].estimatedBackendCost()
+		switch {
+		case leftCost > rightCost:
+			return -1
+		case leftCost < rightCost:
+			return 1
+		default:
+			return 0
+		}
+	})
 }
 
 func (t *packageBuildTask) isRuntime() bool {
@@ -150,6 +175,7 @@ func preparePackageGroup(ctx *context, tasks []*packageBuildTask, verbose bool) 
 			return nil, err
 		}
 	}
+	sortPackageIndexesByEstimatedCost(tasks, isolated)
 	return isolated, nil
 }
 
@@ -168,6 +194,7 @@ func tracePackageBuild(ctx *context, task *packageBuildTask, verbose, isolated, 
 	traceSpan.setArg("package_id", task.pkg.ID)
 	traceSpan.setArg("class", class)
 	traceSpan.setArg("archive_publication", !task.pkg.CacheHit)
+	traceSpan.setArg("ssa_instructions", task.ssaInstructions)
 	ctx.buildTrace.flowFromSSA(task.pkg.ID, traceSpan)
 	defer traceSpan.done()
 	return buildPackage(ctx, task, verbose, isolated)

--- a/internal/build/package_build.go
+++ b/internal/build/package_build.go
@@ -22,7 +22,23 @@ import (
 
 	"github.com/xgo-dev/llgo/cl"
 	"github.com/xgo-dev/llgo/internal/packages"
+	llssa "github.com/xgo-dev/llgo/ssa"
 )
+
+// packageLinkSnapshot is the LLVM-free part of an isolated package needed by
+// later root link plans. Keeping it on aPackage lets the package worker destroy
+// its Program immediately instead of extending that Program's lifetime to the
+// last root that imports it.
+type packageLinkSnapshot struct {
+	needAbiInit     int
+	methodByIndex   map[int]none
+	methodByName    map[string]none
+	abiSymbols      map[string]none
+	abiTypes        []llssa.AbiTypeInfo
+	funcInfo        []funcInfoRecord
+	pcLineInfo      []pcLineRecord
+	hasLocalExports bool
+}
 
 type packageBuildTask struct {
 	pkg       *aPackage
@@ -272,20 +288,48 @@ func (ctx *context) executeIsolatedPackage(task *packageBuildTask, verbose bool)
 	if task.needsRuntimeSignals() {
 		task.pkg.setNeedRuntimeOrPyInit(task.pkg.LPkg.NeedRuntime, task.pkg.LPkg.NeedPyInit)
 	}
-	// Linking still consumes live package state: method tables, globals,
-	// funcinfo/PCLN, C exports, and DCE source modules. Cache hits still rebuild
-	// that frontend module in the isolated Program, skip backend emission, and
-	// keep the module alive until every link has completed.
+	// Cache hits still rebuild the frontend module in the isolated Program even
+	// though they skip backend emission. Linking needs a small metadata subset of
+	// that module in addition to the cached archive.
 	//
-	// LPkg retains the Program that owns its LLVM context. Ownership therefore
-	// moves to the coordinator on every success, not only when dead-code
-	// dropping is enabled.
+	// LPkg retains the Program that owns its LLVM context. Ownership moves to the
+	// caller on success: the native test DAG snapshots the metadata and disposes
+	// it at this package node; other build paths dispose it at their build-level
+	// ownership boundary.
 	return nil
 }
 
-// disposeBackendPackage releases an isolated package Program after the last
-// coordinator link plan has copied its whole-program metadata. Entry-module
-// workers consume only that Go-owned snapshot, object paths, and link args.
+// snapshotBackendPackage copies all link-time metadata out of one isolated
+// Program. It must run on the same package worker before that Program is
+// disposed; root link plans consume only the resulting Go-owned values.
+func (ctx *context) snapshotBackendPackage(pkg *aPackage) {
+	if pkg == nil || pkg.LPkg == nil {
+		return
+	}
+	lpkg := pkg.LPkg
+	snapshot := &packageLinkSnapshot{
+		needAbiInit:     lpkg.NeedAbiInit,
+		methodByIndex:   make(map[int]none, len(lpkg.MethodByIndex)),
+		methodByName:    make(map[string]none, len(lpkg.MethodByName)),
+		abiSymbols:      linkedModuleGlobals([]Package{pkg}),
+		abiTypes:        append([]llssa.AbiTypeInfo(nil), lpkg.Prog.AbiTypes()...),
+		hasLocalExports: hasLocalCExports(lpkg),
+	}
+	for index := range lpkg.MethodByIndex {
+		snapshot.methodByIndex[index] = none{}
+	}
+	for name := range lpkg.MethodByName {
+		snapshot.methodByName[name] = none{}
+	}
+	if ctx.buildConf.PCLNMode != PCLNNone {
+		snapshot.funcInfo = readFuncInfo(lpkg.Module())
+		snapshot.pcLineInfo = readPCLineInfo(lpkg.Module())
+	}
+	pkg.linkSnapshot = snapshot
+}
+
+// disposeBackendPackage releases an isolated package Program. Callers must
+// first snapshot metadata if later root link plans still need the package.
 func (ctx *context) disposeBackendPackage(pkg *aPackage) {
 	if pkg == nil || pkg.LPkg == nil {
 		return

--- a/internal/build/package_build_test.go
+++ b/internal/build/package_build_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -67,6 +68,20 @@ func TestPackageBuildTaskSpecialKinds(t *testing.T) {
 	}})
 	if !runtime.isRuntime() {
 		t.Fatalf("runtime package was not marked runtime: %+v", runtime)
+	}
+}
+
+func TestPackageBackendCostOrdersUncachedSSA(t *testing.T) {
+	tasks := []*packageBuildTask{
+		{pkg: &aPackage{}, ssaInstructions: 10},
+		{pkg: &aPackage{}, ssaInstructions: 100},
+		{pkg: &aPackage{CacheHit: true}, ssaInstructions: 1000},
+		{pkg: &aPackage{}, ssaInstructions: 2000, skip: true},
+	}
+	indexes := []int{0, 1, 2, 3}
+	sortPackageIndexesByEstimatedCost(tasks, indexes)
+	if !slices.Equal(indexes, []int{1, 0, 2, 3}) {
+		t.Fatalf("estimated backend order = %v, want [1 0 2 3]", indexes)
 	}
 }
 
@@ -226,6 +241,62 @@ func TestBuildSSAPkgsEmptyAndNilEntries(t *testing.T) {
 	prog := ssa.NewProgram(token.NewFileSet(), ssa.SanityCheckFunctions)
 	pkg := prog.CreatePackage(types.NewPackage("example.com/ssa", "ssa"), nil, nil, true)
 	buildSSAPkgs(ctx, []ssaBuildEntry{{pkg: pkg}, {pkg: pkg}})
+}
+
+func TestSyntaxNodeCount(t *testing.T) {
+	fset := token.NewFileSet()
+	small, err := parser.ParseFile(fset, "small.go", "package p\nvar x int\n", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	large, err := parser.ParseFile(fset, "large.go", "package p\nfunc f() { x := 1; x++; _ = x }\n", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, wantMin := syntaxNodeCount([]*ast.File{large}), syntaxNodeCount([]*ast.File{small}); got <= wantMin {
+		t.Fatalf("large syntax nodes = %d, want more than %d", got, wantMin)
+	}
+}
+
+func TestRecordPackageSSAInstructions(t *testing.T) {
+	fset := token.NewFileSet()
+	check := func(path, source string) (*types.Package, *ast.File, *types.Info) {
+		file, err := parser.ParseFile(fset, path+".go", source, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info := &types.Info{
+			Types:      make(map[ast.Expr]types.TypeAndValue),
+			Defs:       make(map[*ast.Ident]types.Object),
+			Uses:       make(map[*ast.Ident]types.Object),
+			Implicits:  make(map[ast.Node]types.Object),
+			Scopes:     make(map[ast.Node]*types.Scope),
+			Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		}
+		checked, err := (&types.Config{}).Check(path, fset, []*ast.File{file}, info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return checked, file, info
+	}
+	checked, file, info := check("example.com/p", "package p\nfunc F(x int) int { return x + 1 }\n")
+	altTypes, altFile, altInfo := check("example.com/alt", "package alt\nfunc F(x int) int { return (x + 1) * 2 }\n")
+	prog := ssa.NewProgram(fset, ssa.InstantiateGenerics)
+	ssaPkg := prog.CreatePackage(checked, []*ast.File{file}, info, true)
+	prog.CreatePackage(altTypes, []*ast.File{altFile}, altInfo, true)
+	prog.Build()
+	pkg := &aPackage{
+		Package: &packages.Package{ID: checked.Path()},
+		SSA:     ssaPkg,
+		AltPkg:  &packages.Cached{Types: altTypes},
+	}
+	ctx := &context{progSSA: prog, pkgs: map[*packages.Package]Package{pkg.Package: pkg}}
+	recordPackageSSAInstructions(ctx)
+	if pkg.ssaInstructions == 0 {
+		t.Fatal("recorded zero SSA instructions for a non-empty function")
+	}
+	recordPackageSSAInstructions(nil)
+	recordPackageSSAInstructions(&context{})
 }
 func TestCanUseIsolatedBackend(t *testing.T) {
 	ctx := &context{

--- a/internal/build/package_build_test.go
+++ b/internal/build/package_build_test.go
@@ -445,6 +445,109 @@ func TestExecuteIsolatedPackageReleasesProgramWithoutModule(t *testing.T) {
 	})
 }
 
+func TestSnapshotBackendPackageAndConsumers(t *testing.T) {
+	coordinator := llssa.NewProgram(nil)
+	defer coordinator.Dispose()
+	isolated := llssa.NewProgram(nil)
+	disposed := false
+	defer func() {
+		if !disposed {
+			isolated.Dispose()
+		}
+	}()
+
+	lpkg := isolated.NewPackage("p", "example.com/p")
+	lpkg.NeedAbiInit = 3
+	lpkg.RecordReflectMethodByIndex("example.com/p.useIndex", 7)
+	lpkg.RecordReflectMethodByName("example.com/p.useName", "Method")
+	pkg := &aPackage{
+		Package: &packages.Package{ID: "example.com/p", PkgPath: "example.com/p", Name: "main"},
+		LPkg:    lpkg,
+	}
+	ctx := &context{prog: coordinator, buildConf: &Config{PCLNMode: PCLNNone}}
+	ctx.snapshotBackendPackage(pkg)
+	snapshot := pkg.linkSnapshot
+	if snapshot == nil || snapshot.needAbiInit != 3 {
+		t.Fatalf("link snapshot = %+v", snapshot)
+	}
+	if _, ok := snapshot.methodByIndex[7]; !ok {
+		t.Fatalf("snapshot method indexes = %v", snapshot.methodByIndex)
+	}
+	if _, ok := snapshot.methodByName["Method"]; !ok {
+		t.Fatalf("snapshot method names = %v", snapshot.methodByName)
+	}
+
+	snapshot.abiSymbols = map[string]none{"example.com/p.global": {}}
+	snapshot.abiTypes = []llssa.AbiTypeInfo{{Name: "example.com/p.Type", Raw: types.Typ[types.Int]}}
+	snapshot.funcInfo = []funcInfoRecord{{symbol: "example.com/p.fn", name: "Fn"}}
+	snapshot.pcLineInfo = []pcLineRecord{{id: 1, symbol: "example.com/p.fn", line: 12}}
+	snapshot.hasLocalExports = true
+	if infos := ctx.backendAbiTypes([]Package{pkg}); len(infos) != 1 || infos[0].Name != "example.com/p.Type" {
+		t.Fatalf("snapshot ABI types = %#v", infos)
+	}
+	if globals := linkedModuleGlobals([]Package{nil, pkg}); len(globals) != 1 {
+		t.Fatalf("snapshot globals = %v", globals)
+	}
+	if records := collectFuncInfo([]Package{pkg}); len(records) != 1 || records[0].symbol != "example.com/p.fn" {
+		t.Fatalf("snapshot funcinfo = %+v", records)
+	}
+	if records := collectPCLineInfo([]Package{pkg}); len(records) != 1 || records[0].id != 1 {
+		t.Fatalf("snapshot pcline = %+v", records)
+	}
+	if !mainPackageHasExports([]*aPackage{pkg}) {
+		t.Fatal("snapshot C export was not detected")
+	}
+
+	ctx.disposeBackendPackage(pkg)
+	disposed = true
+	if pkg.LPkg != nil {
+		t.Fatal("disposed package retained LPkg")
+	}
+	pkg.ExportFile = "p.a"
+	pkg.ArchiveFile = "p.a"
+	dependency := &aPackage{
+		Package: &packages.Package{
+			ID:         "example.com/dependency",
+			PkgPath:    "example.com/dependency",
+			Name:       "dependency",
+			ExportFile: "dependency.a",
+		},
+		LPkg: coordinator.NewPackage("dependency", "example.com/dependency"),
+	}
+	dependency.LPkg.NeedAbiInit = 4
+	dependency.LPkg.RecordReflectMethodByIndex("example.com/dependency.useIndex", 8)
+	dependency.LPkg.RecordReflectMethodByName("example.com/dependency.useName", "OtherMethod")
+	pkg.Imports = map[string]*packages.Package{dependency.PkgPath: dependency.Package}
+	ctx.pkgs = map[*packages.Package]Package{pkg.Package: pkg, dependency.Package: dependency}
+	ctx.pkgByID = map[string]Package{pkg.ID: pkg, dependency.ID: dependency}
+	preparation, err := planMainLink(ctx, pkg.Package, []*aPackage{dependency, pkg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preparation.gen.abiInit != 7 {
+		t.Fatalf("planned ABI init = %d, want 7", preparation.gen.abiInit)
+	}
+	for _, index := range []int{7, 8} {
+		if _, ok := preparation.gen.methodByIndex[index]; !ok {
+			t.Fatalf("planned method indexes = %v", preparation.gen.methodByIndex)
+		}
+	}
+	for _, name := range []string{"Method", "OtherMethod"} {
+		if _, ok := preparation.gen.methodByName[name]; !ok {
+			t.Fatalf("planned method names = %v", preparation.gen.methodByName)
+		}
+	}
+	ctx.snapshotBackendPackage(nil)
+	ctx.snapshotBackendPackage(&aPackage{})
+	ctx.disposeBackendPackage(nil)
+	ctx.disposeBackendPackage(&aPackage{})
+	coordinatorPkg := &aPackage{LPkg: coordinator.NewPackage("coordinator", "example.com/coordinator")}
+	ctx.disposeBackendPackage(coordinatorPkg)
+	if coordinatorPkg.LPkg == nil {
+		t.Fatal("package owned by coordinator was disposed")
+	}
+}
+
 func TestPkgSFilesRejectsUnpreparedBackendRead(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "asm.s"), []byte("TEXT ·f(SB),$0-0\n\tRET\n"), 0o644); err != nil {
@@ -546,6 +649,9 @@ func TestBuildPackageGroupEmpty(t *testing.T) {
 	ctx := &context{buildConf: &Config{}}
 	if err := buildPackageGroup(ctx, nil, false); err != nil {
 		t.Fatalf("empty package group = %v", err)
+	}
+	if isolated, err := preparePackageGroup(nil, nil, false); err != nil || isolated != nil {
+		t.Fatalf("empty package preparation = %v, %v", isolated, err)
 	}
 }
 

--- a/internal/build/run.go
+++ b/internal/build/run.go
@@ -30,9 +30,10 @@ import (
 )
 
 type testProgram struct {
-	app     string
-	pkgDir  string
-	pkgName string
+	app              string
+	pkgDir           string
+	pkgName          string
+	temporaryOutputs *OutFmtDetails
 }
 
 type testRunResult struct {
@@ -47,6 +48,7 @@ type testProgramResult struct {
 }
 
 func runNativeTest(commands commandEnv, program testProgram, conf *Config, stdout, stderr io.Writer) error {
+	defer removeOutFmts(program.temporaryOutputs)
 	if conf.PrintCommands {
 		fmt.Fprintf(stderr, "%s %s\n", program.app, strings.Join(conf.RunArgs, " "))
 	}
@@ -68,6 +70,13 @@ func runNativeTest(commands commandEnv, program testProgram, conf *Config, stdou
 }
 
 func runNativeTestPrograms(commands commandEnv, programs []testProgram, conf *Config, stdout, stderr io.Writer) testRunResult {
+	defer func() {
+		// Fail-fast can leave programs unstarted; reclaim their implicit outputs
+		// as well as the ones runNativeTest already removed.
+		for _, program := range programs {
+			removeOutFmts(program.temporaryOutputs)
+		}
+	}()
 	// "go test -c" links test binaries but never executes them. Keep this
 	// check at the batch execution boundary so it also applies when several
 	// test roots were linked from one shared build graph.

--- a/internal/build/test_dag.go
+++ b/internal/build/test_dag.go
@@ -443,6 +443,10 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 			complete: func(err error) {
 				if err != nil {
 					result.links[rootIndex].err = err
+					if link := prepared[rootIndex]; link != nil {
+						removeOutFmts(link.outFmts)
+						prepared[rootIndex] = nil
+					}
 				}
 			},
 		})

--- a/internal/build/test_dag.go
+++ b/internal/build/test_dag.go
@@ -257,10 +257,21 @@ type nativeTestDAGResult struct {
 	tests testRunResult
 }
 
+// The native test DAG is deliberately split at LLVM ownership boundaries:
+//
+//	package backend+.a publication -> coordinator link plan snapshot
+//	-> isolated entry .o -> link/finalize -> test run
+//
+// All non-coordinator nodes share the single -p budget. A link-plan node is
+// coordinator-only because several roots may reference the same package LLVM
+// Program and LLVM does not support concurrent access to one Context here.
+// Its output is LLVM-free, so entry generation can use a fresh Program. Once
+// the last plan snapshot has consumed a package, that package Program is
+// released before downstream link and run work continues.
 func canUseNativeTestDAG(ctx *context, count int) bool {
 	return count > 1 && ctx != nil && ctx.buildConf != nil &&
 		ctx.mode == ModeTest && ctx.buildConf.Target == "" &&
-		ctx.buildConf.BuildMode == BuildModeExe
+		ctx.buildConf.BuildMode == BuildModeExe && !ctx.buildConf.deadcodeDropEnabled()
 }
 
 func prepareNativeTestPackageTasks(ctx *context, pkgs []*aPackage, verbose bool) ([]*packageBuildTask, error) {
@@ -295,7 +306,7 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 		return result, err
 	}
 
-	nodes := make([]buildDAGNode, 0, len(packageTasks)+len(roots)*3)
+	nodes := make([]buildDAGNode, 0, len(packageTasks)+len(roots)*4)
 	packageNodes := make(map[*aPackage]int, len(packageTasks))
 	for _, task := range packageTasks {
 		task := task
@@ -314,28 +325,53 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 	prepared := make([]*initialPackageLink, len(roots))
 	runResults := make([]testProgramResult, len(roots))
 	packageFanout := make([]int, len(packageTasks))
+	packageConsumers := make(map[*aPackage]int, len(packageTasks))
 	for rootIndex, root := range roots {
 		rootIndex, root := rootIndex, root
 		dependencies := make([]int, 0)
+		consumerPackages := make([]*aPackage, 0)
 		seen := make(map[int]bool)
 		for _, pkg := range linkedPackageClosure(ctx, root, allPkgs) {
 			if index, ok := packageNodes[pkg]; ok && !seen[index] {
 				seen[index] = true
 				packageFanout[index]++
+				packageConsumers[pkg]++
 				dependencies = append(dependencies, index)
+				consumerPackages = append(consumerPackages, pkg)
 			}
 		}
-		prepareIndex := len(nodes)
+		planIndex := len(nodes)
 		nodes = append(nodes, buildDAGNode{
-			name:         "prepare link " + root.PkgPath,
+			name:         "plan link " + root.PkgPath,
 			dependencies: dependencies,
 			priority:     dagPriorityPrepareLink,
 			class:        dagLink,
 			coordinator:  true,
 			run: func() error {
-				link, err := prepareInitialPackageLink(ctx, root, allPkgs, conf, verbose, false)
+				link, err := planInitialPackageLink(ctx, root, allPkgs, conf, false)
 				prepared[rootIndex] = link
 				return err
+			},
+			complete: func(err error) {
+				for _, pkg := range consumerPackages {
+					packageConsumers[pkg]--
+					if packageConsumers[pkg] == 0 {
+						ctx.disposeBackendPackage(pkg)
+					}
+				}
+				if err != nil {
+					result.links[rootIndex].err = err
+				}
+			},
+		})
+		entryIndex := len(nodes)
+		nodes = append(nodes, buildDAGNode{
+			name:         "entry object " + root.PkgPath,
+			dependencies: []int{planIndex},
+			priority:     dagPriorityPrepareLink,
+			class:        dagLink,
+			run: func() error {
+				return buildInitialPackageEntry(ctx, prepared[rootIndex], verbose, true)
 			},
 			complete: func(err error) {
 				if err != nil {
@@ -346,7 +382,7 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 		linkIndex := len(nodes)
 		nodes = append(nodes, buildDAGNode{
 			name:         "link " + root.PkgPath,
-			dependencies: []int{prepareIndex},
+			dependencies: []int{entryIndex},
 			priority:     dagPriorityLink,
 			class:        dagLink,
 			run: func() error {

--- a/internal/build/test_dag.go
+++ b/internal/build/test_dag.go
@@ -20,9 +20,11 @@ package build
 
 import (
 	"bytes"
+	"container/heap"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/xgo-dev/llgo/internal/packages"
 )
@@ -50,6 +52,7 @@ type buildDAGNode struct {
 	complete     func(error)
 	skip         func() bool
 	skipped      func()
+	blocked      func()
 }
 
 type buildDAGNodeResult struct {
@@ -68,6 +71,35 @@ type buildDAGState struct {
 	blocked    bool
 }
 
+type buildDAGReadyItem struct {
+	index    int
+	priority int
+	order    int
+}
+
+func (item buildDAGReadyItem) less(other buildDAGReadyItem) bool {
+	return item.priority < other.priority ||
+		item.priority == other.priority && item.order < other.order
+}
+
+type buildDAGReadyQueue []buildDAGReadyItem
+
+func (queue buildDAGReadyQueue) Len() int { return len(queue) }
+func (queue buildDAGReadyQueue) Less(i, j int) bool {
+	return queue[i].less(queue[j])
+}
+func (queue buildDAGReadyQueue) Swap(i, j int) { queue[i], queue[j] = queue[j], queue[i] }
+func (queue *buildDAGReadyQueue) Push(value any) {
+	*queue = append(*queue, value.(buildDAGReadyItem))
+}
+func (queue *buildDAGReadyQueue) Pop() any {
+	old := *queue
+	last := len(old) - 1
+	item := old[last]
+	*queue = old[:last]
+	return item
+}
+
 func runBuildDAG(nodes []buildDAGNode, parallelism int, sequentialTests bool) ([]buildDAGNodeResult, error) {
 	results := make([]buildDAGNodeResult, len(nodes))
 	states := make([]buildDAGState, len(nodes))
@@ -81,10 +113,24 @@ func runBuildDAG(nodes []buildDAGNode, parallelism int, sequentialTests bool) ([
 		}
 	}
 
-	ready := make([]int, 0, len(nodes))
+	readyNonTests := make(buildDAGReadyQueue, 0, len(nodes))
+	readyTests := make(buildDAGReadyQueue, 0, len(nodes))
+	readyBlocked := make(buildDAGReadyQueue, 0)
+	readyOrder := 0
+	pushReady := func(index int) {
+		item := buildDAGReadyItem{index: index, priority: nodes[index].priority, order: readyOrder}
+		readyOrder++
+		if states[index].blocked {
+			heap.Push(&readyBlocked, item)
+		} else if nodes[index].class == dagTest {
+			heap.Push(&readyTests, item)
+		} else {
+			heap.Push(&readyNonTests, item)
+		}
+	}
 	for index := range nodes {
 		if states[index].remaining == 0 {
-			ready = append(ready, index)
+			pushReady(index)
 		}
 	}
 	workers := max(1, parallelism)
@@ -117,44 +163,40 @@ func runBuildDAG(nodes []buildDAGNode, parallelism int, sequentialTests bool) ([
 		if skipped && nodes[index].skipped != nil {
 			nodes[index].skipped()
 		}
+		if blocked && nodes[index].blocked != nil {
+			nodes[index].blocked()
+		}
 		failed := err != nil || blocked
 		for _, dependent := range state.dependents {
 			next := &states[dependent]
 			next.remaining--
 			next.blocked = next.blocked || failed
 			if next.remaining == 0 {
-				ready = append(ready, dependent)
+				pushReady(dependent)
 			}
 		}
 	}
 
 	popReady := func() (int, bool) {
-		selected := -1
-		for pos, index := range ready {
-			node := nodes[index]
-			state := states[index]
-			if !state.blocked {
-				// Test execution overlaps production, but package/link work is
-				// the long pole in full CI. Keep all but one slot advancing it
-				// until every test target exists.
-				if node.class == dagTest && unfinishedNonTests > 0 &&
-					(workers == 1 || activeTests >= 1) {
-					continue
-				}
-				if node.class == dagTest && activeTests >= testLimit {
-					continue
-				}
-			}
-			if selected < 0 || node.priority < nodes[ready[selected]].priority {
-				selected = pos
-			}
+		if readyBlocked.Len() > 0 {
+			return heap.Pop(&readyBlocked).(buildDAGReadyItem).index, true
 		}
-		if selected < 0 {
+		testReady := readyTests.Len() > 0 && activeTests < testLimit
+		// Test execution overlaps production, but package/link work is the
+		// long pole in full CI. After starting one test, prefer every ready
+		// producer; if only active producers remain, tests may fill otherwise
+		// idle slots instead of forming a serial build tail.
+		if testReady && unfinishedNonTests > 0 &&
+			(workers == 1 || activeTests >= 1 && readyNonTests.Len() > 0) {
+			testReady = false
+		}
+		if !testReady && readyNonTests.Len() == 0 {
 			return 0, false
 		}
-		index := ready[selected]
-		ready = append(ready[:selected], ready[selected+1:]...)
-		return index, true
+		if testReady && (readyNonTests.Len() == 0 || readyTests[0].less(readyNonTests[0])) {
+			return heap.Pop(&readyTests).(buildDAGReadyItem).index, true
+		}
+		return heap.Pop(&readyNonTests).(buildDAGReadyItem).index, true
 	}
 
 	runWorker := func(index int) {
@@ -430,8 +472,22 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 			skipped: func() {
 				result.tests.skipped++
 			},
+			blocked: func() {
+				result.tests.failed = true
+				fmt.Fprintf(os.Stderr, "FAIL\t%s [build failed]\n", strings.TrimSuffix(root.PkgPath, ".test"))
+			},
 			run: func() error {
-				program := *result.links[rootIndex].program
+				linked := result.links[rootIndex].program
+				if linked == nil {
+					err := fmt.Errorf("link %s completed without a test program", root.PkgPath)
+					runResults[rootIndex] = testProgramResult{
+						program: testProgram{pkgName: strings.TrimSuffix(root.PkgPath, ".test")},
+						output:  []byte(err.Error() + "\n"),
+						err:     err,
+					}
+					return err
+				}
+				program := *linked
 				var output bytes.Buffer
 				span := ctx.buildTrace.startWorker("test", program.pkgName)
 				defer span.done()

--- a/internal/build/test_dag.go
+++ b/internal/build/test_dag.go
@@ -1,0 +1,408 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/xgo-dev/llgo/internal/packages"
+)
+
+type buildDAGClass int
+
+const (
+	dagPackage buildDAGClass = iota
+	dagLink
+	dagTest
+
+	dagPriorityTest        = 0
+	dagPriorityLink        = 1
+	dagPriorityPrepareLink = 2
+	dagPriorityPackageBase = 1_000_000
+)
+
+type buildDAGNode struct {
+	name         string
+	dependencies []int
+	priority     int
+	class        buildDAGClass
+	coordinator  bool
+	run          func() error
+	complete     func(error)
+	skip         func() bool
+	skipped      func()
+}
+
+type buildDAGNodeResult struct {
+	err     error
+	blocked bool
+}
+
+type buildDAGCompletion struct {
+	index int
+	err   error
+}
+
+type buildDAGState struct {
+	remaining  int
+	dependents []int
+	blocked    bool
+}
+
+func runBuildDAG(nodes []buildDAGNode, parallelism int, sequentialTests bool) ([]buildDAGNodeResult, error) {
+	results := make([]buildDAGNodeResult, len(nodes))
+	states := make([]buildDAGState, len(nodes))
+	for index, node := range nodes {
+		states[index].remaining = len(node.dependencies)
+		for _, dependency := range node.dependencies {
+			if dependency < 0 || dependency >= len(nodes) || dependency == index {
+				return nil, fmt.Errorf("DAG node %d (%s) has invalid dependency %d", index, node.name, dependency)
+			}
+			states[dependency].dependents = append(states[dependency].dependents, index)
+		}
+	}
+
+	ready := make([]int, 0, len(nodes))
+	for index := range nodes {
+		if states[index].remaining == 0 {
+			ready = append(ready, index)
+		}
+	}
+	workers := max(1, parallelism)
+	testLimit := workers
+	if sequentialTests {
+		testLimit = 1
+	}
+	completions := make(chan buildDAGCompletion, workers)
+	active := 0
+	activeTests := 0
+	finished := 0
+	unfinishedNonTests := 0
+	for _, node := range nodes {
+		if node.class != dagTest {
+			unfinishedNonTests++
+		}
+	}
+
+	var finish func(int, error, bool, bool)
+	finish = func(index int, err error, blocked, skipped bool) {
+		state := &states[index]
+		results[index] = buildDAGNodeResult{err: err, blocked: blocked}
+		finished++
+		if nodes[index].class != dagTest {
+			unfinishedNonTests--
+		}
+		if nodes[index].complete != nil && !blocked && !skipped {
+			nodes[index].complete(err)
+		}
+		if skipped && nodes[index].skipped != nil {
+			nodes[index].skipped()
+		}
+		failed := err != nil || blocked
+		for _, dependent := range state.dependents {
+			next := &states[dependent]
+			next.remaining--
+			next.blocked = next.blocked || failed
+			if next.remaining == 0 {
+				ready = append(ready, dependent)
+			}
+		}
+	}
+
+	popReady := func() (int, bool) {
+		selected := -1
+		for pos, index := range ready {
+			node := nodes[index]
+			state := states[index]
+			if !state.blocked {
+				// Test execution overlaps production, but package/link work is
+				// the long pole in full CI. Keep all but one slot advancing it
+				// until every test target exists.
+				if node.class == dagTest && unfinishedNonTests > 0 &&
+					(workers == 1 || activeTests >= 1) {
+					continue
+				}
+				if node.class == dagTest && activeTests >= testLimit {
+					continue
+				}
+			}
+			if selected < 0 || node.priority < nodes[ready[selected]].priority {
+				selected = pos
+			}
+		}
+		if selected < 0 {
+			return 0, false
+		}
+		index := ready[selected]
+		ready = append(ready[:selected], ready[selected+1:]...)
+		return index, true
+	}
+
+	runWorker := func(index int) {
+		go func() {
+			completions <- buildDAGCompletion{index: index, err: runBuildDAGNode(index, nodes[index])}
+		}()
+	}
+	handleCompletion := func(completion buildDAGCompletion) {
+		active--
+		if nodes[completion.index].class == dagTest {
+			activeTests--
+		}
+		finish(completion.index, completion.err, false, false)
+	}
+	drainCompletions := func() bool {
+		drained := false
+		for active != 0 {
+			select {
+			case completion := <-completions:
+				handleCompletion(completion)
+				drained = true
+			default:
+				return drained
+			}
+		}
+		return drained
+	}
+
+	for finished < len(nodes) {
+		progress := drainCompletions()
+		for active < workers {
+			if drainCompletions() {
+				progress = true
+			}
+			index, ok := popReady()
+			if !ok {
+				break
+			}
+			state := &states[index]
+			node := nodes[index]
+			if state.blocked {
+				finish(index, nil, true, false)
+				progress = true
+				continue
+			}
+			if node.skip != nil && node.skip() {
+				finish(index, nil, false, true)
+				progress = true
+				continue
+			}
+			if node.coordinator {
+				finish(index, runBuildDAGNode(index, node), false, false)
+				progress = true
+				continue
+			}
+			active++
+			if node.class == dagTest {
+				activeTests++
+			}
+			runWorker(index)
+			progress = true
+		}
+		if active == 0 {
+			if finished == len(nodes) {
+				break
+			}
+			if !progress {
+				return nil, fmt.Errorf("build DAG stalled with %d/%d nodes complete", finished, len(nodes))
+			}
+			continue
+		}
+		handleCompletion(<-completions)
+	}
+	return results, nil
+}
+
+func runBuildDAGNode(index int, node buildDAGNode) (err error) {
+	defer func() {
+		if value := recover(); value != nil {
+			if recovered, ok := value.(error); ok {
+				err = recovered
+			} else {
+				err = fmt.Errorf("DAG node %d (%s) panicked: %v", index, node.name, value)
+			}
+		}
+	}()
+	if node.run == nil {
+		return nil
+	}
+	return node.run()
+}
+
+type testLinkResult struct {
+	program *testProgram
+	err     error
+}
+
+type nativeTestDAGResult struct {
+	links []testLinkResult
+	tests testRunResult
+}
+
+func canUseNativeTestDAG(ctx *context, count int) bool {
+	return count > 1 && ctx != nil && ctx.buildConf != nil &&
+		ctx.mode == ModeTest && ctx.buildConf.Target == "" &&
+		ctx.buildConf.BuildMode == BuildModeExe
+}
+
+func prepareNativeTestPackageTasks(ctx *context, pkgs []*aPackage, verbose bool) ([]*packageBuildTask, error) {
+	// Resolve the lazy Plan 9 policy before isolated package workers start.
+	_ = ctx.plan9asmEnabled("")
+	var normalTasks, runtimeTasks []*packageBuildTask
+	for _, pkg := range pkgs {
+		task := newPackageBuildTask(pkg)
+		if task.isRuntime() {
+			runtimeTasks = append(runtimeTasks, task)
+		} else {
+			normalTasks = append(normalTasks, task)
+		}
+	}
+	var parallel []*packageBuildTask
+	for _, tasks := range [][]*packageBuildTask{normalTasks, runtimeTasks} {
+		indexes, err := preparePackageGroup(ctx, tasks, verbose)
+		if err != nil {
+			return nil, err
+		}
+		for _, index := range indexes {
+			parallel = append(parallel, tasks[index])
+		}
+	}
+	return parallel, nil
+}
+
+func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Package, conf *Config, verbose bool) (nativeTestDAGResult, error) {
+	result := nativeTestDAGResult{links: make([]testLinkResult, len(roots))}
+	packageTasks, err := prepareNativeTestPackageTasks(ctx, allPkgs, verbose)
+	if err != nil {
+		return result, err
+	}
+
+	nodes := make([]buildDAGNode, 0, len(packageTasks)+len(roots)*3)
+	packageNodes := make(map[*aPackage]int, len(packageTasks))
+	for _, task := range packageTasks {
+		task := task
+		index := len(nodes)
+		packageNodes[task.pkg] = index
+		nodes = append(nodes, buildDAGNode{
+			name:     "package " + task.pkg.PkgPath,
+			priority: dagPriorityPackageBase,
+			class:    dagPackage,
+			run: func() error {
+				return tracePackageBuild(ctx, task, verbose, true, true)
+			},
+		})
+	}
+
+	prepared := make([]*initialPackageLink, len(roots))
+	runResults := make([]testProgramResult, len(roots))
+	packageFanout := make([]int, len(packageTasks))
+	for rootIndex, root := range roots {
+		rootIndex, root := rootIndex, root
+		dependencies := make([]int, 0)
+		seen := make(map[int]bool)
+		for _, pkg := range linkedPackageClosure(ctx, root, allPkgs) {
+			if index, ok := packageNodes[pkg]; ok && !seen[index] {
+				seen[index] = true
+				packageFanout[index]++
+				dependencies = append(dependencies, index)
+			}
+		}
+		prepareIndex := len(nodes)
+		nodes = append(nodes, buildDAGNode{
+			name:         "prepare link " + root.PkgPath,
+			dependencies: dependencies,
+			priority:     dagPriorityPrepareLink,
+			class:        dagLink,
+			coordinator:  true,
+			run: func() error {
+				link, err := prepareInitialPackageLink(ctx, root, allPkgs, conf, verbose, false)
+				prepared[rootIndex] = link
+				return err
+			},
+			complete: func(err error) {
+				if err != nil {
+					result.links[rootIndex].err = err
+				}
+			},
+		})
+		linkIndex := len(nodes)
+		nodes = append(nodes, buildDAGNode{
+			name:         "link " + root.PkgPath,
+			dependencies: []int{prepareIndex},
+			priority:     dagPriorityLink,
+			class:        dagLink,
+			run: func() error {
+				program, err := executeInitialPackageLink(ctx, prepared[rootIndex], verbose, true)
+				result.links[rootIndex] = testLinkResult{program: program, err: err}
+				return err
+			},
+		})
+		if conf.CompileOnly {
+			continue
+		}
+		nodes = append(nodes, buildDAGNode{
+			name:         "test " + root.PkgPath,
+			dependencies: []int{linkIndex},
+			priority:     dagPriorityTest,
+			class:        dagTest,
+			skip: func() bool {
+				return conf.TestFailFast && result.tests.failed
+			},
+			skipped: func() {
+				result.tests.skipped++
+			},
+			run: func() error {
+				program := *result.links[rootIndex].program
+				var output bytes.Buffer
+				span := ctx.buildTrace.startWorker("test", program.pkgName)
+				defer span.done()
+				err := runNativeTest(ctx.commands, program, conf, &output, &output)
+				runResults[rootIndex] = testProgramResult{program: program, output: output.Bytes(), err: err}
+				return err
+			},
+			complete: func(err error) {
+				reportTestProgramResult(os.Stdout, os.Stderr, runResults[rootIndex], conf.TestJSON)
+				if err != nil {
+					result.tests.failed = true
+				}
+			},
+		})
+	}
+	// Package backends are independent after shared frontend preparation. Favor
+	// the packages on the most root closures so shared critical-path work makes
+	// the largest number of prepare-link nodes ready first.
+	for index, fanout := range packageFanout {
+		nodes[index].priority = dagPriorityPackageBase - fanout
+	}
+
+	nodeResults, err := runBuildDAG(nodes, conf.parallelism(), conf.TestRunSequential)
+	if err != nil {
+		return result, err
+	}
+	var buildErrs []error
+	for _, task := range packageTasks {
+		index := packageNodes[task.pkg]
+		if nodeResults[index].err != nil {
+			buildErrs = append(buildErrs, fmt.Errorf("%s: %w", task.pkg.PkgPath, nodeResults[index].err))
+		}
+	}
+	return result, errors.Join(buildErrs...)
+}

--- a/internal/build/test_dag.go
+++ b/internal/build/test_dag.go
@@ -259,15 +259,16 @@ type nativeTestDAGResult struct {
 
 // The native test DAG is deliberately split at LLVM ownership boundaries:
 //
-//	package backend+.a publication -> coordinator link plan snapshot
-//	-> isolated entry .o -> link/finalize -> test run
+//	package backend+.a -> package link snapshot+Program disposal
+//	-> coordinator root link plan -> isolated entry .o
+//	-> link/finalize -> test run
 //
 // All non-coordinator nodes share the single -p budget. A link-plan node is
-// coordinator-only because several roots may reference the same package LLVM
-// Program and LLVM does not support concurrent access to one Context here.
-// Its output is LLVM-free, so entry generation can use a fresh Program. Once
-// the last plan snapshot has consumed a package, that package Program is
-// released before downstream link and run work continues.
+// coordinator-only because patched packages may still belong to the shared
+// coordinator Program, which LLVM does not permit workers to read concurrently.
+// Isolated package workers publish LLVM-free snapshots and dispose their own
+// Programs first. Root plans consume those snapshots, so entry generation can
+// use a fresh Program and downstream link/run work retains no package Context.
 func canUseNativeTestDAG(ctx *context, count int) bool {
 	return count > 1 && ctx != nil && ctx.buildConf != nil &&
 		ctx.mode == ModeTest && ctx.buildConf.Target == "" &&
@@ -301,6 +302,13 @@ func prepareNativeTestPackageTasks(ctx *context, pkgs []*aPackage, verbose bool)
 
 func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Package, conf *Config, verbose bool) (nativeTestDAGResult, error) {
 	result := nativeTestDAGResult{links: make([]testLinkResult, len(roots))}
+	defer func() {
+		for _, pkg := range allPkgs {
+			if pkg != nil {
+				pkg.linkSnapshot = nil
+			}
+		}
+	}()
 	packageTasks, err := prepareNativeTestPackageTasks(ctx, allPkgs, verbose)
 	if err != nil {
 		return result, err
@@ -317,12 +325,28 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 			priority: dagPriorityPackageBase,
 			class:    dagPackage,
 			run: func() error {
-				return tracePackageBuild(ctx, task, verbose, true, true)
+				if err := tracePackageBuild(ctx, task, verbose, true, true); err != nil {
+					return err
+				}
+				span := ctx.buildTrace.startWorker("link-snapshot", task.pkg.PkgPath)
+				ctx.snapshotBackendPackage(task.pkg)
+				ctx.disposeBackendPackage(task.pkg)
+				span.done()
+				return nil
 			},
 		})
 	}
 
 	prepared := make([]*initialPackageLink, len(roots))
+	defer func() {
+		// Scheduler cancellation and fail-fast may leave a planned test without
+		// a run node. Successful runs have already removed the same directories.
+		for _, link := range prepared {
+			if link != nil && link.outFmts.tempDir != "" {
+				removeOutFmts(link.outFmts)
+			}
+		}
+	}()
 	runResults := make([]testProgramResult, len(roots))
 	packageFanout := make([]int, len(packageTasks))
 	packageConsumers := make(map[*aPackage]int, len(packageTasks))
@@ -356,6 +380,7 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 				for _, pkg := range consumerPackages {
 					packageConsumers[pkg]--
 					if packageConsumers[pkg] == 0 {
+						pkg.linkSnapshot = nil
 						ctx.disposeBackendPackage(pkg)
 					}
 				}
@@ -368,7 +393,7 @@ func runNativeTestDAG(ctx *context, allPkgs []*aPackage, roots []*packages.Packa
 		nodes = append(nodes, buildDAGNode{
 			name:         "entry object " + root.PkgPath,
 			dependencies: []int{planIndex},
-			priority:     dagPriorityPrepareLink,
+			priority:     dagPriorityLink,
 			class:        dagLink,
 			run: func() error {
 				return buildInitialPackageEntry(ctx, prepared[rootIndex], verbose, true)

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -20,11 +20,15 @@ package build
 
 import (
 	"errors"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/xgo-dev/llgo/internal/packages"
+	llssa "github.com/xgo-dev/llgo/ssa"
 )
 
 func TestCanUseNativeTestDAG(t *testing.T) {
@@ -357,5 +361,68 @@ func TestSeparatedLinkPhaseValidation(t *testing.T) {
 	}
 	if err := executeMainLink(nil, nil, false); err == nil {
 		t.Fatal("executeMainLink accepted a nil plan")
+	}
+}
+
+func TestRunNativeTestDAGPropagatesPackageFailures(t *testing.T) {
+	t.Run("preparation", func(t *testing.T) {
+		fset, pkg := invalidEmbedPackage(t)
+		conf := &Config{Mode: ModeTest}
+		ctx := &context{
+			conf:      &packages.Config{Fset: fset},
+			mode:      ModeGen,
+			buildConf: conf,
+		}
+		_, err := runNativeTestDAG(ctx, []*aPackage{pkg}, nil, conf, false)
+		if err == nil || !strings.Contains(err.Error(), "only allowed in Go files that import") {
+			t.Fatalf("preparation error = %v", err)
+		}
+	})
+
+	t.Run("package node", func(t *testing.T) {
+		fset, pkg := invalidEmbedPackage(t)
+		coordinator := llssa.NewProgram(&llssa.Target{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH})
+		defer coordinator.Dispose()
+		conf := &Config{Mode: ModeTest, BuildMode: BuildModeExe, Goos: runtime.GOOS, Goarch: runtime.GOARCH}
+		ctx := &context{
+			conf:      &packages.Config{Fset: fset},
+			prog:      coordinator,
+			mode:      ModeTest,
+			buildConf: conf,
+		}
+		_, err := runNativeTestDAG(ctx, []*aPackage{pkg}, nil, conf, false)
+		if err == nil || !strings.Contains(err.Error(), "only allowed in Go files that import") {
+			t.Fatalf("package node error = %v", err)
+		}
+	})
+}
+
+func TestRunNativeTestDAGPropagatesPlanFailure(t *testing.T) {
+	root := &packages.Package{
+		ID:      "example.com/cycle.test",
+		PkgPath: "example.com/cycle.test",
+		Name:    "main",
+		Imports: make(map[string]*packages.Package),
+	}
+	root.Imports["self"] = root
+	conf := &Config{Mode: ModeTest, BuildMode: BuildModeExe}
+	ctx := &context{
+		mode:      ModeTest,
+		buildConf: conf,
+		commands:  commandEnv{dir: t.TempDir()},
+		pkgs:      make(map[*packages.Package]Package),
+		pkgByID:   make(map[string]Package),
+	}
+	readStderr := captureStderr(t)
+	result, err := runNativeTestDAG(ctx, nil, []*packages.Package{root}, conf, false)
+	stderr := readStderr()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.links[0].err == nil || !strings.Contains(result.links[0].err.Error(), "contains a cycle") {
+		t.Fatalf("link result error = %v", result.links[0].err)
+	}
+	if !result.tests.failed || !strings.Contains(stderr, "FAIL\texample.com/cycle [build failed]") {
+		t.Fatalf("test result = %+v; stderr = %q", result.tests, stderr)
 	}
 }

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -20,6 +20,7 @@ package build
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -307,5 +308,54 @@ func TestRunBuildDAGHonorsClassLimitAndDynamicSkip(t *testing.T) {
 	}
 	if got := skipped.Load(); got != 3 {
 		t.Fatalf("skipped tests = %d, want 3", got)
+	}
+}
+
+func TestRunBuildDAGRejectsInvalidGraphs(t *testing.T) {
+	t.Run("invalid dependency", func(t *testing.T) {
+		_, err := runBuildDAG([]buildDAGNode{{name: "invalid", dependencies: []int{1}}}, 1, false)
+		if err == nil || !strings.Contains(err.Error(), "invalid dependency 1") {
+			t.Fatalf("invalid dependency error = %v", err)
+		}
+	})
+
+	t.Run("cycle", func(t *testing.T) {
+		_, err := runBuildDAG([]buildDAGNode{
+			{name: "first", dependencies: []int{1}},
+			{name: "second", dependencies: []int{0}},
+		}, 1, false)
+		if err == nil || !strings.Contains(err.Error(), "stalled with 0/2 nodes complete") {
+			t.Fatalf("cycle error = %v", err)
+		}
+	})
+}
+
+func TestRunBuildDAGRecoversNodePanics(t *testing.T) {
+	wantErr := errors.New("error panic")
+	results, err := runBuildDAG([]buildDAGNode{
+		{name: "nil", coordinator: true},
+		{name: "error", coordinator: true, run: func() error { panic(wantErr) }},
+		{name: "value", coordinator: true, run: func() error { panic("value panic") }},
+	}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0].err != nil {
+		t.Fatalf("nil node error = %v", results[0].err)
+	}
+	if !errors.Is(results[1].err, wantErr) {
+		t.Fatalf("error panic result = %v, want %v", results[1].err, wantErr)
+	}
+	if got := results[2].err; got == nil || !strings.Contains(got.Error(), "node 2 (value) panicked: value panic") {
+		t.Fatalf("value panic result = %v", got)
+	}
+}
+
+func TestSeparatedLinkPhaseValidation(t *testing.T) {
+	if _, err := buildMainLink(nil, nil, nil, "", false); err == nil {
+		t.Fatal("buildMainLink accepted a nil preparation")
+	}
+	if err := executeMainLink(nil, nil, false); err == nil {
+		t.Fatal("executeMainLink accepted a nil plan")
 	}
 }

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -131,6 +131,7 @@ func TestRunBuildDAGBoundsWorkersAndPropagatesFailure(t *testing.T) {
 		}
 	}
 	var dependentRan atomic.Bool
+	var blockedCalled atomic.Bool
 	nodes := []buildDAGNode{
 		{name: "failure", class: dagPackage, run: worker(wantErr)},
 		{name: "success one", class: dagPackage, run: worker(nil)},
@@ -138,7 +139,7 @@ func TestRunBuildDAGBoundsWorkersAndPropagatesFailure(t *testing.T) {
 		{name: "blocked", dependencies: []int{0}, class: dagLink, run: func() error {
 			dependentRan.Store(true)
 			return nil
-		}},
+		}, blocked: func() { blockedCalled.Store(true) }},
 	}
 	done := make(chan []buildDAGNodeResult, 1)
 	go func() {
@@ -158,12 +159,13 @@ func TestRunBuildDAGBoundsWorkersAndPropagatesFailure(t *testing.T) {
 	if !errors.Is(results[0].err, wantErr) {
 		t.Fatalf("failure result = %v, want %v", results[0].err, wantErr)
 	}
-	if !results[3].blocked || dependentRan.Load() {
-		t.Fatalf("dependent result = %+v, ran = %v", results[3], dependentRan.Load())
+	if !results[3].blocked || dependentRan.Load() || !blockedCalled.Load() {
+		t.Fatalf("dependent result = %+v, ran = %v, blocked callback = %v",
+			results[3], dependentRan.Load(), blockedCalled.Load())
 	}
 }
 
-func TestRunBuildDAGKeepsProducerCapacity(t *testing.T) {
+func TestRunBuildDAGFillsCapacityAtProducerTail(t *testing.T) {
 	producerRelease := make(chan struct{})
 	testRelease := make(chan struct{})
 	defer func() {
@@ -199,19 +201,70 @@ func TestRunBuildDAGKeepsProducerCapacity(t *testing.T) {
 		done <- err
 	}()
 
-	first, second := <-started, <-started
-	if first == second {
-		t.Fatalf("initial node classes = %v, %v; want one producer and one test", first, second)
+	counts := map[buildDAGClass]int{}
+	for range 3 {
+		select {
+		case class := <-started:
+			counts[class]++
+		case <-time.After(time.Second):
+			t.Fatalf("workers remained idle at producer tail; started classes = %v", counts)
+		}
 	}
-	select {
-	case class := <-started:
-		t.Fatalf("started extra %v node while producer work remained", class)
-	case <-time.After(100 * time.Millisecond):
+	if counts[dagPackage] != 1 || counts[dagTest] != 2 {
+		t.Fatalf("initial node classes = %v, want one producer and two tests", counts)
 	}
 	close(producerRelease)
-	if class := <-started; class != dagTest {
-		t.Fatalf("node after producer completion = %v, want test", class)
+	close(testRelease)
+	if err := <-done; err != nil {
+		t.Fatal(err)
 	}
+}
+
+func TestRunBuildDAGPrefersReadyProducersAfterOneTest(t *testing.T) {
+	producerRelease := make(chan struct{})
+	testRelease := make(chan struct{})
+	defer func() {
+		for _, release := range []chan struct{}{producerRelease, testRelease} {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}
+	}()
+	started := make(chan buildDAGClass, 4)
+	worker := func(class buildDAGClass, release <-chan struct{}) func() error {
+		return func() error {
+			started <- class
+			<-release
+			return nil
+		}
+	}
+	nodes := []buildDAGNode{
+		{name: "producer one", priority: dagPriorityPackageBase, class: dagPackage, run: worker(dagPackage, producerRelease)},
+		{name: "producer two", priority: dagPriorityPackageBase, class: dagPackage, run: worker(dagPackage, producerRelease)},
+		{name: "test one", priority: dagPriorityTest, class: dagTest, run: worker(dagTest, testRelease)},
+		{name: "test two", priority: dagPriorityTest, class: dagTest, run: worker(dagTest, testRelease)},
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := runBuildDAG(nodes, 3, false)
+		done <- err
+	}()
+
+	counts := map[buildDAGClass]int{}
+	for range 3 {
+		select {
+		case class := <-started:
+			counts[class]++
+		case <-time.After(time.Second):
+			t.Fatalf("workers remained idle; started classes = %v", counts)
+		}
+	}
+	if counts[dagPackage] != 2 || counts[dagTest] != 1 {
+		t.Fatalf("initial node classes = %v, want two producers and one test", counts)
+	}
+	close(producerRelease)
 	close(testRelease)
 	if err := <-done; err != nil {
 		t.Fatal(err)

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -466,3 +466,42 @@ func TestRunNativeTestDAGPropagatesPlanFailure(t *testing.T) {
 		t.Fatalf("compile-only result = %+v", result)
 	}
 }
+
+func TestRunNativeTestDAGPropagatesEntryFailure(t *testing.T) {
+	prog := llssa.NewProgram(nil)
+	defer prog.Dispose()
+	root := &packages.Package{
+		ID:      "example.com/entry.test",
+		PkgPath: "example.com/entry.test",
+		Name:    "main",
+		Imports: make(map[string]*packages.Package),
+	}
+	conf := &Config{
+		Mode:      ModeTest,
+		BuildMode: BuildModeExe,
+		Goos:      runtime.GOOS,
+		Goarch:    runtime.GOARCH,
+	}
+	ctx := &context{
+		prog:      prog,
+		mode:      ModeTest,
+		buildConf: conf,
+		commands:  commandEnv{dir: t.TempDir()},
+		pkgs:      make(map[*packages.Package]Package),
+		pkgByID:   make(map[string]Package),
+	}
+	ctx.crossCompile.ExtraFiles = []string{"missing-entry-file.c"}
+
+	readStderr := captureStderr(t)
+	result, err := runNativeTestDAG(ctx, nil, []*packages.Package{root}, conf, false)
+	stderr := readStderr()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.links[0].err == nil || !strings.Contains(result.links[0].err.Error(), "extra file not found") {
+		t.Fatalf("entry result error = %v", result.links[0].err)
+	}
+	if !result.tests.failed || !strings.Contains(stderr, "FAIL\texample.com/entry [build failed]") {
+		t.Fatalf("test result = %+v; stderr = %q", result.tests, stderr)
+	}
+}

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -425,4 +425,13 @@ func TestRunNativeTestDAGPropagatesPlanFailure(t *testing.T) {
 	if !result.tests.failed || !strings.Contains(stderr, "FAIL\texample.com/cycle [build failed]") {
 		t.Fatalf("test result = %+v; stderr = %q", result.tests, stderr)
 	}
+
+	conf.CompileOnly = true
+	result, err = runNativeTestDAG(ctx, nil, []*packages.Package{root}, conf, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.links[0].err == nil || result.tests.failed || result.tests.skipped != 0 {
+		t.Fatalf("compile-only result = %+v", result)
+	}
 }

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -20,6 +20,7 @@ package build
 
 import (
 	"errors"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -332,6 +333,17 @@ func TestRunBuildDAGRejectsInvalidGraphs(t *testing.T) {
 			t.Fatalf("cycle error = %v", err)
 		}
 	})
+
+	t.Run("progress before cycle", func(t *testing.T) {
+		_, err := runBuildDAG([]buildDAGNode{
+			{name: "independent", coordinator: true},
+			{name: "first", dependencies: []int{2}},
+			{name: "second", dependencies: []int{1}},
+		}, 1, false)
+		if err == nil || !strings.Contains(err.Error(), "stalled with 1/3 nodes complete") {
+			t.Fatalf("partially completed cycle error = %v", err)
+		}
+	})
 }
 
 func TestRunBuildDAGRecoversNodePanics(t *testing.T) {
@@ -361,6 +373,25 @@ func TestSeparatedLinkPhaseValidation(t *testing.T) {
 	}
 	if err := executeMainLink(nil, nil, false); err == nil {
 		t.Fatal("executeMainLink accepted a nil plan")
+	}
+}
+
+func TestExecuteInitialPackageLinkPropagatesStagingFailure(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "missing", "test.wasm")
+	conf := &Config{BuildMode: BuildModeExe}
+	ctx := &context{buildConf: conf}
+	ctx.crossCompile.WasmPostLink.Asyncify = true
+	link := &initialPackageLink{
+		pkg:     &packages.Package{PkgPath: "example.com/test.test"},
+		conf:    conf,
+		outFmts: &OutFmtDetails{Out: output},
+		plan:    &mainLinkPlan{outputPath: output},
+	}
+	if _, err := executeInitialPackageLink(ctx, link, false, false); err == nil {
+		t.Fatal("executeInitialPackageLink succeeded with a missing staging directory")
+	}
+	if link.plan != nil {
+		t.Fatal("failed link retained its consumed plan")
 	}
 }
 

--- a/internal/build/test_dag_test.go
+++ b/internal/build/test_dag_test.go
@@ -1,0 +1,258 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCanUseNativeTestDAG(t *testing.T) {
+	base := &context{mode: ModeTest, buildConf: &Config{BuildMode: BuildModeExe}}
+	if !canUseNativeTestDAG(base, 2) {
+		t.Fatal("two native test roots did not enable the DAG")
+	}
+	for _, test := range []struct {
+		name  string
+		ctx   *context
+		count int
+	}{
+		{name: "one link", ctx: base, count: 1},
+		{name: "build mode", ctx: &context{mode: ModeBuild, buildConf: &Config{BuildMode: BuildModeExe}}, count: 2},
+		{name: "embedded", ctx: &context{mode: ModeTest, buildConf: &Config{BuildMode: BuildModeExe, Target: "rp2040"}}, count: 2},
+		{name: "archive", ctx: &context{mode: ModeTest, buildConf: &Config{BuildMode: BuildModeCArchive}}, count: 2},
+		{name: "nil context", count: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if canUseNativeTestDAG(test.ctx, test.count) {
+				t.Fatal("DAG unexpectedly enabled")
+			}
+		})
+	}
+}
+
+func TestRunBuildDAGPipelinesReadyBranches(t *testing.T) {
+	var mu sync.Mutex
+	var events []string
+	record := func(event string) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	}
+	firstPackageDone := make(chan struct{})
+	releaseSecondPackage := make(chan struct{})
+	nodes := []buildDAGNode{
+		{name: "first package", priority: 3, class: dagPackage, run: func() error {
+			record("package-1")
+			close(firstPackageDone)
+			return nil
+		}},
+		{name: "second package", priority: 3, class: dagPackage, run: func() error {
+			<-firstPackageDone
+			<-releaseSecondPackage
+			record("package-2")
+			return nil
+		}},
+		{name: "prepare", dependencies: []int{0}, priority: 2, class: dagLink, coordinator: true, run: func() error {
+			record("prepare")
+			return nil
+		}},
+		{name: "link", dependencies: []int{2}, priority: 1, class: dagLink, run: func() error {
+			record("link")
+			return nil
+		}},
+		{name: "test", dependencies: []int{3}, priority: 0, class: dagTest, run: func() error {
+			record("test")
+			close(releaseSecondPackage)
+			return nil
+		}},
+	}
+	results, err := runBuildDAG(nodes, 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, result := range results {
+		if result.err != nil || result.blocked {
+			t.Fatalf("node %d result = %+v", index, result)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	positions := make(map[string]int, len(events))
+	for index, event := range events {
+		positions[event] = index
+	}
+	if !(positions["package-1"] < positions["prepare"] &&
+		positions["prepare"] < positions["link"] &&
+		positions["link"] < positions["test"] &&
+		positions["test"] < positions["package-2"]) {
+		t.Fatalf("DAG did not pipeline the ready branch: %v", events)
+	}
+}
+
+func TestRunBuildDAGBoundsWorkersAndPropagatesFailure(t *testing.T) {
+	wantErr := errors.New("package failed")
+	release := make(chan struct{})
+	started := make(chan struct{}, 3)
+	var active atomic.Int32
+	var maximum atomic.Int32
+	worker := func(err error) func() error {
+		return func() error {
+			current := active.Add(1)
+			for {
+				observed := maximum.Load()
+				if current <= observed || maximum.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			started <- struct{}{}
+			<-release
+			active.Add(-1)
+			return err
+		}
+	}
+	var dependentRan atomic.Bool
+	nodes := []buildDAGNode{
+		{name: "failure", class: dagPackage, run: worker(wantErr)},
+		{name: "success one", class: dagPackage, run: worker(nil)},
+		{name: "success two", class: dagPackage, run: worker(nil)},
+		{name: "blocked", dependencies: []int{0}, class: dagLink, run: func() error {
+			dependentRan.Store(true)
+			return nil
+		}},
+	}
+	done := make(chan []buildDAGNodeResult, 1)
+	go func() {
+		results, err := runBuildDAG(nodes, 2, false)
+		if err != nil {
+			t.Errorf("runBuildDAG: %v", err)
+		}
+		done <- results
+	}()
+	<-started
+	<-started
+	if got := maximum.Load(); got != 2 {
+		t.Fatalf("maximum concurrent workers = %d, want 2", got)
+	}
+	close(release)
+	results := <-done
+	if !errors.Is(results[0].err, wantErr) {
+		t.Fatalf("failure result = %v, want %v", results[0].err, wantErr)
+	}
+	if !results[3].blocked || dependentRan.Load() {
+		t.Fatalf("dependent result = %+v, ran = %v", results[3], dependentRan.Load())
+	}
+}
+
+func TestRunBuildDAGKeepsProducerCapacity(t *testing.T) {
+	producerRelease := make(chan struct{})
+	testRelease := make(chan struct{})
+	defer func() {
+		for _, release := range []chan struct{}{producerRelease, testRelease} {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}
+	}()
+	started := make(chan buildDAGClass, 3)
+	nodes := []buildDAGNode{
+		{name: "producer", class: dagPackage, run: func() error {
+			started <- dagPackage
+			<-producerRelease
+			return nil
+		}},
+		{name: "test one", class: dagTest, priority: dagPriorityTest, run: func() error {
+			started <- dagTest
+			<-testRelease
+			return nil
+		}},
+		{name: "test two", class: dagTest, priority: dagPriorityTest, run: func() error {
+			started <- dagTest
+			<-testRelease
+			return nil
+		}},
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := runBuildDAG(nodes, 3, false)
+		done <- err
+	}()
+
+	first, second := <-started, <-started
+	if first == second {
+		t.Fatalf("initial node classes = %v, %v; want one producer and one test", first, second)
+	}
+	select {
+	case class := <-started:
+		t.Fatalf("started extra %v node while producer work remained", class)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(producerRelease)
+	if class := <-started; class != dagTest {
+		t.Fatalf("node after producer completion = %v, want test", class)
+	}
+	close(testRelease)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunBuildDAGHonorsClassLimitAndDynamicSkip(t *testing.T) {
+	var activeTests atomic.Int32
+	var maximumTests atomic.Int32
+	var failed atomic.Bool
+	var skipped atomic.Int32
+	nodes := make([]buildDAGNode, 4)
+	for index := range nodes {
+		index := index
+		nodes[index] = buildDAGNode{
+			name:     "test",
+			priority: 0,
+			class:    dagTest,
+			skip:     failed.Load,
+			skipped:  func() { skipped.Add(1) },
+			run: func() error {
+				current := activeTests.Add(1)
+				if current > maximumTests.Load() {
+					maximumTests.Store(current)
+				}
+				activeTests.Add(-1)
+				if index == 0 {
+					failed.Store(true)
+				}
+				return nil
+			},
+		}
+	}
+	_, err := runBuildDAG(nodes, 4, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := maximumTests.Load(); got != 1 {
+		t.Fatalf("maximum concurrent tests = %d, want 1", got)
+	}
+	if got := skipped.Load(); got != 3 {
+		t.Fatalf("skipped tests = %d, want 3", got)
+	}
+}

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -281,7 +281,8 @@ func TestEffectiveBuildTimeout(t *testing.T) {
 
 func TestRunProgramTimeout(t *testing.T) {
 	if os.Getenv("LLGO_GOROOT_HELPER") == "sleep" {
-		time.Sleep(200 * time.Millisecond)
+		// Leave ample margin for a loaded CI worker to service the 50ms timer.
+		time.Sleep(5 * time.Second)
 		return
 	}
 	disableSystemMemoryLimits(t)

--- a/test/select_test.go
+++ b/test/select_test.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// These tests may run alongside CPU-intensive package builds. Their deadline
+// detects a lost wakeup, so leave enough headroom for a loaded CI scheduler.
+const selectProgressTimeout = 5 * time.Second
+
 func TestSelectRecvWakesForBlockedUnbufferedSend(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		res := make(chan struct{})
@@ -37,14 +41,14 @@ func TestSelectRecvWakesForBlockedUnbufferedSend(t *testing.T) {
 
 		select {
 		case <-sendDone:
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(selectProgressTimeout):
 			close(done)
 			t.Fatalf("iteration %d: unbuffered send did not wake select receiver", i)
 		}
 
 		select {
 		case <-received:
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(selectProgressTimeout):
 			close(done)
 			t.Fatalf("iteration %d: select receiver did not receive sent value", i)
 		}
@@ -77,7 +81,7 @@ func TestSelectMixedUnbufferedPeersMakeProgress(t *testing.T) {
 		for j := 0; j < 2; j++ {
 			select {
 			case <-done:
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(selectProgressTimeout):
 				t.Fatalf("iteration %d: mixed unbuffered select peers did not make progress", i)
 			}
 		}


### PR DESCRIPTION
## Summary

- schedule shared-package production, per-root link/finalize work, and native test execution through the existing bounded worker/DAG machinery
- keep package backend, object/archive publication, links, and runs within the same Go-compatible -p budget
- queue SSA builds by a cheap AST-node estimate, then queue isolated backends by actual Go SSA instruction count (largest first)
- put host runtime packages in the same backend pool as ordinary packages; cross builds retain conditional runtime construction
- preserve coordinator-only LLVM preparation, fail-fast, sequential-run, compile-only, deterministic reporting, and dependent-only failure propagation

## Motivation

#2234 removed duplicate package builds, but left barriers between package production, serial link/finalize work, and test execution. On a successful retry of the previous main full macOS job, llgo test took 2445s (40m45s), and the first test result appeared only after about 39m50s: https://github.com/xgo-dev/llgo/actions/runs/33719707855/attempts/2

The link span includes runtime PCLN and Darwin post-link finalization, which is expensive on macOS. Link plans remain coordinator-owned; independent external links/finalization use immutable plans and package archives.

## Scheduling and profiling

Before SSA exists, the scheduler counts nodes in the already-parsed AST once and uses that as a stable largest-first estimate. After SSA construction, one whole-program scan counts real SSA instructions; cache misses are queued largest first for backend plus archive publication. The Chrome/Perfetto trace records syntax_nodes and ssa_instructions per package, plus separate rank SSA packages and count SSA instructions coordinator spans.

In a local cold 102-package build, AST ranking took 6.658ms and SSA instruction counting took 15.945ms. AST ranking neither reparses nor type-checks source and was about 0.07% of the 10.22s combined-profile build. Runtime entered the initial backend wave instead of waiting behind the longest ordinary package.

The crypto/mldsa LLVM pathology found by profiling is intentionally fixed in separate PR #2498. A combined validation-only branch is published as cpunion/llgo:codex/parallel-profile-combined and is used by https://github.com/cpunion/llgo-etcd-parallel-profile.

## Validation

- go test ./internal/build -count=1 (223s, pass)
- focused ordering, SSA-count, package-group, and DAG tests after rebase to current main
- go test -race ./internal/build -run TestRunBuildDAG -count=1
- go test ./cmd/internal/build ./cmd/internal/test
- go test ./test/goroot -run TestRunProgramTimeout -count=10
- go vet ./internal/build ./cmd/internal/test ./test/goroot
- full local llgo test -p=3 -debug-trace=... ./test/... passed (191 targets)
- select progress regressions passed 100 repetitions under host Go and LLGo
- four concurrent LLGo stress runs passed 40,000 aggregate wakeup-test iterations

The macOS full Go 1.27 acceptance job previously completed llgo test in 740s, compared with the 2445s main baseline: https://github.com/xgo-dev/llgo/actions/runs/33755640219/job/100649569739