### PR TITLE
build: honor test -c for named targets

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1069,9 +1069,7 @@ func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, 
 			}
 			return nil, runNative(linkCtx, link.outFmts.Out, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode)
 		}
-		// runInEmulator returns before inspecting the emulator when -c is set.
-		// Route compile-only tests there instead of treating the target as a device.
-		if link.conf.Emulator || link.conf.CompileOnly {
+		if namedTargetUsesEmulatorPath(link.conf) {
 			return nil, runInEmulator(linkCtx.commands, linkCtx.crossCompile.Emulator, envMap, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode, verbose)
 		}
 		if err := flash.FlashDevice(linkCtx.crossCompile.Device, envMap, linkCtx.buildConf.Port, verbose); err != nil {
@@ -1095,6 +1093,15 @@ func newLinkExecutionContext(ctx *context, plan *mainLinkPlan) *context {
 		pclnExternal:         plan.pclnExternal,
 		stripDarwinLTOLocals: plan.stripDarwinLTOLocals,
 	}
+}
+
+func namedTargetUsesEmulatorPath(conf *Config) bool {
+	if conf.Emulator {
+		return true
+	}
+	// runInEmulator returns before inspecting the emulator when -c is set.
+	// Route compile-only tests there instead of treating the target as a device.
+	return conf.Mode == ModeTest && conf.CompileOnly
 }
 
 func removeOutFmts(outFmts *OutFmtDetails) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1069,7 +1069,18 @@ func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, 
 			}
 			return nil, runNative(linkCtx, link.outFmts.Out, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode)
 		}
-		return nil, runNamedTarget(linkCtx, link.outFmts.Out, envMap, link.pkg, link.conf, verbose)
+		// runInEmulator returns before inspecting the emulator when -c is set.
+		// Route compile-only tests there instead of treating the target as a device.
+		if link.conf.Emulator || link.conf.CompileOnly {
+			return nil, runInEmulator(linkCtx.commands, linkCtx.crossCompile.Emulator, envMap, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode, verbose)
+		}
+		if err := flash.FlashDevice(linkCtx.crossCompile.Device, envMap, linkCtx.buildConf.Port, verbose); err != nil {
+			return nil, err
+		}
+		return nil, monitor.Monitor(monitor.MonitorConfig{
+			Port: linkCtx.buildConf.Port, Target: link.conf.Target, Executable: link.outFmts.Out,
+			BaudRate: link.conf.BaudRate, SerialPort: linkCtx.crossCompile.Device.SerialPort,
+		}, verbose)
 	}
 	return nil, nil
 }
@@ -1084,24 +1095,6 @@ func newLinkExecutionContext(ctx *context, plan *mainLinkPlan) *context {
 		pclnExternal:         plan.pclnExternal,
 		stripDarwinLTOLocals: plan.stripDarwinLTOLocals,
 	}
-}
-
-func runNamedTarget(ctx *context, executable string, envMap map[string]string, pkg *packages.Package, conf *Config, verbose bool) error {
-	// go test -c stops after producing the requested artifact. In particular,
-	// it must not treat a named target without an emulator as hardware to flash.
-	if conf.Mode == ModeTest && conf.CompileOnly {
-		return nil
-	}
-	if conf.Emulator {
-		return runInEmulator(ctx.commands, ctx.crossCompile.Emulator, envMap, pkg.Dir, pkg.PkgPath, conf, conf.Mode, verbose)
-	}
-	if err := flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose); err != nil {
-		return err
-	}
-	return monitor.Monitor(monitor.MonitorConfig{
-		Port: ctx.buildConf.Port, Target: conf.Target, Executable: executable,
-		BaudRate: conf.BaudRate, SerialPort: ctx.crossCompile.Device.SerialPort,
-	}, verbose)
 }
 
 func removeOutFmts(outFmts *OutFmtDetails) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1069,16 +1069,7 @@ func executeInitialPackageLink(ctx *context, link *initialPackageLink, verbose, 
 			}
 			return nil, runNative(linkCtx, link.outFmts.Out, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode)
 		}
-		if link.conf.Emulator {
-			return nil, runInEmulator(linkCtx.commands, linkCtx.crossCompile.Emulator, envMap, link.pkg.Dir, link.pkg.PkgPath, link.conf, link.conf.Mode, verbose)
-		}
-		if err := flash.FlashDevice(linkCtx.crossCompile.Device, envMap, linkCtx.buildConf.Port, verbose); err != nil {
-			return nil, err
-		}
-		return nil, monitor.Monitor(monitor.MonitorConfig{
-			Port: linkCtx.buildConf.Port, Target: link.conf.Target, Executable: link.outFmts.Out,
-			BaudRate: link.conf.BaudRate, SerialPort: linkCtx.crossCompile.Device.SerialPort,
-		}, verbose)
+		return nil, runNamedTarget(linkCtx, link.outFmts.Out, envMap, link.pkg, link.conf, verbose)
 	}
 	return nil, nil
 }
@@ -1093,6 +1084,24 @@ func newLinkExecutionContext(ctx *context, plan *mainLinkPlan) *context {
 		pclnExternal:         plan.pclnExternal,
 		stripDarwinLTOLocals: plan.stripDarwinLTOLocals,
 	}
+}
+
+func runNamedTarget(ctx *context, executable string, envMap map[string]string, pkg *packages.Package, conf *Config, verbose bool) error {
+	// go test -c stops after producing the requested artifact. In particular,
+	// it must not treat a named target without an emulator as hardware to flash.
+	if conf.Mode == ModeTest && conf.CompileOnly {
+		return nil
+	}
+	if conf.Emulator {
+		return runInEmulator(ctx.commands, ctx.crossCompile.Emulator, envMap, pkg.Dir, pkg.PkgPath, conf, conf.Mode, verbose)
+	}
+	if err := flash.FlashDevice(ctx.crossCompile.Device, envMap, ctx.buildConf.Port, verbose); err != nil {
+		return err
+	}
+	return monitor.Monitor(monitor.MonitorConfig{
+		Port: ctx.buildConf.Port, Target: conf.Target, Executable: executable,
+		BaudRate: conf.BaudRate, SerialPort: ctx.crossCompile.Device.SerialPort,
+	}, verbose)
 }
 
 func removeOutFmts(outFmts *OutFmtDetails) {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1484,6 +1484,42 @@ func TestTestOutputFileLogic(t *testing.T) {
 	}
 }
 
+func TestNamedTargetCompileOnlyUsesEmulatorPath(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *Config
+		want bool
+	}{
+		{
+			name: "normal target run uses device path",
+			conf: &Config{Mode: ModeRun},
+		},
+		{
+			name: "test run without -c uses device path",
+			conf: &Config{Mode: ModeTest},
+		},
+		{
+			name: "explicit emulator uses emulator path",
+			conf: &Config{Mode: ModeRun, Emulator: true},
+			want: true,
+		},
+		{
+			name: "compile only test uses non executing emulator path",
+			conf: &Config{Mode: ModeTest, CompileOnly: true},
+			want: true,
+		},
+		{
+			name: "compile only is ignored outside test mode",
+			conf: &Config{Mode: ModeBuild, CompileOnly: true},
+		},
+	}
+	for _, test := range tests {
+		if got := namedTargetUsesEmulatorPath(test.conf); got != test.want {
+			t.Errorf("%s: namedTargetUsesEmulatorPath() = %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
 func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 	// Test that -o flag errors with multiple test packages
 	cfg := &Config{

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1484,6 +1484,16 @@ func TestTestOutputFileLogic(t *testing.T) {
 	}
 }
 
+func TestCompileOnlyNamedTargetDoesNotExecute(t *testing.T) {
+	// A named target without -emulator normally enters the flash/serial-monitor
+	// path. Compile-only must return after linking instead; otherwise even a
+	// WebAssembly test attempts to discover a serial port.
+	conf := &Config{Mode: ModeTest, Target: "emscripten", CompileOnly: true}
+	if err := runNamedTarget(nil, "wasm-test.mjs", nil, nil, conf, false); err != nil {
+		t.Fatalf("compile-only named target tried to execute: %v", err)
+	}
+}
+
 func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 	// Test that -o flag errors with multiple test packages
 	cfg := &Config{

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1484,16 +1484,6 @@ func TestTestOutputFileLogic(t *testing.T) {
 	}
 }
 
-func TestCompileOnlyNamedTargetWithoutEmulatorDoesNotExecute(t *testing.T) {
-	// A named target without -emulator normally enters the flash/serial-monitor
-	// path. Compile-only must return after linking instead; otherwise even a
-	// WebAssembly test attempts to discover a serial port.
-	conf := &Config{Mode: ModeTest, Target: "emscripten", CompileOnly: true}
-	if err := runNamedTarget(nil, "wasm-test.mjs", nil, nil, conf, false); err != nil {
-		t.Fatalf("compile-only named target tried to execute: %v", err)
-	}
-}
-
 func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 	// Test that -o flag errors with multiple test packages
 	cfg := &Config{

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1484,7 +1484,7 @@ func TestTestOutputFileLogic(t *testing.T) {
 	}
 }
 
-func TestCompileOnlyNamedTargetDoesNotExecute(t *testing.T) {
+func TestCompileOnlyNamedTargetWithoutEmulatorDoesNotExecute(t *testing.T) {
 	// A named target without -emulator normally enters the flash/serial-monitor
 	// path. Compile-only must return after linking instead; otherwise even a
 	// WebAssembly test attempts to discover a serial port.

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1520,6 +1520,50 @@ func TestNamedTargetCompileOnlyUsesEmulatorPath(t *testing.T) {
 	}
 }
 
+func TestExecuteInitialPackageLinkCompileOnlyNamedTargetDoesNotExecute(t *testing.T) {
+	// Exercise the production dispatch after a successful link. A named target
+	// without -emulator normally enters the flash/serial-monitor path; -c must
+	// instead stop with the linked artifact in place.
+	t.Setenv("LLGO_TEST_LINKER_HELPER", "write")
+	output := filepath.Join(t.TempDir(), "wasm-test.mjs")
+	conf := &Config{
+		Mode:        ModeTest,
+		Target:      "emscripten",
+		CompileOnly: true,
+		BuildMode:   BuildModeExe,
+		Goos:        runtime.GOOS,
+		Goarch:      runtime.GOARCH,
+		PCLNMode:    PCLNNone,
+	}
+	ctx := &context{
+		mode:      ModeTest,
+		buildConf: conf,
+		crossCompile: crosscompile.Export{
+			CC: os.Args[0],
+		},
+	}
+	link := &initialPackageLink{
+		pkg: &packages.Package{
+			Dir:     t.TempDir(),
+			PkgPath: "example.com/wasm-test.test",
+		},
+		conf:    conf,
+		outFmts: &OutFmtDetails{Out: output},
+		plan:    &mainLinkPlan{outputPath: output},
+	}
+
+	program, err := executeInitialPackageLink(ctx, link, false, false)
+	if err != nil {
+		t.Fatalf("compile-only named target tried to execute: %v", err)
+	}
+	if program != nil {
+		t.Fatalf("compile-only named target returned runnable program: %+v", program)
+	}
+	if data, err := os.ReadFile(output); err != nil || string(data) != "linked" {
+		t.Fatalf("linked output = %q, %v", data, err)
+	}
+}
+
 func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 	// Test that -o flag errors with multiple test packages
 	cfg := &Config{


### PR DESCRIPTION
Fixes #2485.

## Problem

`llgo test -c` must stop after producing the test binary. For a named target without the `-emulator` flag, the test path instead fell through to the generic device flash/serial-monitor path. A WebAssembly compile-only command therefore produced valid `.mjs`/`.wasm` output and then failed while looking for an unrelated serial port.

## Change

Route compile-only named targets through the existing `runInEmulator` path. That path already returns before inspecting or invoking the emulator when `CompileOnly` is set, and already has unit coverage. Normal execution, flashing, and monitoring remain unchanged.

The final implementation changes only the target-selection condition; it does not introduce another execution helper or duplicate existing control flow.

## Validation

- `go test ./internal/build -run TestRunInEmulator -count=1`
- real `llgo test -target emscripten-memory64 -c` compilation produces its WebAssembly outputs without trying to locate a serial port.
