### PR TITLE
runtime: preserve closure values in map buckets

### DIFF
--- a/cl/_testrt/mapclosure/in.go
+++ b/cl/_testrt/mapclosure/in.go
@@ -67,6 +67,21 @@ func main() {
 	if fn1(t) != fn2(t) {
 		panic("error")
 	}
+	testGrowingClosureMap()
+}
+
+func testGrowingClosureMap() {
+	const entries = 64
+	functions := make(map[int]func() int)
+	for i := range entries {
+		value := i + 1000
+		functions[i] = func() int { return value }
+	}
+	for i := range entries {
+		if got := functions[i](); got != i+1000 {
+			panic("map growth corrupted a closure")
+		}
+	}
 }
 
 func (t *typ) String() string {

--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -1501,20 +1501,27 @@ func funcStr(ft *funcType) string {
 // not implement Go's == operator), MapOf panics.
 func MapOf(key, elem Type) Type {
 	ktyp := key.common()
-	etyp := elem.common()
+	publicElem := elem.common()
+	etyp := publicElem
+	if etyp.Kind() == abi.Func {
+		// Map bucket operations copy elements using the element descriptor.
+		// Use LLGo's physical two-word closure there; Elem converts it back
+		// to the public function type returned by this API.
+		etyp = closureOf(etyp.FuncType())
+	}
 
 	if ktyp.Equal == nil {
 		panic("reflect.MapOf: invalid key type " + stringFor(ktyp))
 	}
 
 	// Look in cache.
-	ckey := cacheKey{Map, ktyp, etyp, 0}
+	ckey := cacheKey{Map, ktyp, publicElem, 0}
 	if mt, ok := lookupCache.Load(ckey); ok {
 		return mt.(Type)
 	}
 
 	// Look in known types.
-	s := "map[" + stringFor(ktyp) + "]" + stringFor(etyp)
+	s := "map[" + stringFor(ktyp) + "]" + stringFor(publicElem)
 	for _, tt := range typesByString(s) {
 		mt := (*mapType)(unsafe.Pointer(tt))
 		if mt.Key == ktyp && mt.Elem == etyp {
@@ -1530,7 +1537,7 @@ func MapOf(key, elem Type) Type {
 	mt := **(**mapType)(unsafe.Pointer(&imap))
 	mt.Str_ = s
 	mt.TFlag = 0
-	mt.Hash = fnv1(etyp.Hash, 'm', byte(ktyp.Hash>>24), byte(ktyp.Hash>>16), byte(ktyp.Hash>>8), byte(ktyp.Hash))
+	mt.Hash = fnv1(publicElem.Hash, 'm', byte(ktyp.Hash>>24), byte(ktyp.Hash>>16), byte(ktyp.Hash>>8), byte(ktyp.Hash))
 	mt.Key = ktyp
 	mt.Elem = etyp
 	mt.Bucket = bucketOf(ktyp, etyp)

--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -1524,7 +1524,7 @@ func MapOf(key, elem Type) Type {
 	s := "map[" + stringFor(ktyp) + "]" + stringFor(publicElem)
 	for _, tt := range typesByString(s) {
 		mt := (*mapType)(unsafe.Pointer(tt))
-		if mt.Key == ktyp && mt.Elem == etyp {
+		if mt.Key == ktyp && toPublicType(mt.Elem).common() == publicElem {
 			ti, _ := lookupCache.LoadOrStore(ckey, toRType(tt))
 			return ti.(Type)
 		}

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -2969,6 +2969,12 @@ func (f flag) panicNotMap() {
 // copyVal returns a Value containing the map key or value at ptr,
 // allocating a new variable as needed.
 func copyVal(typ *abi.Type, fl flag, ptr unsafe.Pointer) Value {
+	if typ.IsClosure() {
+		// Maps retain LLGo's physical two-word closure descriptor so bucket
+		// evacuation copies both the code and environment pointers. Expose the
+		// semantic Go kind on the reflected value, just as unpackEface does.
+		fl = fl&^flagKindMask | flag(Func)
+	}
 	if typ.IfaceIndir() {
 		// Copy result so future changes to the map
 		// won't change the underlying value.

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -328,7 +328,10 @@ func (b Builder) abiExtendedFields(t types.Type, name string, global llvm.Value)
 		hasher := b.aggregateValue(prog.Type(hashFunc, InGo), hash.impl, env.impl)
 		fields = []llvm.Value{
 			b.abiType(abi.PublicType(t.Key())).impl,
-			b.abiType(abi.PublicType(t.Elem())).impl,
+			// Map operations use Elem for physical copies during bucket
+			// evacuation. Keep LLGo's two-word closure representation here;
+			// reflect converts it back to the public function type in Elem.
+			b.abiType(t.Elem()).impl,
 			b.abiType(bucket).impl,
 			hasher.impl,
 			prog.IntVal(uint64(keySize), prog.Byte()).impl,

--- a/test/go/reflect_closure_type_test.go
+++ b/test/go/reflect_closure_type_test.go
@@ -59,6 +59,10 @@ func TestReflectClosureNestedTypeString(t *testing.T) {
 	dynamicCaptured := "dynamic"
 	dynamicFunction := func(s string) string { return dynamicCaptured + s }
 	dynamicType := reflect.MapOf(reflect.TypeOf(0), reflect.TypeOf(dynamicFunction))
+	staticType := reflect.TypeOf(map[int]func(string) string{})
+	if dynamicType != staticType {
+		t.Fatalf("reflect.MapOf type = %v (%p), want canonical %v (%p)", dynamicType, dynamicType, staticType, staticType)
+	}
 	dynamic := reflect.MakeMap(dynamicType)
 	dynamic.SetMapIndex(reflect.ValueOf(0), reflect.ValueOf(dynamicFunction))
 	dynamicValue := dynamic.MapIndex(reflect.ValueOf(0))

--- a/test/go/reflect_closure_type_test.go
+++ b/test/go/reflect_closure_type_test.go
@@ -38,6 +38,36 @@ func TestReflectClosureNestedTypeString(t *testing.T) {
 	if got, want := elem.Kind(), reflect.Func; got != want {
 		t.Fatalf("slice element kind = %v, want %v", got, want)
 	}
+	mapElem := reflect.TypeOf(map[int]func(int) bool{}).Elem()
+	if got, want := mapElem.String(), "func(int) bool"; got != want {
+		t.Fatalf("map element type = %q, want %q", got, want)
+	}
+	if got, want := mapElem.Kind(), reflect.Func; got != want {
+		t.Fatalf("map element kind = %v, want %v", got, want)
+	}
+
+	captured := 42
+	functions := map[int]func() int{0: func() int { return captured }}
+	value := reflect.ValueOf(functions).MapIndex(reflect.ValueOf(0))
+	if got, want := value.Kind(), reflect.Func; got != want {
+		t.Fatalf("map value kind = %v, want %v", got, want)
+	}
+	if got := value.Interface().(func() int)(); got != captured {
+		t.Fatalf("map value returned %d, want %d", got, captured)
+	}
+
+	dynamicCaptured := "dynamic"
+	dynamicFunction := func(s string) string { return dynamicCaptured + s }
+	dynamicType := reflect.MapOf(reflect.TypeOf(0), reflect.TypeOf(dynamicFunction))
+	dynamic := reflect.MakeMap(dynamicType)
+	dynamic.SetMapIndex(reflect.ValueOf(0), reflect.ValueOf(dynamicFunction))
+	dynamicValue := dynamic.MapIndex(reflect.ValueOf(0))
+	if got, want := dynamicValue.Kind(), reflect.Func; got != want {
+		t.Fatalf("dynamic map value kind = %v, want %v", got, want)
+	}
+	if got, want := dynamicValue.Interface().(func(string) string)(" map"), "dynamic map"; got != want {
+		t.Fatalf("dynamic map value returned %q, want %q", got, want)
+	}
 }
 
 func TestReflectClosurePointerTypeIdentity(t *testing.T) {


### PR DESCRIPTION
Fixes #2490.

## Problem

LLGo closures occupy two machine words: a code pointer and a captured-environment pointer. Map bucket metadata used the public one-word Go `func` descriptor, so bucket evacuation during map growth copied only the code pointer and silently lost captured state.

## Change

- use the physical two-word closure descriptor for internal map bucket layout and copying;
- keep the public function type for reflection names, cache keys, hashes, and API results;
- preserve canonical identity between `reflect.MapOf` and an equivalent statically declared map type;
- keep ordinary non-closure map elements unchanged.

## Regression coverage

- force map growth with 64 distinct capturing closures and invoke every value after evacuation;
- cover static reflection, `MapIndex`, dynamically constructed `MapOf`/`MakeMap`, and canonical type identity;
- verify the same test-only change fails on current `main` by losing the environment pointer;
- `go test ./ssa ./cl -run "Map|Closure|ABIType" -count=1`;
- standalone LLGo reflection execution test.

This PR is independent of the WebAssembly runtime stack.