### PR TITLE
fix(ssa): keep wasm closure calls opaque through optimization

### DIFF
--- a/ssa/closure_env_test.go
+++ b/ssa/closure_env_test.go
@@ -261,6 +261,46 @@ func TestWasmDynamicClosureUsesTwoExplicitTypedEdges(t *testing.T) {
 	}
 }
 
+func TestWasm64DynamicClosureCodeGenAfterOz(t *testing.T) {
+	Initialize(InitAllTargets | InitAllTargetInfos | InitAllTargetMCs | InitAllAsmPrinters)
+	prog := NewProgram(&Target{
+		GOOS:       "js",
+		GOARCH:     "wasm",
+		LLVMTarget: "wasm64-unknown-emscripten",
+	})
+	defer prog.Dispose()
+	setTestRuntime(t, prog)
+	pkg := prog.NewPackage("p", "example.com/p")
+
+	params := types.NewTuple(types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int]))
+	results := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+	sig := types.NewSignatureType(nil, nil, nil, params, results, false)
+	envStruct := types.NewStruct(
+		[]*types.Var{types.NewField(token.NoPos, nil, "capture", types.Typ[types.Int], false)},
+		nil,
+	)
+	env := types.NewParam(token.NoPos, nil, "$env", types.NewPointer(envStruct))
+	entry := pkg.NewEnvFunc("captured", sig, InGo, env, false)
+	newMatrixCaller(pkg, "callCaptured", sig, func(b Builder) Expr {
+		return b.MakeClosure(entry.Expr, []Expr{prog.Val(7)})
+	})
+
+	mod := pkg.Module()
+	pbo := llvm.NewPassBuilderOptions()
+	defer pbo.Dispose()
+	if err := mod.RunPasses("default<Oz>", prog.TargetMachine(), pbo); err != nil {
+		t.Fatal(err)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("optimized wasm64 closure module is invalid: %v\n%s", err, mod.String())
+	}
+	obj, err := prog.TargetMachine().EmitToMemoryBuffer(mod, llvm.ObjectFile)
+	if err != nil {
+		t.Fatalf("emit optimized wasm64 closure object: %v\n%s", err, mod.String())
+	}
+	obj.Dispose()
+}
+
 func TestNativeDynamicClosureIdentityBarrierSurvivesO2(t *testing.T) {
 	for _, pipeline := range []string{"default<O2>", "lto<O2>"} {
 		t.Run(pipeline, func(t *testing.T) {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1519,6 +1519,13 @@ func (b Builder) callClosure(fn, data Expr, sig *types.Signature, args []Expr) (
 		return
 	}
 
+	// Explicit-context targets use two physical call signatures for one Go
+	// funcval type. Keep the code pointer opaque so optimization cannot
+	// devirtualize both edges to one entry with the other edge's signature.
+	fnSlot := b.AllocaT(fn.Type)
+	b.Store(fnSlot, fn).SetVolatile(true)
+	fn = b.Load(fnSlot).SetVolatile(true)
+
 	logicalBlock := b.blk
 	entryBlock := b.impl.GetInsertBlock()
 	blks := b.Func.MakeBlocks(3)

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1741,8 +1741,8 @@ func TestCallClosureDynamic(t *testing.T) {
 	ir := pkg.String()
 	for _, want := range []string{
 		"icmp ne ptr %2, null",
-		"call i32 %3(ptr ",
-		"call i32 %3(i32 %1)",
+		"call i32 %5(ptr ",
+		"call i32 %5(i32 %1)",
 		"phi i32",
 	} {
 		if !strings.Contains(ir, want) {


### PR DESCRIPTION
## What changed

- keep dynamic closure code pointers opaque on explicit-context targets before selecting the env/no-env call edge
- add a regression test that runs `default<Oz>`, verifies the optimized module, and emits a real wasm64 object

## Why

An LLGo funcval can carry either a plain entry or an environment entry. On explicit-context targets the dynamic call therefore has two physical signatures, selected by whether the environment pointer is nil. Optimization can recover the code pointer identity and turn both edges into direct calls to the same symbol, including the edge with the other physical signature.

LLVM 19 emits the existing `encoding/json/v2` wasm64 package successfully. LLVM 21 and LLVM 22 fail during wasm64 instruction selection after that directization. This is not treated as a pure LLVM bug: the two-signature funcval representation is an LLGo contract that needs to keep the callee identity opaque. A larger uniform-closure-ABI redesign remains outside this fix.

## Verification

- `go test ./ssa -count=1` with LLVM 19.1.7
- focused `default<Oz>` + verifier + wasm64 object-emission test with LLVM 22.1.8
