### PR TITLE
fix(ssa): preserve nonnull closure environments

### DIFF
--- a/cl/_testdata/llgointrinsics/in.go
+++ b/cl/_testdata/llgointrinsics/in.go
@@ -16,7 +16,7 @@ import (
 // CHECK: ret i64 ptrtoint (ptr @write to i64)
 // CHECK-LABEL: define i64 @"{{.*}}.UseClosure"(){{.*}} {
 // CHECK: [[UC_X:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT: [[UC_ENV:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT: [[UC_ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT: [[UC_X_SLOT:%[0-9]+]] = getelementptr inbounds { ptr }, ptr [[UC_ENV]], i32 0, i32 0
 // CHECK-NEXT: store ptr [[UC_X]], ptr [[UC_X_SLOT]]
 // CHECK-NEXT: [[UC_CLOSURE:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"{{.*}}.UseClosure$1", ptr undef }, ptr [[UC_ENV]], 1

--- a/cl/_testgo/chan/in.go
+++ b/cl/_testgo/chan/in.go
@@ -17,7 +17,7 @@ package main
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[CH1_LEN]])
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[CH1_CAP]])
 // CHECK: call void @"{{.*}}PrintEface"(%"{{.*}}eface" [[CH1_EFACE]])
-// CHECK: [[SEND_ENV:%.*]] = call ptr @"{{.*}}AllocU"(i64 8)
+// CHECK: [[SEND_ENV:%.*]] = call nonnull ptr @"{{.*}}AllocU"(i64 8)
 // CHECK: store ptr [[CH1_SLOT]], ptr {{%.*}}
 // CHECK: [[SEND_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr [[SEND_ENV]], 1
 // CHECK: store { ptr, ptr } [[SEND_CLOSURE]], ptr {{%.*}}
@@ -32,7 +32,7 @@ package main
 // CHECK: [[CH2_SLOT:%.*]] = call ptr @"{{.*}}AllocZ"(i64 8)
 // CHECK: [[CH2:%.*]] = call ptr @"{{.*}}NewChan"(i64 8, i64 10)
 // CHECK-NEXT: store ptr [[CH2]], ptr [[CH2_SLOT]]
-// CHECK: [[CLOSE_ENV:%.*]] = call ptr @"{{.*}}AllocU"(i64 8)
+// CHECK: [[CLOSE_ENV:%.*]] = call nonnull ptr @"{{.*}}AllocU"(i64 8)
 // CHECK: store ptr [[CH2_SLOT]], ptr {{%.*}}
 // CHECK: [[CLOSE_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.main$2", ptr undef }, ptr [[CLOSE_ENV]], 1
 // CHECK: store { ptr, ptr } [[CLOSE_CLOSURE]], ptr {{%.*}}

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -112,7 +112,7 @@ func makeWithFree(base int) Fn {
 // CHECK: [[S:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT: [[S_FIELD:%[0-9]+]] = getelementptr inbounds %main.S, ptr [[S]], i32 0, i32 0
 // CHECK-NEXT: store i64 5, ptr [[S_FIELD]]
-// CHECK: [[METHOD_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[METHOD_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[METHOD_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[METHOD_ENV]], i32 0, i32 0
 // CHECK: store ptr [[S]], ptr [[METHOD_ENV_SLOT]]
 // CHECK: [[METHOD_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*S).Add$bound", ptr undef }, ptr [[METHOD_ENV]], 1
@@ -130,7 +130,7 @@ func makeWithFree(base int) Fn {
 // CHECK: [[IFACE_TYPE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}iface" [[IFACE]])
 // CHECK: [[IFACE_OK:%.*]] = icmp ne ptr [[IFACE_TYPE]], null
 // CHECK: br i1 [[IFACE_OK]], label %{{.*}}, label %{{.*}}
-// CHECK: [[IFACE_METHOD_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK: [[IFACE_METHOD_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK: [[IFACE_METHOD_SLOT:%.*]] = getelementptr inbounds { %"{{.*}}iface" }, ptr [[IFACE_METHOD_ENV]], i32 0, i32 0
 // CHECK: store %"{{.*}}iface" [[IFACE]], ptr [[IFACE_METHOD_SLOT]]
 // CHECK: [[IFACE_METHOD:%.*]] = insertvalue { ptr, ptr } { ptr @"main.interface{Add(int) int}.Add$bound", ptr undef }, ptr [[IFACE_METHOD_ENV]], 1
@@ -157,7 +157,7 @@ func makeWithFree(base int) Fn {
 // CHECK-LABEL: define %main.Fn @main.makeWithFree(i64 %0){{.*}} {
 // CHECK: [[BASE_ADDR:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT: store i64 %0, ptr [[BASE_ADDR]]
-// CHECK-NEXT: [[WITH_FREE_ENV_OUT:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT: [[WITH_FREE_ENV_OUT:%[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT: [[WITH_FREE_ENV_SLOT:%[0-9]+]] = getelementptr inbounds { ptr }, ptr [[WITH_FREE_ENV_OUT]], i32 0, i32 0
 // CHECK-NEXT: store ptr [[BASE_ADDR]], ptr [[WITH_FREE_ENV_SLOT]]
 // CHECK-NEXT: [[WITH_FREE_FN:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.makeWithFree$1", ptr undef }, ptr [[WITH_FREE_ENV_OUT]], 1

--- a/cl/_testgo/closureenv/in.go
+++ b/cl/_testgo/closureenv/in.go
@@ -19,7 +19,7 @@ package main
 // CHECK-LABEL: define { ptr, ptr } @main.zeroSizedPointerCapture(ptr %0){{.*}} {
 // CHECK: [[ZSP_VALUE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT: store ptr %0, ptr [[ZSP_VALUE]]
-// CHECK-NEXT: [[ZSP_ENV:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT: [[ZSP_ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store ptr [[ZSP_VALUE]], ptr %{{[0-9]+}}
 // CHECK: [[ZSP_CLOSURE:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.zeroSizedPointerCapture$1", ptr undef }, ptr [[ZSP_ENV]], 1
 // CHECK-NEXT: ret { ptr, ptr } [[ZSP_CLOSURE]]

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -15,7 +15,7 @@ func values(yield func(int) bool) {
 }
 
 // CHECK-LABEL: define i64 @main.sum(%main.Seq %0){{.*}} {
-// CHECK: [[ENV:%[0-9]+]] = call ptr @"{{.*}}AllocU"
+// CHECK: [[ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}AllocU"
 // CHECK: [[RANGE_CLOSURE:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.sum$1", ptr undef }, ptr [[ENV]], 1
 // CHECK: [[SEQ_ENV:%[0-9]+]] = extractvalue %main.Seq %0, 1
 // CHECK: [[SEQ_CODE:%[0-9]+]] = extractvalue %main.Seq %0, 0

--- a/cl/_testgo/deferclosure/in.go
+++ b/cl/_testgo/deferclosure/in.go
@@ -21,7 +21,7 @@ package main
 // The captured 42 is stored in the closure environment before the function pair is deferred.
 // CHECK: [[VALUE_CAPTURE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK: store i64 42, ptr [[VALUE_CAPTURE]]
-// CHECK: [[VALUE_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[VALUE_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store ptr [[VALUE_CAPTURE]], ptr %{{.*}}
 // CHECK: [[VALUE_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.testDeferClosureValue$1", ptr undef }, ptr [[VALUE_ENV]], 1
 // CHECK: [[VALUE_PREV_DEFER:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
@@ -89,7 +89,7 @@ package main
 // CHECK: [[STRUCT_PROCESSOR:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK: [[STRUCT_MSG:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK: store %"{{.*}}String" { ptr @{{.*}}, i64 8 }, ptr [[STRUCT_MSG]]
-// CHECK: [[STRUCT_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[STRUCT_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store ptr [[STRUCT_MSG]], ptr %{{.*}}
 // CHECK: [[STRUCT_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.testDeferStructClosure$1", ptr undef }, ptr [[STRUCT_ENV]], 1
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()

--- a/cl/_testgo/reflectconv/in.go
+++ b/cl/_testgo/reflectconv/in.go
@@ -25,7 +25,7 @@ type namedFunc func(int) int
 // CHECK: call %{{.*}} @reflect.Value.Interface(%reflect.Value [[FUNC_RESULT]])
 
 // CHECK-LABEL: define void @main.functionPointers(){{.*}} {
-// CHECK: [[CAPTURED_ENV:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 8)
+// CHECK: [[CAPTURED_ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}AllocU"(i64 8)
 // CHECK: [[CAPTURED_PAIR:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.functionPointers$1", ptr undef }, ptr [[CAPTURED_ENV]], 1
 // CHECK-NEXT: [[CAPTURED_BOX:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 16)
 // CHECK-NEXT: store { ptr, ptr } [[CAPTURED_PAIR]], ptr [[CAPTURED_BOX]]

--- a/cl/_testrt/closureconv/in.go
+++ b/cl/_testrt/closureconv/in.go
@@ -32,7 +32,7 @@ func add(a int, b int) int {
 // CHECK: [[DEMO1_CALL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK: [[DEMO1_N:%.*]] = getelementptr inbounds %main.Call, ptr [[DEMO1_CALL]], i32 0, i32 1
 // CHECK: store i64 %0, ptr [[DEMO1_N]]
-// CHECK: [[DEMO1_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO1_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[DEMO1_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[DEMO1_ENV]], i32 0, i32 0
 // CHECK: store ptr [[DEMO1_CALL]], ptr [[DEMO1_ENV_SLOT]]
 // CHECK: [[DEMO1_BOUND:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr [[DEMO1_ENV]], 1
@@ -51,7 +51,7 @@ func demo1(n int) Func {
 
 // CHECK-LABEL: define %main.Func @main.demo2(){{.*}} {
 // CHECK: [[DEMO2_CALL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK: [[DEMO2_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO2_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[DEMO2_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[DEMO2_ENV]], i32 0, i32 0
 // CHECK: store ptr [[DEMO2_CALL]], ptr [[DEMO2_ENV_SLOT]]
 // CHECK: [[DEMO2_BOUND:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr [[DEMO2_ENV]], 1
@@ -84,7 +84,7 @@ func demo4() Func {
 // CHECK-LABEL: define %main.Func @main.demo5(i64 %0){{.*}} {
 // CHECK: [[DEMO5_CAPTURE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK: store i64 %0, ptr [[DEMO5_CAPTURE]]
-// CHECK: [[DEMO5_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO5_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[DEMO5_ENV_SLOT:%.*]] = getelementptr inbounds { ptr }, ptr [[DEMO5_ENV]], i32 0, i32 0
 // CHECK: store ptr [[DEMO5_CAPTURE]], ptr [[DEMO5_ENV_SLOT]]
 // CHECK: [[DEMO5_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.demo5$1", ptr undef }, ptr [[DEMO5_ENV]], 1

--- a/cl/_testrt/closureiface/in.go
+++ b/cl/_testrt/closureiface/in.go
@@ -21,7 +21,7 @@ func main() {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP0:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 200, ptr %[[TMP0]], align 8
-// CHECK-NEXT:   %[[TMP1:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %[[TMP1:[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[TMP1]], i32 0, i32 0
 // CHECK-NEXT:   store ptr %[[TMP0]], ptr %[[TMP2]], align 8
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %[[TMP1]], 1

--- a/cl/_testrt/freevars/in.go
+++ b/cl/_testrt/freevars/in.go
@@ -27,7 +27,7 @@ func main() {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP1:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %[[TMP0]], ptr %[[TMP1]], align 8
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[TMP2]], i32 0, i32 0
 // CHECK-NEXT:   store ptr %[[TMP1]], ptr %[[TMP3]], align 8
 // CHECK-NEXT:   %[[TMP4:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1$1", ptr undef }, ptr %[[TMP2]], 1

--- a/cl/_testrt/named/in.go
+++ b/cl/_testrt/named/in.go
@@ -55,7 +55,7 @@ func main() {
 // CHECK: %[[ROOTSLOT:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK: %[[ROOT:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 64)
 // CHECK: store ptr %[[ROOT]], ptr %[[ROOTSLOT]], align 8
-// CHECK: %[[ENV:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: %[[ENV:[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: %[[ENVSLOT:[0-9]+]] = getelementptr inbounds { ptr }, ptr %[[ENV]], i32 0, i32 0
 // CHECK: store ptr %[[ROOTSLOT]], ptr %[[ENVSLOT]], align 8
 // CHECK: %[[CLOSURE:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %[[ENV]], 1

--- a/internal/build/testdata/wasm-profile/main.go
+++ b/internal/build/testdata/wasm-profile/main.go
@@ -10,6 +10,28 @@ func cPointerSize() uintptr
 //go:linkname cLongSize C.llgo_wasm_profile_long_size
 func cLongSize() uintptr
 
+func keepDynamic(fn func()) func() {
+	return fn
+}
+
+func plainRecover() {
+	if got := recover(); got != 42 {
+		panic("plain function value did not recover")
+	}
+}
+
+func checkClosureABI() {
+	base := 41
+	add1 := func() int { return base + 1 }
+	if got := add1(); got != 42 {
+		panic("captured closure call failed")
+	}
+	func() {
+		defer keepDynamic(plainRecover)()
+		panic(42)
+	}()
+}
+
 func main() {
 	if got := unsafe.Sizeof(uintptr(0)); got != expectedWordSize {
 		panic("unexpected Go word size")
@@ -20,5 +42,6 @@ func main() {
 	if got := cLongSize(); got != expectedCLongSize {
 		panic("unexpected C long size")
 	}
+	checkClosureABI()
 	println("wasm ABI profile ok")
 }

--- a/runtime/internal/runtime/z_gc.go
+++ b/runtime/internal/runtime/z_gc.go
@@ -30,6 +30,9 @@ import (
 // AllocU allocates uninitialized memory.
 func AllocU(size uintptr) unsafe.Pointer {
 	ret := bdwgc.Malloc(size)
+	if ret == nil && size != 0 {
+		panic("out of memory")
+	}
 	recordMemProfileAlloc(size)
 	return ret
 }

--- a/runtime/internal/runtime/z_gc_baremetal.go
+++ b/runtime/internal/runtime/z_gc_baremetal.go
@@ -27,6 +27,9 @@ import (
 // AllocU allocates uninitialized memory.
 func AllocU(size uintptr) unsafe.Pointer {
 	ret := tinygogc.Alloc(size)
+	if ret == nil && size != 0 {
+		panic("out of memory")
+	}
 	recordMemProfileAlloc(size)
 	return ret
 }

--- a/runtime/internal/runtime/z_nogc.go
+++ b/runtime/internal/runtime/z_nogc.go
@@ -28,6 +28,9 @@ import (
 // AllocU allocates uninitialized memory.
 func AllocU(size uintptr) unsafe.Pointer {
 	ret := c.Malloc(size)
+	if ret == nil && size != 0 {
+		panic("out of memory")
+	}
 	recordMemProfileAlloc(size)
 	return ret
 }

--- a/ssa/closure_env_test.go
+++ b/ssa/closure_env_test.go
@@ -261,6 +261,64 @@ func TestWasmDynamicClosureUsesTwoExplicitTypedEdges(t *testing.T) {
 	}
 }
 
+func TestWasm64DynamicClosureCodeGenAfterOptimization(t *testing.T) {
+	Initialize(InitAllTargets | InitAllTargetInfos | InitAllTargetMCs | InitAllAsmPrinters)
+	for _, pipeline := range []string{"default<Oz>", "lto<Oz>"} {
+		for _, kind := range []string{"plain", "captured"} {
+			t.Run(pipeline+"/"+kind, func(t *testing.T) {
+				prog := NewProgram(&Target{
+					GOOS:       "js",
+					GOARCH:     "wasm",
+					LLVMTarget: "wasm64-unknown-emscripten",
+				})
+				defer prog.Dispose()
+				setTestRuntime(t, prog)
+				pkg := prog.NewPackage("p", "example.com/p")
+
+				params := types.NewTuple(types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int]))
+				results := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+				sig := types.NewSignatureType(nil, nil, nil, params, results, false)
+				var value func(Builder) Expr
+				if kind == "plain" {
+					entry := pkg.NewFunc("plain", sig, InGo)
+					entry.impl.SetLinkage(llvm.InternalLinkage)
+					body := entry.MakeBody(1)
+					body.Return(entry.Param(0))
+					value = func(b Builder) Expr { return b.MakeClosure(entry.Expr, nil) }
+				} else {
+					envStruct := types.NewStruct(
+						[]*types.Var{types.NewField(token.NoPos, nil, "capture", types.Typ[types.Int], false)},
+						nil,
+					)
+					entry := newMatrixEnvEntry(pkg, "captured", sig, envStruct)
+					entry.impl.SetLinkage(llvm.InternalLinkage)
+					value = func(b Builder) Expr {
+						return b.MakeClosure(entry.Expr, []Expr{prog.Val(7)})
+					}
+				}
+				newMatrixCaller(pkg, "call", sig, value)
+
+				mod := pkg.Module()
+				pbo := llvm.NewPassBuilderOptions()
+				defer pbo.Dispose()
+				if err := mod.RunPasses(pipeline, prog.TargetMachine(), pbo); err != nil {
+					t.Fatal(err)
+				}
+				if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+					t.Fatalf("optimized wasm64 closure module is invalid: %v\n%s", err, mod.String())
+				}
+				// Assembly emission exercises instruction selection without depending
+				// on per-function section options supplied by the package build path.
+				asm, err := prog.TargetMachine().EmitToMemoryBuffer(mod, llvm.AssemblyFile)
+				if err != nil {
+					t.Fatalf("emit optimized wasm64 closure assembly: %v\n%s", err, mod.String())
+				}
+				asm.Dispose()
+			})
+		}
+	}
+}
+
 func TestNativeDynamicClosureIdentityBarrierSurvivesO2(t *testing.T) {
 	for _, pipeline := range []string{"default<O2>", "lto<O2>"} {
 		t.Run(pipeline, func(t *testing.T) {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1386,6 +1386,10 @@ func (b Builder) MakeClosure(fn Expr, bindings []Expr) Expr {
 			data = b.Alloc(tctx, true).impl
 		} else {
 			data = b.aggregateAllocU(tctx, llvmFields(bindings, rawCtx, b)...)
+			// Non-zero closure environments either allocate successfully or the
+			// runtime panics. Preserve that contract at this call site so LLVM can
+			// keep the code/data pair correlated while optimizing dynamic calls.
+			data.AddCallSiteAttribute(0, prog.ctx.CreateEnumAttribute(llvm.AttributeKindID("nonnull"), 0))
 		}
 	} else if len(bindings) != 0 {
 		panic("ssa: closure bindings supplied to a no-env function")

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1386,9 +1386,9 @@ func (b Builder) MakeClosure(fn Expr, bindings []Expr) Expr {
 			data = b.Alloc(tctx, true).impl
 		} else {
 			data = b.aggregateAllocU(tctx, llvmFields(bindings, rawCtx, b)...)
-			// Non-zero closure environments either allocate successfully or the
-			// runtime panics. Preserve that contract at this call site so LLVM can
-			// keep the code/data pair correlated while optimizing dynamic calls.
+			// A non-zero closure environment allocation either succeeds or does not
+			// return. Mark the return value (attribute index 0) non-null so
+			// LLVM can eliminate the impossible no-environment call edge.
 			data.AddCallSiteAttribute(0, prog.ctx.CreateEnumAttribute(llvm.AttributeKindID("nonnull"), 0))
 		}
 	} else if len(bindings) != 0 {

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1789,7 +1789,7 @@ func TestMakeClosureWithCtx(t *testing.T) {
 	for _, want := range []string{
 		"define i64 @inner(ptr ",
 		"i64 %1)",
-		`call ptr @"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocU"(i64 8)`,
+		`call nonnull ptr @"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocU"(i64 8)`,
 		"insertvalue { ptr, ptr } { ptr @inner, ptr undef }",
 	} {
 		if !strings.Contains(ir, want) {


### PR DESCRIPTION
## Summary

- keep LLGo's existing `{code, data}` function-value representation and its two exact call edges
- mark non-zero closure-environment allocations `nonnull` at the allocation call site
- make hosted `AllocU` panic instead of returning nil for a non-zero allocation
- cover optimized wasm64 instruction selection, LTO, and runtime closure calls

## Why

LLVM 22 can devirtualize the code half of a dynamic function value while retaining the `data == nil` edge because the `AllocU` declaration permits a null return. It can then form a direct WebAssembly call without the environment argument, which fails during instruction selection.

The closure environment is required to be non-null whenever the selected entry requires an environment. Encoding the allocation/runtime invariant lets LLVM eliminate the impossible edge without an optimization barrier, wrapper function, or ABI change.

## Scope

This is independent of the LLVM 22 upgrade and starts from current `main` (LLVM 19). It does not add closure adapters or include unrelated IR/LTO modernization.

## Validation

- LLVM 19: `go test ./ssa -count=1`
- LLVM 19: `go test ./internal/build -count=1`
- LLVM 22: focused closure IR/verifier/optimized CodeGen matrix
- LLVM 22: original `encoding/json/v2` wasm64 reproducer
- LLVM 22: wasm target profile script (Emscripten, memory64, WASI, raw wasm)
- LLVM 22: thin and full LTO builds plus Node execution

The complete LLVM 22 `./ssa` run still sees the known current-main DataLayout text expectation for LLVM 19; the closure-focused tests pass.
