### PR TITLE
ssa: avoid materializing large struct comparisons

### DIFF
--- a/cl/_testgo/equal/in.go
+++ b/cl/_testgo/equal/in.go
@@ -37,20 +37,16 @@ package main
 // CHECK: %[[ARRAY_NE:[0-9]+]] = xor i1 %{{[0-9]+}}, true
 // CHECK: call void @main.assert(i1 %[[ARRAY_NE]])
 
-// Structs delegate string and interface fields to their semantic equality
-// helpers and combine both results before asserting the aggregate result.
+// Large structs delegate to their type-specific semantic equality helper
+// instead of expanding every field into aggregate extracts in LLVM IR.
 // CHECK-LABEL: define void @"main.init#3"(){{.*}} {
-// CHECK: %[[STRUCT_L:[0-9]+]] = load %main.T, ptr %{{[0-9]+}}
-// CHECK: %[[STRUCT_R:[0-9]+]] = load %main.T, ptr %{{[0-9]+}}
-// CHECK: %[[STRING_L:[0-9]+]] = extractvalue %main.T %[[STRUCT_L]], 2
-// CHECK: %[[STRING_R:[0-9]+]] = extractvalue %main.T %[[STRUCT_R]], 2
-// CHECK: %[[STRING_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %[[STRING_L]], %"{{.*}}/runtime/internal/runtime.String" %[[STRING_R]])
-// CHECK: %[[WITH_STRING:[0-9]+]] = and i1 %{{[0-9]+}}, %[[STRING_EQ]]
-// CHECK: %[[EFACE_L:[0-9]+]] = extractvalue %main.T %[[STRUCT_L]], 3
-// CHECK: %[[EFACE_R:[0-9]+]] = extractvalue %main.T %[[STRUCT_R]], 3
-// CHECK: %[[EFACE_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %[[EFACE_L]], %"{{.*}}/runtime/internal/runtime.eface" %[[EFACE_R]])
-// CHECK: %[[STRUCT_EQ:[0-9]+]] = and i1 %[[WITH_STRING]], %[[EFACE_EQ]]
+// CHECK: %[[STRUCT_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
 // CHECK: call void @main.assert(i1 %[[STRUCT_EQ]])
+// CHECK: %[[STRUCT_EQ2:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
+// CHECK: call void @main.assert(i1 %[[STRUCT_EQ2]])
+// CHECK: %[[STRUCT_RAW_NE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
+// CHECK: %[[STRUCT_NE:[0-9]+]] = xor i1 %[[STRUCT_RAW_NE]], true
+// CHECK: call void @main.assert(i1 %[[STRUCT_NE]])
 
 // Slices compare with nil through their data pointer. Check the non-empty and
 // zero-length/non-zero-capacity make paths separately.

--- a/cl/_testgo/equal/in.go
+++ b/cl/_testgo/equal/in.go
@@ -47,6 +47,11 @@ package main
 // CHECK: %[[STRUCT_RAW_NE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
 // CHECK: %[[STRUCT_NE:[0-9]+]] = xor i1 %[[STRUCT_RAW_NE]], true
 // CHECK: call void @main.assert(i1 %[[STRUCT_NE]])
+// CHECK: %[[ZERO_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.memequalzero"
+// CHECK: call void @main.assert(i1 %[[ZERO_EQ]])
+// CHECK: %[[ZERO_RAW_NE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.memequalzero"
+// CHECK: %[[ZERO_NE:[0-9]+]] = xor i1 %[[ZERO_RAW_NE]], true
+// CHECK: call void @main.assert(i1 %[[ZERO_NE]])
 
 // Slices compare with nil through their data pointer. Check the non-empty and
 // zero-length/non-zero-capacity make paths separately.
@@ -137,6 +142,13 @@ func init() {
 	assert(x == y)
 	assert(x != z)
 	assert(y != z)
+	var large struct{ data [2049]byte }
+	assert(large == struct{ data [2049]byte }{})
+	large.data[1024] = 1
+	assert(large != struct{ data [2049]byte }{})
+	large.data[1024] = 0
+	large.data[2048] = 1
+	assert(large != struct{ data [2049]byte }{})
 }
 
 // slice

--- a/cl/_testgo/equal/in.go
+++ b/cl/_testgo/equal/in.go
@@ -37,21 +37,26 @@ package main
 // CHECK: %[[ARRAY_NE:[0-9]+]] = xor i1 %{{[0-9]+}}, true
 // CHECK: call void @main.assert(i1 %[[ARRAY_NE]])
 
-// Large structs delegate to their type-specific semantic equality helper
-// instead of expanding every field into aggregate extracts in LLVM IR.
+// Semantic structs retain field-wise comparison, including the interface
+// equality calls whose order and panic behavior are observable. Large regular
+// structs use the bytewise zero helper without materializing the aggregate.
 // CHECK-LABEL: define void @"main.init#3"(){{.*}} {
-// CHECK: %[[STRUCT_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
-// CHECK: call void @main.assert(i1 %[[STRUCT_EQ]])
-// CHECK: %[[STRUCT_EQ2:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
-// CHECK: call void @main.assert(i1 %[[STRUCT_EQ2]])
-// CHECK: %[[STRUCT_RAW_NE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.structequal"
-// CHECK: %[[STRUCT_NE:[0-9]+]] = xor i1 %[[STRUCT_RAW_NE]], true
+// CHECK: %[[ZERO_STRING:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"({{.*}}zeroinitializer, {{.*}}zeroinitializer)
+// CHECK: %[[ZERO_IFACE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"({{.*}}zeroinitializer, {{.*}}zeroinitializer)
+// CHECK: call void @main.assert(i1 %{{[0-9]+}})
+// CHECK: extractvalue %main.T %{{[0-9]+}}, 0
+// CHECK: %[[STRUCT_STRING:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"
+// CHECK: %[[STRUCT_IFACE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK: call void @main.assert(i1 %{{[0-9]+}})
+// CHECK: %[[STRUCT_RAW_NE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
+// CHECK: %[[STRUCT_NE:[0-9]+]] = xor i1 %{{[0-9]+}}, true
 // CHECK: call void @main.assert(i1 %[[STRUCT_NE]])
 // CHECK: %[[ZERO_EQ:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.memequalzero"
 // CHECK: call void @main.assert(i1 %[[ZERO_EQ]])
 // CHECK: %[[ZERO_RAW_NE:[0-9]+]] = call i1 @"{{.*}}/runtime/internal/runtime.memequalzero"
 // CHECK: %[[ZERO_NE:[0-9]+]] = xor i1 %[[ZERO_RAW_NE]], true
 // CHECK: call void @main.assert(i1 %[[ZERO_NE]])
+// CHECK-NOT: runtime.structequal
 
 // Slices compare with nil through their data pointer. Check the non-empty and
 // zero-length/non-zero-capacity make paths separately.

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1494,6 +1494,22 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 				y = p.compileValueAs(b, v.Y, v.X.Type())
 			}
 			ret = b.ArrayBinOp(v.Op, x, y, xaddr, yaddr)
+		} else if typ, ok := v.X.Type().Underlying().(*types.Struct); ok && (v.Op == token.EQL || v.Op == token.NEQ) {
+			xaddr, yaddr := llssa.Nil, llssa.Nil
+			size := p.prog.SizeOf(p.type_(v.X.Type(), llssa.InGo))
+			if !llssa.CanInlineStructEqual(typ, size, p.prog.PointerSize()) {
+				xaddr = p.structZeroCompareAddr(b, v.X, v.Y, v)
+				yaddr = p.structZeroCompareAddr(b, v.Y, v.X, v)
+			}
+			x := p.prog.Zero(p.type_(v.X.Type(), llssa.InGo))
+			if xaddr.IsNil() {
+				x = p.compileValueAs(b, v.X, v.Y.Type())
+			}
+			y := p.prog.Zero(p.type_(v.Y.Type(), llssa.InGo))
+			if yaddr.IsNil() {
+				y = p.compileValueAs(b, v.Y, v.X.Type())
+			}
+			ret = b.StructBinOp(v.Op, x, y, xaddr, yaddr)
 		} else {
 			x := p.compileValueAs(b, v.X, v.Y.Type())
 			y := p.compileValueAs(b, v.Y, v.X.Type())
@@ -1504,7 +1520,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			if _, ok := p.methodNilDerefChecks[v]; ok {
 				return p.compileCheckedDeref(b, v)
 			}
-			if canElideArrayCompareLoad(v) {
+			if canElideArrayCompareLoad(v) || p.canElideStructZeroCompareLoad(v) {
 				return
 			}
 			effectfulArrayDeref := isEffectfulArrayPointerDeref(v)
@@ -1893,6 +1909,80 @@ func (p *context) arrayCompareAddr(b llssa.Builder, v ssa.Value) llssa.Expr {
 		return llssa.Nil
 	}
 	return p.compileValue(b, addr)
+}
+
+// structZeroCompareAddr reuses the source address for an immediately compared
+// aggregate load. The other operand must be a zero value, so no second load or
+// side effect can occur between the snapshot and comparison.
+func (p *context) structZeroCompareAddr(b llssa.Builder, value, other ssa.Value, comparison *ssa.BinOp) llssa.Expr {
+	load := structZeroCompareLoad(value, other, comparison)
+	if load == nil {
+		return llssa.Nil
+	}
+	addr := p.compileValue(b, load.X)
+	p.recordPanicSite(b, load.Pos())
+	p.assertNilDerefBase(b, load.X)
+	b.AssertNilDeref(addr)
+	return addr
+}
+
+func (p *context) canElideStructZeroCompareLoad(load *ssa.UnOp) bool {
+	if load == nil {
+		return false
+	}
+	refs, ok := nonDebugReferrers(load)
+	if !ok || len(refs) != 1 {
+		return false
+	}
+	comparison, ok := refs[0].(*ssa.BinOp)
+	if !ok || (comparison.Op != token.EQL && comparison.Op != token.NEQ) {
+		return false
+	}
+	typ, ok := load.Type().Underlying().(*types.Struct)
+	if !ok {
+		return false
+	}
+	size := p.prog.SizeOf(p.type_(load.Type(), llssa.InGo))
+	if llssa.CanInlineStructEqual(typ, size, p.prog.PointerSize()) {
+		return false
+	}
+	other := comparison.X
+	if other == load {
+		other = comparison.Y
+	}
+	return structZeroCompareLoad(load, other, comparison) != nil
+}
+
+func structZeroCompareLoad(value, other ssa.Value, comparison *ssa.BinOp) *ssa.UnOp {
+	load, ok := value.(*ssa.UnOp)
+	if !ok || load.Op != token.MUL || load.Block() == nil || load.Block() != comparison.Block() {
+		return nil
+	}
+	zero, ok := other.(*ssa.Const)
+	if !ok || zero.Value != nil {
+		return nil
+	}
+	if _, ok := zero.Type().Underlying().(*types.Struct); !ok {
+		return nil
+	}
+	seenLoad := false
+	for _, instruction := range load.Block().Instrs {
+		switch instruction {
+		case load:
+			seenLoad = true
+		case comparison:
+			if seenLoad {
+				return load
+			}
+		default:
+			if seenLoad {
+				if _, ok := instruction.(*ssa.DebugRef); !ok {
+					return nil
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // canElideArrayCompareLoad reports whether every executable use of load is a

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1497,7 +1497,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		} else if typ, ok := v.X.Type().Underlying().(*types.Struct); ok && (v.Op == token.EQL || v.Op == token.NEQ) {
 			xaddr, yaddr := llssa.Nil, llssa.Nil
 			size := p.prog.SizeOf(p.type_(v.X.Type(), llssa.InGo))
-			if !llssa.CanInlineStructEqual(typ, size, p.prog.PointerSize()) {
+			if p.prog.IsRegularMemory(v.X.Type()) && !llssa.CanInlineStructEqual(typ, size, p.prog.PointerSize()) {
 				xaddr = p.structZeroCompareAddr(b, v.X, v.Y, v)
 				yaddr = p.structZeroCompareAddr(b, v.Y, v.X, v)
 			}
@@ -1941,6 +1941,9 @@ func (p *context) canElideStructZeroCompareLoad(load *ssa.UnOp) bool {
 	}
 	typ, ok := load.Type().Underlying().(*types.Struct)
 	if !ok {
+		return false
+	}
+	if !p.prog.IsRegularMemory(load.Type()) {
 		return false
 	}
 	size := p.prog.SizeOf(p.type_(load.Type(), llssa.InGo))

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1912,8 +1912,9 @@ func (p *context) arrayCompareAddr(b llssa.Builder, v ssa.Value) llssa.Expr {
 }
 
 // structZeroCompareAddr reuses the source address for an immediately compared
-// aggregate load. The other operand must be a zero value, so no second load or
-// side effect can occur between the snapshot and comparison.
+// aggregate load. The other operand is a zero constant, so there is no second
+// load, and structZeroCompareLoad has verified that no executable instruction
+// occurs before the comparison, so the address still holds the loaded value.
 func (p *context) structZeroCompareAddr(b llssa.Builder, value, other ssa.Value, comparison *ssa.BinOp) llssa.Expr {
 	load := structZeroCompareLoad(value, other, comparison)
 	if load == nil {

--- a/cl/struct_compare_compile_test.go
+++ b/cl/struct_compare_compile_test.go
@@ -31,6 +31,10 @@ type large struct {
 	value [4096]byte
 }
 
+type semantic struct {
+	value [5]string
+}
+
 func immediate(p *large) bool {
 	return *p == large{}
 }
@@ -39,6 +43,10 @@ func snapshot(p *large, mutate func()) bool {
 	v := *p
 	mutate()
 	return v == large{}
+}
+
+func semanticZero(p *semantic) bool {
+	return *p == semantic{}
 }
 `
 	_, mod := mustCompileLLPkgFromSrc(t, source)
@@ -61,5 +69,11 @@ func snapshot(p *large, mutate func()) bool {
 	}
 	if !strings.Contains(snapshot, ".memequal") || !strings.Contains(snapshot, "load %foo.large") {
 		t.Fatalf("comparison after a call did not preserve its value snapshot:\n%s", snapshot)
+	}
+
+	semantic := mustNamedFunction(t, mod, "foo.semanticZero").String()
+	if strings.Contains(semantic, ".memequalzero") || strings.Contains(semantic, ".structequal") ||
+		!strings.Contains(semantic, ".arrayequal") || !strings.Contains(semantic, "load %foo.semantic") {
+		t.Fatalf("semantic zero comparison did not remain field-wise:\n%s", semantic)
 	}
 }

--- a/cl/struct_compare_compile_test.go
+++ b/cl/struct_compare_compile_test.go
@@ -1,0 +1,65 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLargeStructZeroCompareUsesSourceAddress(t *testing.T) {
+	const source = `
+package foo
+
+type large struct {
+	value [4096]byte
+}
+
+func immediate(p *large) bool {
+	return *p == large{}
+}
+
+func snapshot(p *large, mutate func()) bool {
+	v := *p
+	mutate()
+	return v == large{}
+}
+`
+	_, mod := mustCompileLLPkgFromSrc(t, source)
+	immediate := mustNamedFunction(t, mod, "foo.immediate").String()
+	if !strings.Contains(immediate, ".memequalzero") {
+		t.Fatalf("immediate zero comparison did not use memequalzero:\n%s", immediate)
+	}
+	if strings.Contains(immediate, "load { [4096 x i8] }") ||
+		strings.Contains(immediate, "store { [4096 x i8] }") ||
+		strings.Contains(immediate, "stacksave") {
+		t.Fatalf("immediate zero comparison materialized the aggregate:\n%s", immediate)
+	}
+	if !strings.Contains(immediate, "AssertNilDeref") {
+		t.Fatalf("elided aggregate load lost its nil check:\n%s", immediate)
+	}
+
+	snapshot := mustNamedFunction(t, mod, "foo.snapshot").String()
+	if strings.Contains(snapshot, ".memequalzero") {
+		t.Fatalf("comparison after a call reused mutable source storage:\n%s", snapshot)
+	}
+	if !strings.Contains(snapshot, ".memequal") || !strings.Contains(snapshot, "load %foo.large") {
+		t.Fatalf("comparison after a call did not preserve its value snapshot:\n%s", snapshot)
+	}
+}

--- a/runtime/internal/runtime/alg.go
+++ b/runtime/internal/runtime/alg.go
@@ -211,12 +211,15 @@ func memequal0(p, q unsafe.Pointer) bool {
 	return true
 }
 func memequalzero(p unsafe.Pointer, size uintptr) bool {
-	for i := uintptr(0); i < size; i++ {
-		if *(*byte)(add(p, i)) != 0 {
+	zero := unsafe.Pointer(&zeroVal[0])
+	for size > maxZero {
+		if !memequal(p, zero, maxZero) {
 			return false
 		}
+		p = add(p, maxZero)
+		size -= maxZero
 	}
-	return true
+	return memequal(p, zero, size)
 }
 func memequal8(p, q unsafe.Pointer) bool {
 	return *(*int8)(p) == *(*int8)(q)

--- a/runtime/internal/runtime/alg.go
+++ b/runtime/internal/runtime/alg.go
@@ -210,6 +210,14 @@ func memequalptr(p, q unsafe.Pointer) bool {
 func memequal0(p, q unsafe.Pointer) bool {
 	return true
 }
+func memequalzero(p unsafe.Pointer, size uintptr) bool {
+	for i := uintptr(0); i < size; i++ {
+		if *(*byte)(add(p, i)) != 0 {
+			return false
+		}
+	}
+	return true
+}
 func memequal8(p, q unsafe.Pointer) bool {
 	return *(*int8)(p) == *(*int8)(q)
 }

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -724,23 +724,7 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 		case vkArray:
 			return b.arrayBinOp(op, x, y, Nil, Nil)
 		case vkStruct:
-			typ := x.raw.Type.Underlying().(*types.Struct)
-			ret := prog.BoolVal(true)
-			for i, n := 0, typ.NumFields(); i < n; i++ {
-				if typ.Field(i).Name() == "_" {
-					continue
-				}
-				fx := b.getField(x, i)
-				fy := b.getField(y, i)
-				r := b.BinOp(token.EQL, fx, fy)
-				ret = Expr{b.impl.CreateAnd(ret.impl, r.impl, ""), tret}
-			}
-			switch op {
-			case token.EQL:
-				return ret
-			case token.NEQ:
-				return Expr{b.impl.CreateNot(ret.impl, ""), tret}
-			}
+			return b.StructBinOp(op, x, y, Nil, Nil)
 		case vkSlice:
 			dx := b.impl.CreateExtractValue(x.impl, 0, "")
 			dy := b.impl.CreateExtractValue(y.impl, 0, "")
@@ -768,6 +752,88 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 		}
 	}
 	panic("todo")
+}
+
+// CanInlineStructEqual reports whether direct field comparisons keep the
+// module compact. Larger structs use their runtime equality algorithm,
+// matching the array path and avoiding pathological aggregate IR.
+func CanInlineStructEqual(t *types.Struct, size uint64, pointerSize int) bool {
+	return t.NumFields() <= 4 && size <= uint64(4*pointerSize)
+}
+
+// StructBinOp compares two struct values while allowing the frontend to reuse
+// an operand address when it has proved that doing so preserves value semantics.
+func (b Builder) StructBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
+	if x.kind != vkStruct || y.kind != vkStruct {
+		panic("StructBinOp requires struct operands")
+	}
+	if op != token.EQL && op != token.NEQ {
+		panic("StructBinOp requires an equality operator")
+	}
+	prog := b.Prog
+	tret := prog.Bool()
+	typ := x.raw.Type.Underlying().(*types.Struct)
+	if CanInlineStructEqual(typ, uint64(prog.abi.Size(typ)), prog.PointerSize()) {
+		ret := prog.BoolVal(true)
+		for i, n := 0, typ.NumFields(); i < n; i++ {
+			if typ.Field(i).Name() == "_" {
+				continue
+			}
+			fx := b.getField(x, i)
+			fy := b.getField(y, i)
+			r := b.BinOp(token.EQL, fx, fy)
+			ret = Expr{b.impl.CreateAnd(ret.impl, r.impl, ""), tret}
+		}
+		if op == token.NEQ {
+			ret.impl = llvm.CreateNot(b.impl, ret.impl)
+		}
+		return ret
+	}
+
+	zeroX := xaddr.IsNil() && !x.impl.IsAConstantAggregateZero().IsNil()
+	zeroY := yaddr.IsNil() && !y.impl.IsAConstantAggregateZero().IsNil()
+	if prog.abi.IsRegularMemory(typ) && (zeroX && !yaddr.IsNil() || zeroY && !xaddr.IsNil()) {
+		addr := xaddr
+		if zeroX {
+			addr = yaddr
+		}
+		addr = b.PtrCast(prog.VoidPtr(), addr)
+		ret := b.Call(b.Pkg.rtFunc("memequalzero"), addr, prog.IntVal(prog.SizeOf(x.Type), prog.Uintptr()))
+		if op == token.NEQ {
+			ret.impl = llvm.CreateNot(b.impl, ret.impl)
+		}
+		return ret
+	}
+
+	var sp Expr
+	if xaddr.IsNil() || yaddr.IsNil() {
+		sp = b.StackSave()
+	}
+	if xaddr.IsNil() {
+		xaddr = b.toPtr(x)
+	} else {
+		xaddr = b.PtrCast(prog.VoidPtr(), xaddr)
+	}
+	if yaddr.IsNil() {
+		yaddr = b.toPtr(y)
+	} else {
+		yaddr = b.PtrCast(prog.VoidPtr(), yaddr)
+	}
+	var ret Expr
+	if prog.abi.IsRegularMemory(typ) {
+		ret = b.Call(b.Pkg.rtFunc("memequal"), xaddr, yaddr, prog.IntVal(prog.SizeOf(x.Type), prog.Uintptr()))
+	} else {
+		equal := b.Pkg.rtEnvFunc("structequal")
+		equal = b.aggregateValue(prog.Type(equalFunc, InGo), equal.impl, b.abiType(x.raw.Type).impl)
+		ret = b.Call(equal, xaddr, yaddr)
+	}
+	if !sp.IsNil() {
+		b.StackRestore(sp)
+	}
+	if op == token.NEQ {
+		ret.impl = llvm.CreateNot(b.impl, ret.impl)
+	}
+	return ret
 }
 
 // CanInlineArrayEqual reports whether comparing an array element by element is

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -755,8 +755,8 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 }
 
 // CanInlineStructEqual reports whether direct field comparisons keep the
-// module compact. Larger structs use their runtime equality algorithm,
-// matching the array path and avoiding pathological aggregate IR.
+// module compact. It uses a four-field budget similar to array comparisons,
+// plus a size cap because struct fields can themselves be large aggregates.
 func CanInlineStructEqual(t *types.Struct, size uint64, pointerSize int) bool {
 	return t.NumFields() <= 4 && size <= uint64(4*pointerSize)
 }

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -763,6 +763,9 @@ func CanInlineStructEqual(t *types.Struct, size uint64, pointerSize int) bool {
 
 // StructBinOp compares two struct values while allowing the frontend to reuse
 // an operand address when it has proved that doing so preserves value semantics.
+// Non-regular structs remain field-wise so their semantic comparisons preserve
+// the established ordering and panic behavior; source addresses are used only
+// for regular-memory structs.
 func (b Builder) StructBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
 	if x.kind != vkStruct || y.kind != vkStruct {
 		panic("StructBinOp requires struct operands")
@@ -773,7 +776,9 @@ func (b Builder) StructBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
 	prog := b.Prog
 	tret := prog.Bool()
 	typ := x.raw.Type.Underlying().(*types.Struct)
-	if CanInlineStructEqual(typ, uint64(prog.abi.Size(typ)), prog.PointerSize()) {
+	size := uint64(prog.abi.Size(typ))
+	regular := prog.abi.IsRegularMemory(typ)
+	if !regular || CanInlineStructEqual(typ, size, prog.PointerSize()) {
 		ret := prog.BoolVal(true)
 		for i, n := 0, typ.NumFields(); i < n; i++ {
 			if typ.Field(i).Name() == "_" {
@@ -792,7 +797,7 @@ func (b Builder) StructBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
 
 	zeroX := xaddr.IsNil() && !x.impl.IsAConstantAggregateZero().IsNil()
 	zeroY := yaddr.IsNil() && !y.impl.IsAConstantAggregateZero().IsNil()
-	if prog.abi.IsRegularMemory(typ) && (zeroX && !yaddr.IsNil() || zeroY && !xaddr.IsNil()) {
+	if zeroX && !yaddr.IsNil() || zeroY && !xaddr.IsNil() {
 		addr := xaddr
 		if zeroX {
 			addr = yaddr
@@ -819,14 +824,7 @@ func (b Builder) StructBinOp(op token.Token, x, y, xaddr, yaddr Expr) Expr {
 	} else {
 		yaddr = b.PtrCast(prog.VoidPtr(), yaddr)
 	}
-	var ret Expr
-	if prog.abi.IsRegularMemory(typ) {
-		ret = b.Call(b.Pkg.rtFunc("memequal"), xaddr, yaddr, prog.IntVal(prog.SizeOf(x.Type), prog.Uintptr()))
-	} else {
-		equal := b.Pkg.rtEnvFunc("structequal")
-		equal = b.aggregateValue(prog.Type(equalFunc, InGo), equal.impl, b.abiType(x.raw.Type).impl)
-		ret = b.Call(equal, xaddr, yaddr)
-	}
+	ret := b.Call(b.Pkg.rtFunc("memequal"), xaddr, yaddr, prog.IntVal(prog.SizeOf(x.Type), prog.Uintptr()))
 	if !sp.IsNil() {
 		b.StackRestore(sp)
 	}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2739,7 +2739,7 @@ func TestStructEqualLowering(t *testing.T) {
 		return pkg
 	})
 	pkg := prog.NewPackage("main", "main")
-	compare := func(name string, typ *types.Struct) string {
+	compare := func(name string, typ *types.Struct, op token.Token, addrMask, zeroMask uint) string {
 		sig := types.NewSignatureType(nil, nil, nil,
 			types.NewTuple(
 				types.NewVar(token.NoPos, nil, "x", typ),
@@ -2750,31 +2750,97 @@ func TestStructEqualLowering(t *testing.T) {
 		)
 		fn := pkg.NewFunc(name, sig, InGo)
 		b := fn.MakeBody(1)
-		b.Return(b.BinOp(token.EQL, fn.Param(0), fn.Param(1)))
+		x, y := fn.Param(0), fn.Param(1)
+		xaddr, yaddr := Nil, Nil
+		if addrMask&1 != 0 {
+			xaddr = b.AllocaT(x.Type)
+			b.Store(xaddr, x)
+		}
+		if addrMask&2 != 0 {
+			yaddr = b.AllocaT(y.Type)
+			b.Store(yaddr, y)
+		}
+		if zeroMask&1 != 0 {
+			x = prog.Zero(x.Type)
+		}
+		if zeroMask&2 != 0 {
+			y = prog.Zero(y.Type)
+		}
+		b.Return(b.StructBinOp(op, x, y, xaddr, yaddr))
 		return pkg.Module().NamedFunction(name).String()
 	}
 	field := func(name string, typ types.Type) *types.Var {
 		return types.NewVar(token.NoPos, nil, name, typ)
 	}
 
-	small := compare("smallStruct", types.NewStruct([]*types.Var{
-		field("a", types.Typ[types.Int]), field("b", types.Typ[types.Int]),
-	}, nil))
+	smallType := types.NewStruct([]*types.Var{
+		field("a", types.Typ[types.Int]), field("_", types.Typ[types.Int]),
+		field("b", types.Typ[types.Int]),
+	}, nil)
+	small := compare("smallStruct", smallType, token.NEQ, 0, 0)
 	if strings.Contains(small, "memequal") || strings.Contains(small, "structequal") {
 		t.Fatalf("small struct comparison was not inlined:\n%s", small)
 	}
-	regular := compare("largeRegularStruct", types.NewStruct([]*types.Var{
+	regularType := types.NewStruct([]*types.Var{
 		field("value", types.NewArray(types.Typ[types.Uint8], 1024)),
-	}, nil))
+	}, nil)
+	regular := compare("largeRegularStruct", regularType, token.EQL, 0, 0)
 	if !strings.Contains(regular, ".memequal") || strings.Contains(regular, "extractvalue [1024 x i8]") {
 		t.Fatalf("large regular struct comparison was not lowered to memequal:\n%s", regular)
 	}
+	regularAddr := compare("largeRegularStructAddr", regularType, token.NEQ, 3, 0)
+	if !strings.Contains(regularAddr, ".memequal") {
+		t.Fatalf("addressed regular struct comparison was not lowered to memequal:\n%s", regularAddr)
+	}
+	zeroLeft := compare("largeZeroLeft", regularType, token.EQL, 2, 1)
+	if !strings.Contains(zeroLeft, ".memequalzero") {
+		t.Fatalf("left zero comparison did not reuse the right address:\n%s", zeroLeft)
+	}
+	zeroRight := compare("largeZeroRight", regularType, token.NEQ, 1, 2)
+	if !strings.Contains(zeroRight, ".memequalzero") {
+		t.Fatalf("right zero comparison did not reuse the left address:\n%s", zeroRight)
+	}
 	nonMemory := compare("largeNonMemoryStruct", types.NewStruct([]*types.Var{
 		field("value", types.NewArray(types.Typ[types.String], 5)),
-	}, nil))
+	}, nil), token.EQL, 0, 0)
 	if !strings.Contains(nonMemory, ".structequal") || strings.Contains(nonMemory, "extractvalue [5 x { ptr, i64 }]") {
 		t.Fatalf("large semantic struct comparison was not lowered to structequal:\n%s", nonMemory)
 	}
+	fiveFields := types.NewStruct([]*types.Var{
+		field("a", types.Typ[types.Uint8]), field("b", types.Typ[types.Uint8]),
+		field("c", types.Typ[types.Uint8]), field("d", types.Typ[types.Uint8]),
+		field("e", types.Typ[types.Uint8]),
+	}, nil)
+	if CanInlineStructEqual(fiveFields, 5, prog.PointerSize()) {
+		t.Fatal("five-field struct comparison was inlined")
+	}
+
+	sig := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(
+			types.NewVar(token.NoPos, nil, "x", smallType),
+			types.NewVar(token.NoPos, nil, "y", smallType),
+		),
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Bool])),
+		false,
+	)
+	fn := pkg.NewFunc("invalidStructCompare", sig, InGo)
+	b := fn.MakeBody(1)
+	mustPanic := func(want string, call func()) {
+		t.Helper()
+		defer func() {
+			if got := recover(); got != want {
+				t.Fatalf("panic = %v, want %q", got, want)
+			}
+		}()
+		call()
+	}
+	mustPanic("StructBinOp requires struct operands", func() {
+		b.StructBinOp(token.EQL, prog.Val(1), prog.Val(2), Nil, Nil)
+	})
+	mustPanic("StructBinOp requires an equality operator", func() {
+		b.StructBinOp(token.ADD, fn.Param(0), fn.Param(1), Nil, Nil)
+	})
+	b.Return(prog.BoolVal(false))
 	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
 		t.Fatalf("struct comparison module is invalid: %v\n%s", err, pkg.String())
 	}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2803,8 +2803,8 @@ func TestStructEqualLowering(t *testing.T) {
 	nonMemory := compare("largeNonMemoryStruct", types.NewStruct([]*types.Var{
 		field("value", types.NewArray(types.Typ[types.String], 5)),
 	}, nil), token.EQL, 0, 0)
-	if !strings.Contains(nonMemory, ".structequal") || strings.Contains(nonMemory, "extractvalue [5 x { ptr, i64 }]") {
-		t.Fatalf("large semantic struct comparison was not lowered to structequal:\n%s", nonMemory)
+	if strings.Contains(nonMemory, ".structequal") || !strings.Contains(nonMemory, ".arrayequal") {
+		t.Fatalf("large semantic struct comparison was not kept field-wise:\n%s", nonMemory)
 	}
 	fiveFields := types.NewStruct([]*types.Var{
 		field("a", types.Typ[types.Uint8]), field("b", types.Typ[types.Uint8]),

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2727,6 +2727,59 @@ func TestCanInlineArrayEqual(t *testing.T) {
 	}
 }
 
+func TestStructEqualLowering(t *testing.T) {
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("main", "main")
+	compare := func(name string, typ *types.Struct) string {
+		sig := types.NewSignatureType(nil, nil, nil,
+			types.NewTuple(
+				types.NewVar(token.NoPos, nil, "x", typ),
+				types.NewVar(token.NoPos, nil, "y", typ),
+			),
+			types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Bool])),
+			false,
+		)
+		fn := pkg.NewFunc(name, sig, InGo)
+		b := fn.MakeBody(1)
+		b.Return(b.BinOp(token.EQL, fn.Param(0), fn.Param(1)))
+		return pkg.Module().NamedFunction(name).String()
+	}
+	field := func(name string, typ types.Type) *types.Var {
+		return types.NewVar(token.NoPos, nil, name, typ)
+	}
+
+	small := compare("smallStruct", types.NewStruct([]*types.Var{
+		field("a", types.Typ[types.Int]), field("b", types.Typ[types.Int]),
+	}, nil))
+	if strings.Contains(small, "memequal") || strings.Contains(small, "structequal") {
+		t.Fatalf("small struct comparison was not inlined:\n%s", small)
+	}
+	regular := compare("largeRegularStruct", types.NewStruct([]*types.Var{
+		field("value", types.NewArray(types.Typ[types.Uint8], 1024)),
+	}, nil))
+	if !strings.Contains(regular, ".memequal") || strings.Contains(regular, "extractvalue [1024 x i8]") {
+		t.Fatalf("large regular struct comparison was not lowered to memequal:\n%s", regular)
+	}
+	nonMemory := compare("largeNonMemoryStruct", types.NewStruct([]*types.Var{
+		field("value", types.NewArray(types.Typ[types.String], 5)),
+	}, nil))
+	if !strings.Contains(nonMemory, ".structequal") || strings.Contains(nonMemory, "extractvalue [5 x { ptr, i64 }]") {
+		t.Fatalf("large semantic struct comparison was not lowered to structequal:\n%s", nonMemory)
+	}
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("struct comparison module is invalid: %v\n%s", err, pkg.String())
+	}
+}
+
 func TestUnOp(t *testing.T) {
 	prog := NewProgram(nil)
 	pkg := prog.NewPackage("bar", "foo/bar")

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -224,6 +224,11 @@ func (p Program) PointerSize() int {
 	return p.ptrSize
 }
 
+// IsRegularMemory reports whether values of typ may be compared bytewise.
+func (p Program) IsRegularMemory(typ types.Type) bool {
+	return p.abi.IsRegularMemory(typ)
+}
+
 func (p Program) Slice(typ Type) Type {
 	return p.rawType(types.NewSlice(typ.raw.Type))
 }


### PR DESCRIPTION
Large structs were always expanded field by field. For crypto/mldsa.PrivateKey, comparing a loaded key with its zero value produced a huge aggregate temporary and made LLVM -Os spend almost a minute in one package.

This change:

- keeps small struct comparisons inline;
- lowers large regular structs to runtime memory equality and semantic structs to structequal;
- reuses the source address for an immediate large regular-struct zero comparison and calls memequalzero, while preserving the nil-dereference check; and
- keeps snapshot semantics when any executable instruction occurs between the load and comparison.

Cold local crypto/mldsa build (this branch only, based on current main): backend+publish is 0.026s. Before the fix the same package backend took 58.5s. Whole cold build dropped from about 64s to 17.1s here (the latter also used a fresh Go build cache); peak RSS was 1.19 GB.

Validation:

- go test ./ssa ./cl -run focused equality tests
- go test ./cl -run TestRunAndTestFromTestgo/equal
- runtime module compilation
- LLVM module verification in TestStructEqualLowering

The full local cl suite also exposed pre-existing host LLVM feature-warning mismatches in LTO tests and eventually hit its global 10-minute timeout; the directly affected equality integration case passes after updating its IR expectation.