### PR TITLE
ci: retry MSYS2 package transactions

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -520,11 +520,17 @@ runs:
         path-type: inherit
         update: true
 
+    - name: Test MSYS2 package retry helper
+      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'mingw'
+      shell: msys2 {0}
+      run: .github/actions/setup-deps/pacman_retry_test.sh
+
     - name: Install Windows MinGW dependencies
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'mingw'
       shell: msys2 {0}
       run: |
         set -euo pipefail
+        source .github/actions/setup-deps/pacman_retry.sh
 
         llvm_major="${{ inputs.llvm-version }}"
         case "$llvm_major" in
@@ -572,10 +578,10 @@ runs:
         # libc++ supplies the required compiler runtime. Satisfy the package
         # metadata while installing the exact, mutually consistent LLVM set.
         assumed_cc_runtime="$prefix-cc-libs=$llvm_version"
-        pacman --noconfirm -U \
+        pacman_with_retry --noconfirm -U \
           --assume-installed "$assumed_cc_runtime" \
           "${urls[@]}"
-        pacman --noconfirm -S --needed \
+        pacman_with_retry --noconfirm -S --needed \
           "$prefix-pkgconf" \
           "$prefix-sqlite3" \
           "$prefix-libuv" \

--- a/.github/actions/setup-deps/pacman_retry.sh
+++ b/.github/actions/setup-deps/pacman_retry.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+pacman_command() {
+	command pacman "$@"
+}
+
+pacman_retry_sleep() {
+	command sleep "$1"
+}
+
+pacman_with_retry() {
+	local max_attempts="${LLGO_PACMAN_MAX_ATTEMPTS:-3}"
+	local retry_delay="${LLGO_PACMAN_RETRY_DELAY_SECONDS:-5}"
+	if ! [[ "${max_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+		echo "LLGO_PACMAN_MAX_ATTEMPTS must be a positive integer" >&2
+		return 2
+	fi
+	if ! [[ "${retry_delay}" =~ ^[0-9]+$ ]]; then
+		echo "LLGO_PACMAN_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+		return 2
+	fi
+	if (( $# == 0 )); then
+		echo "no pacman arguments specified" >&2
+		return 2
+	fi
+
+	local attempt
+	for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+		if pacman_command "$@"; then
+			return 0
+		fi
+		if (( attempt < max_attempts )); then
+			echo "pacman failed (attempt ${attempt}/${max_attempts}); retrying the package transaction" >&2
+			pacman_retry_sleep "${retry_delay}"
+		fi
+	done
+
+	echo "pacman failed after ${max_attempts} attempts" >&2
+	return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	set -euo pipefail
+	pacman_with_retry "$@"
+fi

--- a/.github/actions/setup-deps/pacman_retry.sh
+++ b/.github/actions/setup-deps/pacman_retry.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# LLGO_PACMAN_MAX_ATTEMPTS: total transaction attempts (default: 3).
+# LLGO_PACMAN_RETRY_DELAY_SECONDS: delay between attempts (default: 5).
+# Retries intentionally accept any pacman failure, including permanent errors;
+# the bounded attempt count limits the delay before reporting exhaustion.
+
 pacman_command() {
 	command pacman "$@"
 }

--- a/.github/actions/setup-deps/pacman_retry_test.sh
+++ b/.github/actions/setup-deps/pacman_retry_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/actions/setup-deps/pacman_retry.sh
+source "${script_dir}/pacman_retry.sh"
+
+fail() {
+	echo "$1" >&2
+	exit 1
+}
+
+attempts=0
+sleeps=0
+last_sleep=""
+last_args=()
+
+# Called indirectly by pacman_with_retry.
+# shellcheck disable=SC2329
+pacman_command() {
+	attempts=$((attempts + 1))
+	last_args=("$@")
+	(( attempts >= 3 ))
+}
+
+# Called indirectly by pacman_with_retry.
+# shellcheck disable=SC2329
+pacman_retry_sleep() {
+	sleeps=$((sleeps + 1))
+	last_sleep="$1"
+}
+
+LLGO_PACMAN_MAX_ATTEMPTS=3 LLGO_PACMAN_RETRY_DELAY_SECONDS=7 \
+	pacman_with_retry --noconfirm -S --needed example-package 2>/dev/null
+[[ "${attempts}" -eq 3 ]] || fail "pacman attempts = ${attempts}, want 3"
+[[ "${sleeps}" -eq 2 ]] || fail "retry sleeps = ${sleeps}, want 2"
+[[ "${last_sleep}" == 7 ]] || fail "retry delay = ${last_sleep}, want 7"
+[[ " ${last_args[*]} " == *" --noconfirm -S --needed example-package "* ]] ||
+	fail "unexpected pacman arguments: ${last_args[*]}"
+
+attempts=0
+sleeps=0
+# Called indirectly by pacman_with_retry.
+# shellcheck disable=SC2329
+pacman_command() {
+	attempts=$((attempts + 1))
+	return 1
+}
+
+if LLGO_PACMAN_MAX_ATTEMPTS=2 LLGO_PACMAN_RETRY_DELAY_SECONDS=0 \
+	pacman_with_retry -U package.pkg.tar.zst 2>/dev/null; then
+	fail "exhausted pacman retries unexpectedly succeeded"
+fi
+[[ "${attempts}" -eq 2 ]] || fail "exhausted attempts = ${attempts}, want 2"
+[[ "${sleeps}" -eq 1 ]] || fail "exhausted retry sleeps = ${sleeps}, want 1"
+
+if LLGO_PACMAN_MAX_ATTEMPTS=0 pacman_with_retry -S package 2>/dev/null; then
+	fail "invalid attempt count unexpectedly succeeded"
+fi
+if LLGO_PACMAN_RETRY_DELAY_SECONDS=invalid pacman_with_retry -S package 2>/dev/null; then
+	fail "invalid retry delay unexpectedly succeeded"
+fi
+if pacman_with_retry 2>/dev/null; then
+	fail "empty pacman command unexpectedly succeeded"
+fi
+
+echo "MSYS2 pacman retry checks passed"

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -253,13 +253,14 @@ jobs:
           MSYS2_PYTHON_PACKAGE_VERSION: "3.14.6-2"
         run: |
           set -euo pipefail
+          source .github/actions/setup-deps/pacman_retry.sh
           repo=https://repo.msys2.org/mingw/clang64
           prefix=mingw-w64-clang-x86_64
           pacman_args=(--noconfirm -U)
           for dependency in cc-libs expat bzip2 mpdecimal ncurses openssl sqlite3 tcl tk tzdata; do
             pacman_args+=(--assume-installed "$prefix-$dependency")
           done
-          pacman "${pacman_args[@]}" \
+          pacman_with_retry "${pacman_args[@]}" \
             "$repo/$prefix-python-$MSYS2_PYTHON_PACKAGE_VERSION-any.pkg.tar.zst" \
             "$repo/$prefix-lldb-$MSYS2_LLDB_PACKAGE_VERSION-any.pkg.tar.zst"
 


### PR DESCRIPTION
The current main CI can fail before any LLGo code runs when an MSYS2 mirror crosses its low-speed timeout. The observed Windows MinGW ARM64 benchmark failure stopped while downloading `mingw-w64-clang-aarch64-make-4.4.1-5-any.pkg.tar.zst.sig`.

This main-only CI fix:

- retries each complete pinned/current pacman transaction up to three times, including the MinGW LLDB integration-test installation;
- keeps the exact package/version and `--assume-installed` contracts unchanged;
- uses a bounded delay and rejects invalid retry configuration;
- documents the configuration defaults and intentionally error-agnostic retries;
- runs a deterministic helper self-test in every Windows MinGW setup lane, covering success after retries, exhaustion, argument preservation, delay behavior, and invalid input.

Validation:

- `bash -n .github/actions/setup-deps/pacman_retry.sh .github/actions/setup-deps/pacman_retry_test.sh`
- `shellcheck .github/actions/setup-deps/pacman_retry.sh .github/actions/setup-deps/pacman_retry_test.sh`
- `.github/actions/setup-deps/pacman_retry_test.sh`
- `actionlint -shellcheck='' .github/workflows/llgo.yml`
- `git diff --check`

This is independent of the WebAssembly artifact/runner PR stack.
