### PR TITLE
test: stabilize AfterFunc reset coverage

### DIFF
--- a/test/timer_test.go
+++ b/test/timer_test.go
@@ -93,10 +93,11 @@ func TestAfterFuncStop(t *testing.T) {
 	}
 }
 
-// Reset on an active AfterFunc should reschedule the callback.
+// Reset reschedules an AfterFunc and reports whether it was active or expired.
 func TestAfterFuncReset(t *testing.T) {
+	const callbackTimeout = 5 * time.Second
 	var count atomic.Int32
-	fired := make(chan int32, 2)
+	fired := make(chan int32, 2) // Buffered for both expected callbacks.
 	tmr := time.AfterFunc(time.Hour, func() {
 		fired <- count.Add(1)
 	})
@@ -111,10 +112,12 @@ func TestAfterFuncReset(t *testing.T) {
 		if got != 1 {
 			t.Fatalf("first callback count = %d, want 1", got)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(callbackTimeout):
 		t.Fatal("AfterFunc did not fire after active Reset")
 	}
 
+	// The timer becomes inactive before its callback starts. Receiving fired
+	// therefore establishes that this Reset observes an expired timer.
 	if tmr.Reset(30 * time.Millisecond) {
 		t.Fatal("Reset reported an expired AfterFunc as active")
 	}
@@ -123,7 +126,7 @@ func TestAfterFuncReset(t *testing.T) {
 		if got != 2 {
 			t.Fatalf("second callback count = %d, want 2", got)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(callbackTimeout):
 		t.Fatal("AfterFunc did not fire after expired Reset")
 	}
 }

--- a/test/timer_test.go
+++ b/test/timer_test.go
@@ -96,19 +96,35 @@ func TestAfterFuncStop(t *testing.T) {
 // Reset on an active AfterFunc should reschedule the callback.
 func TestAfterFuncReset(t *testing.T) {
 	var count atomic.Int32
-	tmr := time.AfterFunc(100*time.Millisecond, func() {
-		count.Add(1)
+	fired := make(chan int32, 2)
+	tmr := time.AfterFunc(time.Hour, func() {
+		fired <- count.Add(1)
 	})
+	defer tmr.Stop()
 
-	time.Sleep(20 * time.Millisecond)
 	if !tmr.Reset(30 * time.Millisecond) {
-		// Even if Reset returns false, Go's semantics allow the callback to run twice.
+		t.Fatal("Reset reported an active AfterFunc as stopped")
 	}
 
-	// Wait long enough to observe executions triggered before/after Reset.
-	time.Sleep(150 * time.Millisecond)
-	if got := count.Load(); got < 1 || got > 2 {
-		t.Fatalf("expected callback 1 or 2 times after reset, got %d", got)
+	select {
+	case got := <-fired:
+		if got != 1 {
+			t.Fatalf("first callback count = %d, want 1", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AfterFunc did not fire after active Reset")
+	}
+
+	if tmr.Reset(30 * time.Millisecond) {
+		t.Fatal("Reset reported an expired AfterFunc as active")
+	}
+	select {
+	case got := <-fired:
+		if got != 2 {
+			t.Fatalf("second callback count = %d, want 2", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AfterFunc did not fire after expired Reset")
 	}
 }
 


### PR DESCRIPTION
`TestAfterFuncReset` can fail with `got 0` on busy Windows runners because it samples callback progress after a fixed 150 ms sleep. This has failed on main and unrelated PRs, including [this main MinGW job](https://github.com/xgo-dev/llgo/actions/runs/33914613257/job/101158773441).

Wait for callback notification with a bounded timeout, and verify both active and expired `AfterFunc.Reset` return values and callback counts.

Validation:

- Go and LLGo each passed 100 repetitions of `TestAfterFuncReset`.
- The full LLGo `./test` package passed locally.
- Windows MinGW ARM64 and 386 full-test jobs passed on the same commit in [cpunion/llgo#224](https://github.com/cpunion/llgo/pull/224); other jobs are still pending.

Based directly on main; only `test/timer_test.go` changes. The fork PR remains open.
