### PR TITLE
ci: retry transient Debian sysroot package failures

### DIFF
--- a/.github/workflows/install_debian_packages.sh
+++ b/.github/workflows/install_debian_packages.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+apt_get() {
+	# Keep apt invocation replaceable for the shell-level retry test below.
+	command apt-get "$@"
+}
+
+install_debian_packages() {
+	local max_attempts="${LLGO_APT_MAX_ATTEMPTS:-3}"
+	if ! [[ "${max_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+		echo "LLGO_APT_MAX_ATTEMPTS must be a positive integer" >&2
+		return 2
+	fi
+	if (( $# == 0 )); then
+		echo "no Debian packages specified" >&2
+		return 2
+	fi
+
+	local attempt
+	for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+		if (( attempt > 1 )); then
+			# A Debian mirror can publish a new Packages index before all package
+			# objects have reached every CDN edge. Do not retain an index that named
+			# a just-removed package when retrying after a 404 or a reset connection.
+			rm -rf /var/lib/apt/lists/*
+		fi
+		if apt_get -o Acquire::Retries=3 update &&
+			apt_get -o Acquire::Retries=3 install -y "$@"; then
+			return 0
+		fi
+		if (( attempt < max_attempts )); then
+			echo "apt-get failed (attempt ${attempt}/${max_attempts}); retrying with fresh package indexes" >&2
+			sleep "$((attempt * 2))"
+		fi
+	done
+
+	echo "apt-get failed after ${max_attempts} attempts" >&2
+	return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	set -euo pipefail
+	install_debian_packages "$@"
+fi

--- a/.github/workflows/install_debian_packages_test.sh
+++ b/.github/workflows/install_debian_packages_test.sh
@@ -35,7 +35,14 @@ apt_get() {
 # Called indirectly by install_debian_packages.
 # shellcheck disable=SC2329
 rm() {
-	[[ "$*" == "-rf /var/lib/apt/lists/*" ]] || return 2
+	[[ $# -ge 2 && "$1" == -rf ]] || fail "unexpected cleanup arguments: $*"
+	shift
+	local path
+	# Bash expands the glob before calling this stub when apt lists exist on
+	# Linux. On macOS it normally stays literal; accept both forms per argument.
+	for path in "$@"; do
+		[[ "${path}" == /var/lib/apt/lists/* ]] || fail "unexpected cleanup path: ${path}"
+	done
 	list_resets=$((list_resets + 1))
 }
 
@@ -45,7 +52,13 @@ sleep() {
 	delays=$((delays + 1))
 }
 
-LLGO_APT_MAX_ATTEMPTS=3 install_debian_packages build-essential zlib1g-dev rsync 2>/dev/null
+# Exercise both forms without depending on the host's apt directory contents.
+rm -rf '/var/lib/apt/lists/*'
+rm -rf /var/lib/apt/lists/partial /var/lib/apt/lists/debian_Packages
+[[ "${list_resets}" -eq 2 ]] || fail "cleanup stub did not accept both glob forms"
+list_resets=0
+
+LLGO_APT_MAX_ATTEMPTS=3 install_debian_packages build-essential zlib1g-dev rsync
 [[ "${updates}" -eq 3 ]] || fail "update attempts = ${updates}, want 3"
 [[ "${installs}" -eq 3 ]] || fail "install attempts = ${installs}, want 3"
 [[ "${list_resets}" -eq 2 ]] || fail "list resets = ${list_resets}, want 2"
@@ -63,13 +76,15 @@ apt_get() {
 	return 1
 }
 
-if LLGO_APT_MAX_ATTEMPTS=2 install_debian_packages build-essential 2>/dev/null; then
+if LLGO_APT_MAX_ATTEMPTS=2 install_debian_packages build-essential; then
 	fail "exhausted retries unexpectedly succeeded"
 fi
 [[ "${updates}" -eq 2 ]] || fail "exhausted update attempts = ${updates}, want 2"
 [[ "${list_resets}" -eq 1 ]] || fail "exhausted list resets = ${list_resets}, want 1"
 [[ "${delays}" -eq 1 ]] || fail "exhausted retry delays = ${delays}, want 1"
 
-if LLGO_APT_MAX_ATTEMPTS=0 install_debian_packages build-essential 2>/dev/null; then
+if LLGO_APT_MAX_ATTEMPTS=0 install_debian_packages build-essential; then
 	fail "invalid attempt count unexpectedly succeeded"
 fi
+
+echo 'Debian package installation retry checks passed'

--- a/.github/workflows/install_debian_packages_test.sh
+++ b/.github/workflows/install_debian_packages_test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/workflows/install_debian_packages.sh
+source "${SCRIPT_DIR}/install_debian_packages.sh"
+
+fail() {
+	echo "$1" >&2
+	exit 1
+}
+
+updates=0
+installs=0
+list_resets=0
+delays=0
+last_install=""
+# Called indirectly by install_debian_packages.
+# shellcheck disable=SC2329
+apt_get() {
+	if [[ " $* " == *" update "* ]]; then
+		updates=$((updates + 1))
+		return 0
+	fi
+	if [[ " $* " == *" install "* ]]; then
+		installs=$((installs + 1))
+		last_install="$*"
+		(( installs >= 3 ))
+		return
+	fi
+	return 2
+}
+
+# Called indirectly by install_debian_packages.
+# shellcheck disable=SC2329
+rm() {
+	[[ "$*" == "-rf /var/lib/apt/lists/*" ]] || return 2
+	list_resets=$((list_resets + 1))
+}
+
+# Called indirectly by install_debian_packages.
+# shellcheck disable=SC2329
+sleep() {
+	delays=$((delays + 1))
+}
+
+LLGO_APT_MAX_ATTEMPTS=3 install_debian_packages build-essential zlib1g-dev rsync 2>/dev/null
+[[ "${updates}" -eq 3 ]] || fail "update attempts = ${updates}, want 3"
+[[ "${installs}" -eq 3 ]] || fail "install attempts = ${installs}, want 3"
+[[ "${list_resets}" -eq 2 ]] || fail "list resets = ${list_resets}, want 2"
+[[ "${delays}" -eq 2 ]] || fail "retry delays = ${delays}, want 2"
+[[ " ${last_install} " == *" -o Acquire::Retries=3 install -y build-essential zlib1g-dev rsync "* ]] ||
+	fail "unexpected install command: ${last_install}"
+
+updates=0
+list_resets=0
+delays=0
+# Called indirectly by install_debian_packages.
+# shellcheck disable=SC2329
+apt_get() {
+	updates=$((updates + 1))
+	return 1
+}
+
+if LLGO_APT_MAX_ATTEMPTS=2 install_debian_packages build-essential 2>/dev/null; then
+	fail "exhausted retries unexpectedly succeeded"
+fi
+[[ "${updates}" -eq 2 ]] || fail "exhausted update attempts = ${updates}, want 2"
+[[ "${list_resets}" -eq 1 ]] || fail "exhausted list resets = ${list_resets}, want 1"
+[[ "${delays}" -eq 1 ]] || fail "exhausted retry delays = ${delays}, want 1"
+
+if LLGO_APT_MAX_ATTEMPTS=0 install_debian_packages build-essential 2>/dev/null; then
+	fail "invalid attempt count unexpectedly succeeded"
+fi

--- a/.github/workflows/populate_linux_sysroot.sh
+++ b/.github/workflows/populate_linux_sysroot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 TMPDIR="$(mktemp -d)"
 export TMPDIR
@@ -14,10 +14,11 @@ POPULATE_LINUX_SYSROOT_SCRIPT="$(mktemp)"
 cat > "${POPULATE_LINUX_SYSROOT_SCRIPT}" << EOF
 #!/bin/bash
 
+set -e
+
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
-apt-get install -y build-essential zlib1g-dev rsync
+bash /install_debian_packages.sh build-essential zlib1g-dev rsync
 
 error() {
 	echo -e "\$1" >&2
@@ -134,7 +135,8 @@ populate_linux_sysroot() {
 		--rm \
 		--platform "linux/${ARCH}" \
 		-v "$(pwd)/${PREFIX}":/sysroot \
-		-v "${POPULATE_LINUX_SYSROOT_SCRIPT}":/populate_linux_sysroot.sh \
+		-v "$(pwd)/.github/workflows/install_debian_packages.sh":/install_debian_packages.sh:ro \
+		-v "${POPULATE_LINUX_SYSROOT_SCRIPT}":/populate_linux_sysroot.sh:ro \
 		debian:bullseye \
 		/populate_linux_sysroot.sh
 }

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -26,10 +26,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+      - name: Test Debian package installation retries
+        run: bash .github/workflows/install_debian_packages_test.sh
       - name: Calculate cache keys
         id: cache-keys
         run: |
-          LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
+          LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/install_debian_packages.sh', '.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
           echo "linux-key=$LINUX_KEY" >> $GITHUB_OUTPUT
   populate-linux-sysroot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Harden Linux sysroot provisioning against transient Debian mirror/CDN failures.

- Retry the complete apt index refresh and package installation with bounded backoff, clearing stale lists only before retry attempts.
- Propagate a failed package installation immediately instead of later failing as a missing rsync executable.
- Mount the install helper and generated populate script read-only.
- Add a shell-level retry behavior test to the release workflow, including both literal and expanded apt-list cleanup arguments, with visible failure diagnostics.

## Validation

- `bash -n` on the sysroot and retry scripts
- `bash .github/workflows/install_debian_packages_test.sh`, including Bash 3.2
- Local Linux amd64 Debian container: reproduced and fixed the self-test failure when apt-list paths exist and the cleanup glob expands
- ShellCheck on the sysroot and retry scripts
- `git diff --check`

The shell tests mock package installation; they validate retry control flow without claiming that a real network failure has been reproduced and recovered.
