### PR TITLE
ci: retry Windows MinGW test-go access violations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -143,15 +143,19 @@ jobs:
               export LLGO_REQUIRE_MSVC=1
             fi
             export LLGO_STDIO_NOBUF=1
-            # The main batch and the separate test/go batch can expose narrow
-            # hosted-Windows runtime failures. Their wrapper records a
-            # quarantine only for its exact, package-scoped signatures; all
-            # compiler fixture failures remain fail-closed.
+            # Keep the existing exact synctest quarantine on the main batch.
             main_go_test=(bash dev/go_test_windows.sh "${go_test[@]}")
-            test_go=(bash dev/go_test_windows.sh "${go_test[@]}")
           else
             main_go_test=("${go_test[@]}")
-            test_go=("${go_test[@]}")
+          fi
+          test_go=("${go_test[@]}")
+          if [[ "$RUNNER_OS" == Windows && "$RUNNER_ARCH" == X64 && \
+                "${{ matrix.os }}" == windows-2022 && "${{ matrix.windows_abi }}" == mingw ]]; then
+            # Only this lane has the observed standalone test/go access
+            # violation. Retry in a fresh process at most twice, requiring a
+            # real pass; never quarantine it or skip its coverage. Other
+            # platforms, MSVC, compiler fixtures and the main batch are unchanged.
+            test_go=(bash dev/go_test_windows.sh --retry-test-go "${go_test[@]:2}")
           fi
 
           # Keep the direct language-behavior suite in a separate profile so
@@ -171,7 +175,7 @@ jobs:
             -coverpkg=github.com/xgo-dev/llgo/cl,github.com/xgo-dev/llgo/ssa \
             -coverprofile="coverage-compiler.txt" -covermode=atomic \
             -bench '^BenchmarkGo126' -benchtime=1x ./cl
-          "${test_go[@]}" -timeout 45m \
+          "${test_go[@]}" -timeout=45m \
             -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
 
       - name: Test with embedded emulator env

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,6 +88,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          bash dev/go_test_windows_test.sh
+
           # Keep the concurrency stress from the former dedicated workflow;
           # one ordinary package run does not prove mutual exclusion.
           go test -count=20 -timeout=10m -run 'Lock' ./internal/crosscompile
@@ -141,12 +143,15 @@ jobs:
               export LLGO_REQUIRE_MSVC=1
             fi
             export LLGO_STDIO_NOBUF=1
-            # Only the main batch contains the test package tree affected by
-            # golang/go#81238. Its wrapper accepts the single exact fatal
-            # signature, records the quarantine, and preserves other failures.
+            # The main batch and the separate test/go batch can expose narrow
+            # hosted-Windows runtime failures. Their wrapper records a
+            # quarantine only for its exact, package-scoped signatures; all
+            # compiler fixture failures remain fail-closed.
             main_go_test=(bash dev/go_test_windows.sh "${go_test[@]}")
+            test_go=(bash dev/go_test_windows.sh "${go_test[@]}")
           else
             main_go_test=("${go_test[@]}")
+            test_go=("${go_test[@]}")
           fi
 
           # Keep the direct language-behavior suite in a separate profile so
@@ -166,7 +171,7 @@ jobs:
             -coverpkg=github.com/xgo-dev/llgo/cl,github.com/xgo-dev/llgo/ssa \
             -coverprofile="coverage-compiler.txt" -covermode=atomic \
             -bench '^BenchmarkGo126' -benchtime=1x ./cl
-          "${go_test[@]}" -timeout 45m \
+          "${test_go[@]}" -timeout 45m \
             -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
 
       - name: Test with embedded emulator env

--- a/dev/go_test_windows.sh
+++ b/dev/go_test_windows.sh
@@ -4,14 +4,19 @@ set -euo pipefail
 
 if [[ $# -eq 0 ]]; then
 	echo "usage: $0 <go-test-command> [argument ...]" >&2
+	echo "       $0 --retry-test-go [coverage flags] ./test/go" >&2
 	exit 2
 fi
 
+# By default this wraps the host-test batch containing this module's test tree.
+# --retry-test-go is a separate, opt-in mode for the Windows MinGW x64 coverage
+# command only. It retries an observed access violation, not a confirmed runtime
+# bug, and requires a successful full package run instead of quarantining it.
+#
 # Some GitHub-hosted Windows/amd64 machines are affected by golang/go#81238:
 # recovering a hardware exception can write below a goroutine stack and
 # corrupt an unrelated heap object. A corrupted testing.T signal channel then
-# produces this otherwise-impossible synctest fatal error. This wrapper is used
-# only for the host-test batch containing this module's test package tree.
+# produces this otherwise-impossible synctest fatal error.
 module_path="$(go list -m -f '{{.Path}}')"
 
 is_known_runtime_corruption() {
@@ -41,60 +46,115 @@ is_known_runtime_corruption() {
 		! grep -Eiq '^--- FAIL:|\[build failed\]|^panic:|WARNING: DATA RACE|test timed out|SIGQUIT|SIGSEGV|SIGABRT|unexpected fault address|signal: (segmentation fault|aborted)' "${log}"
 }
 
-is_known_test_go_access_violation() {
+is_test_go_access_violation() {
 	local log="$1"
-	shift
+	awk '
+		{ sub(/\r$/, "") }
+		/^exit status / {
+			if ($0 == "exit status 0xc0000005") count++
+			else other = 1
+		}
+		END { exit !(count == 1 && !other) }
+	' "${log}" &&
+		awk -v target="${module_path}/test/go" '
+			$1 == "FAIL" && NF >= 2 {
+				if ($2 == target) target_failure++
+				else other_failure = 1
+			}
+			END { exit !(target_failure == 1 && !other_failure) }
+		' "${log}" &&
+		! grep -Eiq '^[[:space:]]*--- FAIL:|\[build failed\]|^fatal error:|^panic:|WARNING: DATA RACE|test timed out|SIGQUIT|SIGSEGV|SIGABRT|unexpected fault address|signal: (segmentation fault|aborted)' "${log}"
+}
 
-	# This quarantine is deliberately limited to the separately-invoked
-	# language-behavior suite. The compiler fixture suite and every other test
-	# package must continue to report an access violation as a failure.
-	local arg test_go_args=0
+report_test_go_retry() {
+	echo "LLGO_CI_WINDOWS_TEST_GO_RETRY: $*"
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		printf -- '- Windows test/go retry: %s\n' "$*" >>"${GITHUB_STEP_SUMMARY}"
+	fi
+}
+
+retry_test_go() {
+	if [[ "${RUNNER_OS:-}" != Windows || "${RUNNER_ARCH:-}" != X64 ]]; then
+		echo '--retry-test-go is only supported on Windows x64 CI runners' >&2
+		return 2
+	fi
+
+	# This is a workflow-specific API, not an arbitrary command wrapper. Accept
+	# only its coverage flags and one test/go package, so another package or a
+	# flag such as -c, -list, -run or -args cannot bypass a full test execution.
+	local arg target_count=0
+	local command=(go test)
 	for arg in "$@"; do
 		case "${arg}" in
-		./test/go|"${module_path}/test/go")
-			test_go_args=$((test_go_args + 1))
+		-ldflags=*|-timeout=*|-coverprofile=*|-covermode=*)
+			command+=("${arg}")
 			;;
-		./*|"${module_path}"/*)
-			return 1
+		./test/go|"${module_path}/test/go")
+			target_count=$((target_count + 1))
+			;;
+		*)
+			echo "unsupported --retry-test-go argument: ${arg}" >&2
+			return 2
 			;;
 		esac
 	done
-	(( test_go_args == 1 )) &&
-		awk '$0 == "exit status 0xc0000005" { count++ } END { exit !(count == 1) }' "${log}" &&
-		awk -v target="${module_path}/test/go" '
-			$1 == "FAIL" && NF >= 2 {
-				if ($2 == target) target_failure = 1
-				else other_failure = 1
-			}
-			END { exit !(target_failure && !other_failure) }
-		' "${log}" &&
-		! grep -Eiq '^--- FAIL:|\[build failed\]|^fatal error:|^panic:|WARNING: DATA RACE|test timed out|SIGQUIT|SIGSEGV|SIGABRT|unexpected fault address|signal: (segmentation fault|aborted)' "${log}"
+	if [[ ${target_count} -ne 1 ]]; then
+		echo '--retry-test-go requires exactly one ./test/go package' >&2
+		return 2
+	fi
+	# Disable test-result caching, not compilation caching. Each attempt starts
+	# a new go test process; -count=3 would repeat inside the same test process.
+	command+=(-count=1 ./test/go)
+
+	local attempt status
+	local statuses=()
+	for ((attempt = 1; attempt <= 3; attempt++)); do
+		report_test_go_retry "Starting attempt ${attempt}/3 in a new process: all tests in ./test/go, -count=1 (no cached test results). Other packages and CI steps are not rerun."
+		printf 'Command:'
+		printf ' %q' "${command[@]}"
+		printf '\n'
+		set +e
+		"${command[@]}" 2>&1 | tee "${log}"
+		statuses=("${PIPESTATUS[@]}")
+		set -e
+		status=${statuses[0]}
+		if [[ ${statuses[1]} -ne 0 ]]; then
+			report_test_go_retry "Attempt ${attempt}/3: log capture failed; failing without retry."
+			return 1
+		fi
+		if [[ ${status} -eq 0 ]]; then
+			report_test_go_retry "Attempt ${attempt}/3 passed. Tests completed successfully; this retry does not disable coverage upload."
+			return 0
+		fi
+		if ! is_test_go_access_violation "${log}"; then
+			report_test_go_retry "Attempt ${attempt}/3 failed (exit ${status}) without the eligible test/go-only 0xc0000005 signature; failing without further retries."
+			return "${status}"
+		fi
+		if [[ ${attempt} -eq 3 ]]; then
+			report_test_go_retry "Attempt 3/3 failed with 0xc0000005; both retries exhausted. No successful package run; failing (exit ${status}), not quarantining."
+			return "${status}"
+		fi
+		echo '::warning title=Windows test/go access violation::Retrying the standalone test/go package after 0xc0000005; the root cause is unconfirmed and a successful run is required.'
+		report_test_go_retry "Attempt ${attempt}/3 failed (exit ${status}) with the observed test/go-only 0xc0000005 signature. Root cause unconfirmed; retrying the whole package in a new process. Original output is retained above."
+	done
 }
 
 log=
 trap '[[ -z "${log}" ]] || rm -f "${log}"' EXIT
 log="$(mktemp "${TMPDIR:-/tmp}/llgo-go-test-windows.XXXXXX")"
+if [[ "$1" == --retry-test-go ]]; then
+	shift
+	retry_test_go "$@"
+	exit 0
+fi
+
 set +e
 "$@" 2>&1 | tee "${log}"
 status=${PIPESTATUS[0]}
 set -e
 
 if [[ ${status} -eq 0 ]] || ! is_known_runtime_corruption "${log}"; then
-	if [[ ${status} -eq 0 ]] || ! is_known_test_go_access_violation "${log}" "$@"; then
-		exit "${status}"
-	fi
-	echo '::warning title=Quarantined Windows test/go access violation::LLGO_CI_QUARANTINED_WINDOWS_TEST_GO_ACCESS_VIOLATION: matched the narrow test/go-only 0xc0000005 signature'
-	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-		echo 'windows_runtime_corruption=true' >>"${GITHUB_OUTPUT}"
-	fi
-	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-		{
-			echo '### Quarantined Windows test/go access violation'
-			echo
-			echo 'The direct test/go command ended with the narrow 0xc0000005 signature and no test failure. The compiler fixture suite remains fail-closed; coverage upload for this job was skipped.'
-		} >>"${GITHUB_STEP_SUMMARY}"
-	fi
-	exit 0
+	exit "${status}"
 fi
 
 echo '::warning title=Quarantined upstream Go runtime corruption::LLGO_CI_QUARANTINED_GO_RUNTIME_CORRUPTION: matched the narrow golang/go#81238 signature'

--- a/dev/go_test_windows.sh
+++ b/dev/go_test_windows.sh
@@ -41,6 +41,36 @@ is_known_runtime_corruption() {
 		! grep -Eiq '^--- FAIL:|\[build failed\]|^panic:|WARNING: DATA RACE|test timed out|SIGQUIT|SIGSEGV|SIGABRT|unexpected fault address|signal: (segmentation fault|aborted)' "${log}"
 }
 
+is_known_test_go_access_violation() {
+	local log="$1"
+	shift
+
+	# This quarantine is deliberately limited to the separately-invoked
+	# language-behavior suite. The compiler fixture suite and every other test
+	# package must continue to report an access violation as a failure.
+	local arg test_go_args=0
+	for arg in "$@"; do
+		case "${arg}" in
+		./test/go|"${module_path}/test/go")
+			test_go_args=$((test_go_args + 1))
+			;;
+		./*|"${module_path}"/*)
+			return 1
+			;;
+		esac
+	done
+	(( test_go_args == 1 )) &&
+		awk '$0 == "exit status 0xc0000005" { count++ } END { exit !(count == 1) }' "${log}" &&
+		awk -v target="${module_path}/test/go" '
+			$1 == "FAIL" && NF >= 2 {
+				if ($2 == target) target_failure = 1
+				else other_failure = 1
+			}
+			END { exit !(target_failure && !other_failure) }
+		' "${log}" &&
+		! grep -Eiq '^--- FAIL:|\[build failed\]|^fatal error:|^panic:|WARNING: DATA RACE|test timed out|SIGQUIT|SIGSEGV|SIGABRT|unexpected fault address|signal: (segmentation fault|aborted)' "${log}"
+}
+
 log=
 trap '[[ -z "${log}" ]] || rm -f "${log}"' EXIT
 log="$(mktemp "${TMPDIR:-/tmp}/llgo-go-test-windows.XXXXXX")"
@@ -50,7 +80,21 @@ status=${PIPESTATUS[0]}
 set -e
 
 if [[ ${status} -eq 0 ]] || ! is_known_runtime_corruption "${log}"; then
-	exit "${status}"
+	if [[ ${status} -eq 0 ]] || ! is_known_test_go_access_violation "${log}" "$@"; then
+		exit "${status}"
+	fi
+	echo '::warning title=Quarantined Windows test/go access violation::LLGO_CI_QUARANTINED_WINDOWS_TEST_GO_ACCESS_VIOLATION: matched the narrow test/go-only 0xc0000005 signature'
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		echo 'windows_runtime_corruption=true' >>"${GITHUB_OUTPUT}"
+	fi
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		{
+			echo '### Quarantined Windows test/go access violation'
+			echo
+			echo 'The direct test/go command ended with the narrow 0xc0000005 signature and no test failure. The compiler fixture suite remains fail-closed; coverage upload for this job was skipped.'
+		} >>"${GITHUB_STEP_SUMMARY}"
+	fi
+	exit 0
 fi
 
 echo '::warning title=Quarantined upstream Go runtime corruption::LLGO_CI_QUARANTINED_GO_RUNTIME_CORRUPTION: matched the narrow golang/go#81238 signature'

--- a/dev/go_test_windows_test.sh
+++ b/dev/go_test_windows_test.sh
@@ -5,38 +5,211 @@ set -euo pipefail
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
-module_path="$(go list -m -f '{{.Path}}')"
-export MODULE_PATH="${module_path}"
+LLGO_TEST_MODULE_PATH="$(go list -m -f '{{.Path}}')"
+export LLGO_TEST_MODULE_PATH
+test_root="$(mktemp -d)"
+trap 'rm -rf "${test_root}"' EXIT
+case_count=0
+
+# Export a fake Go command into each wrapper process. State lives on disk so
+# separate attempts see the next result without executing real Windows tests.
+go() {
+	if [[ "$1" == list ]]; then
+		printf '%s\n' "${LLGO_TEST_MODULE_PATH}"
+		return 0
+	fi
+	[[ "$1" == test ]] || return 99
+	local count=0 stages=() stage eol=$'\n'
+	if [[ -f "${LLGO_TEST_CASE}/count" ]]; then
+		read -r count <"${LLGO_TEST_CASE}/count"
+	fi
+	count=$((count + 1))
+	printf '%s\n' "${count}" >"${LLGO_TEST_CASE}/count"
+	printf '%s\n' "$@" >>"${LLGO_TEST_CASE}/args"
+	read -r -a stages <<<"${LLGO_TEST_SEQUENCE}"
+	stage="${stages[count - 1]:-unexpected}"
+	printf 'Fake go test attempt %s: %s\n' "${count}" "${stage}"
+	case "${stage}" in
+	pass)
+		printf 'ok\t%s/test/go\t0.1s\n' "${LLGO_TEST_MODULE_PATH}"
+		return 0
+		;;
+	av)
+		[[ "${LLGO_TEST_CRLF}" == 0 ]] || eol=$'\r\n'
+		printf 'exit status 0xc0000005%sFAIL\t%s/%s\t0.1s%s' \
+			"${eol}" "${LLGO_TEST_MODULE_PATH}" "${LLGO_TEST_PACKAGE}" "${eol}"
+		printf '%s' "${LLGO_TEST_EXTRA}"
+		return 23
+		;;
+	fail)
+		printf -- '--- FAIL: TestRealFailure\nFAIL\t%s/test/go\t0.1s\n' "${LLGO_TEST_MODULE_PATH}"
+		return 17
+		;;
+	synctest)
+		printf 'fatal error: receive on synctest channel from outside bubble\ntesting.(*T).Run\nFAIL\t%s/%s\t0.1s\n' \
+			"${LLGO_TEST_MODULE_PATH}" "${LLGO_TEST_PACKAGE}"
+		return 31
+		;;
+	*) return 99 ;;
+	esac
+}
+export -f go
 
 fail() {
-	echo "$1" >&2
+	echo "${LLGO_TEST_CASE}: $*" >&2
+	if [[ -f "${LLGO_TEST_CASE}/log" ]]; then
+		sed -n '1,100p' "${LLGO_TEST_CASE}/log" >&2
+	fi
 	exit 1
 }
 
-run_access_violation() {
-	local package_arg="$1"
-	local package_suffix="$2"
-	local extra_output="$3"
-	bash dev/go_test_windows.sh bash -c '
-		printf "exit status 0xc0000005\\n"
-		printf "FAIL\\t%s/%s\\t0.1s\\n" "$MODULE_PATH" "$1"
-		printf "%s" "$2"
-		exit 1
-	' "${package_arg}" "${package_suffix}" "${extra_output}"
+new_case() {
+	case_count=$((case_count + 1))
+	export LLGO_TEST_CASE="${test_root}/${case_count}-$1"
+	mkdir "${LLGO_TEST_CASE}"
+	export LLGO_TEST_SEQUENCE="$2" LLGO_TEST_EXTRA='' LLGO_TEST_CRLF=0 LLGO_TEST_PACKAGE=test/go
+	export RUNNER_OS=Windows RUNNER_ARCH=X64
+	export GITHUB_OUTPUT="${LLGO_TEST_CASE}/output" GITHUB_STEP_SUMMARY="${LLGO_TEST_CASE}/summary"
+	: >"${GITHUB_OUTPUT}"
+	: >"${GITHUB_STEP_SUMMARY}"
 }
 
-output_file="$(mktemp)"
-trap 'rm -f "${output_file}"' EXIT
-export GITHUB_OUTPUT="${output_file}"
+run_case() {
+	local want_count="$1" want_status="$2" status=0 count=0
+	shift 2
+	if bash dev/go_test_windows.sh "$@" >"${LLGO_TEST_CASE}/log" 2>&1; then
+		status=0
+	else
+		status=$?
+	fi
+	[[ "${status}" == "${want_status}" ]] || fail "exit ${status}, expected ${want_status}"
+	if [[ -f "${LLGO_TEST_CASE}/count" ]]; then
+		read -r count <"${LLGO_TEST_CASE}/count"
+	fi
+	[[ "${count}" == "${want_count}" ]] || fail "ran ${count} times, expected ${want_count}"
+}
 
-run_access_violation ./test/go test/go ''
-grep -Fxq 'windows_runtime_corruption=true' "${output_file}" ||
-	fail "test/go quarantine did not set the coverage-skip output"
+no_coverage_skip() {
+	[[ ! -s "${GITHUB_OUTPUT}" ]] || fail 'unexpected coverage-skip output'
+}
 
-if run_access_violation ./cl cl '' >/dev/null 2>&1; then
-	fail "compiler fixture access violation was unexpectedly quarantined"
+has_log() {
+	grep -Fq -- "$1" "${LLGO_TEST_CASE}/log" || fail "missing log: $1"
+	grep -Fq -- "$1" "${GITHUB_STEP_SUMMARY}" || fail "missing summary: $1"
+}
+
+new_case first_pass pass
+run_case 1 0 --retry-test-go -timeout=45m \
+	'-ldflags=-linkmode=external -extldflags=-lsynchronization' \
+	"-coverprofile=${LLGO_TEST_CASE}/coverage result.txt" -covermode=atomic ./test/go
+for arg in test -timeout=45m '-ldflags=-linkmode=external -extldflags=-lsynchronization' \
+	"-coverprofile=${LLGO_TEST_CASE}/coverage result.txt" -covermode=atomic -count=1 ./test/go; do
+	grep -Fxq -- "${arg}" "${LLGO_TEST_CASE}/args" || fail "lost or split argument: ${arg}"
+done
+[[ "$(wc -l <"${LLGO_TEST_CASE}/args")" -eq 7 ]] || fail 'unexpected test arguments'
+has_log 'Starting attempt 1/3 in a new process: all tests in ./test/go, -count=1'
+has_log 'Other packages and CI steps are not rerun.'
+has_log 'Attempt 1/3 passed.'
+no_coverage_skip
+
+new_case retry_once 'av pass'
+run_case 2 0 --retry-test-go ./test/go
+has_log 'Root cause unconfirmed; retrying the whole package in a new process.'
+has_log 'Original output is retained above.'
+has_log 'Attempt 2/3 passed.'
+grep -Fq 'exit status 0xc0000005' "${LLGO_TEST_CASE}/log" || fail 'original crash output lost'
+[[ "$(grep -Fxc -- '-count=1' "${LLGO_TEST_CASE}/args")" -eq 2 ]] || fail 'a retry could use cached test results'
+no_coverage_skip
+
+new_case retry_twice 'av av pass'
+run_case 3 0 --retry-test-go ./test/go
+has_log 'Attempt 3/3 passed.'
+no_coverage_skip
+
+new_case exhausted 'av av av pass'
+run_case 3 23 --retry-test-go ./test/go
+has_log 'both retries exhausted. No successful package run; failing'
+no_coverage_skip
+
+new_case real_failure_after_crash 'av fail pass'
+run_case 2 17 --retry-test-go ./test/go
+has_log 'failing without further retries.'
+no_coverage_skip
+
+new_case crlf 'av pass'
+export LLGO_TEST_CRLF=1
+run_case 2 0 --retry-test-go ./test/go
+has_log 'Attempt 2/3 passed.'
+no_coverage_skip
+
+new_case module_qualified pass
+run_case 1 0 --retry-test-go "${LLGO_TEST_MODULE_PATH}/test/go"
+grep -Fxq './test/go' "${LLGO_TEST_CASE}/args" || fail 'package was not normalized'
+no_coverage_skip
+
+new_case no_opt_in 'av pass'
+run_case 1 23 go test ./test/go
+no_coverage_skip
+if grep -Fq 'LLGO_CI_WINDOWS_TEST_GO_RETRY' "${LLGO_TEST_CASE}/log"; then
+	fail 'default wrapper unexpectedly retried an access violation'
 fi
 
-if run_access_violation ./test/go test/go $'--- FAIL: TestRealFailure\n' >/dev/null 2>&1; then
-	fail "test/go access violation with a test failure was unexpectedly quarantined"
-fi
+for platform in Linux macOS Windows; do
+	new_case wrong_platform pass
+	export RUNNER_OS="${platform}"
+	[[ "${platform}" != Windows ]] || export RUNNER_ARCH=ARM64
+	run_case 0 2 --retry-test-go ./test/go
+	no_coverage_skip
+done
+
+new_case missing_package pass
+run_case 0 2 --retry-test-go
+no_coverage_skip
+for arg in ./cl ./test net/http "${LLGO_TEST_MODULE_PATH}/cl" ./test/go \
+	"${LLGO_TEST_MODULE_PATH}/test/go" -c -list=. -run=. -skip=. -args -- -count=3 -timeout; do
+	new_case unsupported_argument pass
+	run_case 0 2 --retry-test-go "${arg}" ./test/go
+	no_coverage_skip
+done
+
+# No ordinary failure or additional diagnostic may turn into a retry, even
+# when the access-violation line is also present and a later attempt would pass.
+for diagnostic in \
+	$'--- FAIL: TestRealFailure\n' $'    --- FAIL: TestNestedFailure\n' \
+	$'[build failed]\n' $'fatal error: other failure\n' $'panic: failure\n' \
+	$'WARNING: DATA RACE\n' $'test timed out\n' $'SIGQUIT\n' $'SIGSEGV\n' \
+	$'SIGABRT\n' $'unexpected fault address\n' $'signal: segmentation fault\n' \
+	$'signal: aborted\n' $'exit status 0xc0000005\n' $'exit status 2\n' \
+	"$(printf 'FAIL\t%s/cl\t0.1s\n' "${LLGO_TEST_MODULE_PATH}")" \
+	"$(printf 'FAIL\t%s/test/go\t0.1s\n' "${LLGO_TEST_MODULE_PATH}")"; do
+	new_case ineligible_diagnostic 'av pass'
+	export LLGO_TEST_EXTRA="${diagnostic}"
+	run_case 1 23 --retry-test-go ./test/go
+	no_coverage_skip
+done
+
+new_case wrong_failure_package 'av pass'
+export LLGO_TEST_PACKAGE=cl
+run_case 1 23 --retry-test-go ./test/go
+no_coverage_skip
+
+new_case ordinary_failure 'fail pass'
+run_case 1 17 --retry-test-go ./test/go
+no_coverage_skip
+
+new_case synctest_not_retryable 'synctest pass'
+run_case 1 31 --retry-test-go ./test/go
+no_coverage_skip
+
+new_case legacy_synctest synctest
+export LLGO_TEST_PACKAGE=test
+run_case 1 0 go test "${LLGO_TEST_MODULE_PATH}/test"
+grep -Fxq 'windows_runtime_corruption=true' "${GITHUB_OUTPUT}" || fail 'legacy quarantine lost coverage skip'
+grep -Fq 'LLGO_CI_QUARANTINED_GO_RUNTIME_CORRUPTION' "${LLGO_TEST_CASE}/log" || fail 'legacy quarantine marker lost'
+
+new_case preserve_legacy_skip 'av pass'
+printf 'windows_runtime_corruption=true\n' >"${GITHUB_OUTPUT}"
+run_case 2 0 --retry-test-go ./test/go
+[[ "$(<"${GITHUB_OUTPUT}")" == windows_runtime_corruption=true ]] || fail 'retry changed an existing coverage-skip output'
+
+printf 'Windows Go-test wrapper: %s cases passed\n' "${case_count}"

--- a/dev/go_test_windows_test.sh
+++ b/dev/go_test_windows_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+module_path="$(go list -m -f '{{.Path}}')"
+export MODULE_PATH="${module_path}"
+
+fail() {
+	echo "$1" >&2
+	exit 1
+}
+
+run_access_violation() {
+	local package_arg="$1"
+	local package_suffix="$2"
+	local extra_output="$3"
+	bash dev/go_test_windows.sh bash -c '
+		printf "exit status 0xc0000005\\n"
+		printf "FAIL\\t%s/%s\\t0.1s\\n" "$MODULE_PATH" "$1"
+		printf "%s" "$2"
+		exit 1
+	' "${package_arg}" "${package_suffix}" "${extra_output}"
+}
+
+output_file="$(mktemp)"
+trap 'rm -f "${output_file}"' EXIT
+export GITHUB_OUTPUT="${output_file}"
+
+run_access_violation ./test/go test/go ''
+grep -Fxq 'windows_runtime_corruption=true' "${output_file}" ||
+	fail "test/go quarantine did not set the coverage-skip output"
+
+if run_access_violation ./cl cl '' >/dev/null 2>&1; then
+	fail "compiler fixture access violation was unexpectedly quarantined"
+fi
+
+if run_access_violation ./test/go test/go $'--- FAIL: TestRealFailure\n' >/dev/null 2>&1; then
+	fail "test/go access violation with a test failure was unexpectedly quarantined"
+fi


### PR DESCRIPTION
## Summary

Replace the proposed Windows `test/go` access-violation quarantine with bounded fresh-process retries that require a real passing test run.

- Enable retries only for the standalone `./test/go` coverage command on the existing `windows-2022`, MinGW, x64 lane. Linux, macOS, MSVC, the main test batch, and `./cl` retain their existing behavior.
- Run the complete `./test/go` package with the original linker, timeout, and coverage flags, plus `-count=1`. Each attempt starts a new `go test` process; compilation caching remains available, but cached test results cannot satisfy a retry.
- Allow at most two retries after the initial attempt, and only for the observed single `0xc0000005` / `test/go` failure shape, with no assertion, build, panic, fatal, race, timeout, or other signal failure. Accept both LF and CRLF logs.
- Require an actual successful execution. An ordinary failure stops immediately; three access violations still fail the job. The retry mode never falls back to the existing synctest quarantine or disables coverage upload.
- Log `LLGO_CI_WINDOWS_TEST_GO_RETRY`, the reason and scope, attempt number, exact command, and final outcome. Keep every attempt's raw output in the CI log and record the outcome in the job summary. The access-violation root cause is explicitly unconfirmed.
- Restrict the workflow-specific retry API to the existing coverage flags and one `test/go` package, preventing other packages or compile-only/list/filter flags from bypassing a full execution.

The pre-existing exact synctest quarantine for the main test batch is unchanged. A coverage-skip output already set by that separate batch is not cleared by a successful retry.

## Evidence and limits

[This Windows MinGW job](https://github.com/xgo-dev/llgo/actions/runs/33939780136/job/101234798676) passed `./cl` and then exited with `0xc0000005` in the standalone `./test/go` command. This exit code alone does not prove golang/go#81238 or any other specific root cause, so it must not turn an uncompleted test run into success.

The separate [`./cl` access violation](https://github.com/xgo-dev/llgo/actions/runs/33940020242/job/101235467077) remains a failure and is outside this retry policy. This PR mitigates transient access violations; it does not fix their underlying cause.

## Validation

- All 48 deterministic shell cases pass, including under Bash 3.2: first-attempt success, crash/recovery, retry exhaustion, ordinary failures, LF/CRLF, platform and argument boundaries, preserved flags, diagnostic logs, and coverage-output isolation.
- `bash -n dev/go_test_windows.sh dev/go_test_windows_test.sh`
- `bash dev/go_test_windows_test.sh`
- `shellcheck dev/go_test_windows.sh dev/go_test_windows_test.sh`
- `actionlint -shellcheck='' -ignore 'label "qiniu" is unknown' .github/workflows/go.yml` (the existing self-hosted runner label is not in the local actionlint catalog).
- `git diff --check`

The shell tests simulate child-process outcomes; real Windows behavior is checked by this PR's CI, not inferred from the simulations.
