### PR TITLE
ci: replace Debian 11 release sysroots with Debian 12

### DIFF
--- a/.github/workflows/populate_linux_sysroot.sh
+++ b/.github/workflows/populate_linux_sysroot.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# Pin the architecture-specific images from the same Debian 12 index
+# (sha256:6ebd97fa83deb272194a2cf015b3d26a4d538e9ad3a7a79d544c8af5b0a01443).
+# Refresh the index and child digests with `docker buildx imagetools inspect debian:12`.
+# Docker's classic image store cannot retain two platforms under one index
+# digest. The GCC 12 paths in .goreleaser.yaml must match these sysroots.
+LINUX_AMD64_IMAGE=debian:12@sha256:2f65600e1252c5649d2213e1d1ea4d74253d26514dc6530102a875e429245929
+LINUX_ARM64_IMAGE=debian:12@sha256:5eac3978974cfa26a880057766c683e55c5763355d30a8beecbd263e0e1621d9
+
 TMPDIR="$(mktemp -d)"
 export TMPDIR
 trap 'rm -rf "${TMPDIR}"' EXIT
@@ -14,10 +22,17 @@ POPULATE_LINUX_SYSROOT_SCRIPT="$(mktemp)"
 cat > "${POPULATE_LINUX_SYSROOT_SCRIPT}" << EOF
 #!/bin/bash
 
+set -e
+
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
-apt-get install -y build-essential zlib1g-dev rsync
+apt-get -o Acquire::Retries=3 update
+apt-get -o Acquire::Retries=3 install -y build-essential zlib1g-dev rsync
+dpkg-query -W libc6 libc6-dev gcc g++ libstdc++6
+test -f /usr/include/c++/12/string
+GCC_TRIPLE="\$(gcc -dumpmachine)"
+test -d "/usr/include/\${GCC_TRIPLE}/c++/12"
+test -d "/usr/lib/gcc/\${GCC_TRIPLE}/12"
 
 error() {
 	echo -e "\$1" >&2
@@ -120,7 +135,7 @@ do-sync() {
 	echo "\${args[@]}"
 	rsync "\${args[@]}"
 
-	exit \$?
+	return \$?
 }
 
 do-sync / /sysroot/
@@ -130,16 +145,15 @@ chmod +x "${POPULATE_LINUX_SYSROOT_SCRIPT}"
 populate_linux_sysroot() {
 	local ARCH="$1"
 	local PREFIX="$2"
+	local IMAGE="$3"
 	docker run \
 		--rm \
 		--platform "linux/${ARCH}" \
 		-v "$(pwd)/${PREFIX}":/sysroot \
-		-v "${POPULATE_LINUX_SYSROOT_SCRIPT}":/populate_linux_sysroot.sh \
-		debian:bullseye \
+		-v "${POPULATE_LINUX_SYSROOT_SCRIPT}":/populate_linux_sysroot.sh:ro \
+		"${IMAGE}" \
 		/populate_linux_sysroot.sh
 }
-# Docker's classic image store keeps only one platform for a tag. Pulling the
-# same tag for two platforms concurrently can replace the image while the other
-# container is starting. Populate the sysroots serially to keep the tag stable.
-populate_linux_sysroot amd64 "${LINUX_AMD64_PREFIX}"
-populate_linux_sysroot arm64 "${LINUX_ARM64_PREFIX}"
+# Populate serially to bound the memory and disk pressure of extraction.
+populate_linux_sysroot amd64 "${LINUX_AMD64_PREFIX}" "${LINUX_AMD64_IMAGE}"
+populate_linux_sysroot arm64 "${LINUX_ARM64_PREFIX}" "${LINUX_ARM64_IMAGE}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,12 +57,12 @@ builds:
       - -X github.com/xgo-dev/llgo/internal/env.buildTime={{.Date}}
       - "-extldflags=-Wl,-rpath,$ORIGIN/../crosscompile/clang/lib"
     env:
-      # Use the packaged host Clang driver with the target's complete bullseye sysroot.
+      # Use the packaged host Clang with the Debian 12 sysroot and GCC 12 headers.
       - CC={{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/bin/clang
       - CXX={{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/bin/clang++
       - CGO_CPPFLAGS=--target=x86_64-linux-gnu --gcc-toolchain={{.Env.SYSROOT_LINUX_AMD64}}/usr --sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_CXXFLAGS=-std=c++17 -nostdinc++ -isystem {{.Env.SYSROOT_LINUX_AMD64}}/usr/include/c++/10 -isystem {{.Env.SYSROOT_LINUX_AMD64}}/usr/include/x86_64-linux-gnu/c++/10 -isystem {{.Env.SYSROOT_LINUX_AMD64}}/usr/include/c++/10/backward
-      - CGO_LDFLAGS=--target=x86_64-linux-gnu --gcc-toolchain={{.Env.SYSROOT_LINUX_AMD64}}/usr --sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -L{{.Env.SYSROOT_LINUX_AMD64}}/usr/lib/gcc/x86_64-linux-gnu/10 -L{{.Env.SYSROOT_LINUX_AMD64}}/usr/lib/x86_64-linux-gnu -L{{.Env.SYSROOT_LINUX_AMD64}}/lib/x86_64-linux-gnu -lLLVM-19 -lz
+      - CGO_CXXFLAGS=-std=c++17 -nostdinc++ -isystem {{.Env.SYSROOT_LINUX_AMD64}}/usr/include/c++/12 -isystem {{.Env.SYSROOT_LINUX_AMD64}}/usr/include/x86_64-linux-gnu/c++/12 -isystem {{.Env.SYSROOT_LINUX_AMD64}}/usr/include/c++/12/backward
+      - CGO_LDFLAGS=--target=x86_64-linux-gnu --gcc-toolchain={{.Env.SYSROOT_LINUX_AMD64}}/usr --sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -L{{.Env.SYSROOT_LINUX_AMD64}}/usr/lib/gcc/x86_64-linux-gnu/12 -L{{.Env.SYSROOT_LINUX_AMD64}}/usr/lib/x86_64-linux-gnu -L{{.Env.SYSROOT_LINUX_AMD64}}/lib/x86_64-linux-gnu -lLLVM-19 -lz
       - CGO_LDFLAGS_ALLOW=(--target=.*|--gcc-toolchain=.*|--sysroot.*)
     targets:
       - linux_amd64
@@ -81,8 +81,8 @@ builds:
       - CC={{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/bin/clang
       - CXX={{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/bin/clang++
       - CGO_CPPFLAGS=--target=aarch64-linux-gnu --gcc-toolchain={{.Env.SYSROOT_LINUX_ARM64}}/usr --sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_CXXFLAGS=-std=c++17 -nostdinc++ -isystem {{.Env.SYSROOT_LINUX_ARM64}}/usr/include/c++/10 -isystem {{.Env.SYSROOT_LINUX_ARM64}}/usr/include/aarch64-linux-gnu/c++/10 -isystem {{.Env.SYSROOT_LINUX_ARM64}}/usr/include/c++/10/backward
-      - CGO_LDFLAGS=--target=aarch64-linux-gnu --gcc-toolchain={{.Env.SYSROOT_LINUX_ARM64}}/usr --sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -L{{.Env.SYSROOT_LINUX_ARM64}}/usr/lib/gcc/aarch64-linux-gnu/10 -L{{.Env.SYSROOT_LINUX_ARM64}}/usr/lib/aarch64-linux-gnu -L{{.Env.SYSROOT_LINUX_ARM64}}/lib/aarch64-linux-gnu -lLLVM-19 -lz
+      - CGO_CXXFLAGS=-std=c++17 -nostdinc++ -isystem {{.Env.SYSROOT_LINUX_ARM64}}/usr/include/c++/12 -isystem {{.Env.SYSROOT_LINUX_ARM64}}/usr/include/aarch64-linux-gnu/c++/12 -isystem {{.Env.SYSROOT_LINUX_ARM64}}/usr/include/c++/12/backward
+      - CGO_LDFLAGS=--target=aarch64-linux-gnu --gcc-toolchain={{.Env.SYSROOT_LINUX_ARM64}}/usr --sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -L{{.Env.SYSROOT_LINUX_ARM64}}/usr/lib/gcc/aarch64-linux-gnu/12 -L{{.Env.SYSROOT_LINUX_ARM64}}/usr/lib/aarch64-linux-gnu -L{{.Env.SYSROOT_LINUX_ARM64}}/lib/aarch64-linux-gnu -lLLVM-19 -lz
       - CGO_LDFLAGS_ALLOW=(--target=.*|--gcc-toolchain=.*|--sysroot.*)
     targets:
       - linux_arm64


### PR DESCRIPTION
## Summary

Replace the Debian 11 Linux release sysroots with Debian 12 Bookworm.

- Pin amd64 and arm64 child images from the same official Debian 12 image index. Separate child digests avoid Docker classic image-store conflicts when switching platforms.
- Update Linux C++ header and GCC library paths from GCC 10 to GCC 12. The compiler driver remains the packaged Clang 19.
- Fail immediately when package installation fails, retain bounded APT acquisition retries, mount the generated script read-only, and print/check every configured GCC path.
- Keep the two sysroot extractions serial to bound memory and disk pressure.
- Record the digest refresh command and return from `do-sync` instead of terminating the generated script.

Only **two files change: 29 insertions, 15 deletions**. No platform or test is removed. The complete Release workflow, four-platform Clang downloads, Darwin builds, artifact uploads, and original Go/C/C++ plus ESP32 embedded tests are unchanged.

Debian 12 is covered by [Debian LTS through June 2028](https://www.debian.org/News/2026/20260712). Its GCC 12/glibc 2.36 baseline is more conservative for release compatibility than Ubuntu 24.04 or Debian 13 while moving the build off Debian 11.

## Validation

Current head: `5add4d23ea59b2f89b141da4304c8d87d1660965`, based on main `defc3f08c24051e629ca965fe6af0e6b7e8e6e58`.

- Local Bash syntax, ShellCheck, whitespace, and diff-scope checks passed.
- Both pinned architecture images completed real package installation locally.
- amd64 and arm64 both provide glibc 2.36, GCC/G++ 12.2, and every configured generic/triple-specific GCC 12 header and library path.
- **[Complete Release CI passed](https://github.com/cpunion/llgo/actions/runs/33958825268)** on this exact head in [cpunion/llgo#233](https://github.com/cpunion/llgo/pull/233).
- Both sysroots populated, checked, archived, and uploaded in **2m40s**; the four-platform build/archive job completed in **8m45s**.
- Original native Go/C/C++ plus ESP32 embedded smoke tests passed on [Linux amd64](https://github.com/cpunion/llgo/actions/runs/33958825268/job/101288562613), [Linux arm64](https://github.com/cpunion/llgo/actions/runs/33958825268/job/101288562635), [macOS arm64](https://github.com/cpunion/llgo/actions/runs/33958825268/job/101288562616), and [macOS amd64](https://github.com/cpunion/llgo/actions/runs/33958825268/job/101288562654).
- All seven executed Release jobs passed; the tag-only publishing job was correctly skipped. Earlier runs on superseded commits are not claimed as validation of this head.

The broader full-transaction APT retry hardening remains separate in #2501; this PR keeps its scope to the sysroot distribution/toolchain replacement and directly related safety checks.