### PR TITLE
reflect: fix generic named function channel send

### DIFF
--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -2038,16 +2038,23 @@ func (v Value) assignTo(context string, dst *abi.Type, target unsafe.Pointer) Va
 	if typ.Kind() == abi.Func {
 		typ = closureOf(typ.FuncType())
 	}
+	assignDst := dst
+	if dst.Kind() == abi.Func {
+		// Function values use LLGo's closure struct as their physical
+		// representation. Compare against the same canonical closure type
+		// as the source value, while retaining dst for the returned Value.
+		assignDst = closureOf(dst.FuncType())
+	}
 
 	switch {
-	case directlyAssignable(dst, typ):
+	case directlyAssignable(assignDst, typ):
 		// Overwrite type so that they match.
 		// Same memory layout, so no harm done.
 		fl := v.flag&(flagAddr|flagIndir) | v.flag.ro()
 		fl |= flag(dst.Kind())
 		return Value{dst, v.ptr, fl}
 
-	case implements(dst, typ):
+	case implements(assignDst, typ):
 		if v.Kind() == Interface && v.IsNil() {
 			// A nil ReadWriter passed to nil Reader is OK,
 			// but using ifaceE2I below will panic.

--- a/test/go/reflect_generic_func_send_test.go
+++ b/test/go/reflect_generic_func_send_test.go
@@ -1,0 +1,23 @@
+package gotest
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+//llgo:type C
+type reflectGenericIntFormatter func(int) string
+
+func reflectGenericFormatter[T any](v T) string {
+	return fmt.Sprintf("value: %v", v)
+}
+
+func TestReflectGenericNamedFuncChannelSend(t *testing.T) {
+	ch := make(chan reflectGenericIntFormatter, 1)
+	var fn reflectGenericIntFormatter = reflectGenericFormatter
+	reflect.ValueOf(ch).Send(reflect.ValueOf(fn))
+	if got := (<-ch)(14); got != "value: 14" {
+		t.Fatalf("received formatter result = %q, want %q", got, "value: 14")
+	}
+}


### PR DESCRIPTION
Fixes `reflect.Value.Send` for generic functions assigned to named function types.

### Reproducer

```go
package main

import (
	"fmt"
	"reflect"
)

func genericFormatter[T any](v T) string {
	return fmt.Sprintf("value: %v", v)
}

//llgo:type C
type intFormatter func(int) string

func main() {
	ch := make(chan intFormatter, 1)

	var fn intFormatter = genericFormatter[int]

	reflect.ValueOf(ch).Send(reflect.ValueOf(fn))

	got := (<-ch)(14)
	want := "value: 14"
	if got != want {
		panic(fmt.Sprintf("received formatter result = %q, want %q", got, want))
	}

	fmt.Println(got)
}
```

With LLGo before this fix, the program panics at the generated `z_rt.go` send wrapper:

```text
reflect.Value.Send: value of type main.intFormatter is not assignable to type main.intFormatter
```

The same program runs successfully with the Go 1.27 toolchain and prints `value: 14`. The source and destination function values have identical Go names but distinct closure ABI descriptors in LLGo; canonicalize the destination before assignability checks.

Adds a regression test covering generic function assignment and `reflect.Value.Send`.

Validation: Go 1.27 test binary compilation and `git diff --check`.