### PR TITLE
feat(lto): support pass plugins on macOS

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -186,6 +186,44 @@ jobs:
           files: coverage-main.txt,coverage-compiler.txt,coverage-test-go.txt
           disable_search: true
 
+  macos-lto-plugin:
+    name: macOS LTO plugin
+    timeout-minutes: 45
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          llvm-version: 22
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Set LLGO_ROOT
+        run: echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+
+      - name: Build LTO plugin
+        run: |
+          set -euo pipefail
+          cmake -S ltoplugin -B ltoplugin/build \
+            -DLLVM_DIR="$(llvm-config --cmakedir)" \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build ltoplugin/build --config Release
+          test -f ltoplugin/build/LLGOLTOPlugin.dylib
+          echo "LLGO_LTO_PLUGIN=$GITHUB_WORKSPACE/ltoplugin/build/LLGOLTOPlugin.dylib" >> "$GITHUB_ENV"
+
+      - name: Test LTO plugin passes, runtime behavior, and retained symbols
+        env:
+          LLGO_BUILD_CACHE: "off"
+        run: |
+          set -euo pipefail
+          go test -tags=dev -count=1 ./internal/lto ./cmd/internal/flags
+          go test -tags=dev -count=1 -timeout=30m \
+            -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin|TestLTOPlugin)' \
+            ./cl
+
   dev-lto-globaldce:
     name: Dev LTO GlobalDCE
     timeout-minutes: 60
@@ -250,7 +288,7 @@ jobs:
           go test -tags=dev -timeout 30m -covermode=atomic \
             -coverpkg=github.com/xgo-dev/llgo/ssa,github.com/xgo-dev/llgo/internal/build,github.com/xgo-dev/llgo/internal/crosscompile \
             -coverprofile=coverage-dev-lto-plugin-cl.txt \
-            -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin)' \
+            -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin|TestLTOPlugin)' \
             ./cl
           go tool cover -func=coverage-dev-lto-plugin-cl.txt
 

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -322,8 +322,15 @@ func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {
 	// See TestBuildAndCheckSymbolsFromTestlto: dynamic main.* exports retain
 	// otherwise-dead symbols on Linux and would mask the plugin's DCE result.
 	buildConf.PCLNMode = build.PCLNNone
+	if runtime.GOOS == "darwin" {
+		// Size-optimized Darwin executables strip local symbols after LTO.
+		// Preserve debug info so these checks observe the optimized methods
+		// before symbol stripping, without changing the optimization level.
+		buildConf.LinkOptions.DWARF = build.DWARFPreserve
+	}
 	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginTests,
 		cltest.WithRunConfig(buildConf),
+		cltest.WithOutputCheck(true),
 	)
 }
 
@@ -546,6 +553,76 @@ func TestBuildAndCheckSymbolsFromTestltoLTOPluginAggregateABI(t *testing.T) {
 		"./_testlto/_globaldce_reflect_method_by_name_ltoplugin_string_abi_unknown")
 	if strings.Contains(unknownResult, `metadata !"go.method.type.reflect"`) {
 		t.Fatalf("aggregate ABI output retained a generic type Func marker\n%s", unknownResult)
+	}
+}
+
+func TestLTOPluginAggregateStaticItabDevirt(t *testing.T) {
+	conf := testltoLTOPluginConf(t, build.ModeGen)
+	const input = `
+target datalayout = "e-p:64:64-i64:64-n8:16:32:64-S128"
+%iface = type { ptr, ptr }
+
+@interface.I = constant i8 0
+@type.A = constant i8 0
+@type.B = constant i8 0
+@_llgo_itab$A = weak_odr constant { ptr, ptr, i32, [1 x ptr] } { ptr @interface.I, ptr @type.A, i32 0, [1 x ptr] [ptr @A.M] }, !llgo.static.itab.slot !0
+@_llgo_itab$B = weak_odr constant { ptr, ptr, i32, [1 x ptr] } { ptr @interface.I, ptr @type.B, i32 0, [1 x ptr] [ptr @B.M] }, !llgo.static.itab.slot !0
+
+declare ptr @runtime.NewItab(ptr, ptr)
+declare { ptr, i1 } @llvm.type.checked.load(ptr, i32, metadata)
+declare void @sink(ptr)
+define void @A.M() { ret void }
+define void @B.M() { ret void }
+
+define internal void @invoke(%iface %v) {
+  %itab = extractvalue %iface %v, 0
+  %slot = getelementptr i8, ptr %itab, i64 24
+  %checked = call { ptr, i1 } @llvm.type.checked.load(ptr %slot, i32 0, metadata !"go.method.M:func()")
+  %fn = extractvalue { ptr, i1 } %checked, 0
+  call void @sink(ptr %fn)
+  ret void
+}
+
+define void @entry(%iface %unknown) {
+  %itab.a = call ptr @runtime.NewItab(ptr @interface.I, ptr @type.A)
+  %a0 = insertvalue %iface undef, ptr %itab.a, 0
+  %a = insertvalue %iface %a0, ptr null, 1
+  %itab.b = call ptr @runtime.NewItab(ptr @interface.I, ptr @type.B)
+  %b0 = insertvalue %iface undef, ptr %itab.b, 0
+  %b = insertvalue %iface %b0, ptr null, 1
+  call void @invoke(%iface %a)
+  ; EXTRA_CALL
+  ret void
+}
+!0 = !{i64 24, !"go.method.M:func()"}
+`
+	for _, tt := range []struct {
+		name  string
+		extra string
+		want  int
+	}{
+		{"known", "", 0},
+		{"same_target", "call void @invoke(%iface %a)", 0},
+		{"unknown_caller", "call void @invoke(%iface %unknown)", 1},
+		{"conflicting_targets", "call void @invoke(%iface %b)", 1},
+		{"escaping_function", "call void @sink(ptr @invoke)", 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := filepath.Join(llvmenv.New("").BinDir(), "opt")
+			cmd := exec.Command(opt, "-load-pass-plugin="+conf.LTOPlugin.Path,
+				"-passes=llgo-lto-pre-globaldce", "-verify-each", "-S", "-o", "-")
+			cmd.Stdin = strings.NewReader(strings.Replace(input, "; EXTRA_CALL", tt.extra, 1))
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run aggregate static itab pass: %v\n%s", err, out)
+			}
+			if got := strings.Count(string(out), "call { ptr, i1 } @llvm.type.checked.load"); got != tt.want {
+				t.Fatalf("remaining checked loads = %d, want %d\n%s", got, tt.want, out)
+			}
+			if tt.want == 0 && !strings.Contains(string(out), "{ ptr @A.M, i1 true }") {
+				t.Fatalf("known aggregate itab did not resolve to A.M\n%s", out)
+			}
+		})
 	}
 }
 

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -138,7 +138,7 @@ func AddLTOFlag(fs *flag.FlagSet) {
 	LTO = ltoFlag{Mode: lto.Off}
 	LTOPluginPath = ""
 	fs.Var(&LTO, "lto", "Enable LTO optimization: thin or full (default: off)")
-	fs.StringVar(&LTOPluginPath, "lto-pass-plugin", "", "Load an LLVM LTO pass plugin during full LTO (ELF lld only)")
+	fs.StringVar(&LTOPluginPath, "lto-pass-plugin", "", "Load an LLVM LTO pass plugin during full LTO (ELF lld or Mach-O ld64.lld)")
 }
 
 var GoGlobalDCE *bool

--- a/internal/lto/lto.go
+++ b/internal/lto/lto.go
@@ -64,8 +64,10 @@ func (p PassPlugin) LinkerFlags(goos string) ([]string, error) {
 	if !p.Enabled() {
 		return nil, nil
 	}
-	if goos == "darwin" {
-		return nil, fmt.Errorf("LTO pass plugins are not supported on darwin by the bundled ld64.lld or Apple ld64")
+	if goos == "windows" {
+		return nil, fmt.Errorf("LTO pass plugins are not supported on windows: LLVM 22 lld-link and MinGW lld do not expose a new pass manager plugin loading option")
 	}
-	return []string{"-Wl,--load-pass-plugin=" + p.Path}, nil
+	// Both ELF lld and LLVM 22 Mach-O ld64.lld support this option.
+	// Use -Xlinker so commas in the plugin path are not split by clang.
+	return []string{"-Xlinker", "--load-pass-plugin=" + p.Path}, nil
 }

--- a/internal/lto/lto_test.go
+++ b/internal/lto/lto_test.go
@@ -76,26 +76,29 @@ func TestClangFlag(t *testing.T) {
 }
 
 func TestPassPluginLinkerFlags(t *testing.T) {
-	if got, err := (PassPlugin{}).LinkerFlags("linux"); err != nil || got != nil {
-		t.Fatalf("disabled plugin flags = %v, err = %v; want nil, nil", got, err)
-	}
-
-	if _, err := (PassPlugin{Path: "/tmp/libLLGOLTOPlugin.dylib"}).LinkerFlags("darwin"); err == nil {
-		t.Fatal("darwin plugin flags expected error")
-	}
-
 	if (PassPlugin{}).Enabled() {
 		t.Fatal("empty plugin should be disabled")
 	}
-
-	plugin := PassPlugin{Path: "/tmp/libLLGOLTOPlugin.so"}
-	want := []string{"-Wl,--load-pass-plugin=/tmp/libLLGOLTOPlugin.so"}
-	got, err := plugin.LinkerFlags("linux")
-	if err != nil {
-		t.Fatalf("LinkerFlags() error: %v", err)
+	for _, goos := range []string{"linux", "darwin", "windows"} {
+		if got, err := (PassPlugin{}).LinkerFlags(goos); err != nil || got != nil {
+			t.Fatalf("disabled plugin flags on %s = %v, err = %v; want nil, nil", goos, got, err)
+		}
 	}
-	if !sameStrings(got, want) {
-		t.Fatalf("LinkerFlags() = %v, want %v", got, want)
+	for _, goos := range []string{"linux", "darwin"} {
+		t.Run(goos, func(t *testing.T) {
+			plugin := PassPlugin{Path: "/tmp/plugin dir,with comma/LLGOLTOPlugin.so"}
+			want := []string{"-Xlinker", "--load-pass-plugin=" + plugin.Path}
+			got, err := plugin.LinkerFlags(goos)
+			if err != nil {
+				t.Fatalf("LinkerFlags() error: %v", err)
+			}
+			if !sameStrings(got, want) {
+				t.Fatalf("LinkerFlags() = %v, want %v", got, want)
+			}
+		})
+	}
+	if got, err := (PassPlugin{Path: "C:/plugins/LLGOLTOPlugin.dll"}).LinkerFlags("windows"); err == nil || got != nil {
+		t.Fatalf("windows plugin flags = %v, err = %v; want nil and an unsupported error", got, err)
 	}
 }
 

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -1234,7 +1234,8 @@ std::optional<uint64_t> checkedLoadOffset(CallBase *CheckedLoad) {
   return Offset->getZExtValue();
 }
 
-Constant *collectStaticItabArgumentTarget(Argument *Arg, uint64_t PointerOffset,
+Constant *collectStaticItabArgumentTarget(Argument *Arg, ArrayRef<unsigned> Indices,
+                                          uint64_t PointerOffset,
                                           uint64_t LoadOffset, StringRef TypeID,
                                           const DataLayout &DL);
 
@@ -1277,7 +1278,8 @@ std::optional<StaticItabSlot> resolveNewItabSlot(Module &M, CallBase *NewItab,
   return resolveStaticItabSlot(Template, Offset, TypeID, DL);
 }
 
-Constant *collectStaticItabArgumentTarget(Argument *Arg, uint64_t PointerOffset,
+Constant *collectStaticItabArgumentTarget(Argument *Arg, ArrayRef<unsigned> Indices,
+                                          uint64_t PointerOffset,
                                           uint64_t LoadOffset, StringRef TypeID,
                                           const DataLayout &DL) {
   Function *F = Arg->getParent();
@@ -1291,6 +1293,14 @@ Constant *collectStaticItabArgumentTarget(Argument *Arg, uint64_t PointerOffset,
         Arg->getArgNo() >= CB->arg_size())
       return nullptr;
     Value *Actual = CB->getArgOperand(Arg->getArgNo());
+    if (!Indices.empty()) {
+      // Aggregate ABIs keep the interface's itab in a struct argument.
+      // Recover only a proven field value; an unknown caller must retain
+      // the checked load and its broad method root.
+      Actual = FindInsertedValue(Actual, Indices);
+      if (!Actual)
+        return nullptr;
+    }
     auto Slot =
         resolveStaticItabSlot(Actual, PointerOffset + LoadOffset, TypeID, DL);
     CallBase *NewItab = nullptr;
@@ -1364,10 +1374,17 @@ bool devirtualizeStaticItabCalls(Module &M, const DataLayout &DL) {
           auto *Arg = Base && PointerOffset >= 0
                           ? dyn_cast<Argument>(Base->stripPointerCasts())
                           : nullptr;
+          ArrayRef<unsigned> Indices;
+          if (!Arg && Base && PointerOffset >= 0) {
+            if (auto *Extract = dyn_cast<ExtractValueInst>(Base)) {
+              Arg = dyn_cast<Argument>(Extract->getAggregateOperand());
+              Indices = Extract->getIndices();
+            }
+          }
           if (Arg) {
             Target = collectStaticItabArgumentTarget(
-                Arg, static_cast<uint64_t>(PointerOffset), *LoadOffset, *TypeID,
-                DL);
+                Arg, Indices, static_cast<uint64_t>(PointerOffset), *LoadOffset,
+                *TypeID, DL);
           } else if (auto *NewItab =
                          Base ? dyn_cast<CallBase>(Base->stripPointerCasts())
                               : nullptr) {

--- a/ltoplugin/README.md
+++ b/ltoplugin/README.md
@@ -12,19 +12,39 @@ cmake -S ltoplugin -B ltoplugin/build \
 cmake --build ltoplugin/build
 ```
 
-Load the plugin when building with full LTO on Linux/ELF:
+Load the plugin when building with full LTO on Linux/ELF or macOS/Mach-O:
 
 ```sh
 llgo build -lto=full -lto-pass-plugin=/path/to/LLGOLTOPlugin.so ./...
 ```
 
-On macOS, the built plugin usually uses the `.dylib` suffix.
+On macOS the build produces `LLGOLTOPlugin.dylib`:
+
+```sh
+llgo build -lto=full -lto-pass-plugin=/path/to/LLGOLTOPlugin.dylib ./...
+```
+
+The plugin must match the host architecture and the LLVM toolchain used by the
+linker.
 
 The plugin registers `llgo-lto-pre-globaldce` and also inserts that pass through
 LLVM's full LTO early extension point, so loading the plugin is enough for the
 pass to run before the normal full LTO optimization pipeline proceeds.
 
-LLGo forwards the plugin path through lld's `--load-pass-plugin` option. LLVM 22
-`ld64.lld` and Apple `ld64` do not expose an equivalent new pass manager LTO
-plugin loading option for Mach-O links, so LLGo rejects `-lto-pass-plugin` for
-Darwin targets until the linker side grows that support.
+LLGo forwards the plugin path through lld's `--load-pass-plugin` option using
+Clang's `-Xlinker` forwarding, including paths containing spaces or commas.
+Full LTO selects `-fuse-ld=lld`; on macOS this requires LLVM 22 `ld64.lld`
+on the toolchain's search path. Apple's system linker does not support this
+option.
+
+Windows targets are not supported by the plugin yet. LLVM 22's MSVC-style
+`lld-link` and MinGW lld driver do not expose a new pass manager LTO plugin
+loading option. Ordinary full and thin LTO remain available on Windows.
+Enabling plugins there requires linker-side support and a compatible Windows
+plugin build; forwarding the ELF flag or loading a frontend pass is insufficient.
+
+The relevant LLVM 22 interfaces are
+[Mach-O options](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/lld/MachO/Options.td),
+[Mach-O LTO configuration](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/lld/MachO/LTO.cpp),
+[COFF options](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/lld/COFF/Options.td),
+and [MinGW options](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/lld/MinGW/Options.td).


### PR DESCRIPTION
Full LTO with `-lto-pass-plugin` currently rejects Darwin even though LLVM 22's `ld64.lld` supports loading New PM pass plugins. Enable Mach-O links and forward the plugin with `-Xlinker` so paths containing spaces or commas remain intact. Update the CLI help and build instructions, and report unsupported Windows plugin requests explicitly.

On macOS arm64, interface arguments remain aggregates, so the plugin's scalar-only caller analysis retained unrelated methods such as `B.M` in the static-itab fixture. Follow `extractvalue` fields back to proven caller values while preserving the checked load for unknown callers, conflicting targets, and escaping functions. Keep debug information in Darwin symbol tests to prevent post-link stripping from hiding the optimized methods, and check the output of all nine symbol fixtures. Add a macOS plugin CI job and include the pass-level regressions in the existing Linux job.

Validation on macOS arm64 with Go 1.27.0 and LLVM/LLD 22.1.8, using `byollvm` for the isolated toolchain and `LLGO_BUILD_CACHE=off`:

- Built `LLGOLTOPlugin.dylib` with CMake.
- Passed `go test -tags=byollvm,dev -count=1 ./internal/lto ./cmd/internal/flags`.
- Passed the full `TestRunAndTestFromTestltoLTOPlugin`, `TestBuildAndCheckSymbolsFromTestltoLTOPlugin*`, and `TestLTOPlugin*` selection, including all nine symbol/runtime fixtures.
- Confirmed the new aggregate-argument regression fails with the original plugin and passes with the fix, including conservative fallback cases.
- Linked and ran the static-itab fixture with a plugin path containing spaces and a comma; the Full LTO callback devirtualized the call and output remained `7 true true`.
- `git diff --check` and actionlint passed with shellcheck disabled and the existing custom `qiniu` runner label excluded.

Windows plugin implementation is outside this PR. Remote CI and native Intel macOS validation are not claimed by the local results above.
