### PR TITLE
fix(ssa): mark runtime allocator returns nonnull across modules

### DIFF
--- a/_demo/embed/testdata/esp32-serial/gc-runtime/main.go
+++ b/_demo/embed/testdata/esp32-serial/gc-runtime/main.go
@@ -1136,6 +1136,9 @@ func testPartialGraphUnlinking() bool {
 	}
 
 	unlinkPartialGraph()
+	// Allocator register spills can retain b or c as conservative stack roots
+	// after unlinking. Clear stale stack values before checking reclamation.
+	scrubStack()
 	_, afterUnlink := collectAndPrint("partial-unlink")
 
 	if partialRoot == nil || partialRoot.id != 10000 {

--- a/cl/_testdata/llgointrinsics/in.go
+++ b/cl/_testdata/llgointrinsics/in.go
@@ -16,7 +16,7 @@ import (
 // CHECK: ret i64 ptrtoint (ptr @write to i64)
 // CHECK-LABEL: define i64 @"{{.*}}.UseClosure"(){{.*}} {
 // CHECK: [[UC_X:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT: [[UC_ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT: [[UC_ENV:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT: [[UC_X_SLOT:%[0-9]+]] = getelementptr inbounds nuw { ptr }, ptr [[UC_ENV]], i32 0, i32 0
 // CHECK-NEXT: store ptr [[UC_X]], ptr [[UC_X_SLOT]]
 // CHECK-NEXT: [[UC_CLOSURE:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"{{.*}}.UseClosure$1", ptr undef }, ptr [[UC_ENV]], 1

--- a/cl/_testgo/chan/in.go
+++ b/cl/_testgo/chan/in.go
@@ -17,7 +17,7 @@ package main
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[CH1_LEN]])
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[CH1_CAP]])
 // CHECK: call void @"{{.*}}PrintEface"(%"{{.*}}eface" [[CH1_EFACE]])
-// CHECK: [[SEND_ENV:%.*]] = call nonnull ptr @"{{.*}}AllocU"(i64 8)
+// CHECK: [[SEND_ENV:%.*]] = call ptr @"{{.*}}AllocU"(i64 8)
 // CHECK: store ptr [[CH1_SLOT]], ptr {{%.*}}
 // CHECK: [[SEND_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr [[SEND_ENV]], 1
 // CHECK: store { ptr, ptr } [[SEND_CLOSURE]], ptr {{%.*}}
@@ -32,7 +32,7 @@ package main
 // CHECK: [[CH2_SLOT:%.*]] = call ptr @"{{.*}}AllocZ"(i64 8)
 // CHECK: [[CH2:%.*]] = call ptr @"{{.*}}NewChan"(i64 8, i64 10)
 // CHECK-NEXT: store ptr [[CH2]], ptr [[CH2_SLOT]]
-// CHECK: [[CLOSE_ENV:%.*]] = call nonnull ptr @"{{.*}}AllocU"(i64 8)
+// CHECK: [[CLOSE_ENV:%.*]] = call ptr @"{{.*}}AllocU"(i64 8)
 // CHECK: store ptr [[CH2_SLOT]], ptr {{%.*}}
 // CHECK: [[CLOSE_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.main$2", ptr undef }, ptr [[CLOSE_ENV]], 1
 // CHECK: store { ptr, ptr } [[CLOSE_CLOSURE]], ptr {{%.*}}

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -112,7 +112,7 @@ func makeWithFree(base int) Fn {
 // CHECK: [[S:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT: [[S_FIELD:%[0-9]+]] = getelementptr inbounds nuw %main.S, ptr [[S]], i32 0, i32 0
 // CHECK-NEXT: store i64 5, ptr [[S_FIELD]]
-// CHECK: [[METHOD_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[METHOD_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[METHOD_ENV_SLOT:%.*]] = getelementptr inbounds nuw { ptr }, ptr [[METHOD_ENV]], i32 0, i32 0
 // CHECK: store ptr [[S]], ptr [[METHOD_ENV_SLOT]]
 // CHECK: [[METHOD_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*S).Add$bound", ptr undef }, ptr [[METHOD_ENV]], 1
@@ -130,7 +130,7 @@ func makeWithFree(base int) Fn {
 // CHECK: [[IFACE_TYPE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}iface" [[IFACE]])
 // CHECK: [[IFACE_OK:%.*]] = icmp ne ptr [[IFACE_TYPE]], null
 // CHECK: br i1 [[IFACE_OK]], label %{{.*}}, label %{{.*}}
-// CHECK: [[IFACE_METHOD_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK: [[IFACE_METHOD_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK: [[IFACE_METHOD_SLOT:%.*]] = getelementptr inbounds nuw { %"{{.*}}iface" }, ptr [[IFACE_METHOD_ENV]], i32 0, i32 0
 // CHECK: store %"{{.*}}iface" [[IFACE]], ptr [[IFACE_METHOD_SLOT]]
 // CHECK: [[IFACE_METHOD:%.*]] = insertvalue { ptr, ptr } { ptr @"main.interface{Add(int) int}.Add$bound", ptr undef }, ptr [[IFACE_METHOD_ENV]], 1
@@ -157,7 +157,7 @@ func makeWithFree(base int) Fn {
 // CHECK-LABEL: define %main.Fn @main.makeWithFree(i64 %0){{.*}} {
 // CHECK: [[BASE_ADDR:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT: store i64 %0, ptr [[BASE_ADDR]]
-// CHECK-NEXT: [[WITH_FREE_ENV_OUT:%[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT: [[WITH_FREE_ENV_OUT:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT: [[WITH_FREE_ENV_SLOT:%[0-9]+]] = getelementptr inbounds nuw { ptr }, ptr [[WITH_FREE_ENV_OUT]], i32 0, i32 0
 // CHECK-NEXT: store ptr [[BASE_ADDR]], ptr [[WITH_FREE_ENV_SLOT]]
 // CHECK-NEXT: [[WITH_FREE_FN:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.makeWithFree$1", ptr undef }, ptr [[WITH_FREE_ENV_OUT]], 1

--- a/cl/_testgo/closureenv/in.go
+++ b/cl/_testgo/closureenv/in.go
@@ -19,7 +19,7 @@ package main
 // CHECK-LABEL: define { ptr, ptr } @main.zeroSizedPointerCapture(ptr %0){{.*}} {
 // CHECK: [[ZSP_VALUE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT: store ptr %0, ptr [[ZSP_VALUE]]
-// CHECK-NEXT: [[ZSP_ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT: [[ZSP_ENV:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store ptr [[ZSP_VALUE]], ptr %{{[0-9]+}}
 // CHECK: [[ZSP_CLOSURE:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.zeroSizedPointerCapture$1", ptr undef }, ptr [[ZSP_ENV]], 1
 // CHECK-NEXT: ret { ptr, ptr } [[ZSP_CLOSURE]]

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -15,7 +15,7 @@ func values(yield func(int) bool) {
 }
 
 // CHECK-LABEL: define i64 @main.sum(%main.Seq %0){{.*}} {
-// CHECK: [[ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}AllocU"
+// CHECK: [[ENV:%[0-9]+]] = call ptr @"{{.*}}AllocU"
 // CHECK: [[RANGE_CLOSURE:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.sum$1", ptr undef }, ptr [[ENV]], 1
 // CHECK: [[SEQ_ENV:%[0-9]+]] = extractvalue %main.Seq %0, 1
 // CHECK: [[SEQ_CODE:%[0-9]+]] = extractvalue %main.Seq %0, 0

--- a/cl/_testgo/deferclosure/in.go
+++ b/cl/_testgo/deferclosure/in.go
@@ -21,7 +21,7 @@ package main
 // The captured 42 is stored in the closure environment before the function pair is deferred.
 // CHECK: [[VALUE_CAPTURE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK: store i64 42, ptr [[VALUE_CAPTURE]]
-// CHECK: [[VALUE_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[VALUE_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store ptr [[VALUE_CAPTURE]], ptr %{{.*}}
 // CHECK: [[VALUE_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.testDeferClosureValue$1", ptr undef }, ptr [[VALUE_ENV]], 1
 // CHECK: [[VALUE_PREV_DEFER:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
@@ -89,7 +89,7 @@ package main
 // CHECK: [[STRUCT_PROCESSOR:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK: [[STRUCT_MSG:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK: store %"{{.*}}String" { ptr @{{.*}}, i64 8 }, ptr [[STRUCT_MSG]]
-// CHECK: [[STRUCT_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[STRUCT_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store ptr [[STRUCT_MSG]], ptr %{{.*}}
 // CHECK: [[STRUCT_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.testDeferStructClosure$1", ptr undef }, ptr [[STRUCT_ENV]], 1
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()

--- a/cl/_testgo/reflectconv/in.go
+++ b/cl/_testgo/reflectconv/in.go
@@ -25,7 +25,7 @@ type namedFunc func(int) int
 // CHECK: call %{{.*}} @reflect.Value.Interface(%reflect.Value [[FUNC_RESULT]])
 
 // CHECK-LABEL: define void @main.functionPointers(){{.*}} {
-// CHECK: [[CAPTURED_ENV:%[0-9]+]] = call nonnull ptr @"{{.*}}AllocU"(i64 8)
+// CHECK: [[CAPTURED_ENV:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 8)
 // CHECK: [[CAPTURED_PAIR:%[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.functionPointers$1", ptr undef }, ptr [[CAPTURED_ENV]], 1
 // CHECK-NEXT: [[CAPTURED_BOX:%[0-9]+]] = call ptr @"{{.*}}AllocU"(i64 16)
 // CHECK-NEXT: store { ptr, ptr } [[CAPTURED_PAIR]], ptr [[CAPTURED_BOX]]

--- a/cl/_testrt/closureconv/in.go
+++ b/cl/_testrt/closureconv/in.go
@@ -32,7 +32,7 @@ func add(a int, b int) int {
 // CHECK: [[DEMO1_CALL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK: [[DEMO1_N:%.*]] = getelementptr inbounds nuw %main.Call, ptr [[DEMO1_CALL]], i32 0, i32 1
 // CHECK: store i64 %0, ptr [[DEMO1_N]]
-// CHECK: [[DEMO1_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO1_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[DEMO1_ENV_SLOT:%.*]] = getelementptr inbounds nuw { ptr }, ptr [[DEMO1_ENV]], i32 0, i32 0
 // CHECK: store ptr [[DEMO1_CALL]], ptr [[DEMO1_ENV_SLOT]]
 // CHECK: [[DEMO1_BOUND:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr [[DEMO1_ENV]], 1
@@ -51,7 +51,7 @@ func demo1(n int) Func {
 
 // CHECK-LABEL: define %main.Func @main.demo2(){{.*}} {
 // CHECK: [[DEMO2_CALL:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK: [[DEMO2_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO2_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[DEMO2_ENV_SLOT:%.*]] = getelementptr inbounds nuw { ptr }, ptr [[DEMO2_ENV]], i32 0, i32 0
 // CHECK: store ptr [[DEMO2_CALL]], ptr [[DEMO2_ENV_SLOT]]
 // CHECK: [[DEMO2_BOUND:%.*]] = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr [[DEMO2_ENV]], 1
@@ -84,7 +84,7 @@ func demo4() Func {
 // CHECK-LABEL: define %main.Func @main.demo5(i64 %0){{.*}} {
 // CHECK: [[DEMO5_CAPTURE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK: store i64 %0, ptr [[DEMO5_CAPTURE]]
-// CHECK: [[DEMO5_ENV:%.*]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: [[DEMO5_ENV:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: [[DEMO5_ENV_SLOT:%.*]] = getelementptr inbounds nuw { ptr }, ptr [[DEMO5_ENV]], i32 0, i32 0
 // CHECK: store ptr [[DEMO5_CAPTURE]], ptr [[DEMO5_ENV_SLOT]]
 // CHECK: [[DEMO5_FN:%.*]] = insertvalue { ptr, ptr } { ptr @"main.demo5$1", ptr undef }, ptr [[DEMO5_ENV]], 1

--- a/cl/_testrt/closureiface/in.go
+++ b/cl/_testrt/closureiface/in.go
@@ -21,7 +21,7 @@ func main() {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP0:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 200, ptr %[[TMP0]], align 8
-// CHECK-NEXT:   %[[TMP1:[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %[[TMP1:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = getelementptr inbounds nuw { ptr }, ptr %[[TMP1]], i32 0, i32 0
 // CHECK-NEXT:   store ptr %[[TMP0]], ptr %[[TMP2]], align 8
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %[[TMP1]], 1

--- a/cl/_testrt/freevars/in.go
+++ b/cl/_testrt/freevars/in.go
@@ -27,7 +27,7 @@ func main() {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP1:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %[[TMP0]], ptr %[[TMP1]], align 8
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = getelementptr inbounds nuw { ptr }, ptr %[[TMP2]], i32 0, i32 0
 // CHECK-NEXT:   store ptr %[[TMP1]], ptr %[[TMP3]], align 8
 // CHECK-NEXT:   %[[TMP4:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1$1", ptr undef }, ptr %[[TMP2]], 1

--- a/cl/_testrt/named/in.go
+++ b/cl/_testrt/named/in.go
@@ -55,7 +55,7 @@ func main() {
 // CHECK: %[[ROOTSLOT:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK: %[[ROOT:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 64)
 // CHECK: store ptr %[[ROOT]], ptr %[[ROOTSLOT]], align 8
-// CHECK: %[[ENV:[0-9]+]] = call nonnull ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK: %[[ENV:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: %[[ENVSLOT:[0-9]+]] = getelementptr inbounds nuw { ptr }, ptr %[[ENV]], i32 0, i32 0
 // CHECK: store ptr %[[ROOTSLOT]], ptr %[[ENVSLOT]], align 8
 // CHECK: %[[CLOSURE:[0-9]+]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %[[ENV]], 1

--- a/runtime/internal/runtime/z_alloc.go
+++ b/runtime/internal/runtime/z_alloc.go
@@ -1,0 +1,5 @@
+package runtime
+
+// zerobase is the shared, non-nil address returned for zero-sized allocations.
+// It is static storage, not a heap object, and must never be freed.
+var zerobase uintptr

--- a/runtime/internal/runtime/z_gc.go
+++ b/runtime/internal/runtime/z_gc.go
@@ -27,10 +27,15 @@ import (
 	"github.com/xgo-dev/llgo/runtime/internal/sync/atomic"
 )
 
-// AllocU allocates uninitialized memory.
+// AllocU allocates uninitialized memory and returns a non-nil pointer or panics.
+// A zero-byte request still allocates at least one byte.
 func AllocU(size uintptr) unsafe.Pointer {
-	ret := bdwgc.Malloc(size)
-	if ret == nil && size != 0 {
+	n := size
+	if n == 0 {
+		n = 1
+	}
+	ret := bdwgc.Malloc(n)
+	if ret == nil {
 		panic("out of memory")
 	}
 	recordMemProfileAlloc(size)
@@ -39,13 +44,20 @@ func AllocU(size uintptr) unsafe.Pointer {
 
 // AllocZ allocates zero-initialized memory.
 func AllocZ(size uintptr) unsafe.Pointer {
-	ret := bdwgc.Malloc(size)
-	recordMemProfileAlloc(size)
-	return c.Memset(ret, 0, size)
+	ret := AllocU(size)
+	c.Memset(ret, 0, size)
+	return ret
 }
 
 func AllocRoot(size uintptr) unsafe.Pointer {
-	return bdwgc.MallocUncollectable(size)
+	if size == 0 {
+		size = 1
+	}
+	ret := bdwgc.MallocUncollectable(size)
+	if ret == nil {
+		panic("out of memory")
+	}
+	return ret
 }
 
 func FreeRoot(ptr unsafe.Pointer) {

--- a/runtime/internal/runtime/z_gc.go
+++ b/runtime/internal/runtime/z_gc.go
@@ -28,13 +28,12 @@ import (
 )
 
 // AllocU allocates uninitialized memory and returns a non-nil pointer or panics.
-// A zero-byte request still allocates at least one byte.
+// Zero-byte requests return the shared zerobase without allocating.
 func AllocU(size uintptr) unsafe.Pointer {
-	n := size
-	if n == 0 {
-		n = 1
+	if size == 0 {
+		return unsafe.Pointer(&zerobase)
 	}
-	ret := bdwgc.Malloc(n)
+	ret := bdwgc.Malloc(size)
 	if ret == nil {
 		panic("out of memory")
 	}
@@ -51,7 +50,7 @@ func AllocZ(size uintptr) unsafe.Pointer {
 
 func AllocRoot(size uintptr) unsafe.Pointer {
 	if size == 0 {
-		size = 1
+		return unsafe.Pointer(&zerobase)
 	}
 	ret := bdwgc.MallocUncollectable(size)
 	if ret == nil {
@@ -61,6 +60,9 @@ func AllocRoot(size uintptr) unsafe.Pointer {
 }
 
 func FreeRoot(ptr unsafe.Pointer) {
+	if ptr == unsafe.Pointer(&zerobase) {
+		return
+	}
 	bdwgc.Free(ptr)
 }
 

--- a/runtime/internal/runtime/z_gc_nonmoving.go
+++ b/runtime/internal/runtime/z_gc_nonmoving.go
@@ -24,9 +24,11 @@ import (
 	"github.com/xgo-dev/llgo/runtime/internal/runtime/tinygogc"
 )
 
+// AllocU allocates uninitialized memory and returns a non-nil pointer or panics.
+// tinygogc returns a non-nil sentinel for zero-byte requests.
 func AllocU(size uintptr) unsafe.Pointer {
 	ret := tinygogc.Alloc(size)
-	if ret == nil && size != 0 {
+	if ret == nil {
 		panic("out of memory")
 	}
 	recordMemProfileAlloc(size)
@@ -34,13 +36,15 @@ func AllocU(size uintptr) unsafe.Pointer {
 }
 
 func AllocZ(size uintptr) unsafe.Pointer {
-	ret := tinygogc.Alloc(size)
-	recordMemProfileAlloc(size)
-	return ret
+	return AllocU(size)
 }
 
 func AllocRoot(size uintptr) unsafe.Pointer {
-	return tinygogc.Alloc(size)
+	ret := tinygogc.Alloc(size)
+	if ret == nil {
+		panic("out of memory")
+	}
+	return ret
 }
 
 func FreeRoot(ptr unsafe.Pointer) {

--- a/runtime/internal/runtime/z_gc_nonmoving.go
+++ b/runtime/internal/runtime/z_gc_nonmoving.go
@@ -25,8 +25,11 @@ import (
 )
 
 // AllocU allocates uninitialized memory and returns a non-nil pointer or panics.
-// tinygogc returns a non-nil sentinel for zero-byte requests.
+// Zero-byte requests return the shared zerobase without allocating.
 func AllocU(size uintptr) unsafe.Pointer {
+	if size == 0 {
+		return unsafe.Pointer(&zerobase)
+	}
 	ret := tinygogc.Alloc(size)
 	if ret == nil {
 		panic("out of memory")
@@ -40,6 +43,9 @@ func AllocZ(size uintptr) unsafe.Pointer {
 }
 
 func AllocRoot(size uintptr) unsafe.Pointer {
+	if size == 0 {
+		return unsafe.Pointer(&zerobase)
+	}
 	ret := tinygogc.Alloc(size)
 	if ret == nil {
 		panic("out of memory")
@@ -48,5 +54,8 @@ func AllocRoot(size uintptr) unsafe.Pointer {
 }
 
 func FreeRoot(ptr unsafe.Pointer) {
+	if ptr == unsafe.Pointer(&zerobase) {
+		return
+	}
 	tinygogc.Free(ptr)
 }

--- a/runtime/internal/runtime/z_nogc.go
+++ b/runtime/internal/runtime/z_nogc.go
@@ -25,13 +25,12 @@ import (
 )
 
 // AllocU allocates uninitialized memory and returns a non-nil pointer or panics.
-// A zero-byte request still allocates at least one byte.
+// Zero-byte requests return the shared zerobase without allocating.
 func AllocU(size uintptr) unsafe.Pointer {
-	n := size
-	if n == 0 {
-		n = 1
+	if size == 0 {
+		return unsafe.Pointer(&zerobase)
 	}
-	ret := c.Malloc(n)
+	ret := c.Malloc(size)
 	if ret == nil {
 		panic("out of memory")
 	}
@@ -48,7 +47,7 @@ func AllocZ(size uintptr) unsafe.Pointer {
 
 func AllocRoot(size uintptr) unsafe.Pointer {
 	if size == 0 {
-		size = 1
+		return unsafe.Pointer(&zerobase)
 	}
 	ret := c.Malloc(size)
 	if ret == nil {
@@ -58,6 +57,9 @@ func AllocRoot(size uintptr) unsafe.Pointer {
 }
 
 func FreeRoot(ptr unsafe.Pointer) {
+	if ptr == unsafe.Pointer(&zerobase) {
+		return
+	}
 	c.Free(ptr)
 }
 

--- a/runtime/internal/runtime/z_nogc.go
+++ b/runtime/internal/runtime/z_nogc.go
@@ -24,10 +24,15 @@ import (
 	c "github.com/xgo-dev/llgo/runtime/internal/clite"
 )
 
-// AllocU allocates uninitialized memory.
+// AllocU allocates uninitialized memory and returns a non-nil pointer or panics.
+// A zero-byte request still allocates at least one byte.
 func AllocU(size uintptr) unsafe.Pointer {
-	ret := c.Malloc(size)
-	if ret == nil && size != 0 {
+	n := size
+	if n == 0 {
+		n = 1
+	}
+	ret := c.Malloc(n)
+	if ret == nil {
 		panic("out of memory")
 	}
 	recordMemProfileAlloc(size)
@@ -36,13 +41,20 @@ func AllocU(size uintptr) unsafe.Pointer {
 
 // AllocZ allocates zero-initialized memory.
 func AllocZ(size uintptr) unsafe.Pointer {
-	ret := c.Malloc(size)
-	recordMemProfileAlloc(size)
-	return c.Memset(ret, 0, size)
+	ret := AllocU(size)
+	c.Memset(ret, 0, size)
+	return ret
 }
 
 func AllocRoot(size uintptr) unsafe.Pointer {
-	return c.Malloc(size)
+	if size == 0 {
+		size = 1
+	}
+	ret := c.Malloc(size)
+	if ret == nil {
+		panic("out of memory")
+	}
+	return ret
 }
 
 func FreeRoot(ptr unsafe.Pointer) {

--- a/runtime/internal/test/alloc_test.go
+++ b/runtime/internal/test/alloc_test.go
@@ -1,0 +1,42 @@
+//go:build llgo
+
+package test
+
+import (
+	"sync/atomic"
+	"testing"
+	"unsafe"
+
+	rt "github.com/xgo-dev/llgo/runtime/internal/runtime"
+)
+
+func TestAllocatorNonNull(t *testing.T) {
+	for _, size := range []uintptr{0, 1, 64} {
+		for _, alloc := range []struct {
+			name string
+			fn   func(uintptr) unsafe.Pointer
+		}{
+			{"AllocU", rt.AllocU},
+			{"AllocZ", rt.AllocZ},
+			{"AllocRoot", rt.AllocRoot},
+		} {
+			ptr := alloc.fn(size)
+			// Reload from memory so the compiler cannot discard the assertion
+			// based on the allocator's nonnull return attribute.
+			ptr = atomic.LoadPointer(&ptr)
+			if ptr == nil {
+				t.Fatalf("%s(%d) returned nil", alloc.name, size)
+			}
+			data := unsafe.Slice((*byte)(ptr), size)
+			for i := range data {
+				if alloc.name == "AllocZ" && data[i] != 0 {
+					t.Fatalf("AllocZ(%d) byte %d = %d", size, i, data[i])
+				}
+				data[i] = 0xa5
+			}
+			if alloc.name == "AllocRoot" {
+				rt.FreeRoot(ptr)
+			}
+		}
+	}
+}

--- a/runtime/internal/test/alloc_test.go
+++ b/runtime/internal/test/alloc_test.go
@@ -40,3 +40,40 @@ func TestAllocatorNonNull(t *testing.T) {
 		}
 	}
 }
+
+func TestZeroSizeAllocatorsShareBase(t *testing.T) {
+	base := rt.AllocU(0)
+	base = atomic.LoadPointer(&base)
+	if base == nil {
+		t.Fatal("zero-sized allocation returned nil")
+	}
+	var zero uintptr
+	for i := 0; i < 100; i++ {
+		// Keep the size dynamic so calls exercise the runtime zero-size path.
+		size := atomic.LoadUintptr(&zero)
+		for _, alloc := range []struct {
+			name string
+			fn   func(uintptr) unsafe.Pointer
+		}{
+			{"AllocU", rt.AllocU},
+			{"AllocZ", rt.AllocZ},
+			{"AllocRoot", rt.AllocRoot},
+		} {
+			ptr := alloc.fn(size)
+			ptr = atomic.LoadPointer(&ptr)
+			if ptr != base {
+				t.Fatalf("%s(0) = %p, want shared base %p", alloc.name, ptr, base)
+			}
+			if alloc.name == "AllocRoot" {
+				// Repeated frees of the static base must never reach a heap allocator.
+				rt.FreeRoot(ptr)
+			}
+		}
+	}
+	ptr := rt.AllocRoot(16)
+	if ptr == base {
+		t.Fatal("nonzero allocation returned zerobase")
+	}
+	*(*uintptr)(ptr) = 42
+	rt.FreeRoot(ptr)
+}

--- a/ssa/allocator_nonnull_test.go
+++ b/ssa/allocator_nonnull_test.go
@@ -1,0 +1,79 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestAllocatorNonNullAcrossModules(t *testing.T) {
+	Initialize(InitAllTargets | InitAllTargetInfos | InitAllTargetMCs | InitAllAsmPrinters)
+	for _, target := range []*Target{
+		{GOOS: "linux", GOARCH: "amd64", LLVMTarget: "x86_64-unknown-linux"},
+		{GOOS: "darwin", GOARCH: "arm64", LLVMTarget: "arm64-apple-macosx"},
+		{GOOS: "js", GOARCH: "wasm", LLVMTarget: "wasm64-unknown-emscripten"},
+	} {
+		t.Run(target.LLVMTarget, func(t *testing.T) {
+			prog := NewProgram(target)
+			defer prog.Dispose()
+			kind := llvm.AttributeKindID("nonnull")
+			for _, module := range []string{PkgRuntime, "example.com/caller"} {
+				pkg := prog.NewPackage("p", module)
+				for _, name := range []string{"AllocU", "AllocZ", "AllocRoot", "Nullable"} {
+					fn := pkg.NewFunc(PkgRuntime+"."+name, prog.tyMalloc(), InGo)
+					want := name != "Nullable"
+					if got := !fn.impl.GetEnumAttributeAtIndex(0, kind).IsNil(); got != want {
+						t.Fatalf("%s in %s: nonnull = %v, want %v", name, module, got, want)
+					}
+					if module == PkgRuntime {
+						body := fn.MakeBody(1)
+						body.Return(pkg.moduleZeroSizedAlloc(prog.Byte()))
+						body.EndBuild()
+						continue
+					}
+					// The caller module has no allocator body and no call-site
+					// attributes. Its optimizer must use the external declaration.
+					results := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Bool]))
+					sig := types.NewSignatureType(nil, nil, nil, prog.tyMalloc().Params(), results, false)
+					caller := pkg.NewFunc("check"+name, sig, InGo)
+					body := caller.MakeBody(1)
+					ptr := body.Call(fn.Expr, caller.Param(0))
+					if !ptr.impl.GetCallSiteEnumAttribute(0, kind).IsNil() {
+						t.Fatal("allocation unexpectedly carries call-site nonnull")
+					}
+					body.Return(body.BinOp(token.EQL, ptr, prog.Nil(prog.VoidPtr())))
+					body.EndBuild()
+				}
+				mod := pkg.Module()
+				if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+					t.Fatal(err)
+				}
+				if module == PkgRuntime {
+					continue
+				}
+				pbo := llvm.NewPassBuilderOptions()
+				defer pbo.Dispose()
+				if err := mod.RunPasses("function(instcombine)", prog.TargetMachine(), pbo); err != nil {
+					t.Fatal(err)
+				}
+				for _, name := range []string{"AllocU", "AllocZ", "AllocRoot", "Nullable"} {
+					ir := mod.NamedFunction("check" + name).String()
+					if got := strings.Contains(ir, "icmp eq ptr"); got != (name == "Nullable") {
+						t.Fatalf("unexpected null check after instcombine:\n%s", ir)
+					}
+					if name != "Nullable" && !strings.Contains(ir, "ret i1 false") {
+						t.Fatalf("allocator null check was not folded to false:\n%s", ir)
+					}
+				}
+				if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -383,6 +383,15 @@ func (p Package) newFunc(
 		llvmName = p.Prog.stdcallSymbolName(name)
 	}
 	fn := llvm.AddFunction(p.mod, llvmName, t.ll)
+	switch name {
+	case "github.com/xgo-dev/llgo/runtime/internal/runtime.AllocU",
+		"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocZ",
+		"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocRoot":
+		// These runtime allocators return a non-null pointer, even for zero
+		// bytes, or panic. Attach the contract to declarations as well as
+		// definitions so every module can use it without LTO or inlining.
+		fn.AddAttributeAtIndex(0, p.Prog.ctx.CreateEnumAttribute(llvm.AttributeKindID("nonnull"), 0))
+	}
 	if bg == InStdcall {
 		fn.SetFunctionCallConv(p.Prog.stdcallCallConv())
 	}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1450,10 +1450,6 @@ func (b Builder) MakeClosure(fn Expr, bindings []Expr) Expr {
 			data = b.Alloc(tctx, true).impl
 		} else {
 			data = b.aggregateAllocU(tctx, llvmFields(bindings, rawCtx, b)...)
-			// A non-zero closure environment allocation either succeeds or does not
-			// return. Mark the return value (attribute index 0) non-null so
-			// LLVM can eliminate the impossible no-environment call edge.
-			data.AddCallSiteAttribute(0, prog.ctx.CreateEnumAttribute(llvm.AttributeKindID("nonnull"), 0))
 		}
 	} else if len(bindings) != 0 {
 		panic("ssa: closure bindings supplied to a no-env function")

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1789,7 +1789,8 @@ func TestMakeClosureWithCtx(t *testing.T) {
 	for _, want := range []string{
 		"define i64 @inner(ptr ",
 		"i64 %1)",
-		`call nonnull ptr @"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocU"(i64 8)`,
+		`call ptr @"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocU"(i64 8)`,
+		`declare nonnull ptr @"github.com/xgo-dev/llgo/runtime/internal/runtime.AllocU"(i64)`,
 		"insertvalue { ptr, ptr } { ptr @inner, ptr undef }",
 	} {
 		if !strings.Contains(ir, want) {


### PR DESCRIPTION
Allocation non-nullness is currently attached only to closure-environment call sites. Calls emitted elsewhere cannot use the same guarantee when compiling a module independently.

Attach the `nonnull` return attribute to every declaration and definition of runtime `AllocU`, `AllocZ`, and `AllocRoot`, and remove the closure-specific call-site attribute. This lets LLVM fold allocator null checks using only an external declaration, without LTO or inlining.

Make the runtime contract unconditional: `AllocU`, `AllocZ`, and `AllocRoot` return a shared static `zerobase` for zero-byte requests across hosted GC, no-GC, bare-metal, and wasm linear-GC backends. This performs no heap allocation. `FreeRoot` ignores that static address while retaining the backend's deallocation behavior for real root allocations. Nonzero allocation failures panic, and `AllocZ` reuses the checked allocation path before clearing memory. Profiling continues to record the original nonzero request size.

The embedded partial-graph reclamation test clears stale allocator register spills before collecting. This prevents conservative stack scanning from retaining detached nodes while preserving the assertion that both nodes are reclaimed.

Validation with Go 1.27.0 and LLVM/LLD 22.1.8 on macOS arm64:

- Full `go test ./ssa ./cl -count=1`, including wasm64 closure optimization and CodeGen regressions.
- New amd64, arm64, and wasm64 tests verify allocator definitions and independent caller declarations, null-check folding without call-site attributes, and a nullable control.
- Updated front-end FileCheck fixtures and existing LTO runtime cases pass on rerun with the matching LLD 22 toolchain.
- New runtime allocation tests pass with GC and `nogc`, covering sizes 0, 1, and 64, zero initialization, and freeing root allocations. A separate regression repeatedly verifies the shared zero-size address across all three entry points and safely frees zero-sized roots.
- Existing zero-sized allocation, append, and nil-interface regressions pass.
- `go test ./internal/build -run '^TestWasmGCRootFrameLinksRuntimeChain$' -count=1` passes with wasm linear GC enabled.

- Full `_demo/embed/test-esp-serial-startup.sh` passes for ESP32-C3 and ESP32 using pinned Espressif QEMU `esp_develop_9.2.2_20250817`, including the GC runtime tests.

Bare-metal runtime changes have not been exercised on hardware.

