### PR TITLE
ci: release Windows amd64 and arm64 MSVC and MinGW bundles

### DIFF
--- a/.github/windows/build-release.ps1
+++ b/.github/windows/build-release.ps1
@@ -31,22 +31,20 @@ $llvmRoot = if ($Profile -eq 'mingw') {
 if ($Profile -eq 'msvc' -and $GoArch -eq 'arm64') {
   # The ordinary MSVC CI profile builds an x64 compiler for all targets.
   # A release labelled arm64 must link the actual ARM64 LLVM libraries.
-  $sdkParent = Join-Path $env:RUNNER_TOOL_CACHE "llgo-release-llvm/$llvmVersion/arm64"
+  $sdkParent = Join-Path $env:RUNNER_TEMP "llgo-release-llvm/$llvmVersion/arm64"
   $sdkName = "clang+llvm-$llvmVersion-aarch64-pc-windows-msvc"
   $llvmRoot = Join-Path $sdkParent $sdkName
-  if (-not (Test-Path (Join-Path $llvmRoot '.complete'))) {
-    if (Test-Path $sdkParent) { Remove-Item -LiteralPath $sdkParent -Recurse -Force }
-    $asset = $sdkName.Replace('+', '%2B') + '.tar.xz'
-    Expand-ReleaseXz `
-      -URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvmVersion/$asset" `
-      -SHA256 'de718c58ebbc5f61d58c17b90457fcf42983bc2c4a4aba3e010d108713bfd7f1' `
-      -Destination $sdkParent `
-      -Entries @("$sdkName/include/*", "$sdkName/lib/*", "$sdkName/bin/llvm-config.exe", "$sdkName/bin/*.dll")
-    if (-not (Test-Path (Join-Path $llvmRoot 'include/llvm-c/Core.h')) -or
-        -not (Test-Path (Join-Path $llvmRoot 'lib/LLVMCore.lib'))) {
-      throw 'The ARM64 LLVM development SDK is incomplete'
-    }
-    New-Item -ItemType File (Join-Path $llvmRoot '.complete') | Out-Null
+  if (Test-Path $sdkParent) { Remove-Item -LiteralPath $sdkParent -Recurse -Force }
+  $asset = $sdkName.Replace('+', '%2B') + '.tar.xz'
+  Expand-ReleaseXz `
+    -URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvmVersion/$asset" `
+    -SHA256 'de718c58ebbc5f61d58c17b90457fcf42983bc2c4a4aba3e010d108713bfd7f1' `
+    -CacheDirectory (Join-Path $env:RUNNER_TOOL_CACHE 'llgo-release-downloads/llvm-arm64') `
+    -Destination $sdkParent `
+    -Entries @("$sdkName/include/*", "$sdkName/lib/*", "$sdkName/bin/llvm-config.exe", "$sdkName/bin/*.dll")
+  if (-not (Test-Path (Join-Path $llvmRoot 'include/llvm-c/Core.h')) -or
+      -not (Test-Path (Join-Path $llvmRoot 'lib/LLVMCore.lib'))) {
+    throw 'The ARM64 LLVM development SDK is incomplete'
   }
 }
 
@@ -80,7 +78,7 @@ if ($Profile -eq 'msvc') {
     }
     '-l' + [IO.Path]::GetFileNameWithoutExtension($_)
   }
-  $env:CGO_LDFLAGS = '-L"' + (Join-Path $llvmRoot 'lib').Replace('\', '/') + '" ' + ($libraryFlags -join ' ')
+  $env:CGO_LDFLAGS = Get-ReleaseMSVCLinkFlags -LibraryDirectory (Join-Path $llvmRoot 'lib') -LibraryFlags $libraryFlags
 } else {
   $env:CGO_LDFLAGS = (Invoke-ReleaseCapture $llvmConfig @('--ldflags', '--libs', 'all', '--system-libs')).Trim().Replace('\', '/').Replace("`n", ' ')
 }
@@ -113,6 +111,7 @@ try {
   Expand-ReleaseXz `
     -URL "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/$espVersion/$espAsset" `
     -SHA256 '3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3' `
+    -CacheDirectory (Join-Path $env:RUNNER_TOOL_CACHE 'llgo-release-downloads/esp') `
     -Destination $espParent
   $crosscompile = Join-Path $stage 'crosscompile'
   New-Item -ItemType Directory $crosscompile | Out-Null

--- a/.github/windows/build-release.ps1
+++ b/.github/windows/build-release.ps1
@@ -1,0 +1,143 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('msvc', 'mingw')][string]$Profile,
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('amd64', 'arm64')][string]$GoArch
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-lib.ps1')
+$root = (Get-Location).Path
+$metadata = Get-Content -Raw '.windows-dist/metadata.json' | ConvertFrom-Json
+$commit = (& git rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $metadata.commit -ne $commit) {
+  throw 'The GoReleaser metadata does not describe this checkout'
+}
+if ($metadata.version -notmatch '^[0-9A-Za-z][0-9A-Za-z.+-]*$') {
+  throw "Invalid release version: $($metadata.version)"
+}
+$stage = Join-Path $env:RUNNER_TEMP "llgo-release-$GoArch-$Profile"
+if (Test-Path $stage) { Remove-Item -LiteralPath $stage -Recurse -Force }
+$bin = Join-Path $stage 'bin'
+New-Item -ItemType Directory -Force $bin | Out-Null
+
+$llvmVersion = '22.1.8'
+$readObj = (Get-Command llvm-readobj.exe).Source
+$llvmRoot = if ($Profile -eq 'mingw') {
+  $env:LLGO_MINGW_HOST_ROOT
+} else {
+  Split-Path (Split-Path (Get-Command llvm-config.exe).Source)
+}
+if ($Profile -eq 'msvc' -and $GoArch -eq 'arm64') {
+  # The ordinary MSVC CI profile builds an x64 compiler for all targets.
+  # A release labelled arm64 must link the actual ARM64 LLVM libraries.
+  $sdkParent = Join-Path $env:RUNNER_TOOL_CACHE "llgo-release-llvm/$llvmVersion/arm64"
+  $sdkName = "clang+llvm-$llvmVersion-aarch64-pc-windows-msvc"
+  $llvmRoot = Join-Path $sdkParent $sdkName
+  if (-not (Test-Path (Join-Path $llvmRoot '.complete'))) {
+    if (Test-Path $sdkParent) { Remove-Item -LiteralPath $sdkParent -Recurse -Force }
+    $asset = $sdkName.Replace('+', '%2B') + '.tar.xz'
+    Expand-ReleaseXz `
+      -URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvmVersion/$asset" `
+      -SHA256 'de718c58ebbc5f61d58c17b90457fcf42983bc2c4a4aba3e010d108713bfd7f1' `
+      -Destination $sdkParent `
+      -Entries @("$sdkName/include/*", "$sdkName/lib/*", "$sdkName/bin/llvm-config.exe", "$sdkName/bin/*.dll")
+    if (-not (Test-Path (Join-Path $llvmRoot 'include/llvm-c/Core.h')) -or
+        -not (Test-Path (Join-Path $llvmRoot 'lib/LLVMCore.lib'))) {
+      throw 'The ARM64 LLVM development SDK is incomplete'
+    }
+    New-Item -ItemType File (Join-Path $llvmRoot '.complete') | Out-Null
+  }
+}
+
+$llvmConfig = Join-Path $llvmRoot 'bin/llvm-config.exe'
+if ((Invoke-ReleaseCapture $llvmConfig @('--version')).Trim() -ne $llvmVersion) {
+  throw "The release compiler requires LLVM $llvmVersion"
+}
+$env:CGO_ENABLED = '1'
+$env:GOOS = 'windows'
+$env:GOARCH = $GoArch
+$env:CGO_CPPFLAGS = (Invoke-ReleaseCapture $llvmConfig @('--cflags')).Trim().Replace('\', '/').Replace("`n", ' ')
+$env:CGO_CXXFLAGS = '-std=c++17'
+if ($Profile -eq 'msvc') {
+  . (Join-Path $PSScriptRoot 'msvc-target.ps1')
+  $target = Enter-LLGoVisualStudio2022 -GoArch $GoArch
+  # Keep the bootstrap driver from setup-deps; the developer shell can put a
+  # different Visual Studio Clang first on PATH.
+  $bootstrapBin = Split-Path $readObj
+  $env:CC = '"' + (Join-Path $bootstrapBin 'clang.exe').Replace('\', '/') +
+    '" --target=' + $target.Triple + ' -fuse-ld=lld -fms-runtime-lib=static'
+  $env:CXX = '"' + (Join-Path $bootstrapBin 'clang++.exe').Replace('\', '/') +
+    '" --target=' + $target.Triple + ' -fuse-ld=lld -fms-runtime-lib=static'
+  $libraryNames = (Invoke-ReleaseCapture $llvmConfig @('--link-static', '--libnames', 'all')).Trim() -split '\s+'
+  $systemNames = (Invoke-ReleaseCapture $llvmConfig @('--link-static', '--system-libs')) -split '\s+' |
+    Where-Object { $_ -and $_ -notin @('libxml2s.lib', 'xml2s.lib') }
+  # Match setup-deps: the official SDK advertises optional XML support but
+  # omits its library. LLGo does not link that unused manifest component.
+  $libraryFlags = @($libraryNames) + @($systemNames) | ForEach-Object {
+    if (-not $_.EndsWith('.lib', [StringComparison]::OrdinalIgnoreCase)) {
+      throw "Unexpected MSVC LLVM library: $_"
+    }
+    '-l' + [IO.Path]::GetFileNameWithoutExtension($_)
+  }
+  $env:CGO_LDFLAGS = '-L"' + (Join-Path $llvmRoot 'lib').Replace('\', '/') + '" ' + ($libraryFlags -join ' ')
+} else {
+  $env:CGO_LDFLAGS = (Invoke-ReleaseCapture $llvmConfig @('--ldflags', '--libs', 'all', '--system-libs')).Trim().Replace('\', '/').Replace("`n", ' ')
+}
+
+$executable = Join-Path $bin 'llgo.exe'
+$buildTime = ([DateTimeOffset]$metadata.date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+$linkFlags = "-X github.com/xgo-dev/llgo/internal/env.buildVersion=v$($metadata.version) " +
+  "-X github.com/xgo-dev/llgo/internal/env.buildTime=$buildTime"
+& go build -tags=byollvm -ldflags $linkFlags -o $executable ./cmd/llgo
+if ($LASTEXITCODE -ne 0) { throw 'Building the Windows release compiler failed' }
+Copy-ReleaseDLLs -ReadObj $readObj -Executable $executable -GoArch $GoArch -Profile $Profile `
+  -SourceDirectories @((Join-Path $llvmRoot 'bin'))
+
+foreach ($entry in @('LICENSE', 'LICENSES', 'README.md', 'THIRD_PARTY_NOTICES.md', 'runtime', 'targets')) {
+  Copy-Item -LiteralPath (Join-Path $root $entry) -Destination $stage -Recurse
+}
+if ($Profile -eq 'mingw') {
+  # Preserve the MSYS2 component licenses alongside redistributed LLVM/C++
+  # and transitive DLLs. Nothing from MSYS2's POSIX /usr/bin is packaged.
+  Copy-Item -LiteralPath (Join-Path $llvmRoot 'share/licenses') `
+    -Destination (Join-Path $stage 'LICENSES/windows-runtime') -Recurse
+}
+
+# Keep the existing integrated layout. ESP's Windows payload is x64 for both
+# host architectures, as in LLGo's existing Windows ARM64 download path.
+$espVersion = '22.1.4_20260905'
+$espAsset = "clang-esp-$espVersion-x86_64-w64-mingw32.tar.xz"
+$espParent = Join-Path $env:RUNNER_TEMP ('llgo-release-esp-' + [Guid]::NewGuid())
+try {
+  Expand-ReleaseXz `
+    -URL "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/$espVersion/$espAsset" `
+    -SHA256 '3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3' `
+    -Destination $espParent
+  $crosscompile = Join-Path $stage 'crosscompile'
+  New-Item -ItemType Directory $crosscompile | Out-Null
+  Move-Item -LiteralPath (Join-Path $espParent 'esp-clang') -Destination (Join-Path $crosscompile 'clang')
+} finally {
+  if (Test-Path $espParent) { Remove-Item -LiteralPath $espParent -Recurse -Force }
+}
+Copy-Item -LiteralPath (Join-Path $root 'LICENSES/XGo-LLVM-Apache-2.0-WITH-LLVM-exception.txt') `
+  -Destination (Join-Path $stage 'crosscompile/clang/LICENSE-LLVM.txt')
+@{
+  version = $metadata.version
+  commit = $commit
+  date = $buildTime
+  goos = 'windows'
+  goarch = $GoArch
+  abi = $Profile
+  llvm_version = $llvmVersion
+  esp_clang_version = $espVersion
+  esp_clang_host = 'windows/amd64'
+} | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $stage 'release.json')
+
+$archiveName = "llgo$($metadata.version).windows-$GoArch-$Profile.tar.gz"
+$archive = Join-Path $root ".windows-dist/$archiveName"
+& tar.exe -czf $archive -C $stage .
+if ($LASTEXITCODE -ne 0) { throw 'Creating the integrated Windows archive failed' }
+$checksum = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+"$checksum  $archiveName" | Set-Content -Encoding ascii "$archive.sha256"
+Write-Host "Created $archive"

--- a/.github/windows/release-build_test.ps1
+++ b/.github/windows/release-build_test.ps1
@@ -1,0 +1,58 @@
+# Exercise the real Go/cgo parser and the archive cache's integrity boundary.
+param([string]$Go = 'go')
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-lib.ps1')
+$temporary = Join-Path ([IO.Path]::GetTempPath()) ('llgo-release-build-' + [Guid]::NewGuid())
+New-Item -ItemType Directory $temporary | Out-Null
+$savedEnvironment = @{}
+foreach ($name in @('CGO_ENABLED', 'CGO_LDFLAGS', 'CGO_CPPFLAGS', 'CGO_CFLAGS', 'CGO_CXXFLAGS', 'GOOS', 'GOARCH', 'GOWORK')) {
+  $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
+}
+
+try {
+  # A cache hit must still match the pin. The invalid URL makes accidental
+  # network access on this path fail rather than hide a cache regression.
+  $seed = Join-Path $temporary 'seed'
+  [IO.File]::WriteAllText($seed, 'verified release payload')
+  $sha256 = (Get-FileHash -Algorithm SHA256 $seed).Hash.ToLowerInvariant()
+  $cache = Join-Path $temporary 'cache'
+  New-Item -ItemType Directory $cache | Out-Null
+  $archive = Join-Path $cache "$sha256.tar.xz"
+  Copy-Item $seed $archive
+  $arguments = @{ URL = 'https://invalid.invalid/payload'; SHA256 = $sha256; CacheDirectory = $cache }
+  if ((Get-ReleaseArchive @arguments) -ne $archive) { throw 'The verified cache was not reused' }
+  [IO.File]::WriteAllText($archive, 'tampered release payload')
+  $rejected = $false
+  try { $null = Get-ReleaseArchive @arguments } catch {
+    if ($_.Exception.Message -notmatch 'SHA-256.*expected') { throw }
+    $rejected = $true
+  }
+  if (-not $rejected) { throw 'A corrupted cached archive was accepted' }
+
+  foreach ($name in $savedEnvironment.Keys) { [Environment]::SetEnvironmentVariable($name, $null) }
+  $env:CGO_ENABLED = '1'
+  $env:GOWORK = 'off'
+  Set-Content (Join-Path $temporary 'go.mod') "module release-cgo-test`n`ngo 1.20`n"
+  Set-Content (Join-Path $temporary 'main.go') "package main`nimport `"C`"`nfunc main() {}`n"
+  Push-Location $temporary
+  try {
+    # Compile, but do not execute: Windows CI may be using an x64 bootstrap
+    # compiler on an ARM64 host. Cover both the CI path and a spaced SDK path.
+    foreach ($directory in @('lib', 'LLVM SDK/lib')) {
+      $libraryDirectory = Join-Path $temporary $directory
+      New-Item -ItemType Directory -Force $libraryDirectory | Out-Null
+      $env:CGO_LDFLAGS = Get-ReleaseMSVCLinkFlags -LibraryDirectory $libraryDirectory
+      & $Go build -o (Join-Path $temporary 'cgo-test.exe') .
+      if ($LASTEXITCODE -ne 0) { throw 'The release CGO_LDFLAGS failed a real Go build' }
+    }
+  } finally {
+    Pop-Location
+  }
+  Write-Host 'Passed cached archive integrity and CGO linker argument checks'
+} finally {
+  foreach ($name in $savedEnvironment.Keys) {
+    [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name])
+  }
+  Remove-Item -LiteralPath $temporary -Recurse -Force
+}

--- a/.github/windows/release-lib.ps1
+++ b/.github/windows/release-lib.ps1
@@ -69,12 +69,15 @@ function Copy-ReleaseDLLs {
         }
       }
       if ($source) {
-        $null = Assert-ReleasePE -ReadObj $ReadObj -Path $source -GoArch $GoArch -Profile $Profile
         Copy-Item -LiteralPath $source -Destination $local
+        # Validate the packaged copy when it is dequeued, including its imports.
         $queue.Enqueue($local)
       } elseif (-not (Test-Path -LiteralPath (Join-Path $SystemDirectory $dll))) {
         throw "$path imports $dll, but it is absent from the release and selected LLVM profile"
       }
+      # System32 is the OS dependency boundary, not a strict DLL allowlist.
+      # A runner-specific DLL installed there can mask a missing redistributable;
+      # the standalone test on a fresh runner checks that boundary independently.
     }
   }
 }
@@ -94,24 +97,57 @@ function Invoke-ReleaseCapture {
   return $output
 }
 
+function Get-ReleaseMSVCLinkFlags {
+  param([string]$LibraryDirectory, [string[]]$LibraryFlags = @())
+
+  # cmd/go only recognizes a quote at the start of an argument. -L"path"
+  # preserves literal quotes and breaks the generated //go:cgo_ldflag pragma.
+  $path = $LibraryDirectory.Replace('\', '/')
+  if ($path -match '["\r\n]') { throw "Invalid LLVM library directory: $path" }
+  return (@('"-L' + $path + '"') + $LibraryFlags) -join ' '
+}
+
+function Get-ReleaseArchive {
+  param([string]$URL, [string]$SHA256, [string]$CacheDirectory)
+
+  if ($SHA256 -notmatch '^[0-9a-fA-F]{64}$') { throw 'Invalid release SHA-256' }
+  New-Item -ItemType Directory -Force $CacheDirectory | Out-Null
+  $archive = Join-Path $CacheDirectory "$SHA256.tar.xz"
+  if (-not (Test-Path -LiteralPath $archive)) {
+    $partial = "$archive.$([Guid]::NewGuid()).partial"
+    try {
+      & curl.exe --fail --location --retry 5 --retry-all-errors --output $partial $URL
+      if ($LASTEXITCODE -ne 0) { throw "Downloading $URL failed" }
+      $actual = (Get-FileHash -Algorithm SHA256 $partial).Hash
+      if ($actual -ne $SHA256) { throw "SHA-256 for $URL is $actual, expected $SHA256" }
+      Move-Item -LiteralPath $partial -Destination $archive -Force
+    } finally {
+      if (Test-Path -LiteralPath $partial) { Remove-Item -LiteralPath $partial }
+    }
+  }
+  # Restored caches are untrusted. Verify the pinned archive on every use and
+  # always extract it afresh; neither extracted files nor markers are cached.
+  $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash
+  if ($actual -ne $SHA256) { throw "SHA-256 for $URL is $actual, expected $SHA256" }
+  return $archive
+}
+
 function Expand-ReleaseXz {
-  param([string]$URL, [string]$SHA256, [string]$Destination, [string[]]$Entries = @())
+  param(
+    [string]$URL, [string]$SHA256, [string]$Destination,
+    [string]$CacheDirectory, [string[]]$Entries = @()
+  )
 
   $temporary = Join-Path $env:RUNNER_TEMP ('llgo-release-download-' + [Guid]::NewGuid())
   New-Item -ItemType Directory -Force $temporary, $Destination | Out-Null
   try {
-    $archive = Join-Path $temporary 'payload.tar.xz'
-    & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $URL
-    if ($LASTEXITCODE -ne 0) { throw "Downloading $URL failed" }
-    $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash
-    if ($actual -ne $SHA256) { throw "SHA-256 for $URL is $actual, expected $SHA256" }
+    $archive = Get-ReleaseArchive -URL $URL -SHA256 $SHA256 -CacheDirectory $CacheDirectory
     # Use 7-Zip for xz: the Windows ARM64 runner's bsdtar cannot extract all
     # upstream sparse xz archives. tar.gz release archives use bsdtar normally.
     $sevenZip = Join-Path $env:ProgramFiles '7-Zip/7z.exe'
     & $sevenZip x -y "-o$temporary" $archive | Out-Host
     if ($LASTEXITCODE -ne 0) { throw 'Decompressing the release payload failed' }
-    Remove-Item -LiteralPath $archive
-    & $sevenZip x -y "-o$Destination" (Join-Path $temporary 'payload.tar') @Entries | Out-Host
+    & $sevenZip x -y "-o$Destination" (Join-Path $temporary "$SHA256.tar") @Entries | Out-Host
     if ($LASTEXITCODE -ne 0) { throw 'Extracting the release payload failed' }
   } finally {
     Remove-Item -LiteralPath $temporary -Recurse -Force

--- a/.github/windows/release-lib.ps1
+++ b/.github/windows/release-lib.ps1
@@ -1,0 +1,119 @@
+# Shared checks for the Windows release builder and the extracted-archive test.
+# Resolve DLLs only from the selected LLVM profile, never from the build PATH.
+
+function Get-ReleasePE {
+  param([string]$ReadObj, [string]$Path)
+
+  $output = (& $ReadObj --file-headers --coff-imports $Path | Out-String)
+  if ($LASTEXITCODE -ne 0) {
+    throw "Inspecting $Path failed with exit code $LASTEXITCODE"
+  }
+  if ($output -notmatch 'Machine:\s+IMAGE_FILE_MACHINE_(\w+)\s') {
+    throw "$Path does not have a COFF machine header"
+  }
+  $machine = $Matches[1]
+  $imports = @([regex]::Matches($output, '(?im)^\s*Name:\s*(\S+\.dll)\s*$') |
+    ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+  return [PSCustomObject]@{ Machine = $machine; Imports = $imports }
+}
+
+function Assert-ReleasePE {
+  param([string]$ReadObj, [string]$Path, [string]$GoArch, [string]$Profile)
+
+  $pe = Get-ReleasePE -ReadObj $ReadObj -Path $Path
+  $want = @{ amd64 = 'AMD64'; arm64 = 'ARM64' }[$GoArch]
+  if (-not $want -or $pe.Machine -ne $want) {
+    throw "$Path has PE machine $($pe.Machine), expected windows/$GoArch ($want)"
+  }
+  foreach ($dll in $pe.Imports) {
+    if ($dll -match '^(msys-2\.0|cygwin1|libwinpthread.*|libgcc_s.*|libstdc\+\+.*)\.dll$' -or
+        ($Profile -eq 'msvc' -and $dll -match '^(libc\+\+|libunwind).*\.dll$')) {
+      throw "$Path imports a runtime outside the $Profile release profile: $dll"
+    }
+  }
+  return $pe
+}
+
+function Copy-ReleaseDLLs {
+  param(
+    [string]$ReadObj, [string]$Executable, [string]$GoArch, [string]$Profile,
+    [string[]]$SourceDirectories,
+    [string]$SystemDirectory = (Join-Path $env:SystemRoot 'System32'),
+    [switch]$CheckOnly
+  )
+
+  $destination = Split-Path $Executable
+  $queue = [Collections.Generic.Queue[string]]::new()
+  $queue.Enqueue($Executable)
+  $visited = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+  while ($queue.Count) {
+    $path = $queue.Dequeue()
+    if (-not $visited.Add($path)) { continue }
+    $pe = Assert-ReleasePE -ReadObj $ReadObj -Path $path -GoArch $GoArch -Profile $Profile
+    foreach ($dll in $pe.Imports) {
+      # API-set DLLs are contracts provided by Windows, not redistributable files.
+      if ($dll -match '^(api-ms-|ext-ms-)') { continue }
+      $local = Join-Path $destination $dll
+      if (Test-Path -LiteralPath $local) {
+        $queue.Enqueue($local)
+        continue
+      }
+      $source = $null
+      if (-not $CheckOnly) {
+        foreach ($directory in $SourceDirectories) {
+          $candidate = Join-Path $directory $dll
+          if (Test-Path -LiteralPath $candidate) {
+            $source = $candidate
+            break
+          }
+        }
+      }
+      if ($source) {
+        $null = Assert-ReleasePE -ReadObj $ReadObj -Path $source -GoArch $GoArch -Profile $Profile
+        Copy-Item -LiteralPath $source -Destination $local
+        $queue.Enqueue($local)
+      } elseif (-not (Test-Path -LiteralPath (Join-Path $SystemDirectory $dll))) {
+        throw "$path imports $dll, but it is absent from the release and selected LLVM profile"
+      }
+    }
+  }
+}
+
+function Invoke-ReleaseCapture {
+  param([string]$Executable, [string[]]$ArgumentList)
+
+  $savedPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = 'Continue'
+    $output = (& $Executable @ArgumentList 2>&1 | ForEach-Object { $_.ToString() }) -join "`n"
+    $code = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $savedPreference
+  }
+  if ($code -ne 0) { throw "$Executable exited with $code`n$output" }
+  return $output
+}
+
+function Expand-ReleaseXz {
+  param([string]$URL, [string]$SHA256, [string]$Destination, [string[]]$Entries = @())
+
+  $temporary = Join-Path $env:RUNNER_TEMP ('llgo-release-download-' + [Guid]::NewGuid())
+  New-Item -ItemType Directory -Force $temporary, $Destination | Out-Null
+  try {
+    $archive = Join-Path $temporary 'payload.tar.xz'
+    & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $URL
+    if ($LASTEXITCODE -ne 0) { throw "Downloading $URL failed" }
+    $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash
+    if ($actual -ne $SHA256) { throw "SHA-256 for $URL is $actual, expected $SHA256" }
+    # Use 7-Zip for xz: the Windows ARM64 runner's bsdtar cannot extract all
+    # upstream sparse xz archives. tar.gz release archives use bsdtar normally.
+    $sevenZip = Join-Path $env:ProgramFiles '7-Zip/7z.exe'
+    & $sevenZip x -y "-o$temporary" $archive | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw 'Decompressing the release payload failed' }
+    Remove-Item -LiteralPath $archive
+    & $sevenZip x -y "-o$Destination" (Join-Path $temporary 'payload.tar') @Entries | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw 'Extracting the release payload failed' }
+  } finally {
+    Remove-Item -LiteralPath $temporary -Recurse -Force
+  }
+}

--- a/.github/windows/release-lib_test.ps1
+++ b/.github/windows/release-lib_test.ps1
@@ -82,6 +82,13 @@ try {
       Expect-Failure {
         Assert-ReleasePE -ReadObj $ReadObj -Path "$stage/forbidden.exe" -GoArch $goArch -Profile 'msvc'
       } 'runtime outside'
+      if ($dll -eq 'libc++.dll') {
+        $null = Assert-ReleasePE -ReadObj $ReadObj -Path "$stage/forbidden.exe" -GoArch $goArch -Profile 'mingw'
+      } else {
+        Expect-Failure {
+          Assert-ReleasePE -ReadObj $ReadObj -Path "$stage/forbidden.exe" -GoArch $goArch -Profile 'mingw'
+        } 'runtime outside'
+      }
     }
     Write-Host "Passed $goArch DLL closure, relocation, missing dependency, architecture, and ABI checks"
   }

--- a/.github/windows/release-lib_test.ps1
+++ b/.github/windows/release-lib_test.ps1
@@ -1,0 +1,90 @@
+# Cross-platform regression tests using real, minimal COFF images. No Windows
+# executable is run, so this also works with LLVM and PowerShell on macOS/Linux.
+param(
+  [string]$Clang = 'clang',
+  [string]$Linker = 'lld-link',
+  [string]$ReadObj = 'llvm-readobj'
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-lib.ps1')
+$temporary = Join-Path ([IO.Path]::GetTempPath()) ('llgo-release-pe-' + [Guid]::NewGuid())
+New-Item -ItemType Directory $temporary | Out-Null
+
+function Invoke-TestTool([string]$Tool, [string[]]$ToolArguments) {
+  & $Tool @ToolArguments
+  if ($LASTEXITCODE -ne 0) { throw "$Tool failed: $ToolArguments" }
+}
+
+function Expect-Failure([scriptblock]$Operation, [string]$Pattern) {
+  try { & $Operation } catch {
+    if ($_.Exception.Message -notmatch $Pattern) { throw }
+    return
+  }
+  throw "Expected failure matching $Pattern"
+}
+
+try {
+  $systemDirectory = Join-Path $temporary 'system'
+  New-Item -ItemType Directory $systemDirectory | Out-Null
+  foreach ($goArch in @('amd64', 'arm64')) {
+    $source = Join-Path $temporary $goArch
+    $stage = Join-Path $temporary "$goArch stage"
+    New-Item -ItemType Directory $source, $stage | Out-Null
+    $arch = @{ amd64 = 'x86_64'; arm64 = 'aarch64' }[$goArch]
+    $machine = @{ amd64 = 'x64'; arm64 = 'arm64' }[$goArch]
+    Set-Content (Join-Path $source 'leaf.c') '__declspec(dllexport) int leaf(void) { return 42; }'
+    Set-Content (Join-Path $source 'middle.c') '__declspec(dllimport) int leaf(void); __declspec(dllexport) int middle(void) { return leaf(); }'
+    Set-Content (Join-Path $source 'main.c') '__declspec(dllimport) int middle(void); int entry(void) { return middle(); }'
+    foreach ($name in @('leaf', 'middle', 'main')) {
+      Invoke-TestTool $Clang @("--target=$arch-pc-windows-msvc", '-ffreestanding', '-fno-stack-protector', '-c',
+        (Join-Path $source "$name.c"), '-o', (Join-Path $source "$name.obj"))
+    }
+    Invoke-TestTool $Linker @('/dll', '/noentry', '/nodefaultlib', "/machine:$machine",
+      "/out:$source/leaf.dll", "/implib:$source/leaf.lib", "$source/leaf.obj")
+    Invoke-TestTool $Linker @('/dll', '/noentry', '/nodefaultlib', "/machine:$machine",
+      "/out:$source/middle.dll", "/implib:$source/middle.lib", "$source/middle.obj", "$source/leaf.lib")
+    $executable = Join-Path $stage 'llgo.exe'
+    Invoke-TestTool $Linker @('/entry:entry', '/subsystem:console', '/nodefaultlib', "/machine:$machine",
+      "/out:$executable", "$source/main.obj", "$source/middle.lib")
+    $arguments = @{
+      ReadObj = $ReadObj; Executable = $executable; GoArch = $goArch; Profile = 'mingw'
+      SourceDirectories = @($source); SystemDirectory = $systemDirectory
+    }
+    Copy-ReleaseDLLs @arguments
+    foreach ($dll in @('leaf.dll', 'middle.dll')) {
+      if (-not (Test-Path (Join-Path $stage $dll))) { throw "Transitive DLL $dll was not copied" }
+    }
+    Copy-ReleaseDLLs @arguments -CheckOnly
+
+    # An import must not be satisfied by the build SDK during artifact checks.
+    Remove-Item (Join-Path $stage 'leaf.dll')
+    Expect-Failure { Copy-ReleaseDLLs @arguments -CheckOnly } 'leaf.dll.*absent'
+    Copy-ReleaseDLLs @arguments
+    $otherArch = if ($goArch -eq 'amd64') { 'arm64' } else { 'amd64' }
+    Expect-Failure {
+      Assert-ReleasePE -ReadObj $ReadObj -Path $executable -GoArch $otherArch -Profile 'mingw'
+    } 'PE machine'
+
+    # A DLL with the right name but the wrong architecture must also fail.
+    if ($goArch -eq 'arm64') {
+      Copy-Item (Join-Path $temporary 'amd64/leaf.dll') (Join-Path $stage 'leaf.dll') -Force
+      Expect-Failure { Copy-ReleaseDLLs @arguments -CheckOnly } 'PE machine'
+    }
+
+    # Real PE import tables, rather than a mocked parser, exercise the runtime
+    # boundary shared by the builder and clean-runner artifact checks.
+    foreach ($dll in @('msys-2.0.dll', 'libc++.dll')) {
+      Invoke-TestTool $Linker @('/dll', '/noentry', '/nodefaultlib', "/machine:$machine",
+        "/out:$source/$dll", "/implib:$source/forbidden.lib", "$source/middle.obj", "$source/leaf.lib")
+      Invoke-TestTool $Linker @('/entry:entry', '/subsystem:console', '/nodefaultlib', "/machine:$machine",
+        "/out:$stage/forbidden.exe", "$source/main.obj", "$source/forbidden.lib")
+      Expect-Failure {
+        Assert-ReleasePE -ReadObj $ReadObj -Path "$stage/forbidden.exe" -GoArch $goArch -Profile 'msvc'
+      } 'runtime outside'
+    }
+    Write-Host "Passed $goArch DLL closure, relocation, missing dependency, architecture, and ABI checks"
+  }
+} finally {
+  Remove-Item -LiteralPath $temporary -Recurse -Force
+}

--- a/.github/windows/test-release.ps1
+++ b/.github/windows/test-release.ps1
@@ -1,0 +1,122 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('msvc', 'mingw')][string]$Profile,
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('amd64', 'arm64')][string]$GoArch,
+  [switch]$CheckOnly
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-lib.ps1')
+$archives = @(Get-ChildItem '.windows-dist' -Filter "*.windows-$GoArch-$Profile.tar.gz")
+if ($archives.Count -ne 1) { throw "Expected exactly one windows/$GoArch/$Profile archive" }
+$archive = $archives[0]
+$checksumLine = (Get-Content -Raw ($archive.FullName + '.sha256')).Trim()
+$actual = (Get-FileHash -Algorithm SHA256 $archive.FullName).Hash.ToLowerInvariant()
+if ($checksumLine -ne "$actual  $($archive.Name)") { throw 'The Windows archive checksum does not match' }
+
+# A different location, including a space, makes build-tree dependencies and
+# accidentally unquoted paths observable before an archive can be published.
+$releaseRoot = Join-Path $env:RUNNER_TEMP "extracted llgo-$GoArch-$Profile"
+if (Test-Path $releaseRoot) { Remove-Item -LiteralPath $releaseRoot -Recurse -Force }
+New-Item -ItemType Directory $releaseRoot | Out-Null
+& tar.exe -xzf $archive.FullName -C $releaseRoot
+if ($LASTEXITCODE -ne 0) { throw 'Extracting the integrated Windows archive failed' }
+foreach ($entry in @('bin/llgo.exe', 'runtime/go.mod', 'targets', 'LICENSES', 'THIRD_PARTY_NOTICES.md',
+    'crosscompile/clang/bin/clang++.exe', 'crosscompile/clang/bin/llvm-readobj.exe',
+    'crosscompile/clang/THIRD-PARTY-LICENSES.txt', 'crosscompile/clang/LICENSE-LLVM.txt', 'release.json')) {
+  if (-not (Test-Path (Join-Path $releaseRoot $entry))) { throw "Release archive is missing $entry" }
+}
+$metadata = Get-Content -Raw (Join-Path $releaseRoot 'release.json') | ConvertFrom-Json
+if ($metadata.goos -ne 'windows' -or $metadata.goarch -ne $GoArch -or $metadata.abi -ne $Profile -or
+    $archive.Name -ne "llgo$($metadata.version).windows-$GoArch-$Profile.tar.gz") {
+  throw 'The archive name, host architecture, and ABI metadata disagree'
+}
+$commit = (& git rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $metadata.commit -ne $commit) { throw 'The release belongs to a different commit' }
+
+$llgo = Join-Path $releaseRoot 'bin/llgo.exe'
+$readObj = Join-Path $releaseRoot 'crosscompile/clang/bin/llvm-readobj.exe'
+Copy-ReleaseDLLs -ReadObj $readObj -Executable $llgo -GoArch $GoArch -Profile $Profile -CheckOnly
+$go = (Get-Command go).Source
+$buildInfo = Invoke-ReleaseCapture $go @('version', '-m', $llgo)
+foreach ($setting in @("GOOS=windows", "GOARCH=$GoArch", "CGO_ENABLED=1", "vcs.revision=$commit", 'vcs.modified=false')) {
+  if (-not $buildInfo.Contains($setting)) { throw "Release Go build information is missing $setting" }
+}
+
+$savedPath = $env:PATH
+try {
+  Remove-Item Env:LLGO_ROOT -ErrorAction SilentlyContinue
+  $env:PATH = (Join-Path $releaseRoot 'bin') + ';' + (Join-Path $env:SystemRoot 'System32') + ';' + $env:SystemRoot
+  $version = (Invoke-ReleaseCapture $llgo @('version')).Trim()
+  if ($version -ne "llgo v$($metadata.version) windows/$GoArch") {
+    throw "Unexpected release compiler version: $version"
+  }
+} finally {
+  $env:PATH = $savedPath
+}
+Write-Host "Validated standalone windows/$GoArch/$Profile compiler and DLL closure"
+if ($CheckOnly) { return }
+
+# Native SDK/CRT and gc/libffi/etc. remain host dependencies, as for the Unix
+# integrated releases. setup-deps and activate-windows-target select that ABI.
+# LLGO_ROOT stays unset so both runtime and ESP Clang must come from the archive.
+$env:LLGO_BUILD_CACHE = 'off'
+$work = Join-Path $env:RUNNER_TEMP ('llgo-release-smoke-' + [Guid]::NewGuid())
+New-Item -ItemType Directory $work | Out-Null
+Push-Location $work
+try {
+  @'
+module release-smoke
+
+go 1.27
+
+require github.com/goplus/lib v0.5.1
+'@ | Set-Content -Encoding utf8 'go.mod'
+  @'
+package main
+
+import (
+	"fmt"
+	"github.com/goplus/lib/c"
+	"github.com/goplus/lib/cpp/std"
+)
+
+func main() {
+	fmt.Println("Hello, LLGo!")
+	println("Hello, LLGo!")
+	c.Printf(c.Str("Hello, LLGo!\n"))
+	c.Printf(std.Str("Hello LLGo by cpp/std.Str\n").CStr())
+}
+'@ | Set-Content -Encoding utf8 'main.go'
+  & $go mod tidy
+  if ($LASTEXITCODE -ne 0) { throw 'Preparing the native release smoke test failed' }
+  $program = Join-Path $work 'hello.exe'
+  $trace = Invoke-ReleaseCapture $llgo @('build', '-x', '-o', $program, '.')
+  $arch = @{ amd64 = 'x86_64'; arm64 = 'aarch64' }[$GoArch]
+  $triple = if ($Profile -eq 'msvc') { "$arch-pc-windows-msvc" } else { "$arch-w64-windows-gnu" }
+  if (-not $trace.Contains($triple)) { throw "Release smoke test did not select $triple`n$trace" }
+  $null = Assert-ReleasePE -ReadObj $readObj -Path $program -GoArch $GoArch -Profile $Profile
+  $env:LLGO_STDIO_NOBUF = '1'
+  $output = Invoke-ReleaseCapture $program @()
+  Remove-Item Env:LLGO_STDIO_NOBUF
+  $lines = $output -split "`r?`n"
+  if (@($lines | Where-Object { $_ -eq 'Hello, LLGo!' }).Count -ne 3 -or
+      $lines -notcontains 'Hello LLGo by cpp/std.Str') {
+    throw "Unexpected native Go/C/C++ output:`n$output"
+  }
+
+  New-Item -ItemType Directory 'embedded' | Out-Null
+  Set-Content -Encoding utf8 'embedded/main.go' 'package main; func main() {}'
+  $firmware = Join-Path $work 'embedded/demo.out'
+  $trace = Invoke-ReleaseCapture $llgo @('build', '-x', '-target', 'esp32-coreboard-v2', '-o', $firmware, './embedded')
+  if (-not (Test-Path "$firmware.elf")) { throw 'The integrated ESP Clang did not produce firmware' }
+  # Go traces can use either slash style on Windows.
+  if (-not $trace.Replace('\', '/').Contains($releaseRoot.Replace('\', '/') + '/crosscompile/clang')) {
+    throw "The embedded build did not use the extracted release toolchain`n$trace"
+  }
+  Write-Host "Passed native Go/C/C++ and integrated ESP builds for windows/$GoArch/$Profile"
+} finally {
+  Pop-Location
+  Remove-Item -LiteralPath $work -Recurse -Force
+}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -179,12 +182,18 @@ jobs:
           # MSVC uses the x64 bootstrap Clang, with architecture-matched LLVM
           # libraries and SDK for the resulting llgo.exe. MinGW builds natively.
           architecture: ${{ matrix.abi == 'mingw' && matrix.goarch == 'arm64' && 'arm64' || 'x64' }}
-      - name: Cache ARM64 MSVC release SDK
+      - name: Cache ARM64 MSVC release SDK archive
         if: matrix.abi == 'msvc' && matrix.goarch == 'arm64'
         uses: actions/cache@v6
         with:
-          path: ${{ runner.tool_cache }}/llgo-release-llvm/22.1.8/arm64
-          key: llgo-release-llvm-22.1.8-arm64-de718c58ebbc5f61d58c17b90457fcf42983bc2c4a4aba3e010d108713bfd7f1
+          path: ${{ runner.tool_cache }}/llgo-release-downloads/llvm-arm64
+          key: llgo-release-llvm-archive-v1-de718c58ebbc5f61d58c17b90457fcf42983bc2c4a4aba3e010d108713bfd7f1
+      - name: Cache ESP release archive
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.tool_cache }}/llgo-release-downloads/esp
+          key: llgo-release-esp-archive-v1-3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3
+          enableCrossOsArchive: true
       - name: Download release metadata
         uses: actions/download-artifact@v8
         with:
@@ -192,7 +201,9 @@ jobs:
           path: .windows-dist
       - name: Test Windows packaging checks
         shell: pwsh
-        run: ./.github/windows/release-lib_test.ps1
+        run: |
+          ./.github/windows/release-lib_test.ps1
+          ./.github/windows/release-build_test.ps1
       - name: Build integrated Windows archive
         shell: pwsh
         run: >-

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -143,6 +143,119 @@ jobs:
           retention-days: 3
           include-hidden-files: true
 
+      - name: Upload release metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: llgo-release-metadata
+          path: .dist/metadata.json
+          if-no-files-found: error
+          retention-days: 3
+          include-hidden-files: true
+
+  build-windows:
+    needs: build
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [msvc, mingw]
+        goarch: [amd64, arm64]
+        include:
+          - goarch: amd64
+            os: windows-2022
+          - goarch: arm64
+            os: windows-11-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install build dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          windows-abi: ${{ matrix.abi }}
+          windows-arch: ${{ matrix.goarch }}
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+        with:
+          # MSVC uses the x64 bootstrap Clang, with architecture-matched LLVM
+          # libraries and SDK for the resulting llgo.exe. MinGW builds natively.
+          architecture: ${{ matrix.abi == 'mingw' && matrix.goarch == 'arm64' && 'arm64' || 'x64' }}
+      - name: Cache ARM64 MSVC release SDK
+        if: matrix.abi == 'msvc' && matrix.goarch == 'arm64'
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.tool_cache }}/llgo-release-llvm/22.1.8/arm64
+          key: llgo-release-llvm-22.1.8-arm64-de718c58ebbc5f61d58c17b90457fcf42983bc2c4a4aba3e010d108713bfd7f1
+      - name: Download release metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: llgo-release-metadata
+          path: .windows-dist
+      - name: Test Windows packaging checks
+        shell: pwsh
+        run: ./.github/windows/release-lib_test.ps1
+      - name: Build integrated Windows archive
+        shell: pwsh
+        run: >-
+          ./.github/windows/build-release.ps1
+          -Profile '${{ matrix.abi }}' -GoArch '${{ matrix.goarch }}'
+      - name: Upload Windows archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: llgo-windows-${{ matrix.goarch }}-${{ matrix.abi }}
+          path: |
+            .windows-dist/*.windows-${{ matrix.goarch }}-${{ matrix.abi }}.tar.gz
+            .windows-dist/*.windows-${{ matrix.goarch }}-${{ matrix.abi }}.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 3
+          include-hidden-files: true
+          compression-level: 0
+
+  test-windows-artifacts:
+    needs: build-windows
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [msvc, mingw]
+        goarch: [amd64, arm64]
+        include:
+          - goarch: amd64
+            os: windows-2022
+          - goarch: arm64
+            os: windows-11-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+      - name: Download Windows archive
+        uses: actions/download-artifact@v8
+        with:
+          name: llgo-windows-${{ matrix.goarch }}-${{ matrix.abi }}
+          path: .windows-dist
+      # Execute the unpacked compiler before installing any LLVM or native
+      # dependencies: this catches missing DLLs that the build runner can mask.
+      - name: Verify standalone compiler and archive
+        shell: pwsh
+        run: >-
+          ./.github/windows/test-release.ps1 -CheckOnly
+          -Profile '${{ matrix.abi }}' -GoArch '${{ matrix.goarch }}'
+      - name: Install native target dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          windows-abi: ${{ matrix.abi }}
+          windows-arch: ${{ matrix.goarch }}
+      - name: Activate native Windows target
+        uses: ./.github/actions/activate-windows-target
+        with:
+          windows-abi: ${{ matrix.abi }}
+          windows-arch: ${{ matrix.goarch }}
+      - name: Test extracted native and embedded compiler
+        shell: pwsh
+        run: >-
+          ./.github/windows/test-release.ps1
+          -Profile '${{ matrix.abi }}' -GoArch '${{ matrix.goarch }}'
+
   test-artifacts:
     needs: build
     strategy:
@@ -196,7 +309,7 @@ jobs:
   release:
     permissions:
       contents: write
-    needs: [setup, test-artifacts, populate-linux-sysroot]
+    needs: [setup, test-artifacts, test-windows-artifacts, populate-linux-sysroot]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -211,6 +324,27 @@ jobs:
           path: .sysroot
       - name: Set up Release
         uses: ./.github/actions/setup-goreleaser
+      - name: Download tested Windows archives
+        uses: actions/download-artifact@v8
+        with:
+          pattern: llgo-windows-*
+          merge-multiple: true
+          path: .windows-dist
+      - name: Verify all four Windows archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          cd .windows-dist
+          archives=(llgo*.windows-*.tar.gz)
+          test "${#archives[@]}" = 4
+          for arch in amd64 arm64; do
+            for abi in msvc mingw; do
+              archive="llgo${version}.windows-${arch}-${abi}.tar.gz"
+              test -s "$archive"
+              sha256sum -c "$archive.sha256"
+            done
+          done
       - name: Run GoReleaser (Release)
         env:
           GITHUB_TOKEN: ${{github.token}}

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ go.work*
 # GoReleaser
 .dist/
 .sysroot/
+.windows-dist/
 
 # Embedded firmware files
 *.bin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,7 +89,7 @@ builds:
     mod_timestamp: "{{.CommitTimestamp}}"
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{.ProjectName}}{{.Version}}.{{.Os}}-{{.Arch}}
       {{- if .Arm}}v{{.Arm}}{{end}}
@@ -106,6 +106,11 @@ archives:
           mode: 0755
 checksum:
   name_template: "{{.ProjectName}}{{.Version}}.checksums.txt"
+  # Windows CGO builds run on native Windows runners and arrive as tested
+  # integrated archives. The snapshot pass produces the Unix build metadata
+  # they consume; the tag pass includes all eight archives in one checksum file.
+  extra_files:
+    - glob: '{{ if not .IsSnapshot }}.windows-dist/llgo{{ .Version }}.windows-*.tar.gz{{ end }}'
 
 nfpms:
   - package_name: llgo
@@ -169,7 +174,9 @@ snapcrafts:
       {{- if .Arm}}v{{.Arm}}{{end}}
 
 snapshot:
-  name_template: '{{trimprefix .Summary "v"}}'
+  version_template: '{{trimprefix .Summary "v"}}'
 
 release:
   prerelease: auto
+  extra_files:
+    - glob: '{{ if not .IsSnapshot }}.windows-dist/llgo{{ .Version }}.windows-*.tar.gz{{ end }}'

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Other targets may not provide every OS service or implementation-specific runtim
 
 | Target | Current coverage |
 | --- | --- |
-| Native | Linux amd64/arm64 and macOS amd64/arm64 [release artifacts](https://github.com/xgo-dev/llgo/releases); primary CI on Linux amd64 and macOS arm64 |
+| Native | Linux amd64/arm64, macOS amd64/arm64, and Windows amd64/arm64 (MSVC and MinGW) release builds; primary CI on Linux amd64, macOS arm64, and Windows toolchain profiles |
 | WebAssembly | `js/wasm` and `wasip1/wasm` builds; WASI and Emscripten CI coverage |
 | Embedded | [`-target`](doc/Embedded_Cmd.md) configurations for supported boards and MCUs, with selected QEMU/emulator smoke tests |
 
@@ -392,6 +392,21 @@ llgo run .
 ```
 
 ### on Windows
+
+The release workflow builds four integrated Windows archives:
+`llgo<VERSION>.windows-{amd64,arm64}-{msvc,mingw}.tar.gz`. Check the
+[release assets](https://github.com/xgo-dev/llgo/releases) for availability in
+each version. Add the extracted `bin` directory to `PATH`; the archives keep
+the same `runtime`, `targets`, and `crosscompile/clang` layout as Unix releases.
+The MSVC compiler links LLVM statically; MinGW archives include the native
+LLVM and C++ DLL dependencies beside `llgo.exe`.
+
+Use the archive matching your native architecture and toolchain profile. Native
+programs still need the corresponding SDK/CRT, Clang, and dependencies described
+below: Visual Studio's C++ developer environment for MSVC, or MSYS2 `CLANG64`
+(`amd64`) / `CLANGARM64` (`arm64`) for MinGW. The bundled ESP Clang remains the
+upstream x64 Windows payload, including in ARM64 archives, and runs through
+Windows' x64 emulation there; `llgo.exe` itself is native ARM64 in those archives.
 
 The recommended GNU-hosted setup is an MSYS2 `CLANG64` shell. Install the LLVM
 22 stack and LLGo's native dependencies, then provide the versioned pkg-config

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -57,8 +57,8 @@ included in a firmware image.
 
 ## Go modules compiled into the llgo executable
 
-This list is limited to modules in the shipped Darwin and Linux executable;
-development- and test-only modules are not included.
+This list is limited to modules in the shipped Darwin, Linux, and Windows
+executables; development- and test-only modules are not included.
 
 | Module | License |
 | --- | --- |
@@ -78,10 +78,13 @@ LLGo can download the Espressif-maintained ESP LLVM/Clang 22 toolchain
 [`22.1.4_20260905`](https://github.com/goplus/espressif-llvm-project-prebuilt/releases/tag/22.1.4_20260905).
 
 Current LLGo release archives use the LLVM 22 payload and include it under
-`crosscompile/clang`, because the shipped `llgo` executable dynamically links
-its LLVM library. Each payload includes `THIRD-PARTY-LICENSES.txt` and the
-component license texts for LLVM, Clang, LLD, compiler-rt, libc++, libc++abi,
-and libunwind.
+`crosscompile/clang`. Darwin and Linux executables dynamically link its LLVM
+library. Windows MSVC executables statically link the official LLVM 22.1.8
+development libraries; Windows MinGW executables carry their MSYS2 LLVM and
+transitive runtime DLLs in `bin`, with the component licenses preserved under
+`LICENSES/windows-runtime`. Each ESP payload includes `THIRD-PARTY-LICENSES.txt`
+and the component license texts for LLVM, Clang, LLD, compiler-rt, libc++,
+libc++abi, and libunwind.
 
 LLVM, Clang, LLD, libc++, libc++abi, libunwind, compiler-rt, and other
 LLVM-project components are licensed under Apache License 2.0 with LLVM

--- a/test/std/sync/sync_basic_test.go
+++ b/test/std/sync/sync_basic_test.go
@@ -77,19 +77,22 @@ func TestCondSkip(t *testing.T) {
 
 func TestConcurrentAccess(t *testing.T) {
 	var mu sync.Mutex
+	var wg sync.WaitGroup
 	counter := 0
 
 	// Test concurrent access to mutex
+	wg.Add(10)
 	for i := 0; i < 10; i++ {
 		go func() {
 			mu.Lock()
 			counter++
 			mu.Unlock()
+			wg.Done()
 		}()
 	}
 
 	// Wait for all goroutines to complete
-	time.Sleep(100 * time.Millisecond)
+	wg.Wait()
 
 	if counter != 10 {
 		t.Fatalf("Expected counter = 10, got %d", counter)


### PR DESCRIPTION
LLGo currently publishes integrated archives for Linux and macOS, while its Windows host profiles have no release packages. Add four archives covering Windows amd64 and arm64 with separate MSVC and MinGW builds, retaining the `bin`, `runtime`, `targets`, and `crosscompile/clang` layout.

Windows runners build the CGO compiler with architecture-matched LLVM libraries and package its DLL dependencies. Fresh artifact-test jobs verify checksums, compiler architecture and provenance, startup before installing LLVM dependencies, native Go/C/C++ execution, and firmware compilation with the extracted ESP toolchain. The tag job waits for all artifact tests and publishes the Windows archives through GoReleaser alongside the existing four archives in one checksum file.

The ARM64 MSVC compiler uses the pinned ARM64 LLVM 22.1.8 development libraries instead of the x64 host compiler used by the existing target-test lane. The bundled ESP Clang remains the existing upstream x64 Windows payload on both host architectures; ARM64 executes that companion toolchain through Windows x64 emulation. Native SDK/CRT and target dependencies remain external, as documented.

Validation:
- `actionlint` and GoReleaser 2.18.0 configuration validation passed.
- PowerShell syntax checks passed.
- Real amd64/arm64 PE regression fixtures passed DLL closure, missing dependency, architecture, and ABI checks.
- A local GoReleaser fixture verified inclusion of all four Windows archives in checksums and the snapshot metadata pass.
- `git diff --check` passed. Full Windows builds and extracted-archive runtime tests await PR CI.
