### PR TITLE
fix(build): stabilize wasm test flows

### DIFF
--- a/dev/test_wasm_single_worker.sh
+++ b/dev/test_wasm_single_worker.sh
@@ -89,6 +89,32 @@ run_llgo_test() {
 	grep -Fq "PASS" "${output}"
 }
 
+run_llgo_test_compile_only() {
+	local target="$1"
+	local name="$2"
+	local module
+	case "${target}" in
+	emscripten | emscripten-memory64 | wasm)
+		module="${work_dir}/${name}.mjs"
+		;;
+	*)
+		module="${work_dir}/${name}.wasm"
+		;;
+	esac
+
+	echo "testing public llgo test -c command for ${target}"
+	"${llgo_cmd}" test -target "${target}" -c -o "${module}" "${test_fixture}"
+	case "${module}" in
+	*.mjs)
+		test -s "${module}"
+		wasm-tools validate --features all "${module%.mjs}.wasm"
+		;;
+	*.wasm)
+		wasm-tools validate --features all "${module}"
+		;;
+	esac
+}
+
 # Canonical C-ecosystem profiles exercise the same scheduler semantics under
 # Emscripten wasm32, Emscripten Memory64/LP64, and WASI Preview 1.
 run_emscripten emscripten emscripten-runner.mjs "${scheduler_fixture}" "wasm scheduler ok" "scheduler-emscripten"
@@ -144,5 +170,8 @@ run_wasi wasip1 "${scheduler_fixture}" "wasm scheduler ok" "scheduler-legacy-was
 run_llgo_test emscripten "test-emscripten"
 run_llgo_test emscripten-memory64 "test-memory64"
 run_llgo_test wasi "test-wasi"
+run_llgo_test_compile_only emscripten "test-compile-only-emscripten"
+run_llgo_test_compile_only emscripten-memory64 "test-compile-only-memory64"
+run_llgo_test_compile_only wasi "test-compile-only-wasi"
 
 echo "single-worker WebAssembly scheduler and timer checks passed"

--- a/dev/test_wasm_single_worker.sh
+++ b/dev/test_wasm_single_worker.sh
@@ -94,7 +94,7 @@ run_llgo_test_compile_only() {
 	local name="$2"
 	local module
 	case "${target}" in
-	emscripten | emscripten-memory64 | wasm)
+	emscripten | emscripten-memory64)
 		module="${work_dir}/${name}.mjs"
 		;;
 	*)
@@ -103,7 +103,8 @@ run_llgo_test_compile_only() {
 	esac
 
 	echo "testing public llgo test -c command for ${target}"
-	"${llgo_cmd}" test -target "${target}" -c -o "${module}" "${test_fixture}"
+	run_with_timeout_limit 300s "${llgo_cmd}" test -target "${target}" -c \
+		-o "${module}" "${test_fixture}"
 	case "${module}" in
 	*.mjs)
 		test -s "${module}"

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1622,16 +1622,146 @@ func (c *context) clangConfig() clang.Config {
 func (c *context) linker() *clang.Cmd {
 	config := c.clangConfig()
 	cmd := clang.NewLinker(config)
+	linkerProgram := config.Linker
 	if config.Linker == "" && config.CXX != "" {
 		// Native LLGo historically linked through clang++. Preserve that C++
 		// runtime behavior while allowing CC and CXX to be selected and probed
 		// independently. An explicit -extld keeps Go's precedence.
 		cmd = clang.NewCXXCompiler(config)
+		linkerProgram = config.CXX
+	} else if linkerProgram == "" {
+		linkerProgram = config.CC
 	}
 	cmd.Dir = c.commands.dir
 	cmd.Env = slices.Clone(c.commands.environ)
+	if c.shouldHideClangImplicitWasmOpt(linkerProgram) {
+		cmd.Env = withoutClangImplicitWasmOpt(cmd.Env, linkerProgram)
+	}
 	cmd.Verbose = c.shouldPrintCommands(false)
 	return cmd
+}
+
+func (c *context) shouldHideClangImplicitWasmOpt(linkerProgram string) bool {
+	return c != nil &&
+		c.buildConf != nil &&
+		c.buildConf.Goarch == "wasm" &&
+		c.crossCompile.WasmPostLink.Asyncify &&
+		c.crossCompile.Linker == "" &&
+		clangDriverMayRunWasmOpt(linkerProgram)
+}
+
+func clangDriverMayRunWasmOpt(program string) bool {
+	name := strings.TrimSuffix(strings.ToLower(filepath.Base(program)), ".exe")
+	return name == "clang" || name == "clang++" ||
+		strings.HasSuffix(name, "-clang") || strings.HasSuffix(name, "-clang++")
+}
+
+func withoutClangImplicitWasmOpt(environ []string, compiler string) []string {
+	pathValue := lookupEnvValue(environ, "PATH")
+	if pathValue == "" {
+		return environ
+	}
+	compilerDir := resolveToolDirInPath(compiler, pathValue)
+	parts := filepath.SplitList(pathValue)
+	filtered := make([]string, 0, len(parts))
+	changed := false
+	for _, dir := range parts {
+		if pathEntryHasExecutable(dir, "wasm-opt") && !samePathEntry(dir, compilerDir) {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, dir)
+	}
+	if !changed {
+		return environ
+	}
+	return withEnv(environ, "PATH="+strings.Join(filtered, string(os.PathListSeparator)))
+}
+
+func lookupEnvValue(environ []string, name string) string {
+	for i := len(environ) - 1; i >= 0; i-- {
+		key, value, ok := strings.Cut(environ[i], "=")
+		if !ok {
+			continue
+		}
+		if key == name || runtime.GOOS == "windows" && strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}
+
+func resolveToolDirInPath(tool, pathValue string) string {
+	if tool == "" {
+		tool = "clang++"
+	}
+	if filepath.IsAbs(tool) || strings.ContainsAny(tool, `/\`) {
+		return filepath.Dir(tool)
+	}
+	for _, dir := range filepath.SplitList(pathValue) {
+		if pathEntryHasExecutable(dir, tool) {
+			return dir
+		}
+	}
+	return ""
+}
+
+func pathEntryHasExecutable(dir, name string) bool {
+	if dir == "" {
+		dir = "."
+	}
+	for _, candidate := range executableNames(name) {
+		info, err := os.Stat(filepath.Join(dir, candidate))
+		if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func executableNames(name string) []string {
+	if runtime.GOOS != "windows" || filepath.Ext(name) != "" {
+		return []string{name}
+	}
+	exts := filepath.SplitList(os.Getenv("PATHEXT"))
+	if len(exts) == 0 {
+		exts = []string{".COM", ".EXE", ".BAT", ".CMD"}
+	}
+	names := make([]string, 0, len(exts)+1)
+	names = append(names, name)
+	for _, ext := range exts {
+		if ext == "" {
+			continue
+		}
+		names = append(names, name+ext)
+		names = append(names, name+strings.ToLower(ext))
+	}
+	return names
+}
+
+func samePathEntry(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	a = canonicalPathEntry(a)
+	b = canonicalPathEntry(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func canonicalPathEntry(path string) string {
+	if path == "" {
+		path = "."
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path)
 }
 
 // shouldPrintCommands reports whether command tracing should be enabled.

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1712,7 +1712,7 @@ func pathEntryHasExecutable(dir, name string) bool {
 	}
 	for _, candidate := range executableNames(name) {
 		info, err := os.Stat(filepath.Join(dir, candidate))
-		if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+		if err == nil && !info.IsDir() && (runtime.GOOS == "windows" || info.Mode()&0o111 != 0) {
 			return true
 		}
 	}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1621,29 +1621,32 @@ func (c *context) clangConfig() clang.Config {
 
 func (c *context) linker() *clang.Cmd {
 	config := c.clangConfig()
-	cmd := clang.NewLinker(config)
 	linkerProgram := config.Linker
-	if config.Linker == "" && config.CXX != "" {
+	useCXX := config.Linker == "" && config.CXX != ""
+	if useCXX {
 		// Native LLGo historically linked through clang++. Preserve that C++
 		// runtime behavior while allowing CC and CXX to be selected and probed
 		// independently. An explicit -extld keeps Go's precedence.
-		cmd = clang.NewCXXCompiler(config)
 		linkerProgram = config.CXX
 	} else if linkerProgram == "" {
 		linkerProgram = config.CC
 	}
+	if c.shouldDisableClangImplicitWasmOpt(linkerProgram) {
+		config.LDFLAGS = append(slices.Clone(config.LDFLAGS), "--no-wasm-opt")
+	}
+	cmd := clang.NewLinker(config)
+	if useCXX {
+		cmd = clang.NewCXXCompiler(config)
+	}
 	cmd.Dir = c.commands.dir
 	cmd.Env = slices.Clone(c.commands.environ)
-	if c.shouldHideClangImplicitWasmOpt(linkerProgram) {
-		cmd.Env = withoutClangImplicitWasmOpt(cmd.Env, linkerProgram)
-	}
 	cmd.Verbose = c.shouldPrintCommands(false)
 	return cmd
 }
 
-// shouldHideClangImplicitWasmOpt reports whether clang could run wasm-opt
-// before LLGo's configured Asyncify post-link pass.
-func (c *context) shouldHideClangImplicitWasmOpt(linkerProgram string) bool {
+// shouldDisableClangImplicitWasmOpt reports whether LLGo owns the wasm-opt
+// pipeline and must disable clang's implicit post-link optimization.
+func (c *context) shouldDisableClangImplicitWasmOpt(linkerProgram string) bool {
 	return c != nil &&
 		c.buildConf != nil &&
 		c.buildConf.Goarch == "wasm" &&
@@ -1658,136 +1661,6 @@ func clangDriverMayRunWasmOpt(program string) bool {
 	name := strings.TrimSuffix(strings.ToLower(filepath.Base(program)), ".exe")
 	return name == "clang" || name == "clang++" ||
 		strings.HasSuffix(name, "-clang") || strings.HasSuffix(name, "-clang++")
-}
-
-// withoutClangImplicitWasmOpt hides standalone Binaryen installations from a
-// clang link while retaining the directory that supplies the compiler itself.
-// If the compiler directory cannot be identified safely, it leaves PATH alone.
-func withoutClangImplicitWasmOpt(environ []string, compiler string) []string {
-	pathValue := lookupEnvValue(environ, "PATH")
-	if pathValue == "" {
-		return environ
-	}
-	compilerDir := resolveToolDirInPath(compiler, pathValue)
-	if compilerDir == "" {
-		return environ
-	}
-	canonicalCompilerDir, err := canonicalPathEntry(compilerDir)
-	if err != nil {
-		return environ
-	}
-	parts := filepath.SplitList(pathValue)
-	filtered := make([]string, 0, len(parts))
-	changed := false
-	for _, dir := range parts {
-		if pathEntryHasExecutable(dir, "wasm-opt") {
-			canonicalDir, err := canonicalPathEntry(dir)
-			if err != nil {
-				return environ
-			}
-			if !sameCanonicalPath(canonicalDir, canonicalCompilerDir) {
-				changed = true
-				continue
-			}
-		}
-		filtered = append(filtered, dir)
-	}
-	if !changed {
-		return environ
-	}
-	return withEnv(environ, "PATH="+strings.Join(filtered, string(os.PathListSeparator)))
-}
-
-// lookupEnvValue returns the last well-formed value for name, matching the
-// platform's environment-key case rules.
-func lookupEnvValue(environ []string, name string) string {
-	for i := len(environ) - 1; i >= 0; i-- {
-		key, value, ok := strings.Cut(environ[i], "=")
-		if !ok {
-			continue
-		}
-		if key == name || runtime.GOOS == "windows" && strings.EqualFold(key, name) {
-			return value
-		}
-	}
-	return ""
-}
-
-// resolveToolDirInPath returns the PATH entry that supplies tool, or the
-// containing directory when tool already contains a path.
-func resolveToolDirInPath(tool, pathValue string) string {
-	if tool == "" {
-		tool = "clang++"
-	}
-	if filepath.IsAbs(tool) || strings.ContainsAny(tool, `/\`) {
-		return filepath.Dir(tool)
-	}
-	for _, dir := range filepath.SplitList(pathValue) {
-		if pathEntryHasExecutable(dir, tool) {
-			return dir
-		}
-	}
-	return ""
-}
-
-// pathEntryHasExecutable reports whether dir contains an executable named
-// name, including PATHEXT variants on Windows.
-func pathEntryHasExecutable(dir, name string) bool {
-	if dir == "" {
-		dir = "."
-	}
-	for _, candidate := range executableNames(name) {
-		info, err := os.Stat(filepath.Join(dir, candidate))
-		if err == nil && !info.IsDir() && (runtime.GOOS == "windows" || info.Mode()&0o111 != 0) {
-			return true
-		}
-	}
-	return false
-}
-
-// executableNames returns the filenames Windows or Unix would consider for an
-// executable name in one PATH entry.
-func executableNames(name string) []string {
-	if runtime.GOOS != "windows" || filepath.Ext(name) != "" {
-		return []string{name}
-	}
-	exts := filepath.SplitList(os.Getenv("PATHEXT"))
-	if len(exts) == 0 {
-		exts = []string{".COM", ".EXE", ".BAT", ".CMD"}
-	}
-	names := make([]string, 0, len(exts)+1)
-	names = append(names, name)
-	for _, ext := range exts {
-		if ext == "" {
-			continue
-		}
-		names = append(names, name+ext)
-	}
-	return names
-}
-
-// sameCanonicalPath compares already-canonicalized paths using platform rules.
-func sameCanonicalPath(a, b string) bool {
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(a, b)
-	}
-	return a == b
-}
-
-// canonicalPathEntry makes a PATH entry absolute and resolves its symlinks.
-func canonicalPathEntry(path string) (string, error) {
-	if path == "" {
-		path = "."
-	}
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	resolved, err := filepath.EvalSymlinks(abs)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Clean(resolved), nil
 }
 
 // shouldPrintCommands reports whether command tracing should be enabled.

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1641,6 +1641,8 @@ func (c *context) linker() *clang.Cmd {
 	return cmd
 }
 
+// shouldHideClangImplicitWasmOpt reports whether clang could run wasm-opt
+// before LLGo's configured Asyncify post-link pass.
 func (c *context) shouldHideClangImplicitWasmOpt(linkerProgram string) bool {
 	return c != nil &&
 		c.buildConf != nil &&
@@ -1650,25 +1652,43 @@ func (c *context) shouldHideClangImplicitWasmOpt(linkerProgram string) bool {
 		clangDriverMayRunWasmOpt(linkerProgram)
 }
 
+// clangDriverMayRunWasmOpt identifies clang drivers. Emscripten drivers are
+// deliberately excluded because they manage their own wasm-opt pipeline.
 func clangDriverMayRunWasmOpt(program string) bool {
 	name := strings.TrimSuffix(strings.ToLower(filepath.Base(program)), ".exe")
 	return name == "clang" || name == "clang++" ||
 		strings.HasSuffix(name, "-clang") || strings.HasSuffix(name, "-clang++")
 }
 
+// withoutClangImplicitWasmOpt hides standalone Binaryen installations from a
+// clang link while retaining the directory that supplies the compiler itself.
+// If the compiler directory cannot be identified safely, it leaves PATH alone.
 func withoutClangImplicitWasmOpt(environ []string, compiler string) []string {
 	pathValue := lookupEnvValue(environ, "PATH")
 	if pathValue == "" {
 		return environ
 	}
 	compilerDir := resolveToolDirInPath(compiler, pathValue)
+	if compilerDir == "" {
+		return environ
+	}
+	canonicalCompilerDir, err := canonicalPathEntry(compilerDir)
+	if err != nil {
+		return environ
+	}
 	parts := filepath.SplitList(pathValue)
 	filtered := make([]string, 0, len(parts))
 	changed := false
 	for _, dir := range parts {
-		if pathEntryHasExecutable(dir, "wasm-opt") && !samePathEntry(dir, compilerDir) {
-			changed = true
-			continue
+		if pathEntryHasExecutable(dir, "wasm-opt") {
+			canonicalDir, err := canonicalPathEntry(dir)
+			if err != nil {
+				return environ
+			}
+			if !sameCanonicalPath(canonicalDir, canonicalCompilerDir) {
+				changed = true
+				continue
+			}
 		}
 		filtered = append(filtered, dir)
 	}
@@ -1678,6 +1698,8 @@ func withoutClangImplicitWasmOpt(environ []string, compiler string) []string {
 	return withEnv(environ, "PATH="+strings.Join(filtered, string(os.PathListSeparator)))
 }
 
+// lookupEnvValue returns the last well-formed value for name, matching the
+// platform's environment-key case rules.
 func lookupEnvValue(environ []string, name string) string {
 	for i := len(environ) - 1; i >= 0; i-- {
 		key, value, ok := strings.Cut(environ[i], "=")
@@ -1691,6 +1713,8 @@ func lookupEnvValue(environ []string, name string) string {
 	return ""
 }
 
+// resolveToolDirInPath returns the PATH entry that supplies tool, or the
+// containing directory when tool already contains a path.
 func resolveToolDirInPath(tool, pathValue string) string {
 	if tool == "" {
 		tool = "clang++"
@@ -1706,6 +1730,8 @@ func resolveToolDirInPath(tool, pathValue string) string {
 	return ""
 }
 
+// pathEntryHasExecutable reports whether dir contains an executable named
+// name, including PATHEXT variants on Windows.
 func pathEntryHasExecutable(dir, name string) bool {
 	if dir == "" {
 		dir = "."
@@ -1719,6 +1745,8 @@ func pathEntryHasExecutable(dir, name string) bool {
 	return false
 }
 
+// executableNames returns the filenames Windows or Unix would consider for an
+// executable name in one PATH entry.
 func executableNames(name string) []string {
 	if runtime.GOOS != "windows" || filepath.Ext(name) != "" {
 		return []string{name}
@@ -1734,34 +1762,32 @@ func executableNames(name string) []string {
 			continue
 		}
 		names = append(names, name+ext)
-		names = append(names, name+strings.ToLower(ext))
 	}
 	return names
 }
 
-func samePathEntry(a, b string) bool {
-	if a == "" || b == "" {
-		return false
-	}
-	a = canonicalPathEntry(a)
-	b = canonicalPathEntry(b)
+// sameCanonicalPath compares already-canonicalized paths using platform rules.
+func sameCanonicalPath(a, b string) bool {
 	if runtime.GOOS == "windows" {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
 }
 
-func canonicalPathEntry(path string) string {
+// canonicalPathEntry makes a PATH entry absolute and resolves its symlinks.
+func canonicalPathEntry(path string) (string, error) {
 	if path == "" {
 		path = "."
 	}
-	if abs, err := filepath.Abs(path); err == nil {
-		path = abs
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
 	}
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		path = resolved
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
 	}
-	return filepath.Clean(path)
+	return filepath.Clean(resolved), nil
 }
 
 // shouldPrintCommands reports whether command tracing should be enabled.

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1638,6 +1638,63 @@ func TestExecuteInitialPackageLinkCompileOnlyNamedTargetDoesNotExecute(t *testin
 	}
 }
 
+func TestWithoutClangImplicitWasmOptRemovesStandaloneBinaryenPath(t *testing.T) {
+	binaryenDir := t.TempDir()
+	clangDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binaryenDir, "wasm-opt"))
+	writeExecutable(t, filepath.Join(clangDir, "clang++"))
+
+	got := withoutClangImplicitWasmOpt(
+		[]string{"PATH=" + strings.Join([]string{binaryenDir, clangDir}, string(os.PathListSeparator))},
+		"clang++",
+	)
+	pathValue := lookupEnvValue(got, "PATH")
+	if strings.Contains(pathValue, binaryenDir) {
+		t.Fatalf("PATH still exposes standalone wasm-opt directory: %q", pathValue)
+	}
+	if !strings.Contains(pathValue, clangDir) {
+		t.Fatalf("PATH dropped compiler directory: %q", pathValue)
+	}
+}
+
+func TestWithoutClangImplicitWasmOptKeepsCompilerDirectory(t *testing.T) {
+	toolDir := t.TempDir()
+	writeExecutable(t, filepath.Join(toolDir, "clang++"))
+	writeExecutable(t, filepath.Join(toolDir, "wasm-opt"))
+	environ := []string{"PATH=" + toolDir}
+
+	got := withoutClangImplicitWasmOpt(environ, "clang++")
+	if !slices.Equal(got, environ) {
+		t.Fatalf("withoutClangImplicitWasmOpt changed compiler directory env: got %q want %q", got, environ)
+	}
+}
+
+func TestShouldHideClangImplicitWasmOptOnlyForWasmPostLinkClang(t *testing.T) {
+	ctx := &context{
+		buildConf: &Config{Goarch: "wasm"},
+		crossCompile: crosscompile.Export{
+			WasmPostLink: crosscompile.WasmPostLink{Asyncify: true},
+		},
+	}
+	if !ctx.shouldHideClangImplicitWasmOpt("clang++") {
+		t.Fatal("wasm Asyncify clang link did not hide clang's implicit wasm-opt")
+	}
+	if ctx.shouldHideClangImplicitWasmOpt("emcc") {
+		t.Fatal("Emscripten driver should keep its wasm-opt-visible environment")
+	}
+	ctx.buildConf.Goarch = "arm"
+	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
+		t.Fatal("non-wasm clang link hid wasm-opt")
+	}
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 	// Test that -o flag errors with multiple test packages
 	cfg := &Config{

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1690,6 +1690,9 @@ func TestShouldHideClangImplicitWasmOptOnlyForWasmPostLinkClang(t *testing.T) {
 
 func writeExecutable(t *testing.T, path string) {
 	t.Helper()
+	if runtime.GOOS == "windows" && filepath.Ext(path) == "" {
+		path += ".exe"
+	}
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -39,7 +39,17 @@ import (
 func TestMain(m *testing.M) {
 	if mode := os.Getenv("LLGO_TEST_WASM_OPT_HELPER"); mode != "" {
 		if argsFile := os.Getenv("ARGS_FILE"); argsFile != "" {
-			_ = os.WriteFile(argsFile, []byte(strings.Join(os.Args[1:], "\n")+"\n"), 0o666)
+			file, err := os.OpenFile(argsFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
+			if err == nil {
+				_, err = fmt.Fprintln(file, "---\n"+strings.Join(os.Args[1:], "\n"))
+				if closeErr := file.Close(); err == nil {
+					err = closeErr
+				}
+			}
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(9)
+			}
 		}
 		if mode == "fail" {
 			os.Exit(7)
@@ -78,6 +88,12 @@ func TestMain(m *testing.M) {
 		os.Exit(7)
 	}
 	if mode := os.Getenv("LLGO_TEST_LINKER_HELPER"); mode != "" {
+		if argsFile := os.Getenv("LINK_ARGS_FILE"); argsFile != "" {
+			if err := os.WriteFile(argsFile, []byte(strings.Join(os.Args[1:], "\n")+"\n"), 0o666); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(11)
+			}
+		}
 		if mode == "fail" {
 			fmt.Fprintln(os.Stderr, "link failed")
 			os.Exit(8)
@@ -657,17 +673,6 @@ func TestRewritePrebuiltFuncTabEligibilityAndDiagnostic(t *testing.T) {
 func TestWithEnvLastValueWins(t *testing.T) {
 	got := withEnv([]string{"A=old", "B=keep", "malformed", "A=older"}, "A=new", "C=value")
 	want := []string{"B=keep", "A=new", "C=value"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("withEnv = %q, want %q", got, want)
-	}
-}
-
-func TestWithEnvWindowsKeyCasing(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows environment keys are case-insensitive")
-	}
-	got := withEnv([]string{"Path=old", "PATH=older", "KEEP=value"}, "PATH=new")
-	want := []string{"KEEP=value", "PATH=new"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("withEnv = %q, want %q", got, want)
 	}
@@ -1649,97 +1654,70 @@ func TestExecuteInitialPackageLinkCompileOnlyNamedTargetDoesNotExecute(t *testin
 	}
 }
 
-func TestWithoutClangImplicitWasmOptRemovesStandaloneBinaryenPath(t *testing.T) {
-	binaryenDir := t.TempDir()
-	clangDir := t.TempDir()
-	writeExecutable(t, filepath.Join(binaryenDir, "wasm-opt"))
-	writeExecutable(t, filepath.Join(clangDir, "clang++"))
-
-	got := withoutClangImplicitWasmOpt(
-		[]string{"PATH=" + strings.Join([]string{binaryenDir, clangDir}, string(os.PathListSeparator))},
-		"clang++",
-	)
-	pathValue := lookupEnvValue(got, "PATH")
-	if strings.Contains(pathValue, binaryenDir) {
-		t.Fatalf("PATH still exposes standalone wasm-opt directory: %q", pathValue)
-	}
-	if !strings.Contains(pathValue, clangDir) {
-		t.Fatalf("PATH dropped compiler directory: %q", pathValue)
-	}
-}
-
-func TestWithoutClangImplicitWasmOptKeepsCompilerDirectory(t *testing.T) {
-	toolDir := t.TempDir()
-	writeExecutable(t, filepath.Join(toolDir, "clang++"))
-	writeExecutable(t, filepath.Join(toolDir, "wasm-opt"))
-	environ := []string{"PATH=" + toolDir}
-
-	got := withoutClangImplicitWasmOpt(environ, "clang++")
-	if !slices.Equal(got, environ) {
-		t.Fatalf("withoutClangImplicitWasmOpt changed compiler directory env: got %q want %q", got, environ)
-	}
-}
-
-func TestWithoutClangImplicitWasmOptKeepsEnvironmentWhenCompilerMissing(t *testing.T) {
-	binaryenDir := t.TempDir()
-	writeExecutable(t, filepath.Join(binaryenDir, "wasm-opt"))
-	environ := []string{"PATH=" + binaryenDir}
-
-	got := withoutClangImplicitWasmOpt(environ, "clang++")
-	if !slices.Equal(got, environ) {
-		t.Fatalf("withoutClangImplicitWasmOpt changed env without a compiler: got %q want %q", got, environ)
-	}
-}
-
-func TestWithoutClangImplicitWasmOptKeepsEnvironmentOnCanonicalizationFailure(t *testing.T) {
-	binaryenDir := t.TempDir()
-	writeExecutable(t, filepath.Join(binaryenDir, "wasm-opt"))
-	missingCompiler := filepath.Join(t.TempDir(), "missing", "clang++")
-	environ := []string{"PATH=" + binaryenDir}
-
-	got := withoutClangImplicitWasmOpt(environ, missingCompiler)
-	if !slices.Equal(got, environ) {
-		t.Fatalf("withoutClangImplicitWasmOpt changed env after canonicalization failure: got %q want %q", got, environ)
-	}
-}
-
-func TestWithoutClangImplicitWasmOptKeepsEmptyPath(t *testing.T) {
-	environ := []string{"OTHER=value"}
-	got := withoutClangImplicitWasmOpt(environ, "clang++")
-	if !slices.Equal(got, environ) {
-		t.Fatalf("withoutClangImplicitWasmOpt changed env without PATH: got %q want %q", got, environ)
-	}
-}
-
-func TestShouldHideClangImplicitWasmOptOnlyForWasmPostLinkClang(t *testing.T) {
+func TestShouldDisableClangImplicitWasmOptOnlyForWasmPostLinkClang(t *testing.T) {
 	ctx := &context{
 		buildConf: &Config{Goarch: "wasm"},
 		crossCompile: crosscompile.Export{
 			WasmPostLink: crosscompile.WasmPostLink{Asyncify: true},
 		},
 	}
-	if !ctx.shouldHideClangImplicitWasmOpt("clang++") {
-		t.Fatal("wasm Asyncify clang link did not hide clang's implicit wasm-opt")
+	if !ctx.shouldDisableClangImplicitWasmOpt("clang++") {
+		t.Fatal("wasm Asyncify clang link did not disable clang's implicit wasm-opt")
 	}
-	if ctx.shouldHideClangImplicitWasmOpt("emcc") {
-		t.Fatal("Emscripten driver should keep its wasm-opt-visible environment")
+	if ctx.shouldDisableClangImplicitWasmOpt("emcc") {
+		t.Fatal("Emscripten driver should retain its own wasm-opt pipeline")
 	}
 	ctx.buildConf.Goarch = "arm"
-	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
-		t.Fatal("non-wasm clang link hid wasm-opt")
+	if ctx.shouldDisableClangImplicitWasmOpt("clang++") {
+		t.Fatal("non-wasm clang link disabled wasm-opt")
 	}
 	ctx.buildConf.Goarch = "wasm"
 	ctx.crossCompile.WasmPostLink.Asyncify = false
-	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
-		t.Fatal("non-Asyncify wasm link hid wasm-opt")
+	if ctx.shouldDisableClangImplicitWasmOpt("clang++") {
+		t.Fatal("non-Asyncify wasm link disabled wasm-opt")
 	}
 	ctx.crossCompile.WasmPostLink.Asyncify = true
 	ctx.crossCompile.Linker = "custom-linker"
-	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
-		t.Fatal("explicit external linker hid wasm-opt")
+	if ctx.shouldDisableClangImplicitWasmOpt("clang++") {
+		t.Fatal("explicit external linker disabled wasm-opt")
 	}
-	if (*context)(nil).shouldHideClangImplicitWasmOpt("clang++") {
-		t.Fatal("nil context hid wasm-opt")
+	if (*context)(nil).shouldDisableClangImplicitWasmOpt("clang++") {
+		t.Fatal("nil context disabled wasm-opt")
+	}
+}
+
+func TestLinkerDisablesClangImplicitWasmOpt(t *testing.T) {
+	for _, driver := range []string{"clang", "clang++"} {
+		t.Run(driver, func(t *testing.T) {
+			dir := t.TempDir()
+			tool := writeBuildTestTool(t, dir, driver)
+			argsFile := filepath.Join(dir, "args")
+			output := filepath.Join(dir, "linked.wasm")
+			t.Setenv("LLGO_TEST_LINKER_HELPER", "write")
+			t.Setenv("LINK_ARGS_FILE", argsFile)
+
+			target := crosscompile.Export{
+				CC:           tool,
+				WasmPostLink: crosscompile.WasmPostLink{Asyncify: true},
+			}
+			if driver == "clang++" {
+				target.CXX = tool
+			}
+			ctx := &context{
+				buildConf:    &Config{Goarch: "wasm"},
+				crossCompile: target,
+			}
+			if err := ctx.linker().Link("-o", output); err != nil {
+				t.Fatal(err)
+			}
+			args, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(strings.Split(strings.TrimSpace(string(args)), "\n"), "--no-wasm-opt") {
+				t.Fatalf("%s link args did not disable implicit wasm-opt: %q", driver, args)
+			}
+		})
 	}
 }
 
@@ -1757,16 +1735,6 @@ func TestClangDriverMayRunWasmOpt(t *testing.T) {
 		if got := clangDriverMayRunWasmOpt(program); got != want {
 			t.Errorf("clangDriverMayRunWasmOpt(%q) = %v, want %v", program, got, want)
 		}
-	}
-}
-
-func writeExecutable(t *testing.T, path string) {
-	t.Helper()
-	if runtime.GOOS == "windows" && filepath.Ext(path) == "" {
-		path += ".exe"
-	}
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -662,6 +662,17 @@ func TestWithEnvLastValueWins(t *testing.T) {
 	}
 }
 
+func TestWithEnvWindowsKeyCasing(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows environment keys are case-insensitive")
+	}
+	got := withEnv([]string{"Path=old", "PATH=older", "KEEP=value"}, "PATH=new")
+	want := []string{"KEEP=value", "PATH=new"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("withEnv = %q, want %q", got, want)
+	}
+}
+
 func TestWithResolvedGoToolchain(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1669,6 +1680,37 @@ func TestWithoutClangImplicitWasmOptKeepsCompilerDirectory(t *testing.T) {
 	}
 }
 
+func TestWithoutClangImplicitWasmOptKeepsEnvironmentWhenCompilerMissing(t *testing.T) {
+	binaryenDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binaryenDir, "wasm-opt"))
+	environ := []string{"PATH=" + binaryenDir}
+
+	got := withoutClangImplicitWasmOpt(environ, "clang++")
+	if !slices.Equal(got, environ) {
+		t.Fatalf("withoutClangImplicitWasmOpt changed env without a compiler: got %q want %q", got, environ)
+	}
+}
+
+func TestWithoutClangImplicitWasmOptKeepsEnvironmentOnCanonicalizationFailure(t *testing.T) {
+	binaryenDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binaryenDir, "wasm-opt"))
+	missingCompiler := filepath.Join(t.TempDir(), "missing", "clang++")
+	environ := []string{"PATH=" + binaryenDir}
+
+	got := withoutClangImplicitWasmOpt(environ, missingCompiler)
+	if !slices.Equal(got, environ) {
+		t.Fatalf("withoutClangImplicitWasmOpt changed env after canonicalization failure: got %q want %q", got, environ)
+	}
+}
+
+func TestWithoutClangImplicitWasmOptKeepsEmptyPath(t *testing.T) {
+	environ := []string{"OTHER=value"}
+	got := withoutClangImplicitWasmOpt(environ, "clang++")
+	if !slices.Equal(got, environ) {
+		t.Fatalf("withoutClangImplicitWasmOpt changed env without PATH: got %q want %q", got, environ)
+	}
+}
+
 func TestShouldHideClangImplicitWasmOptOnlyForWasmPostLinkClang(t *testing.T) {
 	ctx := &context{
 		buildConf: &Config{Goarch: "wasm"},
@@ -1685,6 +1727,36 @@ func TestShouldHideClangImplicitWasmOptOnlyForWasmPostLinkClang(t *testing.T) {
 	ctx.buildConf.Goarch = "arm"
 	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
 		t.Fatal("non-wasm clang link hid wasm-opt")
+	}
+	ctx.buildConf.Goarch = "wasm"
+	ctx.crossCompile.WasmPostLink.Asyncify = false
+	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
+		t.Fatal("non-Asyncify wasm link hid wasm-opt")
+	}
+	ctx.crossCompile.WasmPostLink.Asyncify = true
+	ctx.crossCompile.Linker = "custom-linker"
+	if ctx.shouldHideClangImplicitWasmOpt("clang++") {
+		t.Fatal("explicit external linker hid wasm-opt")
+	}
+	if (*context)(nil).shouldHideClangImplicitWasmOpt("clang++") {
+		t.Fatal("nil context hid wasm-opt")
+	}
+}
+
+func TestClangDriverMayRunWasmOpt(t *testing.T) {
+	tests := map[string]bool{
+		"clang":                  true,
+		"clang++":                true,
+		"wasm32-unknown-clang":   true,
+		"wasm32-unknown-clang++": true,
+		"clang.exe":              true,
+		"emcc":                   false,
+		"wasm-ld":                false,
+	}
+	for program, want := range tests {
+		if got := clangDriverMayRunWasmOpt(program); got != want {
+			t.Errorf("clangDriverMayRunWasmOpt(%q) = %v, want %v", program, got, want)
+		}
 	}
 }
 

--- a/internal/build/invocation.go
+++ b/internal/build/invocation.go
@@ -72,14 +72,14 @@ func withEnv(environ []string, values ...string) []string {
 	keys := make(map[string]struct{}, len(values))
 	for _, value := range values {
 		if key, _, ok := strings.Cut(value, "="); ok {
-			keys[normalizedEnvKey(key)] = struct{}{}
+			keys[key] = struct{}{}
 		}
 	}
 	ret := make([]string, 0, len(environ)+len(values))
 	for _, value := range environ {
 		key, _, ok := strings.Cut(value, "=")
 		// Drop malformed passthrough entries: exec.Cmd requires KEY=VALUE.
-		if _, replace := keys[normalizedEnvKey(key)]; ok && replace {
+		if _, replace := keys[key]; ok && replace {
 			continue
 		}
 		if ok {
@@ -87,15 +87,6 @@ func withEnv(environ []string, values ...string) []string {
 		}
 	}
 	return append(ret, values...)
-}
-
-// normalizedEnvKey preserves Unix key semantics and folds Windows keys to
-// match the case-insensitive environment seen by child processes.
-func normalizedEnvKey(key string) string {
-	if runtime.GOOS == "windows" {
-		return strings.ToUpper(key)
-	}
-	return key
 }
 
 func withResolvedGoToolchain(environ []string, goversion string) []string {

--- a/internal/build/invocation.go
+++ b/internal/build/invocation.go
@@ -72,14 +72,14 @@ func withEnv(environ []string, values ...string) []string {
 	keys := make(map[string]struct{}, len(values))
 	for _, value := range values {
 		if key, _, ok := strings.Cut(value, "="); ok {
-			keys[key] = struct{}{}
+			keys[normalizedEnvKey(key)] = struct{}{}
 		}
 	}
 	ret := make([]string, 0, len(environ)+len(values))
 	for _, value := range environ {
 		key, _, ok := strings.Cut(value, "=")
 		// Drop malformed passthrough entries: exec.Cmd requires KEY=VALUE.
-		if _, replace := keys[key]; ok && replace {
+		if _, replace := keys[normalizedEnvKey(key)]; ok && replace {
 			continue
 		}
 		if ok {
@@ -87,6 +87,15 @@ func withEnv(environ []string, values ...string) []string {
 		}
 	}
 	return append(ret, values...)
+}
+
+// normalizedEnvKey preserves Unix key semantics and folds Windows keys to
+// match the case-insensitive environment seen by child processes.
+func normalizedEnvKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
 }
 
 func withResolvedGoToolchain(environ []string, goversion string) []string {

--- a/internal/build/wasm_postlink.go
+++ b/internal/build/wasm_postlink.go
@@ -54,6 +54,16 @@ func wasmPostLinkArgs(target *crosscompile.Export, input, output string, debug b
 	return append(args, input, "-o", output)
 }
 
+func wasmPreAsyncifyArgs(target *crosscompile.Export, input, output string, level optlevel.Level) []string {
+	if target == nil || !target.WasmPostLink.Asyncify || !level.IsValid() || level == optlevel.O0 {
+		return nil
+	}
+	// Clang normally runs this optimization after wasm-ld. Keep it explicit so
+	// LLGo can disable clang's implicit wasm-opt pass without changing the
+	// established optimization order or binary size.
+	return []string{level.Flag(), input, "-o", output}
+}
+
 func prepareWasmLinkOutput(conf *Config, target *crosscompile.Export, output string) (string, error) {
 	if !needsWasmPostLink(conf, target) {
 		return output, nil
@@ -100,6 +110,18 @@ func postLinkWasm(ctx *context, input, output string, verbose bool) error {
 		return fmt.Errorf("WebAssembly Asyncify requires wasm-opt; install Binaryen or set WASMOPT: %w", err)
 	}
 
+	preAsyncifyArgs := wasmPreAsyncifyArgs(
+		&ctx.crossCompile,
+		input,
+		input,
+		ctx.buildConf.OptLevel,
+	)
+	if preAsyncifyArgs != nil {
+		if err := runWasmOpt(resolved, preAsyncifyArgs, verbose, ctx); err != nil {
+			return fmt.Errorf("wasm-opt pre-Asyncify optimization failed: %w", err)
+		}
+	}
+
 	tmpName, err := createClosedTemp(
 		filepath.Dir(output),
 		"."+filepath.Base(output)+".wasm-opt-*",
@@ -116,17 +138,21 @@ func postLinkWasm(ctx *context, input, output string, verbose bool) error {
 		shouldEmitDebugInfo(ctx.buildConf, &ctx.crossCompile),
 		ctx.buildConf.OptLevel,
 	)
-	if ctx.shouldPrintCommands(verbose) {
-		fmt.Fprintln(os.Stderr, resolved, args)
-	}
-	cmd := exec.Command(resolved, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := runWasmOpt(resolved, args, verbose, ctx); err != nil {
 		return fmt.Errorf("wasm-opt Asyncify failed: %w", err)
 	}
 	if err := os.Rename(tmpName, output); err != nil {
 		return err
 	}
 	return nil
+}
+
+func runWasmOpt(resolved string, args []string, verbose bool, ctx *context) error {
+	if ctx.shouldPrintCommands(verbose) {
+		fmt.Fprintln(os.Stderr, resolved, args)
+	}
+	cmd := exec.Command(resolved, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/internal/build/wasm_postlink_test.go
+++ b/internal/build/wasm_postlink_test.go
@@ -42,12 +42,16 @@ func wasmPostLinkTestContext() *context {
 }
 
 func writeWasmOptTestTool(t *testing.T, dir string) string {
+	return writeBuildTestTool(t, dir, "wasm-opt")
+}
+
+func writeBuildTestTool(t *testing.T, dir, name string) string {
 	t.Helper()
 	executable, err := os.Executable()
 	if err != nil {
 		t.Fatal(err)
 	}
-	tool := filepath.Join(dir, "wasm-opt")
+	tool := filepath.Join(dir, name)
 	if filepath.Ext(executable) == ".exe" {
 		tool += ".exe"
 	}
@@ -80,6 +84,26 @@ func TestWasmPostLinkArgs(t *testing.T) {
 	}
 	if got := wasmPostLinkArgs(&crosscompile.Export{}, "in", "out", false, optlevel.O2); got != nil {
 		t.Fatalf("wasmPostLinkArgs(disabled) = %v, want nil", got)
+	}
+}
+
+func TestWasmPreAsyncifyArgs(t *testing.T) {
+	target := &crosscompile.Export{WasmPostLink: crosscompile.WasmPostLink{Asyncify: true}}
+	if got, want := wasmPreAsyncifyArgs(target, "in.wasm", "out.wasm", optlevel.Oz),
+		[]string{"-Oz", "in.wasm", "-o", "out.wasm"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("wasmPreAsyncifyArgs() = %v, want %v", got, want)
+	}
+	if got := wasmPreAsyncifyArgs(target, "in", "out", optlevel.O0); got != nil {
+		t.Fatalf("wasmPreAsyncifyArgs(O0) = %v, want nil", got)
+	}
+	if got := wasmPreAsyncifyArgs(target, "in", "out", optlevel.Unset); got != nil {
+		t.Fatalf("wasmPreAsyncifyArgs(unset) = %v, want nil", got)
+	}
+	if got := wasmPreAsyncifyArgs(nil, "in", "out", optlevel.O2); got != nil {
+		t.Fatalf("wasmPreAsyncifyArgs(nil) = %v, want nil", got)
+	}
+	if got := wasmPreAsyncifyArgs(&crosscompile.Export{}, "in", "out", optlevel.O2); got != nil {
+		t.Fatalf("wasmPreAsyncifyArgs(disabled) = %v, want nil", got)
 	}
 }
 
@@ -190,8 +214,8 @@ func TestPostLinkWasmPublishesOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(args); !strings.Contains(got, "--asyncify\n--translate-to-exnref\n-O2\n") ||
-		!strings.Contains(got, input+"\n-o\n") {
+	if got := string(args); !strings.Contains(got, "---\n-O2\n"+input+"\n-o\n") ||
+		!strings.Contains(got, "---\n--asyncify\n--translate-to-exnref\n-O2\n"+input+"\n-o\n") {
 		t.Fatalf("wasm-opt args = %q", got)
 	}
 }
@@ -211,12 +235,36 @@ func TestPostLinkWasmReportsToolFailure(t *testing.T) {
 	t.Setenv("LLGO_TEST_WASM_OPT_HELPER", "fail")
 
 	ctx := wasmPostLinkTestContext()
+	ctx.buildConf.OptLevel = optlevel.O0
 	err := postLinkWasm(ctx, input, output, false)
 	if err == nil || !strings.Contains(err.Error(), "wasm-opt Asyncify failed") {
 		t.Fatalf("postLinkWasm() error = %v", err)
 	}
 	if data, err := os.ReadFile(output); err != nil || string(data) != "old" {
 		t.Fatalf("failed post-link changed final output: %q, %v", data, err)
+	}
+}
+
+func TestPostLinkWasmReportsPreAsyncifyFailure(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "linked.wasm")
+	output := filepath.Join(dir, "app.wasm")
+	if err := os.WriteFile(input, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(output, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := writeWasmOptTestTool(t, dir)
+	t.Setenv("WASMOPT", tool)
+	t.Setenv("LLGO_TEST_WASM_OPT_HELPER", "fail")
+
+	err := postLinkWasm(wasmPostLinkTestContext(), input, output, false)
+	if err == nil || !strings.Contains(err.Error(), "wasm-opt pre-Asyncify optimization failed") {
+		t.Fatalf("postLinkWasm() error = %v", err)
+	}
+	if data, err := os.ReadFile(output); err != nil || string(data) != "old" {
+		t.Fatalf("failed pre-optimization changed final output: %q, %v", data, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

This starts R3 after the merged R2.1 lifecycle work and focuses on WebAssembly toolchain completeness.

- Route named-target `llgo test -c` through the non-executing emulator path after linking, instead of falling through to device flash or serial discovery.
- Cover compile-only artifacts for Emscripten wasm32, Emscripten Memory64, and WASI in the single-worker integration script.
- Disable clang implicit Binaryen discovery with clang 19+ `--no-wasm-opt` when LLGo owns the Asyncify pipeline.
- Explicitly preserve the established optimized-build order: optimization after `wasm-ld`, then Asyncify/EH translation, then post-Asyncify optimization. This avoids environment-dependent double processing without increasing wasm output size.

This PR intentionally contains no multi-worker runtime work. The fork-runner CI fallback used during development remains isolated in cpunion/llgo#236 and is not part of this upstream contribution.

## Base

Rebased onto the current xgo-dev/main at `9317592bb`, including the merged R2.1 and Windows/CI fixes.

## Validation

- `go test ./internal/build ./internal/crosscompile ./cmd/internal/test ./cmd/internal/flags -count=1`
- `bash -n dev/test_wasm_single_worker.sh`
- `shellcheck dev/test_wasm_single_worker.sh`
- LLVM 22 full `dev/test_wasm_single_worker.sh` run with `LLGO_BUILD_CACHE=off`
- Same-root base/head WebAssembly benchmark across js, wasip1, Emscripten wasm32, Emscripten Memory64, and WASI: all module and glue sizes are byte-for-byte unchanged

The integration run passed scheduler, timer, GC, lifecycle, host-callback, expected deadlock/Goexit failures, public `llgo test` execution, and `llgo test -c` artifact validation across Emscripten wasm32, Emscripten Memory64, and WASI.