### PR TITLE
runtime: use CRT-aware BDWGC threads on Windows

### DIFF
--- a/runtime/_test/windowsruntime/gc.go
+++ b/runtime/_test/windowsruntime/gc.go
@@ -19,11 +19,23 @@ func makeWindowsGCProbe(finalized chan<- int) {
 func checkThreadLifecycleGC() {
 	const workers = 64
 	done := make(chan *windowsGCProbe)
+	// LLGo's native backend creates an OS thread for each goroutine. Alternate
+	// normal returns and Goexit to exercise both CRT-aware thread exit paths.
+	// Receiving done checks the deferred result, not completion of OS teardown.
 	for worker := 0; worker < workers; worker++ {
 		probe := &windowsGCProbe{value: worker}
-		go func(probe *windowsGCProbe) {
-			done <- probe
-		}(probe)
+		go func(probe *windowsGCProbe, useGoexit bool) {
+			defer func() {
+				if recover() != nil {
+					panic("Windows GC thread lifecycle worker panicked")
+				}
+				done <- probe
+			}()
+			if useGoexit {
+				runtime.Goexit()
+				panic("Windows runtime.Goexit returned")
+			}
+		}(probe, worker%2 != 0)
 		got := <-done
 		if got == nil || got.value != worker {
 			panic("Windows GC corrupted a short-lived worker root")

--- a/runtime/_test/windowsruntime/gc.go
+++ b/runtime/_test/windowsruntime/gc.go
@@ -16,6 +16,24 @@ func makeWindowsGCProbe(finalized chan<- int) {
 	})
 }
 
+func checkThreadLifecycleGC() {
+	const workers = 64
+	done := make(chan *windowsGCProbe)
+	for worker := 0; worker < workers; worker++ {
+		probe := &windowsGCProbe{value: worker}
+		go func(probe *windowsGCProbe) {
+			done <- probe
+		}(probe)
+		got := <-done
+		if got == nil || got.value != worker {
+			panic("Windows GC corrupted a short-lived worker root")
+		}
+		if worker%16 == 15 {
+			runtime.GC()
+		}
+	}
+}
+
 func checkConcurrentGC() {
 	const workers = 4
 	ready := make(chan struct{}, workers)
@@ -59,6 +77,7 @@ func checkConcurrentGC() {
 }
 
 func checkGC() {
+	checkThreadLifecycleGC()
 	checkConcurrentGC()
 
 	finalized := make(chan int, 1)

--- a/runtime/internal/thread/_wrap/thread_windows.c
+++ b/runtime/internal/thread/_wrap/thread_windows.c
@@ -5,6 +5,7 @@
  * needed only by the final native link.
  */
 typedef __SIZE_TYPE__ llgo_size_t;
+typedef __UINTPTR_TYPE__ llgo_uintptr_t;
 typedef unsigned long llgo_dword;
 typedef unsigned int llgo_uint;
 typedef int llgo_bool;
@@ -39,7 +40,7 @@ __declspec(dllimport) llgo_bool LLGO_WINAPI
 FlsSetValue(llgo_dword index, void *value);
 
 #if defined(LLGO_USE_BDWGC)
-llgo_size_t GC_beginthreadex(
+llgo_uintptr_t GC_beginthreadex(
     void *security, llgo_uint stack_size, llgo_crt_thread_start start,
     void *arg, llgo_uint flags, llgo_uint *thread_id);
 void GC_endthreadex(llgo_uint exit_code);
@@ -116,7 +117,8 @@ int llgo_win_thread_create_detached(llgo_size_t stack_size,
 #if defined(LLGO_USE_BDWGC)
     /* Goroutine entry can use the C runtime. BDWGC warns that its CreateThread
      * wrapper can leak CRT resources; beginthreadex supplies matching CRT
-     * initialization and teardown around the same GC wrapper. */
+     * initialization and teardown around the same GC wrapper.
+     * See BDWGC doc/README.win32. */
     thread = (llgo_handle)GC_beginthreadex(
         0, (llgo_uint)stack_size, llgo_crt_thread_entry, data,
         (llgo_uint)flags, 0);
@@ -125,8 +127,8 @@ int llgo_win_thread_create_detached(llgo_size_t stack_size,
 #endif
     if (thread == 0) {
 #if defined(LLGO_USE_BDWGC)
-        /* GC_beginthreadex reports errno, while the Go-facing contract only
-         * needs a stable nonzero failure code. */
+        /* GC_beginthreadex reports errno. The Go caller only tests for zero,
+         * so return a fixed nonzero failure sentinel, not a translated errno. */
         error = llgo_error_not_enough_memory;
 #else
         error = GetLastError();

--- a/runtime/internal/thread/_wrap/thread_windows.c
+++ b/runtime/internal/thread/_wrap/thread_windows.c
@@ -17,6 +17,7 @@ typedef void *llgo_handle;
 #endif
 
 typedef llgo_dword(LLGO_WINAPI *llgo_win_thread_start)(void *arg);
+typedef llgo_uint(LLGO_WINAPI *llgo_crt_thread_start)(void *arg);
 typedef void(LLGO_WINAPI *llgo_win_fls_callback)(void *value);
 
 __declspec(dllimport) llgo_handle LLGO_WINAPI CreateThread(
@@ -38,10 +39,10 @@ __declspec(dllimport) llgo_bool LLGO_WINAPI
 FlsSetValue(llgo_dword index, void *value);
 
 #if defined(LLGO_USE_BDWGC)
-llgo_handle LLGO_WINAPI GC_CreateThread(
-    void *attributes, llgo_size_t stack_size, llgo_win_thread_start start,
-    void *arg, llgo_dword flags, llgo_dword *thread_id);
-void LLGO_WINAPI GC_ExitThread(llgo_dword exit_code);
+llgo_size_t GC_beginthreadex(
+    void *security, llgo_uint stack_size, llgo_crt_thread_start start,
+    void *arg, llgo_uint flags, llgo_uint *thread_id);
+void GC_endthreadex(llgo_uint exit_code);
 #endif
 
 enum {
@@ -69,13 +70,26 @@ typedef struct {
     void *arg;
 } llgo_thread_start_data;
 
-static llgo_dword LLGO_WINAPI llgo_thread_start(void *raw)
+static void llgo_thread_run(void *raw)
 {
     llgo_thread_start_data data = *(llgo_thread_start_data *)raw;
     HeapFree(GetProcessHeap(), 0, raw);
     data.routine(data.arg);
+}
+
+#if !defined(LLGO_USE_BDWGC)
+static llgo_dword LLGO_WINAPI llgo_thread_start(void *raw)
+{
+    llgo_thread_run(raw);
     return 0;
 }
+#else
+static llgo_uint LLGO_WINAPI llgo_crt_thread_entry(void *raw)
+{
+    llgo_thread_run(raw);
+    return 0;
+}
+#endif
 
 int llgo_win_thread_create_detached(llgo_size_t stack_size,
                                     llgo_thread_routine routine, void *arg)
@@ -87,6 +101,10 @@ int llgo_win_thread_create_detached(llgo_size_t stack_size,
 
     if (routine == 0)
         return 87; /* ERROR_INVALID_PARAMETER */
+#if defined(LLGO_USE_BDWGC)
+    if (stack_size > (llgo_size_t)0xffffffffU)
+        return 87;
+#endif
     data = (llgo_thread_start_data *)HeapAlloc(
         GetProcessHeap(), 0, sizeof(*data));
     if (data == 0)
@@ -96,12 +114,23 @@ int llgo_win_thread_create_detached(llgo_size_t stack_size,
     if (stack_size != 0)
         flags |= llgo_stack_size_is_a_reservation;
 #if defined(LLGO_USE_BDWGC)
-    thread = GC_CreateThread(0, stack_size, llgo_thread_start, data, flags, 0);
+    /* Goroutine entry can use the C runtime. BDWGC documents that its
+     * CreateThread wrapper leaks CRT thread state; beginthreadex supplies the
+     * matching CRT initialization and teardown around the same GC wrapper. */
+    thread = (llgo_handle)GC_beginthreadex(
+        0, (llgo_uint)stack_size, llgo_crt_thread_entry, data,
+        (llgo_uint)flags, 0);
 #else
     thread = CreateThread(0, stack_size, llgo_thread_start, data, flags, 0);
 #endif
     if (thread == 0) {
+#if defined(LLGO_USE_BDWGC)
+        /* GC_beginthreadex reports errno, while the Go-facing contract only
+         * needs a stable nonzero failure code. */
+        error = llgo_error_not_enough_memory;
+#else
         error = GetLastError();
+#endif
         HeapFree(GetProcessHeap(), 0, data);
         return (int)error;
     }
@@ -112,7 +141,7 @@ int llgo_win_thread_create_detached(llgo_size_t stack_size,
 void llgo_win_thread_exit(void)
 {
 #if defined(LLGO_USE_BDWGC)
-    GC_ExitThread(0);
+    GC_endthreadex(0);
 #else
     ExitThread(0);
 #endif

--- a/runtime/internal/thread/_wrap/thread_windows.c
+++ b/runtime/internal/thread/_wrap/thread_windows.c
@@ -114,9 +114,9 @@ int llgo_win_thread_create_detached(llgo_size_t stack_size,
     if (stack_size != 0)
         flags |= llgo_stack_size_is_a_reservation;
 #if defined(LLGO_USE_BDWGC)
-    /* Goroutine entry can use the C runtime. BDWGC documents that its
-     * CreateThread wrapper leaks CRT thread state; beginthreadex supplies the
-     * matching CRT initialization and teardown around the same GC wrapper. */
+    /* Goroutine entry can use the C runtime. BDWGC warns that its CreateThread
+     * wrapper can leak CRT resources; beginthreadex supplies matching CRT
+     * initialization and teardown around the same GC wrapper. */
     thread = (llgo_handle)GC_beginthreadex(
         0, (llgo_uint)stack_size, llgo_crt_thread_entry, data,
         (llgo_uint)flags, 0);

--- a/runtime/internal/thread/thread_windows.go
+++ b/runtime/internal/thread/thread_windows.go
@@ -59,8 +59,8 @@ func keyGet(index c.Uint) c.Pointer
 //go:linkname keySet C.llgo_win_fls_set
 func keySet(index c.Uint, destructor KeyDestructor, value c.Pointer) c.Int
 
-// CreateDetached starts a detached host thread. GC-enabled builds select
-// GC_CreateThread in the accompanying C shim; nogc builds select CreateThread.
+// CreateDetached starts a detached host thread. GC-enabled builds select the
+// collector's CRT-aware entry point; nogc builds select CreateThread.
 func CreateDetached(stackSize uintptr, routine RoutineFunc, arg c.Pointer) c.Int {
 	return createDetached(stackSize, routine, arg)
 }

--- a/runtime/internal/thread/thread_windows.go
+++ b/runtime/internal/thread/thread_windows.go
@@ -61,6 +61,8 @@ func keySet(index c.Uint, destructor KeyDestructor, value c.Pointer) c.Int
 
 // CreateDetached starts a detached host thread. GC-enabled builds select the
 // collector's CRT-aware entry point; nogc builds select CreateThread.
+// The collector's entry point takes a 32-bit stack size, so GC-enabled builds
+// reject stackSize > 0xffffffff bytes with a nonzero return.
 func CreateDetached(stackSize uintptr, routine RoutineFunc, arg c.Pointer) c.Int {
 	return createDetached(stackSize, routine, arg)
 }


### PR DESCRIPTION
Windows goroutine threads can execute C runtime and FFI code, but the BDWGC backend currently creates and terminates them through `GC_CreateThread` / `GC_ExitThread`. BDWGC warns that this path can leak CRT resources and identifies `GC_beginthreadex` as the alternative with CRT lifecycle support.

Use `GC_beginthreadex` / `GC_endthreadex` for all GC-enabled Windows targets: MinGW and MSVC, each on 386, amd64, and arm64. Keep detached handle ownership and add 64 short-lived goroutines with periodic GC to the existing Windows runtime smoke. Half return normally and half explicitly call `runtime.Goexit`; no CI jobs are added. The `nogc` and non-Windows implementations are unchanged.

References: [BDWGC Windows thread guidance](https://github.com/bdwgc/bdwgc/blob/v8.2.12/doc/README.win32#L190-L199), [BDWGC thread wrappers](https://github.com/bdwgc/bdwgc/blob/v8.2.12/win32_threads.c#L2743-L2804).

### Validation

- Before the review revision, `d21086217` passed all six Windows ABI lanes, including runtime/FFI smoke and full tests. The [ARM64 MinGW full test job](https://github.com/xgo-dev/llgo/actions/runs/34014113924/job/101434842191) passed, including `test/goroot`, which previously exited with `0xC0000005` in a separate run.
- Review revision `09c40d907` passed runtime module host tests and LLVM 22 C-shim syntax checks with warnings as errors for all six Windows target triples, in both GC and nogc configurations.
- The revised lifecycle fixture passed 20 rounds under both official Go 1.27 and LLGo on macOS. This checks the fixture logic, not the Windows CRT teardown implementation; the revised fixture is covered by the existing six-ABI Windows CI smoke.
- The pre-revision macOS release download failure passed on retry. Ubuntu alone failed twice with a self-hosted runner communication-loss annotation during ESP smoke ([retry](https://github.com/xgo-dev/llgo/actions/runs/34014113924/job/101440639838)); its infrastructure cause remains unresolved. CI for the review revision is pending.

The added smoke covers the lifecycle path; it is not a deterministic reproducer of the intermittent access violation or a measurement of CRT resource leakage. Passing runs and improved diagnostic timings do not establish that every previous Windows CI failure has this cause.

CPU-profiler context capture is handled independently in #2506. Both PRs target `main`; this PR contains no profiler changes.
