### PR TITLE
runtime/reflectlite: match Go version Kind ABI

### DIFF
--- a/internal/build/testdata/wasm-test/errors_test.go
+++ b/internal/build/testdata/wasm-test/errors_test.go
@@ -1,0 +1,46 @@
+package wasmtest
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type wasmError struct{}
+
+func (*wasmError) Error() string { return "wasm error" }
+func (*wasmError) Code() int     { return 7 }
+
+type codedError interface {
+	error
+	Code() int
+}
+
+func TestErrorsAsTargets(t *testing.T) {
+	// errors.As calls reflectlite.Type.Kind through an interface. Its return
+	// type must agree with Go's uint8 Kind, including on Memory64 targets.
+	want := &wasmError{}
+	err := fmt.Errorf("wrapped: %w", want)
+	var ptr *wasmError
+	if !errors.As(err, &ptr) || ptr != want {
+		t.Fatalf("errors.As pointer target = %v, want %v", ptr, want)
+	}
+	var iface codedError
+	if !errors.As(err, &iface) || iface != want || iface.Code() != 7 {
+		t.Fatalf("errors.As interface target = %v, want %v", iface, want)
+	}
+
+	// Invalid targets must produce the ordinary recoverable Go panic, not a
+	// host trap from a mismatched indirect-call signature.
+	var notError int
+	for _, target := range []any{42, (*wasmError)(nil), &notError} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("errors.As accepted invalid target %T", target)
+				}
+			}()
+			errors.As(err, target)
+		}()
+	}
+}

--- a/internal/build/testdata/wasm-test/errors_test.go
+++ b/internal/build/testdata/wasm-test/errors_test.go
@@ -3,6 +3,7 @@ package wasmtest
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 )
 
@@ -43,4 +44,21 @@ func TestErrorsAsTargets(t *testing.T) {
 			errors.As(err, target)
 		}()
 	}
+}
+
+func TestReflectliteSwapperKinds(t *testing.T) {
+	// sort.Slice uses reflectlite.Swapper, including its string fast path.
+	values := []string{"charlie", "alpha", "bravo"}
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	if values[0] != "alpha" || values[1] != "bravo" || values[2] != "charlie" {
+		t.Fatalf("sort.Slice = %v", values)
+	}
+
+	// Formatting ValueError also crosses the Kind-to-runtime-Kind boundary.
+	defer func() {
+		if got := fmt.Sprint(recover()); got != "reflect: call of Swapper on int Value" {
+			t.Fatalf("sort.Slice panic = %q", got)
+		}
+	}()
+	sort.Slice(42, func(i, j int) bool { return i < j })
 }

--- a/runtime/internal/lib/internal/reflectlite/kind_go123.go
+++ b/runtime/internal/lib/internal/reflectlite/kind_go123.go
@@ -1,0 +1,6 @@
+//go:build go1.23
+
+package reflectlite
+
+// Go 1.23 narrowed internal/abi.Kind to one byte.
+type kindRepr = uint8

--- a/runtime/internal/lib/internal/reflectlite/kind_pre_go123.go
+++ b/runtime/internal/lib/internal/reflectlite/kind_pre_go123.go
@@ -1,0 +1,6 @@
+//go:build !go1.23
+
+package reflectlite
+
+// Go 1.20-1.22 use a word-sized Kind.
+type kindRepr = uint

--- a/runtime/internal/lib/internal/reflectlite/kind_pre_go123.go
+++ b/runtime/internal/lib/internal/reflectlite/kind_pre_go123.go
@@ -2,5 +2,5 @@
 
 package reflectlite
 
-// Go 1.20-1.22 use a word-sized Kind.
+// Go versions before 1.23 use a word-sized Kind.
 type kindRepr = uint

--- a/runtime/internal/lib/internal/reflectlite/swapper.go
+++ b/runtime/internal/lib/internal/reflectlite/swapper.go
@@ -43,7 +43,7 @@ func Swapper(slice any) func(i, j int) {
 			ps := *(*[]unsafe.Pointer)(v.ptr)
 			return func(i, j int) { ps[i], ps[j] = ps[j], ps[i] }
 		}
-		if typ.Kind() == String {
+		if Kind(typ.Kind()) == String {
 			ss := *(*[]string)(v.ptr)
 			return func(i, j int) { ss[i], ss[j] = ss[j], ss[i] }
 		}

--- a/runtime/internal/lib/internal/reflectlite/type.go
+++ b/runtime/internal/lib/internal/reflectlite/type.go
@@ -76,21 +76,27 @@ type Type interface {
 
 // A Kind represents the specific kind of type that a Type represents.
 // The zero Kind is not a valid kind.
-type Kind = abi.Kind
+// Match the selected Go version's Kind rather than LLGo's word-sized abi.Kind.
+// Since Go 1.23, Type.Kind's interface ABI must return uint8 on wasm64 too.
+type Kind kindRepr
 
-const Ptr = abi.Pointer
+func (k Kind) String() string { return abi.Kind(k).String() }
+
+const Ptr = Kind(abi.Pointer)
 
 const (
 	// Import-and-export these constants as necessary
-	Interface = abi.Interface
-	Slice     = abi.Slice
-	String    = abi.String
-	Struct    = abi.Struct
+	Interface = Kind(abi.Interface)
+	Slice     = Kind(abi.Slice)
+	String    = Kind(abi.String)
+	Struct    = Kind(abi.Struct)
 )
 
 type rtype struct {
 	*abi.Type
 }
+
+func (t rtype) Kind() Kind { return Kind(t.Type.Kind()) }
 
 // uncommonType is present only for defined types or types with methods
 // (if T is a defined type, the uncommonTypes for T and *T have methods).
@@ -161,7 +167,7 @@ func (t rtype) PkgPath() string {
 	if t.TFlag&abi.TFlagNamed == 0 {
 		return ""
 	}
-	if t.Kind() == abi.UnsafePointer {
+	if t.Type.Kind() == abi.UnsafePointer {
 		return "unsafe"
 	}
 	ut := t.uncommon()
@@ -391,7 +397,7 @@ func haveIdenticalUnderlyingType(T, V *abi.Type, cmpTags bool) bool {
 		}
 		return true
 
-	case Interface:
+	case abi.Interface:
 		t := (*interfaceType)(unsafe.Pointer(T))
 		v := (*interfaceType)(unsafe.Pointer(V))
 		if len(t.Methods) == 0 && len(v.Methods) == 0 {
@@ -404,7 +410,7 @@ func haveIdenticalUnderlyingType(T, V *abi.Type, cmpTags bool) bool {
 	case abi.Map:
 		return haveIdenticalType(T.Key(), V.Key(), cmpTags) && haveIdenticalType(T.Elem(), V.Elem(), cmpTags)
 
-	case Ptr, abi.Slice:
+	case abi.Pointer, abi.Slice:
 		return haveIdenticalType(T.Elem(), V.Elem(), cmpTags)
 
 	case abi.Struct:

--- a/runtime/internal/lib/internal/reflectlite/type.go
+++ b/runtime/internal/lib/internal/reflectlite/type.go
@@ -77,19 +77,25 @@ type Type interface {
 // A Kind represents the specific kind of type that a Type represents.
 // The zero Kind is not a valid kind.
 // Match the selected Go version's Kind rather than LLGo's word-sized abi.Kind.
-// Since Go 1.23, Type.Kind's interface ABI must return uint8 on wasm64 too.
+// Since Go 1.23, Type.Kind's interface ABI must return uint8, including on
+// wasm64 targets.
 type Kind kindRepr
 
 func (k Kind) String() string { return abi.Kind(k).String() }
 
-const Ptr = Kind(abi.Pointer)
-
 const (
-	// Import-and-export these constants as necessary
-	Interface = Kind(abi.Interface)
-	Slice     = Kind(abi.Slice)
-	String    = Kind(abi.String)
-	Struct    = Kind(abi.Struct)
+	// Keep every kind used by reflectlite in the version-selected local type.
+	Invalid       = Kind(abi.Invalid)
+	Array         = Kind(abi.Array)
+	Chan          = Kind(abi.Chan)
+	Func          = Kind(abi.Func)
+	Interface     = Kind(abi.Interface)
+	Map           = Kind(abi.Map)
+	Ptr           = Kind(abi.Pointer)
+	Slice         = Kind(abi.Slice)
+	String        = Kind(abi.String)
+	Struct        = Kind(abi.Struct)
+	UnsafePointer = Kind(abi.UnsafePointer)
 )
 
 type rtype struct {

--- a/runtime/internal/lib/internal/reflectlite/value.go
+++ b/runtime/internal/lib/internal/reflectlite/value.go
@@ -205,7 +205,7 @@ func (f flag) mustBeExported() {
 // or it is not addressable.
 func (f flag) mustBeAssignable() {
 	if f == 0 {
-		panic(&ValueError{methodName(), abi.Invalid})
+		panic(&ValueError{methodName(), Kind(abi.Invalid)})
 	}
 	// Assignable if addressable and not read-only.
 	if f&flagRO != 0 {
@@ -232,7 +232,7 @@ func (v Value) CanSet() bool {
 func (v Value) Elem() Value {
 	k := v.kind()
 	switch k {
-	case abi.Interface:
+	case Interface:
 		var eface any
 		if v.typ.NumMethod() == 0 {
 			eface = *(*any)(v.ptr)
@@ -246,7 +246,7 @@ func (v Value) Elem() Value {
 			x.flag |= v.flag.ro()
 		}
 		return x
-	case abi.Pointer:
+	case Ptr:
 		ptr := v.ptr
 		if v.flag&flagIndir != 0 {
 			ptr = *(*unsafe.Pointer)(ptr)
@@ -269,7 +269,7 @@ func valueInterface(v Value) any {
 		panic(&ValueError{"reflectlite.Value.Interface", 0})
 	}
 
-	if v.kind() == abi.Interface {
+	if v.kind() == Interface {
 		// Special case: return the element inside the interface.
 		// Empty interface has one layout, all interfaces with
 		// methods have a second layout.
@@ -295,7 +295,7 @@ func valueInterface(v Value) any {
 func (v Value) IsNil() bool {
 	k := v.kind()
 	switch k {
-	case abi.Chan, abi.Func, abi.Map, abi.Pointer, abi.UnsafePointer:
+	case Kind(abi.Chan), Kind(abi.Func), Kind(abi.Map), Ptr, Kind(abi.UnsafePointer):
 		// if v.flag&flagMethod != 0 {
 		// 	return false
 		// }
@@ -304,7 +304,7 @@ func (v Value) IsNil() bool {
 			ptr = *(*unsafe.Pointer)(ptr)
 		}
 		return ptr == nil
-	case abi.Interface, abi.Slice:
+	case Interface, Slice:
 		// Both interface and slice are nil if first word is 0.
 		// Both are always bigger than a word; assume flagIndir.
 		return *(*unsafe.Pointer)(v.ptr) == nil
@@ -338,18 +338,18 @@ func maplen(ch unsafe.Pointer) int
 func (v Value) Len() int {
 	k := v.kind()
 	switch k {
-	case abi.Slice:
+	case Slice:
 		// Slice is bigger than a word; assume flagIndir.
 		return (*unsafeheaderSlice)(v.ptr).Len
-	case abi.String:
+	case String:
 		// String is bigger than a word; assume flagIndir.
 		return (*unsafeheaderString)(v.ptr).Len
-	case abi.Array:
+	case Kind(abi.Array):
 		tt := (*arrayType)(unsafe.Pointer(v.typ))
 		return int(tt.Len)
-	case abi.Chan:
+	case Kind(abi.Chan):
 		return chanlen(v.pointer())
-	case abi.Map:
+	case Kind(abi.Map):
 		return maplen(v.pointer())
 	}
 	panic(&ValueError{"reflect.Value.Len", v.kind()})
@@ -358,7 +358,7 @@ func (v Value) Len() int {
 // NumMethod returns the number of exported methods in the value's method set.
 func (v Value) numMethod() int {
 	if v.typ == nil {
-		panic(&ValueError{"reflectlite.Value.NumMethod", abi.Invalid})
+		panic(&ValueError{"reflectlite.Value.NumMethod", Kind(abi.Invalid)})
 	}
 	return v.typ.NumMethod()
 }
@@ -370,7 +370,7 @@ func (v Value) Set(x Value) {
 	v.mustBeAssignable()
 	x.mustBeExported() // do not let unexported x leak
 	var target unsafe.Pointer
-	if v.kind() == abi.Interface {
+	if v.kind() == Interface {
 		target = v.ptr
 	}
 	x = x.assignTo("reflectlite.Set", v.typ, target)
@@ -385,7 +385,7 @@ func (v Value) Set(x Value) {
 func (v Value) Type() Type {
 	f := v.flag
 	if f == 0 {
-		panic(&ValueError{"reflectlite.Value.Type", abi.Invalid})
+		panic(&ValueError{"reflectlite.Value.Type", Kind(abi.Invalid)})
 	}
 	// closure func
 	if v.typ.IsClosure() {
@@ -436,7 +436,7 @@ func (v Value) assignTo(context string, dst *abi.Type, target unsafe.Pointer) Va
 		if target == nil {
 			target = unsafe_New(dst)
 		}
-		if v.Kind() == abi.Interface && v.IsNil() {
+		if v.Kind() == Interface && v.IsNil() {
 			// A nil ReadWriter passed to nil Reader is OK,
 			// but using ifaceE2I below will panic.
 			// Avoid the panic by returning a nil dst (e.g., Reader) explicitly.

--- a/runtime/internal/lib/internal/reflectlite/value.go
+++ b/runtime/internal/lib/internal/reflectlite/value.go
@@ -205,7 +205,7 @@ func (f flag) mustBeExported() {
 // or it is not addressable.
 func (f flag) mustBeAssignable() {
 	if f == 0 {
-		panic(&ValueError{methodName(), Kind(abi.Invalid)})
+		panic(&ValueError{methodName(), Invalid})
 	}
 	// Assignable if addressable and not read-only.
 	if f&flagRO != 0 {
@@ -295,7 +295,7 @@ func valueInterface(v Value) any {
 func (v Value) IsNil() bool {
 	k := v.kind()
 	switch k {
-	case Kind(abi.Chan), Kind(abi.Func), Kind(abi.Map), Ptr, Kind(abi.UnsafePointer):
+	case Chan, Func, Map, Ptr, UnsafePointer:
 		// if v.flag&flagMethod != 0 {
 		// 	return false
 		// }
@@ -344,12 +344,12 @@ func (v Value) Len() int {
 	case String:
 		// String is bigger than a word; assume flagIndir.
 		return (*unsafeheaderString)(v.ptr).Len
-	case Kind(abi.Array):
+	case Array:
 		tt := (*arrayType)(unsafe.Pointer(v.typ))
 		return int(tt.Len)
-	case Kind(abi.Chan):
+	case Chan:
 		return chanlen(v.pointer())
-	case Kind(abi.Map):
+	case Map:
 		return maplen(v.pointer())
 	}
 	panic(&ValueError{"reflect.Value.Len", v.kind()})
@@ -358,7 +358,7 @@ func (v Value) Len() int {
 // NumMethod returns the number of exported methods in the value's method set.
 func (v Value) numMethod() int {
 	if v.typ == nil {
-		panic(&ValueError{"reflectlite.Value.NumMethod", Kind(abi.Invalid)})
+		panic(&ValueError{"reflectlite.Value.NumMethod", Invalid})
 	}
 	return v.typ.NumMethod()
 }
@@ -385,7 +385,7 @@ func (v Value) Set(x Value) {
 func (v Value) Type() Type {
 	f := v.flag
 	if f == 0 {
-		panic(&ValueError{"reflectlite.Value.Type", Kind(abi.Invalid)})
+		panic(&ValueError{"reflectlite.Value.Type", Invalid})
 	}
 	// closure func
 	if v.typ.IsClosure() {


### PR DESCRIPTION
## Problem

On Emscripten Memory64, errors.As can trap with RuntimeError: function signature mismatch. The indirect reflectlite.Type.Kind call expects (i64) -> i32, while LLGo promoted rtype.Kind as (i64) -> i64.

Go narrowed internal/abi.Kind from uint to uint8 in Go 1.23. LLGo reflectlite still exposed a word-sized runtime Kind, which is observable on Memory64; wasm32 lowers both widths to i32 and masks the mismatch.

## Fix

- Select reflectlite Kind representation by Go version: word-sized before Go 1.23 and uint8 since Go 1.23.
- Explicitly adapt rtype.Kind and internal Kind conversions without changing LLGo runtime metadata ABI or public reflect.Kind.
- Add wasm regression coverage for errors.As, invalid targets, reflectlite Swapper fast paths, and Kind formatting.

## Validation

- Rebased without conflicts onto upstream main 9317592bb; range-diff confirms both patches are unchanged.
- Host Go regression tests pass on the rebased branch.
- Before rebase, the complete wasm fixture plus test/std/errors, test/std/sort, and test/std/encoding/json passed on Emscripten wasm32, Emscripten Memory64, and WASI with the build cache disabled.
- Go 1.20, 1.22, and 1.23 compatibility checks passed before rebase.
- git diff --check passes.

This is a standalone main fix; it does not include R3 worker, GC, or toolchain changes.