### PR TITLE
ssa: use LLVM saturating float conversion intrinsics

### DIFF
--- a/cl/_testdata/floatint/in.go
+++ b/cl/_testdata/floatint/in.go
@@ -44,36 +44,28 @@ func zMixedUntypedFloat(i64 int64, u64 uint64) (uint64, int64, int64, uint64) {
 	return u64, i64, c, d
 }
 
-// The conversion sequence differs by target. Check the saturation boundaries,
-// conversion opcode, and final saturation selection without snapshotting every
-// temporary and block name.
+// Saturating targets use intrinsics while amd64 keeps its legacy CVTT
+// behavior. uint32 must still convert through signed i64 before truncation.
 // CHECK-LABEL: define i32 @main.f32ToI32(
-// ARM64: fcmp ole float {{.*}}, 0xC1E0000000000000
+// ARM64: call i32 @llvm.fptosi.sat.i32.f32(float
 // AMD64: fcmp olt float {{.*}}, 0xC1E0000000000000
-// CHECK: fcmp oge float {{.*}}, 0x41E0000000000000
-// CHECK: fcmp uno float
-// CHECK: fptosi float {{.*}} to i32
-// ARM64: select i1 {{.*}}, i32 -2147483648, i32
-// ARM64: select i1 {{.*}}, i32 2147483647, i32
+// AMD64: fcmp oge float {{.*}}, 0x41E0000000000000
+// AMD64: fcmp uno float
+// AMD64: fptosi float {{.*}} to i32
 // AMD64: select i1 {{.*}}, i32 -2147483648, i32
 // CHECK: ret i32
 
 // CHECK-LABEL: define i32 @main.f32ToU32(
-// ARM64: fcmp ole float {{.*}}, 0xC3E0000000000000
+// ARM64: call i64 @llvm.fptosi.sat.i64.f32(float
 // AMD64: fcmp olt float {{.*}}, 0xC3E0000000000000
-// CHECK: fcmp oge float {{.*}}, 0x43E0000000000000
-// CHECK: fptosi float {{.*}} to i64
-// ARM64: select i1 {{.*}}, i64 -9223372036854775808, i64
-// ARM64: select i1 {{.*}}, i64 9223372036854775807, i64
+// AMD64: fcmp oge float {{.*}}, 0x43E0000000000000
+// AMD64: fptosi float {{.*}} to i64
 // AMD64: select i1 {{.*}}, i64 -9223372036854775808, i64
 // CHECK: trunc i64 {{.*}} to i32
 // CHECK: ret i32
 
 // CHECK-LABEL: define i64 @main.f64ToUintptr(
-// ARM64: fcmp olt double {{.*}}, 0.000000e+00
-// ARM64: fcmp oge double {{.*}}, 0x43F0000000000000
-// ARM64: fptoui double {{.*}} to i64
-// ARM64: select i1 {{.*}}, i64 -1, i64
+// ARM64: call i64 @llvm.fptoui.sat.i64.f64(double
 // AMD64: fcmp oge double {{.*}}, 0x43E0000000000000
 // AMD64: fsub double {{.*}}, 0x43E0000000000000
 // AMD64: fptosi double {{.*}} to i64

--- a/cl/float_int_conversion_compile_test.go
+++ b/cl/float_int_conversion_compile_test.go
@@ -3,7 +3,6 @@
 package cl
 
 import (
-	"go/types"
 	"strings"
 	"testing"
 
@@ -28,14 +27,6 @@ func F64(x float64) uint32 { return uint32(x) }
 					SaturatingFloatToUint32: saturating,
 				})
 				defer prog.Dispose()
-				if arch == "386" {
-					// The host runtime import omits this 386-only declaration.
-					rt := types.NewPackage(llssa.PkgRuntime, "runtime")
-					params := types.NewTuple(types.NewParam(0, rt, "x", types.Typ[types.Float64]))
-					results := types.NewTuple(types.NewParam(0, rt, "", types.Typ[types.Uint64]))
-					rt.Scope().Insert(types.NewFunc(0, rt, "Float64ToUint64", types.NewSignatureType(nil, nil, nil, params, results, false)))
-					prog.SetRuntime(rt)
-				}
 				pkg, err := NewPackage(prog, ssaPkg, files)
 				if err != nil {
 					t.Fatal(err)
@@ -47,8 +38,6 @@ func F64(x float64) uint32 { return uint32(x) }
 						want = "@llvm.fptoui.sat.i32." + strings.ToLower(name) + "("
 					} else if arch == "arm64" {
 						want = "@llvm.fptosi.sat.i64." + strings.ToLower(name) + "("
-					} else if arch == "386" {
-						want = "Float64ToUint64"
 					}
 					if !strings.Contains(ir, want) {
 						t.Fatalf("%s conversion IR missing %q in %s mode:\n%s", name, want, mode, ir)

--- a/cl/float_int_conversion_compile_test.go
+++ b/cl/float_int_conversion_compile_test.go
@@ -3,6 +3,7 @@
 package cl
 
 import (
+	"go/types"
 	"strings"
 	"testing"
 
@@ -11,33 +12,52 @@ import (
 
 func TestFloatToUint32ConversionMode(t *testing.T) {
 	const src = `package floatconvert
-func Convert(x float32) uint32 { return uint32(x) }
+func F32(x float32) uint32 { return uint32(x) }
+func F64(x float64) uint32 { return uint32(x) }
 `
-	tests := []struct {
-		name       string
-		saturating bool
-		want       string
-		notWant    string
-	}{
-		{name: "legacy", want: "fptosi float", notWant: "fptoui float"},
-		{name: "saturating", saturating: true, want: "fptoui float", notWant: "fptosi float"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ssaPkg, _, files := buildGoSSAPkg(t, src)
-			prog := newLLSSAProgForTarget(t, &llssa.Target{
-				GOOS:                    "linux",
-				GOARCH:                  "amd64",
-				SaturatingFloatToUint32: tt.saturating,
+	for _, arch := range []string{"amd64", "arm64", "386"} {
+		for _, saturating := range []bool{false, true} {
+			mode := "legacy"
+			if saturating {
+				mode = "saturating"
+			}
+			t.Run(arch+"/"+mode, func(t *testing.T) {
+				ssaPkg, _, files := buildGoSSAPkg(t, src)
+				prog := newLLSSAProgForTarget(t, &llssa.Target{
+					GOOS: "linux", GOARCH: arch,
+					SaturatingFloatToUint32: saturating,
+				})
+				defer prog.Dispose()
+				if arch == "386" {
+					// The host runtime import omits this 386-only declaration.
+					rt := types.NewPackage(llssa.PkgRuntime, "runtime")
+					params := types.NewTuple(types.NewParam(0, rt, "x", types.Typ[types.Float64]))
+					results := types.NewTuple(types.NewParam(0, rt, "", types.Typ[types.Uint64]))
+					rt.Scope().Insert(types.NewFunc(0, rt, "Float64ToUint64", types.NewSignatureType(nil, nil, nil, params, results, false)))
+					prog.SetRuntime(rt)
+				}
+				pkg, err := NewPackage(prog, ssaPkg, files)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, name := range []string{"F32", "F64"} {
+					ir := mustNamedFunction(t, pkg.Module(), "floatconvert."+name).String()
+					want := "fptosi "
+					if saturating {
+						want = "@llvm.fptoui.sat.i32." + strings.ToLower(name) + "("
+					} else if arch == "arm64" {
+						want = "@llvm.fptosi.sat.i64." + strings.ToLower(name) + "("
+					} else if arch == "386" {
+						want = "Float64ToUint64"
+					}
+					if !strings.Contains(ir, want) {
+						t.Fatalf("%s conversion IR missing %q in %s mode:\n%s", name, want, mode, ir)
+					}
+					if !saturating && !strings.Contains(ir, "trunc i64") {
+						t.Fatalf("%s legacy uint32 conversion must truncate i64:\n%s", name, ir)
+					}
+				}
 			})
-			pkg, err := NewPackage(prog, ssaPkg, files)
-			if err != nil {
-				t.Fatal(err)
-			}
-			ir := mustNamedFunction(t, pkg.Module(), "floatconvert.Convert").String()
-			if !strings.Contains(ir, tt.want) || strings.Contains(ir, tt.notWant) {
-				t.Fatalf("conversion IR does not use %s mode:\n%s", tt.name, ir)
-			}
-		})
+		}
 	}
 }

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1296,8 +1296,8 @@ func castFloatToIntAMD64(b Builder, x llvm.Value, typ Type, dstSize uint64) llvm
 }
 
 // castFloatToInt386 mirrors gc's 386 split: the native CVTT instruction
-// handles signed 32-bit conversions, while 64-bit and unsigned-word results
-// use the software conversion inherited from runtime/vlrt.go.
+// handles signed 32-bit conversions. Unsigned words truncate a signed 64-bit
+// x87 conversion; 64-bit results use the software conversion from runtime/vlrt.go.
 func castFloatToInt386(b Builder, x llvm.Value, typ Type, dstSize uint64) llvm.Value {
 	if dstSize < 4 || (typ.kind != vkUnsigned && dstSize == 4) {
 		tmp := castFloatToSignedIntX86(b, x, b.Prog.Int32(), 32)
@@ -1305,6 +1305,15 @@ func castFloatToInt386(b Builder, x llvm.Value, typ Type, dstSize uint64) llvm.V
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}
 		return tmp
+	}
+
+	if dstSize == 4 {
+		// gc's runtime.float64touint32 uses x87 FISTP to signed i64 and
+		// returns its low word. NaN and signed-i64 overflow produce the
+		// integer-indefinite value, whose low word is zero. The software
+		// uint64 conversion instead wraps some of these out-of-range inputs.
+		tmp := castFloatToSignedIntX86(b, x, b.Prog.Int64(), 64)
+		return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 	}
 
 	input := x
@@ -1315,11 +1324,7 @@ func castFloatToInt386(b Builder, x llvm.Value, typ Type, dstSize uint64) llvm.V
 	if typ.kind == vkUnsigned {
 		fn = "Float64ToUint64"
 	}
-	ret := b.InlineCall(b.Pkg.rtFunc(fn), Expr{input, b.Prog.Float64()}).impl
-	if dstSize < 8 {
-		ret = llvm.CreateTrunc(b.impl, ret, typ.ll)
-	}
-	return ret
+	return b.InlineCall(b.Pkg.rtFunc(fn), Expr{input, b.Prog.Float64()}).impl
 }
 
 func castFloatToSignedIntX86(b Builder, x llvm.Value, typ Type, bits uint64) llvm.Value {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1230,7 +1230,7 @@ func castFloatToInt(b Builder, x llvm.Value, typ Type) llvm.Value {
 	target := b.Prog.Target()
 	saturatingUint32 := target.SaturatingFloatToUint32 && typ.kind == vkUnsigned && dstSize == 4
 	// The amd64 lowering only models legacy CVTT semantics. Saturating uint32
-	// conversions must use the guarded unsigned conversion below.
+	// conversions must use the unsigned saturating conversion below.
 	if target.effectiveGOARCH() == "amd64" && !saturatingUint32 {
 		return castFloatToIntAMD64(b, x, typ, dstSize)
 	}
@@ -1241,23 +1241,23 @@ func castFloatToInt(b Builder, x llvm.Value, typ Type) llvm.Value {
 		if dstSize < 4 {
 			// Go's converthash transition only changes float-to-uint32.
 			// Preserve the existing signed conversion and truncation for uint8/uint16.
-			tmp := castFloatToSignedInt(b, x, b.Prog.Int32(), 32)
+			tmp := castFloatToSignedInt(b, x, b.Prog.Int32())
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}
 		if dstSize == 4 && !saturatingUint32 {
-			tmp := castFloatToSignedInt(b, x, b.Prog.Int64(), 64)
+			tmp := castFloatToSignedInt(b, x, b.Prog.Int64())
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}
-		return castFloatToUnsignedInt(b, x, typ, dstSize*8)
+		return castFloatToUnsignedInt(b, x, typ)
 	}
 	if dstSize < 8 {
-		tmp := castFloatToSignedInt(b, x, b.Prog.Int32(), 32)
+		tmp := castFloatToSignedInt(b, x, b.Prog.Int32())
 		if dstSize < 4 {
 			return llvm.CreateTrunc(b.impl, tmp, typ.ll)
 		}
 		return tmp
 	}
-	return castFloatToSignedInt(b, x, typ, 64)
+	return castFloatToSignedInt(b, x, typ)
 }
 
 // castFloatToIntAMD64 reproduces gc's legacy SSE conversion semantics without
@@ -1337,47 +1337,14 @@ func castFloatToSignedIntX86(b Builder, x llvm.Value, typ Type, bits uint64) llv
 	return llvm.CreateSelect(b.impl, invalid, minInt, ret)
 }
 
-// Unlike the amd64 CVTT path above, other targets use Go's implementation-
-// specific saturating behavior: clamp low/high values and map NaN to zero.
-func castFloatToSignedInt(b Builder, x llvm.Value, typ Type, bits uint64) llvm.Value {
-	bound := floatPow2(bits - 1)
-	lower := llvm.ConstFloat(x.Type(), -bound)
-	upper := llvm.ConstFloat(x.Type(), bound)
-	zeroFloat := llvm.ConstNull(x.Type())
-	zeroInt := llvm.ConstInt(typ.ll, 0, false)
-	minInt := llvm.ConstInt(typ.ll, uint64(1)<<(bits-1), false)
-	maxInt := llvm.ConstInt(typ.ll, (uint64(1)<<(bits-1))-1, false)
-
-	tooLow := llvm.CreateFCmp(b.impl, llvm.FloatOLE, x, lower)
-	tooHigh := llvm.CreateFCmp(b.impl, llvm.FloatOGE, x, upper)
-	isNaN := llvm.CreateFCmp(b.impl, llvm.FloatUNO, x, x)
-	safe := llvm.CreateSelect(b.impl, tooLow, zeroFloat, x)
-	safe = llvm.CreateSelect(b.impl, tooHigh, zeroFloat, safe)
-	safe = llvm.CreateSelect(b.impl, isNaN, zeroFloat, safe)
-
-	ret := llvm.CreateFPToSI(b.impl, safe, typ.ll)
-	ret = llvm.CreateSelect(b.impl, tooLow, minInt, ret)
-	ret = llvm.CreateSelect(b.impl, tooHigh, maxInt, ret)
-	return llvm.CreateSelect(b.impl, isNaN, zeroInt, ret)
+// Saturating conversions clamp low/high values and map NaN to zero, unlike
+// the legacy x86 CVTT path above.
+func castFloatToSignedInt(b Builder, x llvm.Value, typ Type) llvm.Value {
+	return b.impl.CreateIntrinsic(typ.ll, llvm.LookupIntrinsicID("llvm.fptosi.sat"), []llvm.Value{x}, "")
 }
 
-func castFloatToUnsignedInt(b Builder, x llvm.Value, typ Type, bits uint64) llvm.Value {
-	upper := llvm.ConstFloat(x.Type(), floatPow2(bits))
-	zeroFloat := llvm.ConstNull(x.Type())
-	zeroInt := llvm.ConstInt(typ.ll, 0, false)
-	maxInt := llvm.ConstInt(typ.ll, intMask(bits), false)
-
-	isNeg := llvm.CreateFCmp(b.impl, llvm.FloatOLT, x, zeroFloat)
-	tooHigh := llvm.CreateFCmp(b.impl, llvm.FloatOGE, x, upper)
-	isNaN := llvm.CreateFCmp(b.impl, llvm.FloatUNO, x, x)
-	safe := llvm.CreateSelect(b.impl, isNeg, zeroFloat, x)
-	safe = llvm.CreateSelect(b.impl, tooHigh, zeroFloat, safe)
-	safe = llvm.CreateSelect(b.impl, isNaN, zeroFloat, safe)
-
-	ret := llvm.CreateFPToUI(b.impl, safe, typ.ll)
-	ret = llvm.CreateSelect(b.impl, tooHigh, maxInt, ret)
-	ret = llvm.CreateSelect(b.impl, isNeg, zeroInt, ret)
-	return llvm.CreateSelect(b.impl, isNaN, zeroInt, ret)
+func castFloatToUnsignedInt(b Builder, x llvm.Value, typ Type) llvm.Value {
+	return b.impl.CreateIntrinsic(typ.ll, llvm.LookupIntrinsicID("llvm.fptoui.sat"), []llvm.Value{x}, "")
 }
 
 func floatPow2(bits uint64) float64 {
@@ -1385,13 +1352,6 @@ func floatPow2(bits uint64) float64 {
 		return 18446744073709551616
 	}
 	return float64(uint64(1) << bits)
-}
-
-func intMask(bits uint64) uint64 {
-	if bits == 64 {
-		return ^uint64(0)
-	}
-	return (uint64(1) << bits) - 1
 }
 
 func castFloat(b Builder, x llvm.Value, typ Type) llvm.Value {

--- a/ssa/float_int_conversion_test.go
+++ b/ssa/float_int_conversion_test.go
@@ -112,3 +112,58 @@ func Test386FloatToIntegerConversionIR(t *testing.T) {
 		})
 	}
 }
+
+// Check the conversion width as well as signedness: directly saturating to a
+// narrow Go type would change the required wide-conversion-then-truncation.
+func TestSaturatingFloatToIntegerConversionIR(t *testing.T) {
+	for _, arch := range []string{"arm64", "riscv64", "wasm"} {
+		t.Run(arch, func(t *testing.T) {
+			target := &Target{GOOS: "linux", GOARCH: arch}
+			if arch == "wasm" {
+				target.GOOS = "wasip1"
+			}
+			prog := NewProgram(target)
+			defer prog.Dispose()
+			pkg := prog.NewPackage("floatconvert", "floatconvert")
+			for _, src := range []struct {
+				typ    *types.Basic
+				suffix string
+			}{
+				{types.Typ[types.Float32], "f32"},
+				{types.Typ[types.Float64], "f64"},
+			} {
+				for _, dst := range []struct {
+					typ       *types.Basic
+					intrinsic string
+					trunc     string
+				}{
+					{types.Typ[types.Int8], "fptosi.sat.i32", "trunc i32"},
+					{types.Typ[types.Int16], "fptosi.sat.i32", "trunc i32"},
+					{types.Typ[types.Int32], "fptosi.sat.i32", ""},
+					{types.Typ[types.Int64], "fptosi.sat.i64", ""},
+					{types.Typ[types.Uint8], "fptosi.sat.i32", "trunc i32"},
+					{types.Typ[types.Uint16], "fptosi.sat.i32", "trunc i32"},
+					{types.Typ[types.Uint32], "fptosi.sat.i64", "trunc i64"},
+					{types.Typ[types.Uint64], "fptoui.sat.i64", ""},
+				} {
+					name := src.suffix + "To" + dst.typ.Name()
+					t.Run(name, func(t *testing.T) {
+						params := types.NewTuple(types.NewParam(0, nil, "x", src.typ))
+						results := types.NewTuple(types.NewParam(0, nil, "", dst.typ))
+						fn := pkg.NewFunc(name, types.NewSignatureType(nil, nil, nil, params, results, false), InGo)
+						b := fn.MakeBody(1)
+						b.Return(b.Convert(prog.Type(dst.typ, InGo), fn.Param(0)))
+						ir := fn.impl.String()
+						want := "@llvm." + dst.intrinsic + "." + src.suffix + "("
+						if !strings.Contains(ir, want) || !strings.Contains(ir, dst.trunc) {
+							t.Fatalf("conversion IR missing %q or %q:\n%s", want, dst.trunc, ir)
+						}
+						if strings.Contains(ir, "fcmp") || strings.Contains(ir, "select") {
+							t.Fatalf("conversion still emits manual saturation guards:\n%s", ir)
+						}
+					})
+				}
+			}
+		})
+	}
+}

--- a/ssa/float_int_conversion_test.go
+++ b/ssa/float_int_conversion_test.go
@@ -90,7 +90,10 @@ func Test386FloatToIntegerConversionIR(t *testing.T) {
 	}{
 		{name: "I32", src: types.Typ[types.Float64], dst: types.Typ[types.Int32], wants: []string{"fptosi double", "to i32", "i32 -2147483648"}},
 		{name: "I64", src: types.Typ[types.Float64], dst: types.Typ[types.Int64], wants: []string{"Float64ToInt64", "(double"}},
-		{name: "U32", src: types.Typ[types.Float64], dst: types.Typ[types.Uint32], wants: []string{"Float64ToUint64", "trunc i64", "to i32"}},
+		{name: "U32", src: types.Typ[types.Float64], dst: types.Typ[types.Uint32], wants: []string{"fcmp olt double", "fcmp oge double", "fptosi double", "i64 -9223372036854775808", "trunc i64", "to i32"}},
+		{name: "Uint", src: types.Typ[types.Float64], dst: types.Typ[types.Uint], wants: []string{"fptosi double", "i64 -9223372036854775808", "trunc i64", "to i32"}},
+		{name: "Uintptr", src: types.Typ[types.Float64], dst: types.Typ[types.Uintptr], wants: []string{"fptosi double", "i64 -9223372036854775808", "trunc i64", "to i32"}},
+		{name: "F32ToU32", src: types.Typ[types.Float32], dst: types.Typ[types.Uint32], wants: []string{"fptosi float", "i64 -9223372036854775808", "trunc i64", "to i32"}},
 		{name: "U64", src: types.Typ[types.Float64], dst: types.Typ[types.Uint64], wants: []string{"Float64ToUint64", "(double"}},
 		{name: "F32ToI64", src: types.Typ[types.Float32], dst: types.Typ[types.Int64], wants: []string{"fpext float", "to double", "Float64ToInt64"}},
 	}

--- a/test/cmd/llgo/float_int_conversion_test.go
+++ b/test/cmd/llgo/float_int_conversion_test.go
@@ -44,6 +44,12 @@ func main() {
 		id(float32(-math.MaxFloat32)), id(float32(-one / 0)), id(float32(-1.5)),
 		id(float32(math.NaN())), id(float32(1.5)), id(float32(1 << 31)),
 		id(float32(1 << 32)), id(float32(math.MaxFloat32)), id(float32(one / 0)),
+		id(float32(0)), id(float32(math.Copysign(0, -1))),
+		id(float32(math.SmallestNonzeroFloat32)), id(float32(-math.SmallestNonzeroFloat32)),
+		id(math.Nextafter32(1 << 31, 0)), id(math.Nextafter32(-1 << 31, float32(math.Inf(-1)))),
+		id(math.Nextafter32(1 << 32, 0)), id(float32(-1 << 63)),
+		id(math.Nextafter32(1 << 63, 0)), id(float32(1 << 63)),
+		id(math.Nextafter32(1 << 64, 0)), id(float32(1 << 64)),
 	} {
 		emit(x)
 	}
@@ -51,6 +57,12 @@ func main() {
 		id(-math.MaxFloat64), id(-one / 0), id(-1.5), id(math.NaN()), id(1.5),
 		id(float64(1 << 31)), id(float64(1 << 32)), id(float64(1 << 63)),
 		id(math.MaxFloat64), id(one / 0),
+		id(0.0), id(math.Copysign(0, -1)),
+		id(math.SmallestNonzeroFloat64), id(-math.SmallestNonzeroFloat64),
+		id(math.Nextafter(1 << 31, 0)), id(math.Nextafter(-1 << 31, math.Inf(-1))),
+		id(math.Nextafter(1 << 32, 0)), id(float64(-1 << 63)),
+		id(math.Nextafter(-1 << 63, math.Inf(-1))), id(math.Nextafter(1 << 63, 0)),
+		id(math.Nextafter(1 << 64, 0)), id(float64(1 << 64)),
 	} {
 		emit(x)
 	}


### PR DESCRIPTION
Replace the hand-written bounds/NaN checks and selects in saturating float-to-integer conversion helpers with `llvm.fptosi.sat` and `llvm.fptoui.sat`. On AArch64, the emitted float64-to-int64/uint64 functions reduce to `fcvtzs`/`fcvtzu` and `ret` with LLVM 22.1.8.

Preserve amd64 legacy CVTT results, 386 software int64/uint64 conversions, narrow integer conversion followed by truncation, and the `SaturatingFloatToUint32` mode. Extend IR tests for those distinctions and the existing gc comparison probe with signed zero, subnormals, and adjacent boundary values.

The expanded probe also exposes an existing 386 unsigned-word conversion bug. gc converts through signed i64 with x87 and takes the low word; truncating the software uint64 conversion instead gives nonzero results for some inputs outside signed-i64 range. Correct float32/float64 conversion to uint32, uint, and uintptr using the guarded signed-i64 path. For example, `math.Nextafter(math.Exp2(64), 0)` now converts to zero rather than 4294965248 on 386, matching gc. The int64/uint64 software paths retain their distinct behavior. See [Go 1.27's 386 conversion helper](https://github.com/golang/go/blob/go1.27.0/src/runtime/asm_386.s#L963).

Validation with Go 1.27.0 and LLVM/LLD 22.1.8 on macOS arm64:

- `go test ./ssa -count=1` and the complete `go test ./cl -count=1` suite passed, including the four-target POST-ABI `floatint` FileCheck fixture.
- `go test -tags=llgo ./test/cmd/llgo -run '^TestFloatToIntegerConversionSemantics$' -count=1` passed using the newly built compiler; its output matches gc.
- 160,912 production-SSA conversion results matched an independent clamp/truncation oracle on arm64, including random bit patterns and special/boundary values.
- Production SSA IR passed `llc -O2 -verify-machineinstrs` for AArch64, x86-64, RISC-V64, and wasm32 (with and without nontrapping float-to-integer support). Other architectures were not executed.
- `go fmt ./...`, `git diff --check`, and `go vet ./ssa ./cl` passed. Full `go vet ./...` reports existing test cases for discarded cancellation, self-assignment, unsafe pointers, non-pointer JSON arguments, and copied locks.

Additional validation for the 386 correction:
- Full SSA/CL tests, `go vet ./ssa ./cl`, and the rebuilt LLGo/gc conversion probe passed locally on macOS arm64.
- 300,282 results from production 386 lowering matched an independent signed-i64/truncation oracle across float32/float64, uint32/uint/uintptr, random bit patterns, and boundaries around 2^31, 2^32, 2^63, and 2^64. Execution retargeted the IR to arm64; it is not a native 386 run.
- Both i686 MSVC and MinGW outputs passed `llc -O2 -verify-machineinstrs` and use x87 `fistpll` with truncation rounding. The existing Windows 386 end-to-end regression remains enabled without removing any boundary samples.

Remote CI for the updated head remains pending.

