### PR TITLE
ci: route benchmark notifications to llgo-test

### DIFF
--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -1,6 +1,7 @@
 name: Notify benchmarks
 
 on:
+  workflow_dispatch:
   # A push to main is the authoritative post-merge state, including squash and
   # rebase merges. The classifier below decides whether the change affects the
   # compiler and should start the expensive benchmarks.
@@ -32,9 +33,8 @@ jobs:
     if: github.repository == 'xgo-dev/llgo' && github.event_name != 'pull_request'
     runs-on: [qiniu, ubuntu-24.04]
     env:
-      # Set this repository variable to the temporary personal repository
-      # before the migration, then remove it to use xgo-dev/benchmarks.
-      BENCHMARKS_REPOSITORY: ${{ vars.BENCHMARKS_REPOSITORY || 'xgo-dev/benchmarks' }}
+      # Override this repository variable only when testing another receiver.
+      BENCHMARKS_REPOSITORY: ${{ vars.BENCHMARKS_REPOSITORY || 'llgo-test/benchmarks' }}
       BENCHMARKS_DISPATCH_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
@@ -59,7 +59,7 @@ jobs:
             --github-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Request benchmarks for this LLGo revision
-        if: github.event_name == 'release' || steps.changes.outputs.compiler == 'true'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.compiler == 'true'
         run: |
           set -euo pipefail
           if [[ -z "$BENCHMARKS_DISPATCH_TOKEN" ]]; then
@@ -80,6 +80,14 @@ jobs:
               llgo_commit="$(awk -v ref="$tag_ref" '$2 == ref { print $1; exit }' <<<"$tag_rows")"
             fi
             event_type=llgo-tag-released
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Manual runs are an end-to-end transport check, not a request to
+            # benchmark the selected workflow ref. Always resolve authoritative
+            # main so the llgo-main-updated event cannot carry a branch commit.
+            llgo_commit="$(git ls-remote \
+              "https://github.com/${GITHUB_REPOSITORY}.git" \
+              refs/heads/main | awk 'NR == 1 { print $1 }')"
+            event_type=llgo-main-updated
           else
             llgo_commit="$GITHUB_SHA"
             event_type=llgo-main-updated

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LLGo - A Go compiler based on LLVM
 [![Build Status](https://github.com/xgo-dev/llgo/actions/workflows/go.yml/badge.svg)](https://github.com/xgo-dev/llgo/actions/workflows/go.yml)
 [![GitHub release](https://img.shields.io/github/v/tag/xgo-dev/llgo.svg?label=release)](https://github.com/xgo-dev/llgo/releases)
 [![Coverage Status](https://codecov.io/gh/xgo-dev/llgo/branch/main/graph/badge.svg)](https://codecov.io/gh/xgo-dev/llgo)
-[![Benchmark](https://img.shields.io/badge/benchmark-LLGo_vs_Go-yellowgreen.svg)](https://xgo-dev.github.io/benchmarks/)
+[![Benchmark](https://img.shields.io/badge/benchmark-LLGo_vs_Go-yellowgreen.svg)](https://llgo-test.github.io/benchmarks/)
 [![GoDoc](https://pkg.go.dev/badge/github.com/xgo-dev/llgo.svg)](https://pkg.go.dev/github.com/xgo-dev/llgo)
 [![XGo](https://img.shields.io/badge/project-XGo-blue.svg)](https://github.com/goplus/xgo)
 

--- a/benchmark/binary_size/README.md
+++ b/benchmark/binary_size/README.md
@@ -2,7 +2,7 @@
 
 These fixed programs keep LLGo binary-size measurements comparable across
 linker and PCLN packaging changes. The comprehensive linker/PCLN matrix is
-maintained by `xgo-dev/benchmarks`; `benchmark/baseline` reuses the three
+maintained by `llgo-test/benchmarks`; `benchmark/baseline` reuses the three
 smallest workloads for the per-commit lightweight size and timing gate.
 
 - `cprintf`: the smallest C-library hello world, using only `lib/c.Printf`.


### PR DESCRIPTION
## Summary
- route post-merge and release benchmark notifications to `llgo-test/benchmarks`
- update the benchmark dashboard badge and binary-size documentation
- add a manual dispatch entry point for end-to-end receiver-token validation

## Validation
- benchmark change-classifier tests
- workflow YAML parsing
- actionlint, allowing the existing `qiniu` self-hosted runner label
- `git diff --check`

The receiver repository has been transferred to `llgo-test/benchmarks`; receiver-side ownership/link updates are tracked in llgo-test/benchmarks#48. The live repository variable already targets the new receiver during this transition.