### PR TITLE
ci: consolidate setup-heavy jobs and support fork runners

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -34,18 +34,18 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_ABI=${{ inputs.windows-abi }}"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_ARCH=${{ inputs.windows-arch }}"
 
-    - name: Cache full-target Windows LLVM
+    - name: Cache compressed full-target Windows LLVM archive
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'
-      id: windows_llvm_cache
       uses: actions/cache@v6
       with:
-        path: ${{ runner.tool_cache }}\llgo-llvm\clang+llvm-22.1.8-x86_64-pc-windows-msvc
-        # Configuration later installs target compiler-rt builtins into this
-        # tree, so each target architecture must own an immutable cache.
-        key: llgo-llvm-22.1.8-full-target-windows-${{ inputs.windows-arch }}-d96c2cc1736f4eb7fa43cb9bbdf56d93551a9ae0a9aadb9c99c3c3b2b712a234
+        # All MSVC profiles use the same x64 host LLVM. Cache its compressed
+        # immutable input once instead of three 1.2 GiB extracted trees; the
+        # target-specific builtins and LLDB remain in the caches below.
+        path: ${{ runner.tool_cache }}\llgo-llvm-archives\clang+llvm-22.1.8-x86_64-pc-windows-msvc.tar.xz
+        key: llgo-llvm-archive-22.1.8-x86_64-pc-windows-msvc-d96c2cc1736f4eb7fa43cb9bbdf56d93551a9ae0a9aadb9c99c3c3b2b712a234
 
     - name: Install full-target Windows LLVM
-      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc' && steps.windows_llvm_cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'
       shell: pwsh
       env:
         # The development archive contains llvm-config, headers, libraries,
@@ -60,12 +60,16 @@ runs:
         }
 
         $archiveName = "clang+llvm-$env:LLVM_VERSION-x86_64-pc-windows-msvc.tar.xz"
-        $archive = Join-Path $env:RUNNER_TEMP $archiveName
-        $urlAsset = $archiveName.Replace("+", "%2B")
-        $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_VERSION/$urlAsset"
-        & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $url
-        if ($LASTEXITCODE -ne 0) {
-          throw "Downloading LLVM failed with exit code $LASTEXITCODE"
+        $archiveParent = Join-Path $env:RUNNER_TOOL_CACHE "llgo-llvm-archives"
+        $archive = Join-Path $archiveParent $archiveName
+        New-Item -ItemType Directory -Force $archiveParent | Out-Null
+        if (-not (Test-Path $archive)) {
+          $urlAsset = $archiveName.Replace("+", "%2B")
+          $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_VERSION/$urlAsset"
+          & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $url
+          if ($LASTEXITCODE -ne 0) {
+            throw "Downloading LLVM failed with exit code $LASTEXITCODE"
+          }
         }
         $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash
         if (-not $actual.Equals($env:LLVM_ARCHIVE_SHA256, [StringComparison]::OrdinalIgnoreCase)) {
@@ -99,7 +103,7 @@ runs:
           throw "llvm-config.exe was not found in the full-target LLVM archive"
         }
         Move-Item -LiteralPath $extractedRoot.FullName -Destination $installRoot
-        Remove-Item -LiteralPath $archive, $tar.FullName
+        Remove-Item -LiteralPath $tar.FullName
 
     - name: Cache Windows LLDB and target builtins
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && (inputs.windows-abi == 'msvc' || inputs.windows-arch != 'amd64')
@@ -276,7 +280,7 @@ runs:
 
         $llvmRoot = Join-Path $env:RUNNER_TOOL_CACHE "llgo-llvm\clang+llvm-$env:LLVM_VERSION-x86_64-pc-windows-msvc"
         if (-not (Test-Path (Join-Path $llvmRoot "bin\llvm-config.exe"))) {
-          throw "The cached full-target LLVM installation is incomplete: $llvmRoot"
+          throw "The full-target LLVM installation is incomplete: $llvmRoot"
         }
         $llvmBin = Join-Path $llvmRoot "bin"
         $llvmConfig = Join-Path $llvmBin "llvm-config.exe"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,7 +69,7 @@ jobs:
             windows_arch: "386"
             host_go_arch: x64
             timeout: 90
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
       GOMAXPROCS: "2"
@@ -255,7 +255,7 @@ jobs:
 
   wasm-benchmark:
     name: benchmark (WebAssembly)
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     env:
       GOMAXPROCS: "2"

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -32,7 +32,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/doc-link-checker.yml
+++ b/.github/workflows/doc-link-checker.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   doc_verify:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -104,6 +104,8 @@ jobs:
       - name: Test default and full local installs
         shell: bash
         run: |
+          # Keep nounset disabled: this wrapper sources the README and
+          # generated virtualenv scripts, which manage optional variables.
           set -eo pipefail
           set -x
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -50,11 +50,10 @@ jobs:
           source doc/_readme/scripts/run.sh
 
   local_install:
-    name: local ${{ matrix.install_mode == 'full' && 'full ' || '' }}install (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
+    name: local installs (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
     timeout-minutes: 30
     strategy:
       matrix:
-        install_mode: [default, full]
         platform: [macos, ubuntu, windows-msvc, windows-mingw]
         include:
           - platform: macos
@@ -89,9 +88,6 @@ jobs:
           set -e
           set -x
           source doc/_readme/scripts/install_ubuntu.sh
-          if [[ "${{ matrix.install_mode }}" == "full" ]]; then
-            echo "PATH=/usr/lib/llvm-22/bin:$PATH" >> "$GITHUB_ENV"
-          fi
 
       - name: Set up Python 3.12 on Windows
         if: startsWith(matrix.os, 'windows')
@@ -105,18 +101,22 @@ jobs:
         with:
           windows-abi: ${{ matrix.windows_abi || 'msvc' }}
 
-      - name: Install llgo with tools
+      - name: Test default and full local installs
         shell: bash
         run: |
-          set -e
+          set -eo pipefail
           set -x
+
+          base_path="$PATH"
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             python_lib=$(python -c 'import os, sys; print(os.path.join(sys.base_prefix, "libs", f"python{sys.version_info.major}{sys.version_info.minor}"))')
             export LLGO_LIB_PYTHON="$python_lib"
             export LLGO_STDIO_NOBUF=1
-            echo "LLGO_LIB_PYTHON=$LLGO_LIB_PYTHON" >> "$GITHUB_ENV"
-            echo "LLGO_STDIO_NOBUF=$LLGO_STDIO_NOBUF" >> "$GITHUB_ENV"
           fi
+
+          # Both README installation modes run after one platform dependency
+          # setup, but use separate binary directories. Reset PATH between
+          # them so the full install cannot pass using the default install.
           git() {
             if [ "$1" = "clone" ]; then
               # do nothing because we already have the branch
@@ -125,16 +125,28 @@ jobs:
               command git "$@"
             fi
           }
-          if [[ "${{ matrix.install_mode }}" == "full" ]]; then
-            source doc/_readme/scripts/install_full.sh
-          else
-            source doc/_readme/scripts/install_llgo.sh
-          fi
-          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
-      - name: Test doc code blocks
-        shell: bash
-        run: |
-          set -e
-          set -x
-          source doc/_readme/scripts/run.sh
+          for install_mode in default full; do
+            cd "$GITHUB_WORKSPACE"
+            install_bin="$RUNNER_TEMP/llgo-$install_mode-bin"
+            path_bin="$install_bin"
+            if [[ "$RUNNER_OS" == "Windows" ]]; then
+              install_bin=$(cygpath -m "$install_bin")
+              path_bin=$(cygpath -u "$install_bin")
+            fi
+            mkdir -p "$path_bin"
+            export GOBIN="$install_bin"
+            export PATH="$path_bin:$base_path"
+            if [[ "$install_mode" == "full" && "$RUNNER_OS" == "Linux" ]]; then
+              export PATH="/usr/lib/llvm-22/bin:$PATH"
+            fi
+
+            if [[ "$install_mode" == "full" ]]; then
+              source doc/_readme/scripts/install_full.sh
+            else
+              source doc/_readme/scripts/install_llgo.sh
+            fi
+            export LLGO_ROOT="$GITHUB_WORKSPACE"
+            cd "$GITHUB_WORKSPACE"
+            source doc/_readme/scripts/run.sh
+          done

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -68,7 +68,7 @@ jobs:
           - platform: windows-mingw
             os: windows-2022
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   fmt:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -228,7 +228,7 @@ jobs:
   dev-lto-globaldce:
     name: Dev LTO GlobalDCE
     timeout-minutes: 60
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -309,7 +309,7 @@ jobs:
   dev-go-methoddrop:
     name: Dev Go Method Drop
     timeout-minutes: 60
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -226,7 +226,7 @@ jobs:
             ./cl
 
   dev-lto-globaldce:
-    name: Dev LTO GlobalDCE
+    name: Dev LTO GlobalDCE and Go Method Drop
     timeout-minutes: 60
     runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
@@ -304,32 +304,8 @@ jobs:
           files: coverage-dev-globaldce-unit.txt,coverage-dev-lto-globaldce-cl.txt,coverage-dev-lto-globaldce-symbols.txt,coverage-dev-lto-plugin-cl.txt
           flags: dev-lto-globaldce
 
-  # Tests deletion of unreachable Go methods.
-  # See https://github.com/xgo-dev/llgo/issues/1853.
-  dev-go-methoddrop:
-    name: Dev Go Method Drop
-    timeout-minutes: 60
-    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install dependencies
-        uses: ./.github/actions/setup-deps
-        with:
-          llvm-version: 22
-
-      - name: Set up Go
-        uses: ./.github/actions/setup-go
-
-      - name: Setup demo dependencies
-        uses: ./.github/actions/setup-demo-deps
-
-      - name: Set LLGO_ROOT
-        run: echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-
-      - name: Build llgo with dev tag
-        run: go install -tags=dev ./cmd/llgo
-
+      # Tests deletion of unreachable Go methods.
+      # See https://github.com/xgo-dev/llgo/issues/1853.
       - name: Run Go method drop tests
         run: go test -tags=dev -timeout 30m -run '^TestBuildAndCheckSymbolsFromTestdrop$' ./cl
 

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -54,7 +54,7 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -206,7 +206,7 @@ jobs:
     name: GOROOT summary
     if: always()
     needs: goroot
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - name: Download shard statistics
         uses: actions/download-artifact@v8

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -646,8 +646,12 @@ jobs:
           windows-arch: ${{ matrix.windows_arch }}
 
   wasm-runtime:
-    name: wasm-runtime (Go 1.24 and 1.27)
+    name: wasm-runtime (${{ matrix.suite }})
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [runtime, test-command]
     runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
@@ -691,6 +695,7 @@ jobs:
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
       - name: Test WebAssembly target profiles
+        if: matrix.suite == 'runtime'
         shell: bash
         env:
           LLGO: ${{ runner.temp }}/llgo-bin/llgo
@@ -698,6 +703,7 @@ jobs:
         run: dev/test_wasm_target_profiles.sh
 
       - name: Build standard runtime for wasm
+        if: matrix.suite == 'runtime'
         shell: bash
         env:
           LLGO: ${{ runner.temp }}/llgo-bin/llgo
@@ -709,4 +715,4 @@ jobs:
         env:
           LLGO: ${{ runner.temp }}/llgo-bin/llgo
           LLGO_BUILD_CACHE: "off"
-        run: dev/test_wasm_single_worker.sh
+        run: dev/test_wasm_single_worker.sh "${{ matrix.suite }}"

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -71,7 +71,7 @@ jobs:
             windows_arch: "386"
             host_go_arch: x64
             shard_total: "1"
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -475,7 +475,7 @@ jobs:
             windows_abi: msvc
             windows_arch: arm64
             host_go_arch: x64
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -562,7 +562,7 @@ jobs:
         # artifact smoke tests.
         os: [ubuntu-latest]
         llvm: [22]
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -615,7 +615,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -647,7 +647,7 @@ jobs:
   wasm-runtime:
     name: wasm-runtime (Go 1.24 and 1.27)
     timeout-minutes: 30
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -16,49 +16,61 @@ concurrency:
 
 jobs:
   llgo:
-    name: llgo (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, LLVM ${{ matrix.llvm }}, Go current)
+    name: llgo + test (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, LLVM ${{ matrix.llvm }}, Go 1.27, shard 0/${{ matrix.shard_total }})
     timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || 60 }}
     strategy:
       fail-fast: false
       matrix:
-        # Build the compiler and run compiler-owned integration checks once per
-        # native toolchain profile, always with .go-version.
+        # The compiler-owned integration checks and the first (or only) full
+        # Go 1.27 test shard use the same native toolchain profile. Keep them in
+        # one job so checkout, dependency setup, and tool builds happen once.
+        # The two historically slow profiles retain an independent shard 1.
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04-large]
             llvm: 22
+            shard_total: "2"
+            check_symbols: true
+            std_buildmodes: true
           - os: macos-latest
             llvm: 22
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: msvc
             windows_arch: amd64
             host_go_arch: x64
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
             windows_arch: amd64
             host_go_arch: x64
+            shard_total: "1"
           - os: windows-11-arm
             llvm: 22
             windows_abi: msvc
             windows_arch: arm64
             host_go_arch: x64
+            shard_total: "2"
           - os: windows-11-arm
             llvm: 22
             windows_abi: mingw
             windows_arch: arm64
             host_go_arch: arm64
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: msvc
             windows_arch: "386"
             host_go_arch: x64
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
+            shard_total: "1"
     runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -88,10 +100,11 @@ jobs:
       - name: Restore LLGo cache
         uses: ./.github/actions/setup-llgo-cache
 
-      - name: Install
+      - name: Build LLGo and test tools
         shell: bash
         run: |
-          go install ./...
+          dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
+          echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
       - name: Activate native Windows target
@@ -100,6 +113,45 @@ jobs:
         with:
           windows-abi: ${{ matrix.windows_abi }}
           windows-arch: ${{ matrix.windows_arch }}
+
+      - name: Check Windows native runtime and FFI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $llgo = Join-Path $env:RUNNER_TEMP 'llgo-bin\llgo.exe'
+          .\.github\workflows\test_windows_runtime.ps1 `
+            -LLGo $llgo `
+            -Profile "${{ matrix.windows_abi }}" `
+            -GoArch "${{ matrix.windows_arch || 'amd64' }}"
+
+      - name: Run Go 1.27 LLGo tests
+        env:
+          LLGO_BUILD_CACHE: "1"
+          LLGO_TEST_BENCH_GO126: "1"
+          LLGO_TEST_CHECK_SYMBOLS: ${{ matrix.check_symbols && '1' || '0' }}
+          LLGO_TEST_STD_BUILDMODES: ${{ matrix.std_buildmodes && '1' || '0' }}
+          SHARD_INDEX: "0"
+          SHARD_TOTAL: ${{ matrix.shard_total }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tool_suffix=
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            tool_suffix=.exe
+            export LLGO_STDIO_NOBUF=1
+          fi
+          export LLGO="$RUNNER_TEMP/llgo-bin/llgo${tool_suffix}"
+          export LLGO_TEST_LLGEN="$RUNNER_TEMP/llgo-bin/llgen${tool_suffix}"
+          export CHECK_STD_SYMBOLS="$RUNNER_TEMP/llgo-bin/check_std_symbols${tool_suffix}"
+          dev/test_go_version.sh 1.27
+
+      - name: Check std symbol coverage
+        # Split profiles leave this profile-wide check on shard 1. Unsharded
+        # non-amd64 profiles run it here after their full package test.
+        if: runner.os == 'Windows' && matrix.windows_arch != 'amd64' && matrix.shard_total == '1'
+        shell: bash
+        run: bash doc/_readme/scripts/check_std_cover.sh
 
       - name: Test Hello World with go.mod 1.21 through 1.26
         if: matrix.os == 'ubuntu-latest'
@@ -393,11 +445,9 @@ jobs:
         # selects a real target toolchain and matching alternate module file.
         # Go 1.20-1.26 share one focused compatibility lane. Go 1.27 is the
         # primary release and runs the complete test tree on every native
-        # toolchain profile. Ubuntu remains split because its LLVM 22 cold
-        # setup plus each shard can exceed 40 minutes. Four recent full runs
-        # put Windows ARM64 MSVC at 45-48 minutes, so it is the only other
-        # profile split here; the next slowest profiles stay below 35 minutes
-        # and avoid duplicate setup.
+        # toolchain profile. Its shard 0 now shares the matching integration
+        # job above. Only the second shards for Ubuntu and Windows ARM64 MSVC
+        # remain here, preserving their established parallel split.
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04-large]
@@ -412,53 +462,10 @@ jobs:
             llvm: 22
             go_version: "1.27"
             lane: full
-            shard_index: "0"
-            shard_total: "2"
-            check_symbols: true
-            std_buildmodes: true
-          - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
-            llvm: 22
-            go_version: "1.27"
-            lane: full
             shard_index: "1"
             shard_total: "2"
             check_symbols: true
             std_buildmodes: true
-          - os: macos-latest
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-          # Each Windows ABI profile runs the latest complete set with -p=2.
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: msvc
-            windows_arch: amd64
-            host_go_arch: x64
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: mingw
-            windows_arch: amd64
-            host_go_arch: x64
-          - os: windows-11-arm
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "2"
-            windows_abi: msvc
-            windows_arch: arm64
-            host_go_arch: x64
           - os: windows-11-arm
             llvm: 22
             go_version: "1.27"
@@ -467,33 +474,6 @@ jobs:
             shard_total: "2"
             windows_abi: msvc
             windows_arch: arm64
-            host_go_arch: x64
-          - os: windows-11-arm
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: mingw
-            windows_arch: arm64
-            host_go_arch: arm64
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: msvc
-            windows_arch: "386"
-            host_go_arch: x64
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: mingw
-            windows_arch: "386"
             host_go_arch: x64
     runs-on: ${{ matrix.runner || matrix.os }}
     steps:
@@ -529,18 +509,6 @@ jobs:
         with:
           windows-abi: ${{ matrix.windows_abi }}
           windows-arch: ${{ matrix.windows_arch }}
-
-      - name: Check Windows native runtime and FFI
-        # This check is profile-wide rather than package-specific. Run it once
-        # on the first shard instead of duplicating it in every shard.
-        if: runner.os == 'Windows' && matrix.shard_index == '0'
-        shell: pwsh
-        run: |
-          $llgo = Join-Path $env:RUNNER_TEMP 'llgo-bin\llgo.exe'
-          .\.github\workflows\test_windows_runtime.ps1 `
-            -LLGo $llgo `
-            -Profile "${{ matrix.windows_abi }}" `
-            -GoArch "${{ matrix.windows_arch || 'amd64' }}"
 
       - name: Run versioned LLGo tests
         env:

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   llgo:
     name: llgo + test (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, LLVM ${{ matrix.llvm }}, Go 1.27, shard 0/${{ matrix.shard_total }})
+    # Combined-job validation stayed below 25 min on macOS and 33 min on
+    # Windows amd64, including a cold dependency run. Keep the 60-min headroom
+    # and the larger existing limits for Windows 386 and ARM64.
     timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || 60 }}
     strategy:
       fail-fast: false
@@ -435,8 +438,6 @@ jobs:
 
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, Go ${{ matrix.go_version }}, shard ${{ matrix.shard_index }}/${{ matrix.shard_total }})
-    # The macOS full test phase alone can normally exceed 41 minutes; leave
-    # enough headroom for setup and cleanup instead of racing a 45-minute cap.
     timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 60 || 60 }}
     strategy:
       fail-fast: false

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -438,7 +438,7 @@ jobs:
 
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, Go ${{ matrix.go_version }}, shard ${{ matrix.shard_index }}/${{ matrix.shard_total }})
-    timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 60 || 60 }}
+    timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || 60 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/model-demo.yml
+++ b/.github/workflows/model-demo.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   llama2:
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   classifier-tests:
     if: github.event_name == 'pull_request'
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Test benchmark change classifier
@@ -31,7 +31,7 @@ jobs:
 
   dispatch:
     if: github.repository == 'xgo-dev/llgo' && github.event_name != 'pull_request'
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     env:
       # Override this repository variable only when testing another receiver.
       BENCHMARKS_REPOSITORY: ${{ vars.BENCHMARKS_REPOSITORY || 'llgo-test/benchmarks' }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,10 +22,9 @@ env:
   GORELEASER_CROSS_IMAGE: ghcr.io/goreleaser/goreleaser-cross:v1.27.0-1
 
 jobs:
-  setup:
+  populate-linux-sysroot:
     runs-on: ubuntu-latest
-    outputs:
-      linux-cache-key: ${{ steps.cache-keys.outputs.linux-key }}
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -33,20 +32,13 @@ jobs:
         id: cache-keys
         run: |
           LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
-          echo "linux-key=$LINUX_KEY" >> $GITHUB_OUTPUT
-  populate-linux-sysroot:
-    runs-on: ubuntu-latest
-    needs: setup
-    timeout-minutes: 30
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
+          echo "linux-key=$LINUX_KEY" >> "$GITHUB_OUTPUT"
       - name: Check Linux sysroot cache
         id: cache-linux-sysroot
         uses: actions/cache/restore@v6
         with:
           path: .sysroot/linux.tar.gz
-          key: ${{ needs.setup.outputs.linux-cache-key }}
+          key: ${{ steps.cache-keys.outputs.linux-key }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         if: steps.cache-linux-sysroot.outputs.cache-hit != 'true'
@@ -65,7 +57,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: .sysroot/linux.tar.gz
-          key: ${{ needs.setup.outputs.linux-cache-key }}
+          key: ${{ steps.cache-keys.outputs.linux-key }}
       # The cache is only a cross-run optimization: repository cache pressure
       # may evict it while a downstream job is queued. Use an artifact as the
       # required, run-scoped handoff so release correctness never depends on it.
@@ -80,7 +72,7 @@ jobs:
           retention-days: 3
   build:
     runs-on: ubuntu-latest
-    needs: [setup, populate-linux-sysroot]
+    needs: populate-linux-sysroot
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -320,7 +312,7 @@ jobs:
   release:
     permissions:
       contents: write
-    needs: [setup, test-artifacts, test-windows-artifacts, populate-linux-sysroot]
+    needs: [test-artifacts, test-windows-artifacts, populate-linux-sysroot]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-latest
         llvm: [22]
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -13,9 +13,12 @@ concurrency:
 
 jobs:
   llgo:
+    name: llgo (${{ matrix.test_dir }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }})
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
+        test_dir: [empty, defer]
         os:
           - ubuntu-latest
         llvm: [22]
@@ -35,12 +38,6 @@ jobs:
           go install ./...
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
-      - name: Build targets (empty)
-        run: |
-          cd _demo/embed/targetsbuild
-          bash build.sh empty
-
-      - name: Build targets (defer)
-        run: |
-          cd _demo/embed/targetsbuild
-          bash build.sh defer
+      - name: Build targets (${{ matrix.test_dir }})
+        working-directory: _demo/embed/targetsbuild
+        run: bash build.sh "${{ matrix.test_dir }}"

--- a/dev/test_wasm_single_worker.sh
+++ b/dev/test_wasm_single_worker.sh
@@ -12,9 +12,18 @@ callback_fixture="${repo_root}/internal/build/testdata/wasm-callback"
 gc_fixture="${repo_root}/internal/build/testdata/wasm-gc"
 lifecycle_fixture="${repo_root}/internal/build/testdata/wasm-lifecycle"
 test_fixture="${repo_root}/internal/build/testdata/wasm-test"
+suite="${1:-all}"
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/llgo-wasm-single-worker.XXXXXX")"
 trap 'rm -rf "${work_dir}"' EXIT
 export LLGO_WASM_TEST_ENV=wasm-env-ok
+
+case "${suite}" in
+all | runtime | test-command) ;;
+*)
+	echo "unknown single-worker WebAssembly suite: ${suite}" >&2
+	exit 2
+	;;
+esac
 
 run_with_timeout() {
 	run_with_timeout_limit 180s "$@"
@@ -116,6 +125,7 @@ run_llgo_test_compile_only() {
 	esac
 }
 
+if [[ "${suite}" != "test-command" ]]; then
 # Canonical C-ecosystem profiles exercise the same scheduler semantics under
 # Emscripten wasm32, Emscripten Memory64/LP64, and WASI Preview 1.
 run_emscripten emscripten emscripten-runner.mjs "${scheduler_fixture}" "wasm scheduler ok" "scheduler-emscripten"
@@ -163,7 +173,9 @@ run_emscripten emscripten-memory64 emscripten-memory64-runner.mjs "${callback_fi
 # browser/worker-only compatibility path defined by R0.
 run_emscripten wasm emscripten-runner.mjs "${scheduler_fixture}" "wasm scheduler ok" "scheduler-legacy-wasm"
 run_wasi wasip1 "${scheduler_fixture}" "wasm scheduler ok" "scheduler-legacy-wasip1"
+fi
 
+if [[ "${suite}" != "runtime" ]]; then
 # Exercise test-main generation, process exit, verbose output, and host runners
 # through the public test command. The JS-specific callback case also verifies
 # that host readiness interrupts a longer Go timer wait without re-entering an
@@ -174,5 +186,6 @@ run_llgo_test wasi "test-wasi"
 run_llgo_test_compile_only emscripten "test-compile-only-emscripten"
 run_llgo_test_compile_only emscripten-memory64 "test-compile-only-memory64"
 run_llgo_test_compile_only wasi "test-compile-only-wasi"
+fi
 
-echo "single-worker WebAssembly scheduler and timer checks passed"
+echo "single-worker WebAssembly ${suite} checks passed"


### PR DESCRIPTION
## Summary

CI currently repeats checkout, dependency setup, and LLGo/tool builds across jobs that use the same platform and toolchain. This PR consolidates the setup-heavy jobs whose combined runtime remains acceptable, while retaining every Go-version, platform, ABI, README-install, cache, and release-artifact check.

- Combine the compiler integration job with the first (or only) Go 1.27 full-test shard for all eight native toolchain profiles. Ubuntu and Windows ARM64 MSVC keep their independent second shard.
- Run the README default and full local installation flows sequentially in one job per platform, with separate `GOBIN` directories and a reset `PATH` so one installation cannot satisfy the other.
- Run Go method-drop checks after the Linux dev LTO/GlobalDCE checks, sharing LLVM, Go, demo dependencies, and the dev-tagged LLGo build.
- Move release cache-key calculation into the Linux sysroot producer while preserving the producer/build artifact boundary and cross-run sysroot cache.
- Run the independent `empty` and `defer` target sweeps in isolated matrix jobs. Serial execution exceeded the 30-minute limit on two consecutive attempts; separate runners avoid shared-output/cache races while keeping each job near the 25-minute target.
- Split the independent WebAssembly scheduler/runtime and public `llgo test` suites into isolated matrix jobs. The combined job's main steps succeeded only after 30:05 on a slow runner and were then marked cancelled during cleanup.
- Cache one hash-verified official Windows LLVM compressed archive across MSVC target architectures instead of three extracted LLVM trees.
- Select Qiniu runners only for repositories owned by `xgo-dev`; fork-owned workflow runs use GitHub-hosted runners. This is repository-owner selection, not automatic fallback when Qiniu is unavailable.

The rebase preserves the runner split introduced by #2523: setup-heavy Linux jobs use `ubuntu-24.04-large`, while the intentionally lightweight format, link-check, GOROOT-summary, and benchmark-notification jobs remain on standard `ubuntu-24.04`.

Build-cache jobs remain separate because they intentionally mutate and clear LLGo cache state. Long macOS LTO/coverage jobs also remain separate, and every release archive still has an independent runtime test.

## Job impact

| Workflow | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| LLGo | 27 | 20 | 7 |
| Docs | 10 | 6 | 4 |
| Go | 6 | 5 | 1 |
| Release Build | 16 | 15 | 1 |
| Targets | 1 | 2 | +1 |
| All PR-triggered workflows | 76 | 64 | 12 (15.8%) |

No validation coverage is removed; the reductions come from sharing setup and tool builds or moving a short producer-owned calculation into that producer.

## Measured results

The first consolidation was validated in [cpunion/llgo#240](https://github.com/cpunion/llgo/pull/240). Its completed LLGo run reduced aggregate runner execution across the eight paired profiles from 197:35 to 169:06 (28:29, or 14.4%):

| Profile | Previous two jobs | Combined job |
| --- | ---: | ---: |
| Ubuntu | 24:43 | 22:15 |
| macOS | 22:58 | 19:02 |
| Windows amd64 MSVC | 18:51 | 15:20 |
| Windows amd64 MinGW | 19:55 | 17:56 |
| Windows ARM64 MSVC | 33:56 | 24:52 |
| Windows ARM64 MinGW | 31:22 | 26:30 |
| Windows 386 MSVC | 22:54 | 21:53 |
| Windows 386 MinGW | 22:56 | 21:18 |

The follow-up consolidation was validated in [cpunion/llgo#241](https://github.com/cpunion/llgo/pull/241) before that validation-only PR was closed:

- All six Docs jobs passed. Consolidated local-install jobs took 1:54 on Ubuntu, 3:09 on Windows MinGW, 3:30 on macOS, and 15:24 on Windows MSVC.
- The combined `Dev LTO GlobalDCE and Go Method Drop` job passed in 8:34.
- The release sysroot producer passed from a cold cache in 2:16; its downstream build and every release-package runtime test passed.
- Format and Go passed. Unrelated fork workflows were intentionally cancelled to conserve runner capacity.

The original serial Targets job usually completed in 20–23 minutes, but [run 34097666600](https://github.com/xgo-dev/llgo/actions/runs/34097666600) timed out twice: the `empty` sweep took 23:02 and 20:03, leaving only 4:58 and 8:10 for `defer`. The two isolated jobs retain the Qiniu large runner selected by #2523 and avoid solving this by merely raising the timeout. In the [replacement run](https://github.com/xgo-dev/llgo/actions/runs/34105788602), `empty` passed in 15:58 (14:24 build step), `defer` passed in 17:12 (15:38 build step), and the workflow completed in 17:26.

The combined WebAssembly runtime job then hit the same boundary: setup and preliminary runtime checks took 7:17, the single-worker step took 22:48, and the main work completed at 30:05 before cleanup was cancelled by the 30-minute job limit. The single-worker step contains two independent groups: scheduler/runtime coverage took 9:52 and public `llgo test`/`test -c` coverage took 12:56. They now run as separate matrix jobs while the script's default invocation still runs both groups for local compatibility. In the [split-suite validation run](https://github.com/xgo-dev/llgo/actions/runs/34109295984), `test-command` passed in 9:47 and `runtime` passed in 16:52; both completed within 16:57 wall-clock and below the 25-minute target.

These are separate CI runs with cache, queue, and runner variability, so the figures demonstrate headroom and aggregate setup savings rather than a controlled per-second benchmark.

## Validation

- Rebased onto `xgo-dev/llgo@728351d37` (#2523) and resolved runner changes by preserving both the new large/standard labels and the fork-owner gate.
- `actionlint` syntax and expression validation passes for all workflows (ShellCheck disabled because unchanged scripts have existing warnings).
- `git diff --check` passes.
- Go method-drop tests passed locally with LLVM 22 before the rebase.
- Pre-rebase functional CI coverage passed in the two fork validation PRs above; the upstream checks validate the exact rebased combined head.
