### PR TITLE
[superseded by #2521] ci: consolidate short setup-heavy jobs

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -34,18 +34,18 @@ runs:
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_ABI=${{ inputs.windows-abi }}"
         Add-Content -Encoding utf8 $env:GITHUB_ENV "LLGO_WINDOWS_ARCH=${{ inputs.windows-arch }}"
 
-    - name: Cache full-target Windows LLVM
+    - name: Cache compressed full-target Windows LLVM archive
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'
-      id: windows_llvm_cache
       uses: actions/cache@v6
       with:
-        path: ${{ runner.tool_cache }}\llgo-llvm\clang+llvm-22.1.8-x86_64-pc-windows-msvc
-        # Configuration later installs target compiler-rt builtins into this
-        # tree, so each target architecture must own an immutable cache.
-        key: llgo-llvm-22.1.8-full-target-windows-${{ inputs.windows-arch }}-d96c2cc1736f4eb7fa43cb9bbdf56d93551a9ae0a9aadb9c99c3c3b2b712a234
+        # All MSVC profiles use the same x64 host LLVM. Cache its compressed
+        # immutable input once instead of three 1.2 GiB extracted trees; the
+        # target-specific builtins and LLDB remain in the caches below.
+        path: ${{ runner.tool_cache }}\llgo-llvm-archives\clang+llvm-22.1.8-x86_64-pc-windows-msvc.tar.xz
+        key: llgo-llvm-archive-22.1.8-x86_64-pc-windows-msvc-d96c2cc1736f4eb7fa43cb9bbdf56d93551a9ae0a9aadb9c99c3c3b2b712a234
 
     - name: Install full-target Windows LLVM
-      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc' && steps.windows_llvm_cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Windows' && inputs.install-llvm == 'true' && inputs.windows-abi == 'msvc'
       shell: pwsh
       env:
         # The development archive contains llvm-config, headers, libraries,
@@ -60,12 +60,16 @@ runs:
         }
 
         $archiveName = "clang+llvm-$env:LLVM_VERSION-x86_64-pc-windows-msvc.tar.xz"
-        $archive = Join-Path $env:RUNNER_TEMP $archiveName
-        $urlAsset = $archiveName.Replace("+", "%2B")
-        $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_VERSION/$urlAsset"
-        & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $url
-        if ($LASTEXITCODE -ne 0) {
-          throw "Downloading LLVM failed with exit code $LASTEXITCODE"
+        $archiveParent = Join-Path $env:RUNNER_TOOL_CACHE "llgo-llvm-archives"
+        $archive = Join-Path $archiveParent $archiveName
+        New-Item -ItemType Directory -Force $archiveParent | Out-Null
+        if (-not (Test-Path $archive)) {
+          $urlAsset = $archiveName.Replace("+", "%2B")
+          $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_VERSION/$urlAsset"
+          & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $url
+          if ($LASTEXITCODE -ne 0) {
+            throw "Downloading LLVM failed with exit code $LASTEXITCODE"
+          }
         }
         $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash
         if (-not $actual.Equals($env:LLVM_ARCHIVE_SHA256, [StringComparison]::OrdinalIgnoreCase)) {
@@ -99,7 +103,7 @@ runs:
           throw "llvm-config.exe was not found in the full-target LLVM archive"
         }
         Move-Item -LiteralPath $extractedRoot.FullName -Destination $installRoot
-        Remove-Item -LiteralPath $archive, $tar.FullName
+        Remove-Item -LiteralPath $tar.FullName
 
     - name: Cache Windows LLDB and target builtins
       if: runner.os == 'Windows' && inputs.install-llvm == 'true' && (inputs.windows-abi == 'msvc' || inputs.windows-arch != 'amd64')
@@ -276,7 +280,7 @@ runs:
 
         $llvmRoot = Join-Path $env:RUNNER_TOOL_CACHE "llgo-llvm\clang+llvm-$env:LLVM_VERSION-x86_64-pc-windows-msvc"
         if (-not (Test-Path (Join-Path $llvmRoot "bin\llvm-config.exe"))) {
-          throw "The cached full-target LLVM installation is incomplete: $llvmRoot"
+          throw "The full-target LLVM installation is incomplete: $llvmRoot"
         }
         $llvmBin = Join-Path $llvmRoot "bin"
         $llvmConfig = Join-Path $llvmBin "llvm-config.exe"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,7 +69,7 @@ jobs:
             windows_arch: "386"
             host_go_arch: x64
             timeout: 90
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
       GOMAXPROCS: "2"

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -32,7 +32,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/doc-link-checker.yml
+++ b/.github/workflows/doc-link-checker.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   doc_verify:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -104,6 +104,8 @@ jobs:
       - name: Test default and full local installs
         shell: bash
         run: |
+          # Keep nounset disabled: this wrapper sources the README and
+          # generated virtualenv scripts, which manage optional variables.
           set -eo pipefail
           set -x
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -68,7 +68,7 @@ jobs:
           - platform: windows-mingw
             os: windows-2022
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -50,11 +50,10 @@ jobs:
           source doc/_readme/scripts/run.sh
 
   local_install:
-    name: local ${{ matrix.install_mode == 'full' && 'full ' || '' }}install (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
+    name: local installs (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }})
     timeout-minutes: 30
     strategy:
       matrix:
-        install_mode: [default, full]
         platform: [macos, ubuntu, windows-msvc, windows-mingw]
         include:
           - platform: macos
@@ -89,9 +88,6 @@ jobs:
           set -e
           set -x
           source doc/_readme/scripts/install_ubuntu.sh
-          if [[ "${{ matrix.install_mode }}" == "full" ]]; then
-            echo "PATH=/usr/lib/llvm-22/bin:$PATH" >> "$GITHUB_ENV"
-          fi
 
       - name: Set up Python 3.12 on Windows
         if: startsWith(matrix.os, 'windows')
@@ -105,18 +101,22 @@ jobs:
         with:
           windows-abi: ${{ matrix.windows_abi || 'msvc' }}
 
-      - name: Install llgo with tools
+      - name: Test default and full local installs
         shell: bash
         run: |
-          set -e
+          set -eo pipefail
           set -x
+
+          base_path="$PATH"
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             python_lib=$(python -c 'import os, sys; print(os.path.join(sys.base_prefix, "libs", f"python{sys.version_info.major}{sys.version_info.minor}"))')
             export LLGO_LIB_PYTHON="$python_lib"
             export LLGO_STDIO_NOBUF=1
-            echo "LLGO_LIB_PYTHON=$LLGO_LIB_PYTHON" >> "$GITHUB_ENV"
-            echo "LLGO_STDIO_NOBUF=$LLGO_STDIO_NOBUF" >> "$GITHUB_ENV"
           fi
+
+          # Both README installation modes run after one platform dependency
+          # setup, but use separate binary directories. Reset PATH between
+          # them so the full install cannot pass using the default install.
           git() {
             if [ "$1" = "clone" ]; then
               # do nothing because we already have the branch
@@ -125,16 +125,28 @@ jobs:
               command git "$@"
             fi
           }
-          if [[ "${{ matrix.install_mode }}" == "full" ]]; then
-            source doc/_readme/scripts/install_full.sh
-          else
-            source doc/_readme/scripts/install_llgo.sh
-          fi
-          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
-      - name: Test doc code blocks
-        shell: bash
-        run: |
-          set -e
-          set -x
-          source doc/_readme/scripts/run.sh
+          for install_mode in default full; do
+            cd "$GITHUB_WORKSPACE"
+            install_bin="$RUNNER_TEMP/llgo-$install_mode-bin"
+            path_bin="$install_bin"
+            if [[ "$RUNNER_OS" == "Windows" ]]; then
+              install_bin=$(cygpath -m "$install_bin")
+              path_bin=$(cygpath -u "$install_bin")
+            fi
+            mkdir -p "$path_bin"
+            export GOBIN="$install_bin"
+            export PATH="$path_bin:$base_path"
+            if [[ "$install_mode" == "full" && "$RUNNER_OS" == "Linux" ]]; then
+              export PATH="/usr/lib/llvm-22/bin:$PATH"
+            fi
+
+            if [[ "$install_mode" == "full" ]]; then
+              source doc/_readme/scripts/install_full.sh
+            else
+              source doc/_readme/scripts/install_llgo.sh
+            fi
+            export LLGO_ROOT="$GITHUB_WORKSPACE"
+            cd "$GITHUB_WORKSPACE"
+            source doc/_readme/scripts/run.sh
+          done

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   fmt:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -187,7 +187,7 @@ jobs:
           disable_search: true
 
   dev-lto-globaldce:
-    name: Dev LTO GlobalDCE
+    name: Dev LTO GlobalDCE and Go Method Drop
     timeout-minutes: 60
     runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
@@ -265,32 +265,8 @@ jobs:
           files: coverage-dev-globaldce-unit.txt,coverage-dev-lto-globaldce-cl.txt,coverage-dev-lto-globaldce-symbols.txt,coverage-dev-lto-plugin-cl.txt
           flags: dev-lto-globaldce
 
-  # Tests deletion of unreachable Go methods.
-  # See https://github.com/xgo-dev/llgo/issues/1853.
-  dev-go-methoddrop:
-    name: Dev Go Method Drop
-    timeout-minutes: 60
-    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install dependencies
-        uses: ./.github/actions/setup-deps
-        with:
-          llvm-version: 22
-
-      - name: Set up Go
-        uses: ./.github/actions/setup-go
-
-      - name: Setup demo dependencies
-        uses: ./.github/actions/setup-demo-deps
-
-      - name: Set LLGO_ROOT
-        run: echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-
-      - name: Build llgo with dev tag
-        run: go install -tags=dev ./cmd/llgo
-
+      # Tests deletion of unreachable Go methods.
+      # See https://github.com/xgo-dev/llgo/issues/1853.
       - name: Run Go method drop tests
         run: go test -tags=dev -timeout 30m -run '^TestBuildAndCheckSymbolsFromTestdrop$' ./cl
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -189,7 +189,7 @@ jobs:
   dev-lto-globaldce:
     name: Dev LTO GlobalDCE
     timeout-minutes: 60
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -270,7 +270,7 @@ jobs:
   dev-go-methoddrop:
     name: Dev Go Method Drop
     timeout-minutes: 60
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -54,7 +54,7 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -206,7 +206,7 @@ jobs:
     name: GOROOT summary
     if: always()
     needs: goroot
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - name: Download shard statistics
         uses: actions/download-artifact@v8

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   llgo:
     name: llgo + test (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, LLVM ${{ matrix.llvm }}, Go 1.27, shard 0/${{ matrix.shard_total }})
+    # Combined-job validation stayed below 25 min on macOS and 33 min on
+    # Windows amd64, including a cold dependency run. Keep the 60-min headroom
+    # and the larger existing limits for Windows 386 and ARM64.
     timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || 60 }}
     strategy:
       fail-fast: false
@@ -434,8 +437,6 @@ jobs:
 
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, Go ${{ matrix.go_version }}, shard ${{ matrix.shard_index }}/${{ matrix.shard_total }})
-    # The macOS full test phase alone can normally exceed 41 minutes; leave
-    # enough headroom for setup and cleanup instead of racing a 45-minute cap.
     timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 60 || 60 }}
     strategy:
       fail-fast: false

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -559,7 +559,7 @@ jobs:
         # artifact smoke tests.
         os: [ubuntu-latest]
         llvm: [22]
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -612,7 +612,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             runner: [qiniu, ubuntu-24.04]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -644,7 +644,7 @@ jobs:
   wasm-runtime:
     name: wasm-runtime (Go 1.24 and 1.27)
     timeout-minutes: 30
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -16,48 +16,60 @@ concurrency:
 
 jobs:
   llgo:
-    name: llgo (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, LLVM ${{ matrix.llvm }}, Go current)
+    name: llgo + test (${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, LLVM ${{ matrix.llvm }}, Go 1.27, shard 0/${{ matrix.shard_total }})
     timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || 60 }}
     strategy:
       fail-fast: false
       matrix:
-        # Build the compiler and run compiler-owned integration checks once per
-        # native toolchain profile, always with .go-version.
+        # The compiler-owned integration checks and the first (or only) full
+        # Go 1.27 test shard use the same native toolchain profile. Keep them in
+        # one job so checkout, dependency setup, and tool builds happen once.
+        # The two historically slow profiles retain an independent shard 1.
         include:
           - os: ubuntu-latest
             llvm: 22
+            shard_total: "2"
+            check_symbols: true
+            std_buildmodes: true
           - os: macos-latest
             llvm: 22
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: msvc
             windows_arch: amd64
             host_go_arch: x64
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
             windows_arch: amd64
             host_go_arch: x64
+            shard_total: "1"
           - os: windows-11-arm
             llvm: 22
             windows_abi: msvc
             windows_arch: arm64
             host_go_arch: x64
+            shard_total: "2"
           - os: windows-11-arm
             llvm: 22
             windows_abi: mingw
             windows_arch: arm64
             host_go_arch: arm64
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: msvc
             windows_arch: "386"
             host_go_arch: x64
+            shard_total: "1"
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
+            shard_total: "1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -87,10 +99,11 @@ jobs:
       - name: Restore LLGo cache
         uses: ./.github/actions/setup-llgo-cache
 
-      - name: Install
+      - name: Build LLGo and test tools
         shell: bash
         run: |
-          go install ./...
+          dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
+          echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
       - name: Activate native Windows target
@@ -99,6 +112,45 @@ jobs:
         with:
           windows-abi: ${{ matrix.windows_abi }}
           windows-arch: ${{ matrix.windows_arch }}
+
+      - name: Check Windows native runtime and FFI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $llgo = Join-Path $env:RUNNER_TEMP 'llgo-bin\llgo.exe'
+          .\.github\workflows\test_windows_runtime.ps1 `
+            -LLGo $llgo `
+            -Profile "${{ matrix.windows_abi }}" `
+            -GoArch "${{ matrix.windows_arch || 'amd64' }}"
+
+      - name: Run Go 1.27 LLGo tests
+        env:
+          LLGO_BUILD_CACHE: "1"
+          LLGO_TEST_BENCH_GO126: "1"
+          LLGO_TEST_CHECK_SYMBOLS: ${{ matrix.check_symbols && '1' || '0' }}
+          LLGO_TEST_STD_BUILDMODES: ${{ matrix.std_buildmodes && '1' || '0' }}
+          SHARD_INDEX: "0"
+          SHARD_TOTAL: ${{ matrix.shard_total }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tool_suffix=
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            tool_suffix=.exe
+            export LLGO_STDIO_NOBUF=1
+          fi
+          export LLGO="$RUNNER_TEMP/llgo-bin/llgo${tool_suffix}"
+          export LLGO_TEST_LLGEN="$RUNNER_TEMP/llgo-bin/llgen${tool_suffix}"
+          export CHECK_STD_SYMBOLS="$RUNNER_TEMP/llgo-bin/check_std_symbols${tool_suffix}"
+          dev/test_go_version.sh 1.27
+
+      - name: Check std symbol coverage
+        # Split profiles leave this profile-wide check on shard 1. Unsharded
+        # non-amd64 profiles run it here after their full package test.
+        if: runner.os == 'Windows' && matrix.windows_arch != 'amd64' && matrix.shard_total == '1'
+        shell: bash
+        run: bash doc/_readme/scripts/check_std_cover.sh
 
       - name: Test Hello World with go.mod 1.21 through 1.26
         if: matrix.os == 'ubuntu-latest'
@@ -392,11 +444,9 @@ jobs:
         # selects a real target toolchain and matching alternate module file.
         # Go 1.20-1.26 share one focused compatibility lane. Go 1.27 is the
         # primary release and runs the complete test tree on every native
-        # toolchain profile. Ubuntu remains split because its LLVM 22 cold
-        # setup plus each shard can exceed 40 minutes. Four recent full runs
-        # put Windows ARM64 MSVC at 45-48 minutes, so it is the only other
-        # profile split here; the next slowest profiles stay below 35 minutes
-        # and avoid duplicate setup.
+        # toolchain profile. Its shard 0 now shares the matching integration
+        # job above. Only the second shards for Ubuntu and Windows ARM64 MSVC
+        # remain here, preserving their established parallel split.
         include:
           - os: ubuntu-latest
             llvm: 22
@@ -409,52 +459,10 @@ jobs:
             llvm: 22
             go_version: "1.27"
             lane: full
-            shard_index: "0"
-            shard_total: "2"
-            check_symbols: true
-            std_buildmodes: true
-          - os: ubuntu-latest
-            llvm: 22
-            go_version: "1.27"
-            lane: full
             shard_index: "1"
             shard_total: "2"
             check_symbols: true
             std_buildmodes: true
-          - os: macos-latest
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-          # Each Windows ABI profile runs the latest complete set with -p=2.
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: msvc
-            windows_arch: amd64
-            host_go_arch: x64
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: mingw
-            windows_arch: amd64
-            host_go_arch: x64
-          - os: windows-11-arm
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "2"
-            windows_abi: msvc
-            windows_arch: arm64
-            host_go_arch: x64
           - os: windows-11-arm
             llvm: 22
             go_version: "1.27"
@@ -463,33 +471,6 @@ jobs:
             shard_total: "2"
             windows_abi: msvc
             windows_arch: arm64
-            host_go_arch: x64
-          - os: windows-11-arm
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: mingw
-            windows_arch: arm64
-            host_go_arch: arm64
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: msvc
-            windows_arch: "386"
-            host_go_arch: x64
-          - os: windows-2022
-            llvm: 22
-            go_version: "1.27"
-            lane: full
-            shard_index: "0"
-            shard_total: "1"
-            windows_abi: mingw
-            windows_arch: "386"
             host_go_arch: x64
     runs-on: ${{ matrix.os }}
     steps:
@@ -525,18 +506,6 @@ jobs:
         with:
           windows-abi: ${{ matrix.windows_abi }}
           windows-arch: ${{ matrix.windows_arch }}
-
-      - name: Check Windows native runtime and FFI
-        # This check is profile-wide rather than package-specific. Run it once
-        # on the first shard instead of duplicating it in every shard.
-        if: runner.os == 'Windows' && matrix.shard_index == '0'
-        shell: pwsh
-        run: |
-          $llgo = Join-Path $env:RUNNER_TEMP 'llgo-bin\llgo.exe'
-          .\.github\workflows\test_windows_runtime.ps1 `
-            -LLGo $llgo `
-            -Profile "${{ matrix.windows_abi }}" `
-            -GoArch "${{ matrix.windows_arch || 'amd64' }}"
 
       - name: Run versioned LLGo tests
         env:

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -437,7 +437,7 @@ jobs:
 
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}${{ matrix.windows_abi && format(', {0}', matrix.windows_abi) || '' }}${{ matrix.windows_arch && format(', {0}', matrix.windows_arch) || '' }}, Go ${{ matrix.go_version }}, shard ${{ matrix.shard_index }}/${{ matrix.shard_total }})
-    timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || startsWith(matrix.os, 'windows') && 60 || startsWith(matrix.os, 'macos') && 60 || 60 }}
+    timeout-minutes: ${{ matrix.windows_arch == 'arm64' && 120 || matrix.windows_arch == '386' && 90 || 60 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/model-demo.yml
+++ b/.github/workflows/model-demo.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   llama2:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   classifier-tests:
     if: github.event_name == 'pull_request'
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Test benchmark change classifier
@@ -30,7 +30,7 @@ jobs:
 
   dispatch:
     if: github.repository == 'xgo-dev/llgo' && github.event_name != 'pull_request'
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     env:
       # Set this repository variable to the temporary personal repository
       # before the migration, then remove it to use xgo-dev/benchmarks.

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,10 +22,9 @@ env:
   GORELEASER_CROSS_IMAGE: ghcr.io/goreleaser/goreleaser-cross:v1.27.0-1
 
 jobs:
-  setup:
+  populate-linux-sysroot:
     runs-on: ubuntu-latest
-    outputs:
-      linux-cache-key: ${{ steps.cache-keys.outputs.linux-key }}
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -33,20 +32,13 @@ jobs:
         id: cache-keys
         run: |
           LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
-          echo "linux-key=$LINUX_KEY" >> $GITHUB_OUTPUT
-  populate-linux-sysroot:
-    runs-on: ubuntu-latest
-    needs: setup
-    timeout-minutes: 30
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
+          echo "linux-key=$LINUX_KEY" >> "$GITHUB_OUTPUT"
       - name: Check Linux sysroot cache
         id: cache-linux-sysroot
         uses: actions/cache/restore@v6
         with:
           path: .sysroot/linux.tar.gz
-          key: ${{ needs.setup.outputs.linux-cache-key }}
+          key: ${{ steps.cache-keys.outputs.linux-key }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         if: steps.cache-linux-sysroot.outputs.cache-hit != 'true'
@@ -65,7 +57,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: .sysroot/linux.tar.gz
-          key: ${{ needs.setup.outputs.linux-cache-key }}
+          key: ${{ steps.cache-keys.outputs.linux-key }}
       # The cache is only a cross-run optimization: repository cache pressure
       # may evict it while a downstream job is queued. Use an artifact as the
       # required, run-scoped handoff so release correctness never depends on it.
@@ -80,7 +72,7 @@ jobs:
           retention-days: 3
   build:
     runs-on: ubuntu-latest
-    needs: [setup, populate-linux-sysroot]
+    needs: populate-linux-sysroot
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -320,7 +312,7 @@ jobs:
   release:
     permissions:
       contents: write
-    needs: [setup, test-artifacts, test-windows-artifacts, populate-linux-sysroot]
+    needs: [test-artifacts, test-windows-artifacts, populate-linux-sysroot]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-latest
         llvm: [22]
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository_owner == 'xgo-dev' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies


### PR DESCRIPTION
## Summary

This is stacked on #2521. The focused follow-up diff is [cpunion/llgo@`codex/ci-go127-matrix-coalesce-20260906...codex/ci-followup-job-consolidation-20260907`](https://github.com/cpunion/llgo/compare/codex/ci-go127-matrix-coalesce-20260906...codex/ci-followup-job-consolidation-20260907). Once #2521 lands, this branch will be rebased onto the updated `main`.

Several short CI jobs spend more time repeating checkout, dependency setup, and tool builds than running their distinct checks. This change consolidates only jobs whose combined measured runtime stays comfortably below the 25-minute target:

- Run the README default and full local installation flows sequentially in one job per platform. Each mode has a separate `GOBIN`, resets `PATH`, and runs the documentation examples, so the first installed LLGo binary cannot accidentally satisfy the second mode.
- Move release cache-key calculation into the Linux sysroot producer. The producer/build artifact boundary remains intact, preserving cheap downstream retries and cross-run sysroot caching.
- Run Go method-drop checks after the Linux dev LTO/GlobalDCE checks, sharing LLVM, Go, demo dependencies, and the dev-tagged LLGo build.

Build-cache jobs remain separate because they intentionally mutate and clear LLGo cache state. macOS LTO and the long platform coverage jobs also remain separate to preserve isolation and avoid making individual jobs longer.

## Job impact

| Workflow | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Docs | 10 | 6 | 4 |
| Go | 6 | 5 | 1 |
| Release Build | 16 | 15 | 1 |
| All PR-triggered workflows after #2521 | 68 | 62 | 6 (8.8%) |

The six removed jobs comprise one macOS, two Windows, and three Ubuntu jobs. Relative to `main` before #2521, the two stacked PRs reduce the same PR-triggered scope from 76 to 62 jobs (18.4%) without removing validation coverage.

## Validation

Validated in cpunion/llgo#241 before closing that validation PR:

- Format passed.
- All six Docs jobs passed. The consolidated local-install jobs took 1:54 on Ubuntu, 3:09 on Windows MinGW, 3:30 on macOS, and 15:24 on Windows MSVC.
- The consolidated `Dev LTO GlobalDCE and Go Method Drop` job passed in 8:34.
- The release sysroot producer passed from a cold cache in 2:16, and its downstream build and release-package runtime tests passed.
- `actionlint` syntax/expression validation passes for all workflows (ShellCheck disabled because unchanged scripts have existing warnings); full `actionlint` reports no warning on newly consolidated lines.
- `git diff --check` passes.
- Go method-drop tests pass locally with LLVM 22.

Unrelated workflows on the fork validation PR were intentionally cancelled to conserve runner capacity; the three modified workflows and Format were allowed to complete.
