### PR TITLE
ci: restrict Qiniu runners to the upstream repository

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             id: linux
             display: Linux
             timeout: 20
@@ -69,7 +69,7 @@ jobs:
             windows_arch: "386"
             host_go_arch: x64
             timeout: 90
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
       GOMAXPROCS: "2"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,7 +69,7 @@ jobs:
             windows_arch: "386"
             host_go_arch: x64
             timeout: 90
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
       GOMAXPROCS: "2"
@@ -255,7 +255,7 @@ jobs:
 
   wasm-benchmark:
     name: benchmark (WebAssembly)
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     env:
       GOMAXPROCS: "2"

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -32,7 +32,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -24,7 +24,7 @@ jobs:
           - os: macos-latest
             llvm: 22
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             llvm: 22
           - os: windows-2022
             llvm: 22
@@ -32,7 +32,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/doc-link-checker.yml
+++ b/.github/workflows/doc-link-checker.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   doc_verify:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,8 +21,8 @@ jobs:
           - ubuntu-latest
         include:
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -61,14 +61,14 @@ jobs:
             os: macos-latest
           - platform: ubuntu
             os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
           - platform: windows-msvc
             os: windows-2022
             windows_abi: msvc
           - platform: windows-mingw
             os: windows-2022
             windows_abi: mingw
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -68,7 +68,7 @@ jobs:
           - platform: windows-mingw
             os: windows-2022
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   fmt:
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -228,7 +228,7 @@ jobs:
   dev-lto-globaldce:
     name: Dev LTO GlobalDCE
     timeout-minutes: 60
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -309,7 +309,7 @@ jobs:
   dev-go-methoddrop:
     name: Dev Go Method Drop
     timeout-minutes: 60
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
           - os: macos-latest
             llvm: 22
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             llvm: 22
           - os: windows-2022
             llvm: 22
@@ -38,7 +38,7 @@ jobs:
           - os: windows-2022
             llvm: 22
             windows_abi: mingw
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -54,7 +54,7 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -206,7 +206,7 @@ jobs:
     name: GOROOT summary
     if: always()
     needs: goroot
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-latest' }}
     steps:
       - name: Download shard statistics
         uses: actions/download-artifact@v8

--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -53,8 +53,8 @@ jobs:
             windows_arch: "386"
         include:
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -59,7 +59,7 @@ jobs:
             windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -495,7 +495,7 @@ jobs:
             windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -594,7 +594,7 @@ jobs:
         # artifact smoke tests.
         os: [ubuntu-latest]
         llvm: [22]
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -647,7 +647,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner || matrix.os }}
+    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -679,7 +679,7 @@ jobs:
   wasm-runtime:
     name: wasm-runtime (Go 1.24 and 1.27)
     timeout-minutes: 30
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -25,7 +25,7 @@ jobs:
         # native toolchain profile, always with .go-version.
         include:
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             llvm: 22
           - os: macos-latest
             llvm: 22
@@ -59,7 +59,7 @@ jobs:
             windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -400,7 +400,7 @@ jobs:
         # and avoid duplicate setup.
         include:
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             llvm: 22
             go_version: "1.20-1.26"
             lane: compatibility
@@ -408,7 +408,7 @@ jobs:
             shard_total: "1"
             check_symbols: true
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             llvm: 22
             go_version: "1.27"
             lane: full
@@ -417,7 +417,7 @@ jobs:
             check_symbols: true
             std_buildmodes: true
           - os: ubuntu-latest
-            runner: [qiniu, ubuntu-24.04-large]
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
             llvm: 22
             go_version: "1.27"
             lane: full
@@ -495,7 +495,7 @@ jobs:
             windows_abi: mingw
             windows_arch: "386"
             host_go_arch: x64
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -594,7 +594,10 @@ jobs:
         # artifact smoke tests.
         os: [ubuntu-latest]
         llvm: [22]
-    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+        include:
+          - os: ubuntu-latest
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -646,8 +649,8 @@ jobs:
         windows_arch: [amd64, arm64, "386"]
         include:
           - os: ubuntu-24.04
-            runner: [qiniu, ubuntu-24.04-large]
-    runs-on: ${{ matrix.runner && (github.repository == 'xgo-dev/llgo' && matrix.runner || 'ubuntu-latest') || matrix.os }}
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/model-demo.yml
+++ b/.github/workflows/model-demo.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   llama2:
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   classifier-tests:
     if: github.event_name == 'pull_request'
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Test benchmark change classifier
@@ -31,7 +31,7 @@ jobs:
 
   dispatch:
     if: github.repository == 'xgo-dev/llgo' && github.event_name != 'pull_request'
-    runs-on: [qiniu, ubuntu-24.04]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04"]') || 'ubuntu-latest' }}
     env:
       # Override this repository variable only when testing another receiver.
       BENCHMARKS_REPOSITORY: ${{ vars.BENCHMARKS_REPOSITORY || 'llgo-test/benchmarks' }}

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-latest
         llvm: [22]
-    runs-on: [qiniu, ubuntu-24.04-large]
+    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -19,7 +19,10 @@ jobs:
         os:
           - ubuntu-latest
         llvm: [22]
-    runs-on: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+        include:
+          - os: ubuntu-latest
+            runner: ${{ github.repository == 'xgo-dev/llgo' && fromJSON('["qiniu", "ubuntu-24.04-large"]') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies


### PR DESCRIPTION
Fork workflows currently request Qiniu runners, which may leave their Linux jobs queued without an available runner. Use Qiniu only when `github.repository` is `xgo-dev/llgo`; otherwise run the corresponding Linux jobs on `ubuntu-latest`.

The implementation includes:

- Gate all 21 Qiniu scheduling entries across 11 workflows by the workflow repository.
- Preserve the upstream standard/large runner choices and existing matrix OS values, macOS runners, and Windows runners.
- Keep the release workflow unchanged. Pull requests running in the upstream repository still use Qiniu, including those submitted from forks.

This lets forks run their Linux CI on GitHub-hosted runners while retaining upstream Qiniu scheduling. Validation: all workflow YAML files parsed, `actionlint -shellcheck= -pyflakes= -oneline` passed, and `git diff --check` passed. Runtime CI validation is pending.
