### PR TITLE
release: publish Windows ZIPs and prepare WinGet candidates

### DIFF
--- a/.github/windows/WINGET.md
+++ b/.github/windows/WINGET.md
@@ -1,0 +1,24 @@
+# Preparing WinGet manifests
+
+The Windows release pipeline builds and tests four ABI/architecture variants as ZIP archives. ZIP directory records are stored without compression, because WinGet's pure ZIP checker rejects directory entries with nonzero compressed data. `release_zip.py` compares every file and directory against the staging tree when building the ZIP and verifies the extracted contents during artifact tests; `test-release.ps1` executes the ZIP's compiler before and after native dependencies are installed.
+
+The `prepare-winget` job emits the `llgo-winget-candidates` workflow artifact only after all Windows artifact tests pass. It does not upload release assets or submit a winget-pkgs PR. The candidates use two proposed package IDs, `XGo.LLGo.MSVC` and `XGo.LLGo.MinGW`, each with x64 and ARM64 installers. Review the IDs before the initial public submission. Both expose `llgo`, so users should select one ABI profile on PATH.
+
+To prepare the same candidates locally with Python 3.11 or newer:
+
+```sh
+python .github/windows/prepare-winget.py \
+  --artifacts .windows-dist --version 1.2.3 --output .winget
+```
+
+`1.2.3` is an example: use the actual release version without `v`. The input directory must contain all four `llgo<VERSION>.windows-{amd64,arm64}-{msvc,mingw}.zip` files and their `.zip.sha256` sidecars. The generator hashes the actual ZIP bytes, checks release version/architecture/ABI metadata, requires a common source commit, and emits standard version/installer/defaultLocale YAML files. The public installer URLs point to the matching `v<VERSION>` GitHub release.
+
+Before submitting to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs):
+
+1. Publish the tested ZIPs through the normal tag release. Confirm every public URL serves the bytes whose hashes appear in the candidates. PR/snapshot artifacts alone do not establish that those URLs exist.
+2. Run `winget validate --manifest <version-directory>` for each profile, then test real installation, command startup, upgrade, and uninstall on a clean Windows environment. Keep WinGet's archive and hash checks enabled.
+3. Submit the reviewed `manifests/x/XGo/LLGo/...` directories. Candidate package IDs and public-source upgrade behavior still require initial publication review.
+
+The MinGW installer manifest sets `ArchiveBinariesDependOnPath: true`; MSVC retains the portable alias. Both point at `bin/llgo.exe` and include the external dependency notes from [WINDOWS.md](../../WINDOWS.md). No complete SDK/toolchain bundle is implied.
+
+Do not copy local validation `ProductCode` values ending in `__DefaultSource` into public manifests. A synthetic packaging upgrade using unchanged compiler bytes validates only the local lifecycle. In the local WinGet 1.29.290 test, upgrading a portable package moved it from the custom location to WinGet's default location; do not promise custom-location preservation from that test.

--- a/.github/windows/build-release.ps1
+++ b/.github/windows/build-release.ps1
@@ -92,7 +92,7 @@ if ($LASTEXITCODE -ne 0) { throw 'Building the Windows release compiler failed' 
 Copy-ReleaseDLLs -ReadObj $readObj -Executable $executable -GoArch $GoArch -Profile $Profile `
   -SourceDirectories @((Join-Path $llvmRoot 'bin'))
 
-foreach ($entry in @('LICENSE', 'LICENSES', 'README.md', 'THIRD_PARTY_NOTICES.md', 'runtime', 'targets')) {
+foreach ($entry in @('LICENSE', 'LICENSES', 'README.md', 'WINDOWS.md', 'THIRD_PARTY_NOTICES.md', 'runtime', 'targets')) {
   Copy-Item -LiteralPath (Join-Path $root $entry) -Destination $stage -Recurse
 }
 if ($Profile -eq 'mingw') {
@@ -133,10 +133,11 @@ Copy-Item -LiteralPath (Join-Path $root 'LICENSES/XGo-LLVM-Apache-2.0-WITH-LLVM-
   esp_clang_host = 'windows/amd64'
 } | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $stage 'release.json')
 
-$archiveName = "llgo$($metadata.version).windows-$GoArch-$Profile.tar.gz"
-$archive = Join-Path $root ".windows-dist/$archiveName"
-& tar.exe -czf $archive -C $stage .
-if ($LASTEXITCODE -ne 0) { throw 'Creating the integrated Windows archive failed' }
-$checksum = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
-"$checksum  $archiveName" | Set-Content -Encoding ascii "$archive.sha256"
-Write-Host "Created $archive"
+# Directory records must be STORE for WinGet compatibility.
+$zipName = "llgo$($metadata.version).windows-$GoArch-$Profile.zip"
+$zip = Join-Path $root ".windows-dist/$zipName"
+& python (Join-Path $PSScriptRoot 'release_zip.py') create $zip $stage
+if ($LASTEXITCODE -ne 0) { throw 'Creating or verifying the Windows ZIP failed' }
+$zipChecksum = (Get-FileHash -Algorithm SHA256 $zip).Hash.ToLowerInvariant()
+"$zipChecksum  $zipName" | Set-Content -Encoding ascii "$zip.sha256"
+Write-Host "Created $zip"

--- a/.github/windows/prepare-winget.py
+++ b/.github/windows/prepare-winget.py
@@ -1,0 +1,94 @@
+"""Prepare reviewable WinGet manifests from four checksummed Windows release ZIPs.
+
+This never uploads release assets or submits to winget-pkgs.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import zipfile
+
+PROFILES = {'msvc': 'MSVC', 'mingw': 'MinGW'}
+ARCHITECTURES = {'amd64': 'x64', 'arm64': 'arm64'}
+SCHEMA = '1.9.0'
+REPOSITORY = 'https://github.com/xgo-dev/llgo'
+
+
+def release_info(artifacts, version, arch, profile):
+    path = artifacts / f'llgo{version}.windows-{arch}-{profile}.zip'
+    with path.open('rb') as stream:
+        checksum = hashlib.file_digest(stream, 'sha256').hexdigest()
+    if path.with_suffix('.zip.sha256').read_text().strip() != f'{checksum}  {path.name}':
+        raise ValueError(f'ZIP checksum does not match: {path.name}')
+    with zipfile.ZipFile(path) as archive:
+        for required in ('bin/llgo.exe', 'runtime/go.mod', 'WINDOWS.md'):
+            if not archive.getinfo(required).file_size:
+                raise ValueError(f'Empty release component: {required}')
+        metadata = json.loads(archive.read('release.json'))
+    expected = {'version': version, 'goos': 'windows', 'goarch': arch, 'abi': profile}
+    if any(metadata.get(k) != v for k, v in expected.items()):
+        raise ValueError(f'ZIP metadata does not match {path.name}')
+    if not re.fullmatch(r'[0-9a-f]{40}', metadata.get('commit', '')):
+        raise ValueError(f'Missing release commit: {path.name}')
+    return metadata['commit'], f'{REPOSITORY}/releases/download/v{version}/{path.name}', checksum
+
+
+def yaml_scalar(value):
+    # JSON quoted strings are also YAML scalars, including versions and URLs.
+    return json.dumps(value, ensure_ascii=False)
+
+
+def write_manifest(directory, filename, kind, body):
+    header = f'# yaml-language-server: $schema=https://aka.ms/winget-manifest.{kind}.{SCHEMA}.schema.json\n'
+    footer = f'ManifestType: {kind}\nManifestVersion: {SCHEMA}\n'
+    (directory / filename).write_text(header + body + footer, encoding='utf-8')
+
+
+def prepare(artifacts, output, version):
+    if not re.fullmatch(r'[0-9][0-9A-Za-z.+-]*', version):
+        raise ValueError('Invalid release version (omit the leading v)')
+    # Verify all four inputs before emitting anything; ABI/architecture mixing
+    # and stale hashes must fail before a candidate can reach winget-pkgs.
+    releases = {(p, a): release_info(artifacts, version, a, p)
+                for p in PROFILES for a in ARCHITECTURES}
+    if len({r[0] for r in releases.values()}) != 1:
+        raise ValueError('Windows ZIPs belong to different source commits')
+    for profile, label in PROFILES.items():
+        identifier = f'XGo.LLGo.{label}'
+        directory = output / 'manifests' / 'x' / 'XGo' / 'LLGo' / label / version
+        directory.mkdir(parents=True, exist_ok=True)
+        common = f'PackageIdentifier: {identifier}\nPackageVersion: {yaml_scalar(version)}\n'
+        write_manifest(directory, f'{identifier}.yaml', 'version', common + 'DefaultLocale: en-US\n')
+        notes = ('Native compilation requires Go, native Clang, SDK/CRT, pkg-config, '
+                 f'and libraries for the {label} ABI. See WINDOWS.md in the package. '
+                 'The bundled crosscompile/clang is the ESP toolchain. '
+                 'Use one LLGo ABI profile on PATH at a time.')
+        locale = common + 'PackageLocale: en-US\nPublisher: XGo\n'
+        locale += f'PackageName: {yaml_scalar(f"LLGo ({label})")}\n'
+        locale += f'PackageUrl: {REPOSITORY}\nLicense: Apache-2.0\n'
+        locale += f'LicenseUrl: {REPOSITORY}/blob/v{version}/LICENSE\n'
+        locale += 'ShortDescription: Go compiler based on LLVM.\n'
+        locale += f'InstallationNotes: {yaml_scalar(notes)}\n'
+        locale += f'Documentations:\n- DocumentLabel: Windows dependencies\n  DocumentUrl: {REPOSITORY}/blob/v{version}/WINDOWS.md\n'
+        write_manifest(directory, f'{identifier}.locale.en-US.yaml', 'defaultLocale', locale)
+        installer = common + 'InstallerType: zip\nNestedInstallerType: portable\n'
+        if profile == 'mingw':
+            installer += 'ArchiveBinariesDependOnPath: true\n'
+        installer += ('NestedInstallerFiles:\n- RelativeFilePath: bin/llgo.exe\n'
+                      '  PortableCommandAlias: llgo\nUpgradeBehavior: uninstallPrevious\n'
+                      'Commands:\n- llgo\nInstallers:\n')
+        for arch, winget_arch in ARCHITECTURES.items():
+            _, url, checksum = releases[profile, arch]
+            installer += f'- Architecture: {winget_arch}\n  InstallerUrl: {yaml_scalar(url)}\n  InstallerSha256: {checksum}\n'
+        write_manifest(directory, f'{identifier}.installer.yaml', 'installer', installer)
+    print(f'Prepared local WinGet candidates in {output}; release publication and submission are separate steps.')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--artifacts', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--version', required=True)
+    args = parser.parse_args()
+    prepare(args.artifacts, args.output, args.version)

--- a/.github/windows/prepare-winget.py
+++ b/.github/windows/prepare-winget.py
@@ -46,7 +46,9 @@ def write_manifest(directory, filename, kind, body):
 
 
 def prepare(artifacts, output, version):
-    if not re.fullmatch(r'[0-9][0-9A-Za-z.+-]*', version):
+    # Match build-release.ps1: GoReleaser snapshots may use a short commit
+    # hash instead of a numeric tag, while paths must remain single components.
+    if not re.fullmatch(r'[0-9A-Za-z][0-9A-Za-z.+-]*', version):
         raise ValueError('Invalid release version (omit the leading v)')
     # Verify all four inputs before emitting anything; ABI/architecture mixing
     # and stale hashes must fail before a candidate can reach winget-pkgs.

--- a/.github/windows/release-lib.ps1
+++ b/.github/windows/release-lib.ps1
@@ -143,7 +143,7 @@ function Expand-ReleaseXz {
   try {
     $archive = Get-ReleaseArchive -URL $URL -SHA256 $SHA256 -CacheDirectory $CacheDirectory
     # Use 7-Zip for xz: the Windows ARM64 runner's bsdtar cannot extract all
-    # upstream sparse xz archives. tar.gz release archives use bsdtar normally.
+    # upstream sparse xz archives.
     $sevenZip = Join-Path $env:ProgramFiles '7-Zip/7z.exe'
     & $sevenZip x -y "-o$temporary" $archive | Out-Host
     if ($LASTEXITCODE -ne 0) { throw 'Decompressing the release payload failed' }

--- a/.github/windows/release_zip.py
+++ b/.github/windows/release_zip.py
@@ -1,0 +1,79 @@
+"""Create WinGet-compatible ZIPs and compare them with an extracted release."""
+import argparse
+import hashlib
+from pathlib import Path, PurePosixPath
+import stat
+import zipfile
+
+
+def entries(root):
+    root = Path(root).resolve()
+    result = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"Release contains a symbolic link: {path}")
+        name = path.relative_to(root).as_posix() + ("/" if path.is_dir() else "")
+        result[name] = path
+    return result
+
+
+def create(source, destination):
+    source, destination = Path(source).resolve(), Path(destination).resolve()
+    if destination.is_relative_to(source):
+        raise ValueError("The ZIP must be outside the release directory")
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, path in entries(source).items():
+            if path.is_dir():
+                # DEFLATE produces nonzero compressed data even for empty input.
+                # WinGet's pure ZIP checker rejects such directory records.
+                info = zipfile.ZipInfo(name)
+                info.external_attr = (stat.S_IFDIR | 0o755) << 16 | 0x10
+                archive.writestr(info, b"", compress_type=zipfile.ZIP_STORED)
+            else:
+                archive.write(path, name)
+    verify(destination, source)
+
+
+def digest(stream):
+    return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def verify(archive_path, directory):
+    expected = entries(directory)
+    with zipfile.ZipFile(archive_path) as archive:
+        names = set()
+        for info in archive.infolist():
+            name = info.filename
+            if (name in names or "\\" in name or name.startswith("/") or
+                    ".." in PurePosixPath(name).parts or name not in expected):
+                raise ValueError(f"Unexpected ZIP entry: {name}")
+            names.add(name)
+            path = expected[name]
+            if info.flag_bits & 1 or info.is_dir() != path.is_dir():
+                raise ValueError(f"Invalid ZIP entry: {name}")
+            if info.is_dir():
+                if info.file_size or info.compress_size or info.compress_type != zipfile.ZIP_STORED:
+                    raise ValueError(f"ZIP directory must be empty and stored: {name}")
+            else:
+                with archive.open(info) as packed, path.open("rb") as original:
+                    if info.file_size != path.stat().st_size or digest(packed) != digest(original):
+                        raise ValueError(f"ZIP file differs from release: {name}")
+        if names != set(expected):
+            raise ValueError(f"ZIP is missing release entries: {sorted(set(expected) - names)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("create", "verify"))
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("directory", type=Path)
+    args = parser.parse_args()
+    if args.operation == "create":
+        create(args.directory, args.archive)
+    else:
+        verify(args.archive, args.directory)
+    print(f"Verified ZIP contents and directory records: {args.archive.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/windows/test-release.ps1
+++ b/.github/windows/test-release.ps1
@@ -8,28 +8,28 @@ param(
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'release-lib.ps1')
-$archives = @(Get-ChildItem '.windows-dist' -Filter "*.windows-$GoArch-$Profile.tar.gz")
-if ($archives.Count -ne 1) { throw "Expected exactly one windows/$GoArch/$Profile archive" }
+$archives = @(Get-ChildItem '.windows-dist' -Filter "*.windows-$GoArch-$Profile.zip")
+if ($archives.Count -ne 1) { throw "Expected exactly one windows/$GoArch/$Profile ZIP" }
 $archive = $archives[0]
 $checksumLine = (Get-Content -Raw ($archive.FullName + '.sha256')).Trim()
 $actual = (Get-FileHash -Algorithm SHA256 $archive.FullName).Hash.ToLowerInvariant()
-if ($checksumLine -ne "$actual  $($archive.Name)") { throw 'The Windows archive checksum does not match' }
+if ($checksumLine -ne "$actual  $($archive.Name)") { throw 'The Windows ZIP checksum does not match' }
 
-# A different location, including a space, makes build-tree dependencies and
-# accidentally unquoted paths observable before an archive can be published.
-$releaseRoot = Join-Path $env:RUNNER_TEMP "extracted llgo-$GoArch-$Profile"
+# A different location, including Unicode and spaces, makes build-tree dependencies
+# and accidentally unquoted paths observable before an archive can be published.
+$releaseRoot = Join-Path $env:RUNNER_TEMP "extracted ZIP 空格 llgo-$GoArch-$Profile"
 if (Test-Path $releaseRoot) { Remove-Item -LiteralPath $releaseRoot -Recurse -Force }
-New-Item -ItemType Directory $releaseRoot | Out-Null
-& tar.exe -xzf $archive.FullName -C $releaseRoot
-if ($LASTEXITCODE -ne 0) { throw 'Extracting the integrated Windows archive failed' }
-foreach ($entry in @('bin/llgo.exe', 'runtime/go.mod', 'targets', 'LICENSES', 'THIRD_PARTY_NOTICES.md',
+Expand-Archive -LiteralPath $archive.FullName -DestinationPath $releaseRoot
+& python (Join-Path $PSScriptRoot 'release_zip.py') verify $archive.FullName $releaseRoot
+if ($LASTEXITCODE -ne 0) { throw 'The extracted Windows ZIP is incomplete or has invalid directory records' }
+foreach ($entry in @('bin/llgo.exe', 'runtime/go.mod', 'targets', 'LICENSES', 'WINDOWS.md', 'THIRD_PARTY_NOTICES.md',
     'crosscompile/clang/bin/clang++.exe', 'crosscompile/clang/bin/llvm-readobj.exe',
     'crosscompile/clang/THIRD-PARTY-LICENSES.txt', 'crosscompile/clang/LICENSE-LLVM.txt', 'release.json')) {
   if (-not (Test-Path (Join-Path $releaseRoot $entry))) { throw "Release archive is missing $entry" }
 }
 $metadata = Get-Content -Raw (Join-Path $releaseRoot 'release.json') | ConvertFrom-Json
 if ($metadata.goos -ne 'windows' -or $metadata.goarch -ne $GoArch -or $metadata.abi -ne $Profile -or
-    $archive.Name -ne "llgo$($metadata.version).windows-$GoArch-$Profile.tar.gz") {
+    $archive.Name -ne "llgo$($metadata.version).windows-$GoArch-$Profile.zip") {
   throw 'The archive name, host architecture, and ABI metadata disagree'
 }
 $commit = (& git rev-parse HEAD).Trim()

--- a/.github/windows/test_prepare_winget.py
+++ b/.github/windows/test_prepare_winget.py
@@ -1,0 +1,72 @@
+import importlib.util
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+import zipfile
+
+spec = importlib.util.spec_from_file_location('prepare_winget', Path(__file__).with_name('prepare-winget.py'))
+winget = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(winget)
+
+
+class WinGetTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.output = self.root / 'output'
+        for profile in winget.PROFILES:
+            for arch in winget.ARCHITECTURES:
+                self.fixture(profile, arch)
+
+    def fixture(self, profile, arch, **overrides):
+        path = self.root / f'llgo1.2.3.windows-{arch}-{profile}.zip'
+        metadata = dict(version='1.2.3', goos='windows', goarch=arch, abi=profile, commit='a' * 40)
+        metadata.update(overrides)
+        with zipfile.ZipFile(path, 'w') as archive:
+            archive.writestr('release.json', json.dumps(metadata))
+            for name in ('bin/llgo.exe', 'runtime/go.mod', 'WINDOWS.md'):
+                archive.writestr(name, 'fixture')
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        path.with_suffix('.zip.sha256').write_text(f'{digest}  {path.name}\n')
+        return path
+
+    def test_two_profiles_two_architectures_real_hashes(self):
+        winget.prepare(self.root, self.output, '1.2.3')
+        files = list(self.output.rglob('*.yaml'))
+        self.assertEqual(len(files), 6)
+        for label in ('MSVC', 'MinGW'):
+            path = self.output / 'manifests/x/XGo/LLGo' / label / '1.2.3'
+            text = (path / f'XGo.LLGo.{label}.installer.yaml').read_text()
+            self.assertIn('Architecture: x64', text)
+            self.assertIn('Architecture: arm64', text)
+            self.assertEqual('ArchiveBinariesDependOnPath: true' in text, label == 'MinGW')
+            self.assertNotIn('ProductCode', text)
+            self.assertNotIn('Scope:', text)
+            for arch in ('amd64', 'arm64'):
+                archive = self.root / f'llgo1.2.3.windows-{arch}-{label.lower()}.zip'
+                self.assertIn(hashlib.sha256(archive.read_bytes()).hexdigest(), text)
+                self.assertIn('/releases/download/v1.2.3/' + archive.name, text)
+
+    def test_corrupted_archive_rejected_before_output(self):
+        path = self.root / 'llgo1.2.3.windows-arm64-mingw.zip'
+        path.write_bytes(path.read_bytes() + b'tampered')
+        with self.assertRaisesRegex(ValueError, 'checksum'):
+            winget.prepare(self.root, self.output, '1.2.3')
+        self.assertFalse(self.output.exists())
+
+    def test_wrong_architecture_rejected(self):
+        self.fixture('mingw', 'arm64', goarch='amd64')
+        with self.assertRaisesRegex(ValueError, 'metadata'):
+            winget.prepare(self.root, self.output, '1.2.3')
+
+    def test_mixed_commits_rejected(self):
+        self.fixture('mingw', 'arm64', commit='b' * 40)
+        with self.assertRaisesRegex(ValueError, 'different source commits'):
+            winget.prepare(self.root, self.output, '1.2.3')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/windows/test_prepare_winget.py
+++ b/.github/windows/test_prepare_winget.py
@@ -21,9 +21,9 @@ class WinGetTests(unittest.TestCase):
             for arch in winget.ARCHITECTURES:
                 self.fixture(profile, arch)
 
-    def fixture(self, profile, arch, **overrides):
-        path = self.root / f'llgo1.2.3.windows-{arch}-{profile}.zip'
-        metadata = dict(version='1.2.3', goos='windows', goarch=arch, abi=profile, commit='a' * 40)
+    def fixture(self, profile, arch, version='1.2.3', **overrides):
+        path = self.root / f'llgo{version}.windows-{arch}-{profile}.zip'
+        metadata = dict(version=version, goos='windows', goarch=arch, abi=profile, commit='a' * 40)
         metadata.update(overrides)
         with zipfile.ZipFile(path, 'w') as archive:
             archive.writestr('release.json', json.dumps(metadata))
@@ -49,6 +49,31 @@ class WinGetTests(unittest.TestCase):
                 archive = self.root / f'llgo1.2.3.windows-{arch}-{label.lower()}.zip'
                 self.assertIn(hashlib.sha256(archive.read_bytes()).hexdigest(), text)
                 self.assertIn('/releases/download/v1.2.3/' + archive.name, text)
+
+    def test_snapshot_and_prerelease_versions(self):
+        # GoReleaser's .Summary can be a short commit hash without a tag.
+        for version in ('fb4049f', '123abcd', '1.2.3-rc.1'):
+            with self.subTest(version=version):
+                for profile in winget.PROFILES:
+                    for arch in winget.ARCHITECTURES:
+                        self.fixture(profile, arch, version=version)
+                winget.prepare(self.root, self.output, version)
+                for profile, label in winget.PROFILES.items():
+                    directory = self.output / 'manifests/x/XGo/LLGo' / label / version
+                    self.assertEqual(len(list(directory.glob('*.yaml'))), 3)
+                    text = (directory / f'XGo.LLGo.{label}.installer.yaml').read_text()
+                    self.assertIn(f'PackageVersion: "{version}"', text)
+                    for arch in winget.ARCHITECTURES:
+                        name = f'llgo{version}.windows-{arch}-{profile}.zip'
+                        self.assertIn(f'/releases/download/v{version}/{name}', text)
+                        self.assertIn(hashlib.sha256((self.root / name).read_bytes()).hexdigest(), text)
+
+    def test_unsafe_versions_rejected_before_output(self):
+        for version in ('', '../escape', '/absolute', 'a/b', 'a\\b', 'a b', 'a\nb'):
+            with self.subTest(version=version):
+                with self.assertRaisesRegex(ValueError, 'Invalid release version'):
+                    winget.prepare(self.root, self.output, version)
+                self.assertFalse(self.output.exists())
 
     def test_corrupted_archive_rejected_before_output(self):
         path = self.root / 'llgo1.2.3.windows-arm64-mingw.zip'

--- a/.github/windows/test_release_zip.py
+++ b/.github/windows/test_release_zip.py
@@ -1,0 +1,65 @@
+import tempfile
+from pathlib import Path
+import unittest
+import zipfile
+
+import release_zip
+
+
+class ReleaseZIPTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.stage = self.root / 'release 空格'
+        (self.stage / 'empty').mkdir(parents=True)
+        (self.stage / 'bin').mkdir()
+        (self.stage / 'bin/llgo.exe').write_bytes(bytes(range(256)))
+        (self.stage / '.hidden').write_text('hidden release file')
+        (self.stage / '说明.txt').write_text('UTF-8 content', encoding='utf-8')
+        self.archive = self.root / 'release.zip'
+
+    def test_roundtrip_and_stored_empty_directories(self):
+        release_zip.create(self.stage, self.archive)
+        with zipfile.ZipFile(self.archive) as archive:
+            directory = archive.getinfo('empty/')
+            self.assertEqual((directory.file_size, directory.compress_size, directory.compress_type), (0, 0, 0))
+            archive.extractall(self.root / 'extracted')
+        release_zip.verify(self.archive, self.root / 'extracted')
+
+    def test_deflated_directory_regression(self):
+        release_zip.create(self.stage, self.archive)
+        broken = self.root / 'broken.zip'
+        with zipfile.ZipFile(self.archive) as source, zipfile.ZipFile(broken, 'w') as target:
+            for entry in source.infolist():
+                target.writestr(entry.filename, source.read(entry),
+                                compress_type=zipfile.ZIP_DEFLATED)
+        with self.assertRaisesRegex(ValueError, 'directory must be empty and stored'):
+            release_zip.verify(broken, self.stage)
+
+    def test_changed_file(self):
+        release_zip.create(self.stage, self.archive)
+        (self.stage / 'bin/llgo.exe').write_bytes(b'other compiler')
+        with self.assertRaisesRegex(ValueError, 'differs from release'):
+            release_zip.verify(self.archive, self.stage)
+
+    def test_missing_file(self):
+        release_zip.create(self.stage, self.archive)
+        (self.stage / 'new-file').write_text('must also be packaged')
+        with self.assertRaisesRegex(ValueError, 'missing release entries'):
+            release_zip.verify(self.archive, self.stage)
+
+    def test_extra_path_rejected(self):
+        release_zip.create(self.stage, self.archive)
+        with zipfile.ZipFile(self.archive, 'a') as archive:
+            archive.writestr('../outside', 'not a release entry')
+        with self.assertRaisesRegex(ValueError, 'Unexpected ZIP entry'):
+            release_zip.verify(self.archive, self.stage)
+
+    def test_no_output_inside_source(self):
+        with self.assertRaisesRegex(ValueError, 'outside the release directory'):
+            release_zip.create(self.stage, self.stage / 'recursive.zip')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -199,9 +199,16 @@ jobs:
         with:
           name: llgo-release-metadata
           path: .windows-dist
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
       - name: Test Windows packaging checks
         shell: pwsh
         run: |
+          python .github/windows/test_release_zip.py
+          if ($LASTEXITCODE -ne 0) { throw 'ZIP regression tests failed' }
+          python .github/windows/test_prepare_winget.py
+          if ($LASTEXITCODE -ne 0) { throw 'WinGet manifest tests failed' }
           ./.github/windows/release-lib_test.ps1
           ./.github/windows/release-build_test.ps1
       - name: Build integrated Windows archive
@@ -214,8 +221,8 @@ jobs:
         with:
           name: llgo-windows-${{ matrix.goarch }}-${{ matrix.abi }}
           path: |
-            .windows-dist/*.windows-${{ matrix.goarch }}-${{ matrix.abi }}.tar.gz
-            .windows-dist/*.windows-${{ matrix.goarch }}-${{ matrix.abi }}.tar.gz.sha256
+            .windows-dist/*.windows-${{ matrix.goarch }}-${{ matrix.abi }}.zip
+            .windows-dist/*.windows-${{ matrix.goarch }}-${{ matrix.abi }}.zip.sha256
           if-no-files-found: error
           retention-days: 3
           include-hidden-files: true
@@ -246,6 +253,9 @@ jobs:
           path: .windows-dist
       # Execute the unpacked compiler before installing any LLVM or native
       # dependencies: this catches missing DLLs that the build runner can mask.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
       - name: Verify standalone compiler and archive
         shell: pwsh
         run: >-
@@ -266,6 +276,36 @@ jobs:
         run: >-
           ./.github/windows/test-release.ps1
           -Profile '${{ matrix.abi }}' -GoArch '${{ matrix.goarch }}'
+
+  prepare-winget:
+    needs: test-windows-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: llgo-windows-*
+          merge-multiple: true
+          path: .windows-dist
+      - uses: actions/download-artifact@v8
+        with:
+          name: llgo-release-metadata
+          path: .windows-dist
+      - name: Prepare WinGet candidates from tested ZIPs
+        shell: bash
+        run: |
+          version=$(python -c 'import json; print(json.load(open(".windows-dist/metadata.json"))["version"])')
+          python .github/windows/prepare-winget.py --artifacts .windows-dist --version "$version" --output .winget
+      - uses: actions/upload-artifact@v7
+        with:
+          name: llgo-winget-candidates
+          path: .winget/manifests
+          if-no-files-found: error
+          retention-days: 7
+          include-hidden-files: true
 
   test-artifacts:
     needs: build
@@ -320,7 +360,7 @@ jobs:
   release:
     permissions:
       contents: write
-    needs: [setup, test-artifacts, test-windows-artifacts, populate-linux-sysroot]
+    needs: [setup, test-artifacts, test-windows-artifacts, prepare-winget, populate-linux-sysroot]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -341,17 +381,17 @@ jobs:
           pattern: llgo-windows-*
           merge-multiple: true
           path: .windows-dist
-      - name: Verify all four Windows archives
+      - name: Verify all four Windows ZIPs
         shell: bash
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
           cd .windows-dist
-          archives=(llgo*.windows-*.tar.gz)
+          archives=(llgo*.windows-*.zip)
           test "${#archives[@]}" = 4
           for arch in amd64 arm64; do
             for abi in msvc mingw; do
-              archive="llgo${version}.windows-${arch}-${abi}.tar.gz"
+              archive="llgo${version}.windows-${arch}-${abi}.zip"
               test -s "$archive"
               sha256sum -c "$archive.sha256"
             done

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,9 +108,9 @@ checksum:
   name_template: "{{.ProjectName}}{{.Version}}.checksums.txt"
   # Windows CGO builds run on native Windows runners and arrive as tested
   # integrated archives. The snapshot pass produces the Unix build metadata
-  # they consume; the tag pass includes all eight archives in one checksum file.
+  # they consume; the tag pass includes all four Windows ZIPs in the common checksum file.
   extra_files:
-    - glob: '{{ if not .IsSnapshot }}.windows-dist/llgo{{ .Version }}.windows-*.tar.gz{{ end }}'
+    - glob: '{{ if not .IsSnapshot }}.windows-dist/llgo{{ .Version }}.windows-*.zip{{ end }}'
 
 nfpms:
   - package_name: llgo
@@ -179,4 +179,4 @@ snapshot:
 release:
   prerelease: auto
   extra_files:
-    - glob: '{{ if not .IsSnapshot }}.windows-dist/llgo{{ .Version }}.windows-*.tar.gz{{ end }}'
+    - glob: '{{ if not .IsSnapshot }}.windows-dist/llgo{{ .Version }}.windows-*.zip{{ end }}'

--- a/README.md
+++ b/README.md
@@ -386,7 +386,9 @@ llgo run .
 
 ### on Windows
 
-The release workflow builds four integrated Windows archives: `llgo<VERSION>.windows-{amd64,arm64}-{msvc,mingw}.tar.gz`. Check the [release assets](https://github.com/xgo-dev/llgo/releases) for availability in each version. Add the extracted `bin` directory to `PATH`; the archives keep the same `runtime`, `targets`, and `crosscompile/clang` layout as Unix releases. The MSVC compiler links LLVM statically; MinGW archives include the native LLVM and C++ DLL dependencies beside `llgo.exe`. 
+The release workflow builds four integrated Windows variants, each as a ZIP: `llgo<VERSION>.windows-{amd64,arm64}-{msvc,mingw}.zip`. Check the [release assets](https://github.com/xgo-dev/llgo/releases) for availability in each version. Add the extracted `bin` directory to `PATH`; the archives keep the same `runtime`, `targets`, and `crosscompile/clang` layout as Unix releases. The MSVC compiler links LLVM statically; MinGW archives include the native LLVM and C++ DLL dependencies beside `llgo.exe`.
+
+See [Windows release dependencies and PowerShell setup](WINDOWS.md) for the external tools, ABI-specific libraries, and pkg-config configuration needed to compile native programs. The document is included in every Windows ZIP.
 
 Use the archive matching your native architecture and toolchain profile. Native programs still need the corresponding SDK/CRT, Clang, and dependencies described below: Visual Studio's C++ developer environment for MSVC, or MSYS2 `CLANG64` (`amd64`) / `CLANGARM64` (`arm64`) for MinGW. The bundled ESP Clang remains the upstream x64 Windows payload, including in ARM64 archives, and runs through Windows' x64 emulation there; `llgo.exe` itself is native ARM64 in those archives.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,97 @@
+# Using LLGo Windows releases
+
+Choose the release matching your host architecture (`amd64` or `arm64`) and native ABI (`msvc` or `mingw`). The release workflow produces a ZIP for each variant; check the [release assets](https://github.com/xgo-dev/llgo/releases) for the formats available in your version. Extract the entire archive and add its `bin` directory to PATH.
+
+The integrated package contains LLGo, its own DLL dependencies, `runtime`, `targets`, licenses, and the ESP Clang under `crosscompile/clang`. Native Windows development tools are installed separately.
+
+| Operation | Additional requirements |
+|---|---|
+| `llgo version` | No Go or native Clang. Keep the packaged DLLs beside `llgo.exe`. |
+| Compile native Windows programs | Go, native Clang/Clang++ and a linker, matching SDK/CRT and native libraries, and pkg-config. |
+| Compile ESP firmware | Go and the bundled ESP toolchain. The first build may download and compile target libraries such as newlib and compiler-rt. |
+
+Do not use `crosscompile/clang` as your native Windows Clang. The ESP payload is x64, including in the ARM64 release, where it uses Windows x64 emulation. Use one native ABI profile at a time; mixing MSVC and MinGW headers, libraries, DLLs, or pkg-config metadata can break builds.
+
+## Versions and shared dependencies
+
+The v1.0.2 release validation used Go **1.27.0** and native LLVM **22.1.8**. These are tested versions, not a claim about the minimum compatible versions. See the [v1.0.2 setup-deps action](https://github.com/xgo-dev/llgo/blob/v1.0.2/.github/actions/setup-deps/action.yml); for another release, select its tag to find the matching setup.
+
+Native runtime dependencies include **BDWGC** and **libffi**. Depending on the standard-library and C/C++ packages used, also install **OpenSSL, libuv, zlib, cJSON, and SQLite**. The release tests install this complete set, including headers, link libraries, runtime DLLs, and pkg-config metadata.
+
+Go may need network access for an empty module cache. ESP builds may also need to download target support sources. Installing LLGo alone does not make every first build offline.
+
+## MSVC profile
+
+1. Install Visual Studio **2022 Build Tools**, including C++ build tools and a Windows SDK. For ARM64, include the ARM64 compiler tools and SDK libraries.
+2. Install native **LLVM 22.1.8** for your host. Prebuilt LLGo needs the native Clang drivers and linker; it does not require rebuilding LLGo or linking LLVM's development libraries yourself.
+3. Install the native libraries with vcpkg using `x64-windows` or `arm64-windows`. Use the [release's vcpkg manifest](https://github.com/xgo-dev/llgo/blob/v1.0.2/.github/windows/vcpkg/vcpkg.json) and baseline. In v1.0.2, the baseline is `ddd0023b0eee70986e42ed49d9d4afb8098f212e` and libffi is pinned to **3.4.6**.
+4. Enter the Visual Studio developer shell for the target architecture, providing `INCLUDE`, `LIB`, SDK tools, and CRT libraries.
+5. Add Go, native LLVM, LLGo, and the vcpkg triplet's `bin` directory to the current terminal PATH. Select the native ABI explicitly:
+
+```powershell
+# For amd64; use aarch64-pc-windows-msvc for arm64.
+$env:CC = 'clang --target=x86_64-pc-windows-msvc -fuse-ld=lld -fms-runtime-lib=dll'
+$env:CXX = 'clang++ --target=x86_64-pc-windows-msvc -fuse-ld=lld -fms-runtime-lib=dll -std=c++17'
+```
+
+The VC++ Redistributable alone does not provide the SDK, headers, or link libraries. Git, CMake, Ninja, and vcpkg are tools used to prepare the dependencies; they are not all required simply to run the prebuilt LLGo executable.
+
+## MinGW profile
+
+Use MSYS2 **CLANG64** for amd64 or **CLANGARM64** for arm64. Do not substitute the GCC-based MINGW64 environment for this LLVM profile.
+
+For the v1.0.2 tested toolchain, Clang, clang-libs, compiler-rt, LLVM, llvm-libs, llvm-tools, and LLD use package revision **22.1.8-2**; libc++ and libunwind use **22.1.8-1**. The [setup-deps action](https://github.com/xgo-dev/llgo/blob/v1.0.2/.github/actions/setup-deps/action.yml) contains the pinned package URLs. Install headers/CRT and the native libraries from the same MSYS2 environment, along with pkgconf. The v1.0.2 MSVC libffi pin does not apply to MinGW; MinGW validation also passed with libffi 3.8.0.
+
+MSYS2 repositories change over time. Check installed package versions; an unqualified update to the newest LLVM does not reproduce the tested LLVM 22 configuration.
+
+For ordinary PowerShell, add Go, LLGo, and your `msys64/clang64/bin` (or `clangarm64/bin`) to the current terminal PATH, then select:
+
+```powershell
+$env:CC = 'clang'
+$env:CXX = 'clang++'
+clang -dumpmachine
+# amd64: x86_64-w64-windows-gnu
+```
+
+The native PowerShell build does not need MSYS2's POSIX `usr/bin` first on PATH. MSYS2's native Clang supplies the matching default header and library search paths.
+
+## pkg-config in PowerShell
+
+LLGo invokes `pkg-config`. If only `pkgconf.exe` is installed, or you want to select one profile's metadata explicitly, create `pkg-config.cmd` in a private tools directory and add that directory to the current terminal PATH. Replace these example paths with your actual installation paths.
+
+MSVC/vcpkg:
+
+```bat
+@echo off
+"C:\dev\vcpkg-installed\x64-windows\tools\pkgconf\pkgconf.exe" --dont-define-prefix "--with-path=C:\dev\vcpkg-installed\x64-windows\lib\pkgconfig" "--with-path=C:\dev\vcpkg-installed\x64-windows\share\pkgconfig" %*
+```
+
+MinGW/CLANG64:
+
+```bat
+@echo off
+"C:\msys64\clang64\bin\pkgconf.exe" --define-prefix "--with-path=C:\msys64\clang64\lib\pkgconfig" %*
+```
+
+Use `--define-prefix` for MSYS2 packages in PowerShell so paths such as `/clang64/include/cjson` relocate to the actual Windows installation. Do not copy the vcpkg `--dont-define-prefix` setting into that environment. Clear unrelated `PKG_CONFIG_PATH`/`PKG_CONFIG_LIBDIR` overrides, and keep each wrapper in its own profile's activation environment.
+
+## Check the activated environment
+
+```powershell
+go version
+llgo version
+clang --version
+clang -dumpmachine
+pkg-config --modversion bdw-gc libffi openssl
+pkg-config --cflags --libs bdw-gc libffi openssl libcjson
+llgo build -o hello.exe .
+.\hello.exe
+```
+
+Run the generated program as well as compiling it. Its DLL dependencies are separate from those of `llgo.exe`; successful execution with the activated PATH does not imply the generated EXE can be copied alone to another machine.
+
+## WinGet packaging
+
+MinGW requires `ArchiveBinariesDependOnPath: true` so WinGet adds the actual packaged `bin` directory to PATH. The default portable symbolic-link entry can fail with `0xC0000135` when the packaged DLLs are not on the DLL search path. MSVC can use the portable command alias.
+
+The repository can [prepare WinGet candidates](https://github.com/xgo-dev/llgo/blob/main/.github/windows/WINGET.md) from tested release ZIPs. Candidate generation does not publish a package to the public WinGet source; check publication status before using a package ID. Each candidate explains the external development dependencies rather than installing a complete native development environment.


### PR DESCRIPTION
Windows release artifacts currently use tar.gz, which cannot serve as WinGet ZIP installers. Publish all four Windows architecture/ABI variants as ZIP only, and prepare reviewable WinGet candidates from their verified bytes. Linux and macOS packaging stays unchanged.

The ZIP writer stores directory records without compression for WinGet's pure ZIP checker and compares the archive with the staging tree. Artifact tests verify SHA-256, extract into a Unicode/spaced path, compare every file and directory, and run the existing standalone, DLL-closure, native, and embedded checks from that extraction.

After all Windows artifact tests pass, CI accepts both tagged release versions and short-hash snapshot versions, and emits proposed `XGo.LLGo.MSVC` and `XGo.LLGo.MinGW` manifests with checksums and matching release metadata. MinGW sets `ArchiveBinariesDependOnPath` so packaged DLLs resolve correctly. Generation does not publish to winget-pkgs. Packaged `WINDOWS.md` documents the separate native toolchains, ABI-specific dependencies, and PowerShell/pkg-config setup.

Validation:

- Twelve Python regression tests passed on macOS and Windows, including snapshot/prerelease versions and unsafe-path rejection; PowerShell parser checks, actionlint, and `git diff --check` passed.
- Repacked all four previously validated v1.0.2 payloads with the new ZIP writer and verified their contents. Both x64 ZIPs passed the upstream pure checker and Windows extraction/startup from Unicode/spaced paths.
- Both generated profiles, including letter-leading snapshot version `fb4049f`, passed WinGet 1.30.130-preview manifest validation without suppressing warnings.
- The fixed generator successfully processed all four original ZIPs downloaded from failing run `34167005698`, verified their checksums/metadata, and emitted all six manifests.
- After switching to ZIP only, executed the updated archive-check/extraction section with no tar.gz present and confirmed rejection of an invalid ZIP checksum.

The repack tests exercise v1.0.2 compiler payloads. All four Windows build and artifact-test jobs subsequently passed on `6dde34986e`; that run exposed the snapshot-version validation bug covered by the new regression. CI for the fix at `b95ad10173` is pending. Public installation URLs and package IDs require validation when a release containing this change is published.

