### PR TITLE
fix(build): fingerprint injected Go source patch bodies

### DIFF
--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -191,6 +191,18 @@ func (c *context) collectCommonInputs(m *manifestBuilder) {
 	}
 }
 
+// Source patches are appended to CompiledGoFiles after go list; they are not
+// present in GoFiles. Their overlaid bodies must participate in cache keys too.
+func packageGoSourceInputs(p *packages.Package, overlay map[string][]byte) []string {
+	files := slices.Clone(p.GoFiles)
+	for _, file := range p.CompiledGoFiles {
+		if _, ok := overlay[file]; ok && !slices.Contains(files, file) {
+			files = append(files, file)
+		}
+	}
+	return files
+}
+
 // collectPackageInputs collects package-specific inputs.
 func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error {
 	p := pkg.Package
@@ -199,7 +211,7 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 	m.pkg.PkgID = p.ID
 
 	// Go source files
-	goFilesList, err := digestFilesWithOverlay(p.GoFiles, c.buildConf.Overlay)
+	goFilesList, err := digestFilesWithOverlay(packageGoSourceInputs(p, c.buildConf.Overlay), c.buildConf.Overlay)
 	if err != nil {
 		return fmt.Errorf("digest go files: %w", err)
 	}
@@ -207,7 +219,7 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 
 	// Alt package files (if any)
 	if pkg.AltPkg != nil {
-		altList, err := digestFilesWithOverlay(pkg.AltPkg.GoFiles, c.buildConf.Overlay)
+		altList, err := digestFilesWithOverlay(packageGoSourceInputs(pkg.AltPkg.Package, c.buildConf.Overlay), c.buildConf.Overlay)
 		if err != nil {
 			return fmt.Errorf("digest alt go files: %w", err)
 		}

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -191,12 +191,12 @@ func (c *context) collectCommonInputs(m *manifestBuilder) {
 	}
 }
 
-// Source patches are appended to CompiledGoFiles after go list; they are not
-// present in GoFiles. Their overlaid bodies must participate in cache keys too.
-func packageGoSourceInputs(p *packages.Package, overlay map[string][]byte) []string {
+// Appended source-patch files are selected after go list and therefore are not
+// present in GoFiles. Their source bodies must participate in cache keys too.
+func packageGoSourceInputs(p *packages.Package, sourcePatches []string) []string {
 	files := slices.Clone(p.GoFiles)
-	for _, file := range p.CompiledGoFiles {
-		if _, ok := overlay[file]; ok && !slices.Contains(files, file) {
+	for _, file := range sourcePatches {
+		if !slices.Contains(files, file) {
 			files = append(files, file)
 		}
 	}
@@ -211,7 +211,7 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 	m.pkg.PkgID = p.ID
 
 	// Go source files
-	goFilesList, err := digestFilesWithOverlay(packageGoSourceInputs(p, c.buildConf.Overlay), c.buildConf.Overlay)
+	goFilesList, err := digestFilesWithOverlay(packageGoSourceInputs(p, c.patchFiles[p.PkgPath]), c.buildConf.Overlay)
 	if err != nil {
 		return fmt.Errorf("digest go files: %w", err)
 	}
@@ -219,7 +219,8 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 
 	// Alt package files (if any)
 	if pkg.AltPkg != nil {
-		altList, err := digestFilesWithOverlay(packageGoSourceInputs(pkg.AltPkg.Package, c.buildConf.Overlay), c.buildConf.Overlay)
+		altPath := pkg.AltPkg.Package.PkgPath
+		altList, err := digestFilesWithOverlay(packageGoSourceInputs(pkg.AltPkg.Package, c.patchFiles[altPath]), c.buildConf.Overlay)
 		if err != nil {
 			return fmt.Errorf("digest alt go files: %w", err)
 		}

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -35,6 +35,46 @@ import (
 	gopackages "golang.org/x/tools/go/packages"
 )
 
+func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	original := filepath.Join(dir, "original.go")
+	patch := filepath.Join(dir, "llgo_patch.go")
+	unused := filepath.Join(dir, "unselected.go")
+	pkg := &aPackage{Package: &packages.Package{
+		ID: "example.test", PkgPath: "example.test",
+		GoFiles: []string{original}, CompiledGoFiles: []string{original, patch},
+	}}
+	ctx := &context{
+		mode: ModeGen,
+		buildConf: &Config{Overlay: map[string][]byte{
+			original: []byte("package p\n"),
+			patch:    []byte("package p\nfunc Value() int { return 1 }\n"),
+		}},
+		sfilesCache: map[string][]string{"example.test": nil},
+	}
+	manifest := func() string {
+		t.Helper()
+		m := newManifestBuilder()
+		if err := ctx.collectPackageInputs(m, pkg); err != nil {
+			t.Fatal(err)
+		}
+		if len(m.pkg.GoFiles) != 2 {
+			t.Fatalf("source patch absent or counted twice: %+v", m.pkg.GoFiles)
+		}
+		return m.Build()
+	}
+	first := manifest()
+	ctx.buildConf.Overlay[patch] = []byte("package p\nfunc Value() int { return 2 }\n")
+	second := manifest()
+	if first == second {
+		t.Fatal("changing only a source patch body did not invalidate the package cache")
+	}
+	ctx.buildConf.Overlay[unused] = []byte("package p\nconst Unused = 1\n")
+	if manifest() != second {
+		t.Fatal("unselected source invalidated the package cache")
+	}
+}
+
 func TestCollectFingerprint(t *testing.T) {
 	td := t.TempDir()
 

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -40,6 +40,9 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 	original := filepath.Join(dir, "original.go")
 	patch := filepath.Join(dir, "_patch", "llgo_patch.go")
 	injected := filepath.Join(dir, "z_llgo_patch_llgo_patch.go")
+	altOriginal := filepath.Join(dir, "original_test.go")
+	altPatch := filepath.Join(dir, "_patch", "llgo_patch_test.go")
+	altInjected := filepath.Join(dir, "z_llgo_patch_llgo_patch_test.go")
 	unused := filepath.Join(dir, "unselected.go")
 	if err := os.MkdirAll(filepath.Dir(patch), 0755); err != nil {
 		t.Fatal(err)
@@ -47,17 +50,28 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 	if err := os.WriteFile(patch, []byte("package p\nfunc Value() int { return 1 }\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(altPatch, []byte("package p_test\nfunc TestValue() int { return 1 }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	pkg := &aPackage{Package: &packages.Package{
 		ID: "example.test", PkgPath: "example.test",
 		GoFiles: []string{original}, CompiledGoFiles: []string{original, patch},
-	}}
+	}, AltPkg: &packages.Cached{Package: &packages.Package{
+		ID: "example.test_test", PkgPath: "example.test_test",
+		GoFiles: []string{altOriginal}, CompiledGoFiles: []string{altOriginal, altPatch},
+	}}}
 	ctx := &context{
 		mode: ModeGen,
 		buildConf: &Config{Overlay: map[string][]byte{
-			original: []byte("package p\n"),
-			injected: []byte("package p\nfunc Value() int { return 1 }\n"),
+			original:    []byte("package p\n"),
+			injected:    []byte("package p\nfunc Value() int { return 1 }\n"),
+			altOriginal: []byte("package p_test\n"),
+			altInjected: []byte("package p_test\nfunc TestValue() int { return 1 }\n"),
 		}},
-		patchFiles:  map[string][]string{"example.test": {patch}},
+		patchFiles: map[string][]string{
+			"example.test":      {patch},
+			"example.test_test": {altPatch},
+		},
 		sfilesCache: map[string][]string{"example.test": nil},
 	}
 	manifest := func() string {
@@ -69,6 +83,9 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 		if len(m.pkg.GoFiles) != 2 {
 			t.Fatalf("source patch absent or counted twice: %+v", m.pkg.GoFiles)
 		}
+		if len(m.pkg.AltGoFiles) != 2 {
+			t.Fatalf("alternate source patch absent or counted twice: %+v", m.pkg.AltGoFiles)
+		}
 		return m.Build()
 	}
 	first := manifest()
@@ -79,8 +96,15 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 	if first == second {
 		t.Fatal("changing only a source patch body did not invalidate the package cache")
 	}
+	if err := os.WriteFile(altPatch, []byte("package p_test\nfunc TestValue() int { return 2 }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	third := manifest()
+	if second == third {
+		t.Fatal("changing only an alternate source patch body did not invalidate the package cache")
+	}
 	ctx.buildConf.Overlay[unused] = []byte("package p\nconst Unused = 1\n")
-	if manifest() != second {
+	if manifest() != third {
 		t.Fatal("unselected source invalidated the package cache")
 	}
 }

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -89,14 +89,14 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 		return m.Build()
 	}
 	first := manifest()
-	if err := os.WriteFile(patch, []byte("package p\nfunc Value() int { return 2 }\n"), 0644); err != nil {
+	if err := os.WriteFile(patch, []byte("package p\nfunc Value() int { return 200 }\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	second := manifest()
 	if first == second {
 		t.Fatal("changing only a source patch body did not invalidate the package cache")
 	}
-	if err := os.WriteFile(altPatch, []byte("package p_test\nfunc TestValue() int { return 2 }\n"), 0644); err != nil {
+	if err := os.WriteFile(altPatch, []byte("package p_test\nfunc TestValue() int { return 200 }\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	third := manifest()

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -38,8 +38,15 @@ import (
 func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 	dir := t.TempDir()
 	original := filepath.Join(dir, "original.go")
-	patch := filepath.Join(dir, "llgo_patch.go")
+	patch := filepath.Join(dir, "_patch", "llgo_patch.go")
+	injected := filepath.Join(dir, "z_llgo_patch_llgo_patch.go")
 	unused := filepath.Join(dir, "unselected.go")
+	if err := os.MkdirAll(filepath.Dir(patch), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(patch, []byte("package p\nfunc Value() int { return 1 }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	pkg := &aPackage{Package: &packages.Package{
 		ID: "example.test", PkgPath: "example.test",
 		GoFiles: []string{original}, CompiledGoFiles: []string{original, patch},
@@ -48,8 +55,9 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 		mode: ModeGen,
 		buildConf: &Config{Overlay: map[string][]byte{
 			original: []byte("package p\n"),
-			patch:    []byte("package p\nfunc Value() int { return 1 }\n"),
+			injected: []byte("package p\nfunc Value() int { return 1 }\n"),
 		}},
+		patchFiles:  map[string][]string{"example.test": {patch}},
 		sfilesCache: map[string][]string{"example.test": nil},
 	}
 	manifest := func() string {
@@ -64,7 +72,9 @@ func TestSourcePatchBodyChangesPackageFingerprint(t *testing.T) {
 		return m.Build()
 	}
 	first := manifest()
-	ctx.buildConf.Overlay[patch] = []byte("package p\nfunc Value() int { return 2 }\n")
+	if err := os.WriteFile(patch, []byte("package p\nfunc Value() int { return 2 }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	second := manifest()
 	if first == second {
 		t.Fatal("changing only a source patch body did not invalidate the package cache")


### PR DESCRIPTION
## Problem

Injected Go source patches are added to `CompiledGoFiles` after `go list`, but package cache fingerprints previously considered only `GoFiles`. Changing an injected function body could silently reuse a stale archive. This common build-cache defect was found while validating a wasm syscall timestamp fix.

## Fix

- Include selected overlaid `CompiledGoFiles` in Go source inputs without counting original files twice.
- Apply the same rule to alternate packages.
- Keep unselected overlays out of the cache key.
- Add a regression that changes only an injected patch body and verifies cache invalidation.

This is independent of the WASM R4 runtime changes; it changes only build fingerprinting and its tests.

## Validation

- Focused build/fingerprint tests pass on LLVM 22 against upstream main `be23e488a`.
- The cache-enabled wide-stat regression in R4 passes with this fix.
- [Fork PR cpunion/llgo#242](https://github.com/cpunion/llgo/pull/242) completed 62 successful CI checks and one skipped check at `b1082dd3590a25c86efd4606cfd91da408713d20`, with no failed or pending checks before this upstream contribution.
- Upstream's subsequent float-conversion changes through `3dce98b91` do not overlap this patch.
## Why earlier CI did not expose this

A clean build is unaffected: the injected source is compiled correctly on the first cache miss. The stale result requires two builds sharing one package cache where only the selected injected patch body changes. Earlier clean-checkout and ordinary cache-hit lanes did not exercise that transition. The new regression performs that exact second build, so prior green clean-build results are not evidence against this fix.
