### PR TITLE
fix(build): preserve ordinary and test package identities

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -3616,7 +3616,10 @@ func applyPatches(ctx *context, p *packages.Package, verbose bool) {
 }
 
 func createSSAPkg(ctx *context, prog *ssa.Program, p *packages.Package, verbose bool) (*ssa.Package, bool) {
-	pkgSSA := prog.ImportedPackage(p.ID)
+	// SSA imports are keyed by types.Package identity. A path lookup can
+	// return the test-augmented variant and leave the ordinary package
+	// unregistered (or vice versa), even though both have the same PkgPath.
+	pkgSSA := prog.Package(p.Types)
 	if pkgSSA == nil {
 		if debugBuild || verbose {
 			log.Println("==> BuildSSA", p.ID)

--- a/internal/build/package_build_test.go
+++ b/internal/build/package_build_test.go
@@ -54,6 +54,34 @@ func TestPackageBuildTask(t *testing.T) {
 	}
 }
 
+func TestCreateSSAPkgKeepsTestPackageIdentities(t *testing.T) {
+	const path = "example.com/helper"
+	const testID = path + " [" + path + ".test]"
+	for _, order := range [][]string{{path, testID}, {testID, path}} {
+		t.Run(order[0], func(t *testing.T) {
+			prog := ssa.NewProgram(token.NewFileSet(), ssa.SanityCheckFunctions)
+			ctx := &context{}
+			loaded := make(map[string]*packages.Package)
+			for _, id := range order {
+				pkg := &packages.Package{ID: id, PkgPath: path, Types: types.NewPackage(path, "helper"), TypesInfo: &types.Info{}}
+				pkg.Types.MarkComplete()
+				loaded[id] = pkg
+				got, created := createSSAPkg(ctx, prog, pkg, false)
+				if !created || got.Pkg != pkg.Types || prog.Package(pkg.Types) != got {
+					t.Fatalf("%s did not register its own SSA package", id)
+				}
+			}
+			for _, id := range order {
+				pkg := loaded[id]
+				got, created := createSSAPkg(ctx, prog, pkg, false)
+				if created || got != prog.Package(pkg.Types) {
+					t.Fatalf("%s did not reuse its own SSA package", id)
+				}
+			}
+		})
+	}
+}
+
 func TestPackageBuildTaskSpecialKinds(t *testing.T) {
 	decl := newPackageBuildTask(&aPackage{Package: &packages.Package{
 		PkgPath: "unsafe",

--- a/internal/build/package_build_test.go
+++ b/internal/build/package_build_test.go
@@ -62,6 +62,7 @@ func TestCreateSSAPkgKeepsTestPackageIdentities(t *testing.T) {
 			prog := ssa.NewProgram(token.NewFileSet(), ssa.SanityCheckFunctions)
 			ctx := &context{}
 			loaded := make(map[string]*packages.Package)
+			ssaPackages := make(map[string]*ssa.Package)
 			for _, id := range order {
 				pkg := &packages.Package{ID: id, PkgPath: path, Types: types.NewPackage(path, "helper"), TypesInfo: &types.Info{}}
 				pkg.Types.MarkComplete()
@@ -70,6 +71,10 @@ func TestCreateSSAPkgKeepsTestPackageIdentities(t *testing.T) {
 				if !created || got.Pkg != pkg.Types || prog.Package(pkg.Types) != got {
 					t.Fatalf("%s did not register its own SSA package", id)
 				}
+				ssaPackages[id] = got
+			}
+			if ssaPackages[path] == ssaPackages[testID] {
+				t.Fatal("ordinary and test-augmented packages share an SSA package")
 			}
 			for _, id := range order {
 				pkg := loaded[id]

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -328,7 +328,10 @@ func (tc *typecheckContext) typecheckPackage(pkg *Package) {
 		}
 		defer func() {
 			if !pkg.IllTyped && pkg.Types != nil && pkg.Types.Complete() {
-				tc.dedup.set(pkg.PkgPath, &Cached{
+				// The ordinary package and its test-augmented variant share
+				// PkgPath but not types.Package identity. Match the lookup key
+				// above so a later load cannot import the wrong variant.
+				tc.dedup.set(pkg.ID, &Cached{
 					Package:   pkg,
 					Types:     pkg.Types,
 					TypesInfo: pkg.TypesInfo,

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -342,6 +342,8 @@ func (tc *typecheckContext) typecheckPackage(pkg *Package) {
 		if tc.dedup.setpath != nil {
 			pkg.PkgPath = tc.dedup.setpath(pkg.PkgPath, pkg.Name)
 		}
+		// Source-patch files are selected per import path and intentionally
+		// shared by the ordinary and test-augmented variants.
 		if _, ok := tc.dedup.checked.Load(pkg.PkgPath); !ok {
 			tc.dedup.checked.Store(pkg.PkgPath, struct{}{})
 			if files, ok := tc.dedup.llgoFiles[pkg.PkgPath]; ok {

--- a/internal/packages/load_test.go
+++ b/internal/packages/load_test.go
@@ -51,6 +51,51 @@ func identity[T any](value T) T { return value }
 	}
 }
 
+func TestDeduperKeepsTestPackageIdentities(t *testing.T) {
+	dir := t.TempDir()
+	baseFile := filepath.Join(dir, "helper.go")
+	testFile := filepath.Join(dir, "helper_test.go")
+	writeLoadTestFile(t, baseFile, "package helper\nconst Value = 1\n")
+	writeLoadTestFile(t, testFile, "package helper\nconst TestOnly = 2\n")
+	const path = "example.com/helper"
+	const testID = path + " [" + path + ".test]"
+	for _, order := range [][]string{{path, testID}, {testID, path}} {
+		t.Run(order[0], func(t *testing.T) {
+			dedup := NewDeduper()
+			tc := &typecheckContext{dedup: dedup, cfg: loadTestConfig(dir), fset: token.NewFileSet(), origMode: NeedTypes | NeedTypesInfo}
+			makePackage := func(id string) *Package {
+				pkg := &Package{ID: id, PkgPath: path, Name: "helper", CompiledGoFiles: []string{baseFile}}
+				if id == testID {
+					pkg.CompiledGoFiles = append(pkg.CompiledGoFiles, testFile)
+				}
+				return pkg
+			}
+			loaded := make(map[string]*Package)
+			for _, id := range order {
+				pkg := makePackage(id)
+				tc.typecheckPackage(pkg)
+				if pkg.IllTyped {
+					t.Fatalf("typecheck %s: %v", id, pkg.Errors)
+				}
+				loaded[id] = pkg
+			}
+			for _, id := range order {
+				pkg := makePackage(id)
+				tc.typecheckPackage(pkg)
+				if pkg.Types != loaded[id].Types || pkg.TypesInfo != loaded[id].TypesInfo {
+					t.Errorf("%s did not reuse its own package identity", id)
+				}
+				if got := pkg.Types.Scope().Lookup("TestOnly") != nil; got != (id == testID) {
+					t.Errorf("%s test-only declaration = %v, want %v", id, got, id == testID)
+				}
+			}
+			if loaded[path].Types == loaded[testID].Types {
+				t.Fatal("ordinary and test-augmented packages share a type identity")
+			}
+		})
+	}
+}
+
 func TestNormalizeEmbedDriverDiagnostics(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Problem

The ordinary package and its test-augmented variant have the same import path but different package IDs and `types.Package` identities. Two path-keyed shortcuts mixed them:

- The type checker looked up the deduper by ID but stored by path.
- SSA registration queried `ImportedPackage` by ID, even though that API indexes import paths and assumes they are unique.

This causes `Program.CreatePackage(...) was not called` when one tested package is also imported by another tested package. Expanded WebAssembly acceptance CI reproduced it on Linux, macOS and Windows with `test/internal/binaryfixture` and `test/std/debug/elf`/`dwarf`. Both faulty paths exist on upstream main `be23e488a`; this PR contains only their fixes and regressions, without unrelated runtime changes.

## Fix and coverage

- Use package IDs consistently in the type cache.
- Reuse SSA packages by their exact `types.Package` identity.
- Regression tests exercise ordinary-first and test-variant-first ordering, repeat loads/registration, and test-only declaration isolation. Both regressions fail before their corresponding fix.
- Main-based focused package/build tests pass.
- LLGo compilation and execution in the recorded integration tests of `TestParserFixturesContainCodeAndDWARF` and `TestOpenELFAndCoreMethods`, built together with debug info, pass; the same package combination fails before the fix.

This contribution replaces [fork PR cpunion/llgo#244](https://github.com/cpunion/llgo/pull/244). Per request, the remaining fork CI is cancelled and verification continues in this upstream PR; the fork CI is not claimed as passing. No fixture duplication, test skipping, dependency changes, or wasm-only workaround is included.
## Why earlier CI did not expose this

The trigger requires the ordinary package and its test-augmented variant to coexist in one loader/SSA program. Earlier standard-library slices generally compiled these identities independently. The expanded native debug fixture combination loaded test/internal/binaryfixture both directly and through the debug/elf and debug/dwarf tests; [integration CI run 34168818541](https://github.com/cpunion/llgo/actions/runs/34168818541) then reproduced the same missing CreatePackage failure across Linux, macOS, and Windows. The focused regressions now cover both load orders without depending on that large integration matrix.


## CI, coverage, and diff audit (2026-09-11)

At head `e84b667f8`, all existing non-skipped checks pass, including the [platform/Wasm tests](https://github.com/xgo-dev/llgo/actions/runs/34446997090) and [benchmark matrix](https://github.com/xgo-dev/llgo/actions/runs/34446997008). [Codecov patch coverage](https://app.codecov.io/gh/xgo-dev/llgo/pull/2528) is **100.00% of the measured diff**, not merely an upload-action success. These are results for this exact head; a later rebase still requires new validation.

The 4-file diff remains two package-identity fixes plus focused regressions (88 insertions, 2 deletions); the review-requested distinct SSA-package assertion is present. No skip or unrelated runtime change was added.

Size audit of the benchmark artifacts against each artifact's recorded base: Wasm module/glue sizes are unchanged across all five recorded build entries (historical configurations, not five profiles in the revised model). Linux cprintf/println (with and without LTO) are unchanged; fmtprintf differs by +8 file bytes with identical text/data size.

Performance follow-up: The existing Linux run measured ChannelHandoff 14,326 → 20,056 ns/op (+40%, five samples). That is a signal requiring a controlled repeat, not evidence of a diagnosed regression or a demonstrated no-regression result.

The Wasm benchmark results recorded above cover `println` only. [cpunion/llgo#247](https://github.com/cpunion/llgo/pull/247) adds `cprintf`/`fmtprintf` build and size measurements; those measurements do not establish runtime throughput or independent Go-compatible JavaScript provider acceptance. Native results above must not be read as Wasm measurements. No blanket performance-completion claim is made here.

