### PR TITLE
[Superseded by #2530] fix(ssa): preserve synthetic debug locations

### DIFF
--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -517,13 +517,20 @@ func (p Function) NewBuilder() Builder {
 	b := prog.ctx.NewBuilder()
 	// TODO(xsw): Finalize may cause panic, so comment it.
 	// b.Finalize()
-	return &aBuilder{
+	ret := &aBuilder{
 		impl:         b,
 		Func:         p,
 		Pkg:          p.Pkg,
 		Prog:         prog,
 		diScopeCache: make(map[*types.Scope]DIScope),
 	}
+	if p.diFunc != nil {
+		// Synthetic builders emit calls too. LLVM requires a location for
+		// inlinable calls in a function with debug info; line zero denotes
+		// compiler-generated code without inventing a source position.
+		ret.setDebugLocation(llvm.DebugLoc{Scope: p.diFunc.ll})
+	}
+	return ret
 }
 
 // HasBody reports whether the function has a body.

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -830,13 +830,20 @@ func (b Builder) DIGlobal(v Expr, name string, pos token.Position) {
 	b.Pkg.glbDbgVars[v] = true
 }
 
+func (b Builder) setDebugLocation(loc llvm.DebugLoc) {
+	// The LLVM binding's getter cannot read an unset location. Keep the
+	// logical source location here, including for builders created before
+	// DebugFunction attaches the function's DISubprogram.
+	b.diLocation = loc
+	b.impl.SetCurrentDebugLocation(loc.Line, loc.Col, loc.Scope, loc.InlinedAt)
+}
+
 func (b Builder) DISetCurrentDebugLocation(diScope DIScope, pos token.Position) {
-	b.impl.SetCurrentDebugLocation(
-		uint(pos.Line),
-		uint(pos.Column),
-		diScope.scopeMeta(b.di(), pos).ll,
-		llvm.Metadata{},
-	)
+	b.setDebugLocation(llvm.DebugLoc{
+		Line:  uint(pos.Line),
+		Col:   uint(pos.Column),
+		Scope: diScope.scopeMeta(b.di(), pos).ll,
+	})
 }
 
 func (b Builder) DebugFunction(f Function, funcScope *types.Scope, pos token.Position, bodyPos token.Position) {
@@ -869,12 +876,11 @@ func (b Builder) DebugFunction(f Function, funcScope *types.Scope, pos token.Pos
 		}
 		p.impl.SetSubprogram(p.diFunc.ll)
 	}
-	b.impl.SetCurrentDebugLocation(
-		uint(bodyPos.Line),
-		uint(bodyPos.Column),
-		p.diFunc.ll,
-		llvm.Metadata{},
-	)
+	b.setDebugLocation(llvm.DebugLoc{
+		Line:  uint(bodyPos.Line),
+		Col:   uint(bodyPos.Column),
+		Scope: p.diFunc.ll,
+	})
 }
 
 func (b Builder) Param(idx int) Expr {

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -835,6 +835,14 @@ func (b Builder) setDebugLocation(loc llvm.DebugLoc) {
 	// logical source location here, including for builders created before
 	// DebugFunction attaches the function's DISubprogram.
 	b.diLocation = loc
+	b.restoreDebugLocation()
+}
+
+func (b Builder) restoreDebugLocation() {
+	loc := b.diLocation
+	if loc.Scope.IsNil() {
+		return
+	}
 	b.impl.SetCurrentDebugLocation(loc.Line, loc.Col, loc.Scope, loc.InlinedAt)
 }
 

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -374,6 +374,36 @@ func TestSyntheticBuilderDebugLocation(t *testing.T) {
 	}
 }
 
+func TestSetBlockRestoresTrackedDebugLocation(t *testing.T) {
+	prog := NewProgram(&Target{OptLevel: optlevel.O0})
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	pkg := prog.NewPackage("p", "example.com/p")
+	pkg.InitDebug("p", "example.com/p", token.NewFileSet())
+	fn := pkg.NewFunc("example.com/p.f", NoArgsNoRet, InGo)
+	builder := fn.MakeBody(2)
+	defer builder.Dispose()
+	pos := token.Position{Filename: "blocks.go", Line: 3, Column: 2}
+	builder.DebugFunction(fn, nil, pos, pos)
+	builder.Jump(fn.Block(1))
+
+	// Model LLVM losing its current location during a synthetic CFG rewrite.
+	// SetBlock must restore the Go-side shadow before emitting in the new block.
+	builder.impl.SetCurrentDebugLocation(0, 0, llvm.Metadata{}, llvm.Metadata{})
+	builder.SetBlock(fn.Block(1))
+	call := builder.impl.CreateCall(fn.impl.GlobalValueType(), fn.impl, nil, "")
+	loc := call.InstructionDebugLoc()
+	if loc.IsNil() || loc.LocationLine() != uint(pos.Line) || loc.LocationColumn() != uint(pos.Column) {
+		t.Fatalf("restored call location = %+v, want %s:%d:%d", loc, pos.Filename, pos.Line, pos.Column)
+	}
+	builder.Return()
+
+	pkg.FinalizeDebug()
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("invalid restored debug metadata: %v\n%s", err, pkg.Module().String())
+	}
+}
+
 func newDebugRuntimePackage() *types.Package {
 	pkg := types.NewPackage(PkgRuntime, "runtime")
 	unsafePointer := types.Typ[types.UnsafePointer]

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -317,6 +317,63 @@ func f() {}
 	}
 }
 
+func TestSyntheticBuilderDebugLocation(t *testing.T) {
+	for _, mode := range []string{"before debug init", "after debug init", "without debug"} {
+		t.Run(mode, func(t *testing.T) {
+			prog := NewProgram(&Target{OptLevel: optlevel.O0})
+			defer prog.Dispose()
+			prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+			pkg := prog.NewPackage("p", "example.com/p")
+			fn := pkg.NewFunc("example.com/p.f", NoArgsNoRet, InGo)
+			body := fn.MakeBody(1)
+			defer body.Dispose()
+			body.Return()
+
+			var synthetic Builder
+			if mode != "after debug init" {
+				synthetic = fn.NewBuilder()
+			}
+			debug := mode != "without debug"
+			if debug {
+				pkg.InitDebug("p", "example.com/p", token.NewFileSet())
+				pos := token.Position{Filename: "defer.go", Line: 2, Column: 1}
+				body.DebugFunction(fn, nil, pos, pos)
+			}
+			if synthetic == nil {
+				synthetic = fn.NewBuilder()
+				if synthetic.diLocation.Scope != fn.diFunc.ll {
+					t.Fatal("new synthetic builder has no function debug scope")
+				}
+			}
+			defer synthetic.Dispose()
+
+			init, next := fn.deferInitBuilder(synthetic)
+			defer init.Dispose()
+			if debug {
+				loc := init.impl.GetCurrentDebugLocation()
+				if loc.Scope != fn.diFunc.ll || loc.Line != 0 || loc.Col != 0 || !loc.InlinedAt.IsNil() {
+					t.Fatalf("synthetic location = %+v, want line zero in the function scope", loc)
+				}
+			} else if !init.diLocation.Scope.IsNil() {
+				t.Fatal("non-debug function acquired debug info")
+			}
+			// A recursive call is inlinable and forces LLVM's !dbg verifier to
+			// exercise the same rule as calls in generated defer paths.
+			call := init.impl.CreateCall(fn.impl.GlobalValueType(), fn.impl, nil, "")
+			if debug && call.InstructionDebugLoc().IsNil() {
+				t.Fatal("synthetic call has no debug location")
+			}
+			init.Jump(next)
+			if debug {
+				pkg.FinalizeDebug()
+			}
+			if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+				t.Fatalf("invalid synthetic debug metadata: %v\n%s", err, pkg.Module().String())
+			}
+		})
+	}
+}
+
 func newDebugRuntimePackage() *types.Package {
 	pkg := types.NewPackage(PkgRuntime, "runtime")
 	unsafePointer := types.Typ[types.UnsafePointer]

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -232,11 +232,8 @@ func (b Builder) cLongjmp(jb, retval Expr) {
 
 func (p Function) deferInitBuilder(from Builder) (b Builder, next BasicBlock) {
 	b = p.NewBuilder()
-	if p.diFunc != nil {
-		loc := from.impl.GetCurrentDebugLocation()
-		if !loc.Scope.IsNil() {
-			b.impl.SetCurrentDebugLocation(loc.Line, loc.Col, loc.Scope, loc.InlinedAt)
-		}
+	if loc := from.diLocation; p.diFunc != nil && !loc.Scope.IsNil() {
+		b.setDebugLocation(loc)
 	}
 	next = b.setBlockMoveLast(p.blks[0])
 	p.blks[0].last = next.last

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -232,6 +232,8 @@ func (b Builder) cLongjmp(jb, retval Expr) {
 
 func (p Function) deferInitBuilder(from Builder) (b Builder, next BasicBlock) {
 	b = p.NewBuilder()
+	// NewBuilder supplies a line-zero function location for generated code;
+	// replace it only when the originating builder has a source location.
 	if loc := from.diLocation; p.diFunc != nil && !loc.Scope.IsNil() {
 		b.setDebugLocation(loc)
 	}

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -139,6 +139,10 @@ func (b Builder) SetBlockEx(blk BasicBlock, pos InsertPoint, setBlk bool) {
 	if setBlk {
 		b.blk = blk
 	}
+	// Synthetic control-flow rewrites can leave the underlying LLVM builder
+	// without a current location. Reapply the tracked location at the common
+	// block-positioning boundary before subsequent instructions are emitted.
+	b.restoreDebugLocation()
 }
 
 func instrAfterInit(blk llvm.BasicBlock) llvm.Value {

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -66,7 +66,9 @@ type aBuilder struct {
 
 	diScopeCache map[*types.Scope]DIScope // avoid duplicated DILexicalBlock(s)
 	diFuncScope  *types.Scope
-	diLocation   llvm.DebugLoc
+	// diLocation mirrors the LLVM builder state. Route every debug-location
+	// mutation through setDebugLocation so generated builders can copy it safely.
+	diLocation llvm.DebugLoc
 }
 
 // Builder represents a builder for creating instructions in a function.

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -66,6 +66,7 @@ type aBuilder struct {
 
 	diScopeCache map[*types.Scope]DIScope // avoid duplicated DILexicalBlock(s)
 	diFuncScope  *types.Scope
+	diLocation   llvm.DebugLoc
 }
 
 // Builder represents a builder for creating instructions in a function.


### PR DESCRIPTION
> Consolidated into [#2530](https://github.com/xgo-dev/llgo/pull/2530), which includes these commits, regression tests, and review fixes together with the dependent local-stack allocation fix. Please review the combined contribution and its current CI there; the results below are retained as historical evidence.

## Problem

Synthetic builders may not have a current source location even when their function has a DISubprogram. The LLVM binding explicitly requires a location to have been set before calling `GetCurrentDebugLocation`; `deferInitBuilder` violated that precondition and crashed in `LLVMGoGetCurrentDebugLocation` during CI.

Other synthetic calls in debug-enabled functions failed LLVM verification: an inlinable call must have a `!dbg` location. The expanded macOS LTO checks exposed this for `os.(*root).decref`. The affected code exists on upstream main `be23e488a`; this PR contains no unrelated runtime changes.

## Fix

- Track explicitly assigned source locations in the Go builder instead of reading a potentially unset LLVM location.
- Initialize synthetic builders in debug-enabled functions with a line-zero function location, denoting generated code without inventing a source line.
- Preserve the originating source location for generated defer setup when available.

## Validation

- The full SSA suite passed in the recorded integration tests; focused tests also pass on this main-based branch.
- Regressions cover builders created before/after debug initialization, debug-disabled functions, exact source-location inheritance, and LLVM verification of an inlinable synthetic call.
- Native fixture tests built with debug info passed in the recorded integration tests.
- The three failing macOS LTO cases advance past the original LLVM verifier error locally. Final local linking is blocked by this machine's LLVM 22 plugin / LLD 23 mismatch; this is not counted as an end-to-end pass. Matching LLVM 22 CI remains required.

This contribution replaces [fork PR cpunion/llgo#245](https://github.com/cpunion/llgo/pull/245). Per request, the remaining fork CI is cancelled and verification continues in this upstream PR; the fork CI is not claimed as passing. No debug-info disabling or LLVM dependency replacement is used.
## Why earlier CI did not expose this

The affected path needs debug metadata plus a synthetic builder that either has no current location or emits an inlinable generated call checked by LLVM verification/LTO. Earlier completed WASM startup and release lanes did not combine those conditions, and shallower compilation failures could stop before this verifier path. The new tests construct the missing-location states directly and verify the generated LLVM module, making the invariant independent of a particular target matrix.


## CI, coverage, and diff audit (2026-09-11)

At head `85854a71c`, all existing non-skipped checks pass, including the [platform/Wasm tests](https://github.com/xgo-dev/llgo/actions/runs/34179471828) and [benchmark matrix](https://github.com/xgo-dev/llgo/actions/runs/34179471837). [Codecov patch coverage](https://app.codecov.io/gh/xgo-dev/llgo/pull/2529) is **100.00% of the measured diff**, not merely an upload-action success. These are results for this exact head; a later rebase still requires new validation.

The 5-file diff is limited to debug-location state, initialization/restoration, and tests. Both review requests are implemented. No debug-info disabling or new test exclusion was added.

Size audit of the benchmark artifacts against each artifact's recorded base: All recorded Wasm module/glue sizes and Linux cprintf/println/fmtprintf size metrics, including LTO variants, are unchanged.

Performance follow-up: TimerRearmStopped measured 2,609 → 3,425 ns/op (+31.3%, five samples) in this run. A controlled repeat is still needed before attributing that timing difference to the debug-location change.

The Wasm benchmark results recorded above cover `println` only. [cpunion/llgo#247](https://github.com/cpunion/llgo/pull/247) adds `cprintf`/`fmtprintf` build and size measurements; those measurements do not establish runtime throughput or independent Go-compatible JavaScript provider acceptance. Native results above must not be read as Wasm measurements. No blanket performance-completion claim is made here.


