### PR TITLE
cl: rename and restrict locality directives

### DIFF
--- a/chore/litgen/rewrite_test.go
+++ b/chore/litgen/rewrite_test.go
@@ -378,11 +378,11 @@ func makeFn() func() { return func() {} }
 			src: `// LITTEST
 package main
 
-//llgo:tls
+//llgointernal:tls
 var fn = func() {}
 `,
 			ir:        initIR,
-			adjacency: "//llgo:tls\nvar fn",
+			adjacency: "//llgointernal:tls\nvar fn",
 		},
 		{
 			name: "variable specification",
@@ -390,12 +390,12 @@ var fn = func() {}
 package main
 
 var (
-	//llgo:tls
+	//llgointernal:tls
 	fn = func() {}
 )
 `,
 			ir:        initIR,
-			adjacency: "\t//llgo:tls\n\tfn =",
+			adjacency: "\t//llgointernal:tls\n\tfn =",
 		},
 	}
 	for _, test := range tests {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -64,6 +64,9 @@ type Options struct {
 	DebugSymbols bool
 	Trace        bool
 	ExportRename bool
+	// AllowInternalDirectives permits directives reserved for LLGo's runtime.
+	// Package loaders set it only for verified Go standard-library sources.
+	AllowInternalDirectives bool
 	// CExportWrappers keeps //export implementations under their Go symbols;
 	// the final-link module supplies the public C entry points.
 	CExportWrappers bool

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -184,6 +184,11 @@ func TestRunAndTestFromTestgo(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testgo", ignore)
 }
 
+func TestRunAndTestRuntimeCodegen(t *testing.T) {
+	t.Chdir("../runtime")
+	cltest.RunAndTestFromDir(t, "", "./_test/codegen", nil)
+}
+
 func TestRunAndTestFromTestmeta(t *testing.T) {
 	conf := build.NewDefaultConf(build.ModeRun)
 	conf.CollectPackageMeta = true

--- a/cl/import.go
+++ b/cl/import.go
@@ -887,6 +887,9 @@ func ParsePkgSyntaxWithOptions(prog llssa.Program, fset *token.FileSet, pkg *typ
 	if prog.PackageSyntaxParsed(pkg) {
 		return nil
 	}
+	if err := validateInternalDirectives(fset, pkg.Path(), files, options.AllowInternalDirectives); err != nil {
+		return err
+	}
 	ctx := &context{prog: prog, options: options}
 	pkgPath := llssa.PathOf(pkg)
 	syms := make(map[string]string)
@@ -954,6 +957,23 @@ func ParsePkgSyntaxWithOptions(prog llssa.Program, fset *token.FileSet, pkg *typ
 	}
 	collectGoLinknames(prog, fileComments, syms)
 	prog.MarkPackageSyntaxParsed(pkg)
+	return nil
+}
+
+func validateInternalDirectives(fset *token.FileSet, pkgPath string, files []*ast.File, allow bool) error {
+	if allow || pkgPath == env.LLGoRuntimePkg || strings.HasPrefix(pkgPath, env.LLGoRuntimePkg+"/") {
+		return nil
+	}
+	for _, file := range files {
+		for _, group := range file.Comments {
+			for _, comment := range group.List {
+				d, ok := directive.Parse(comment)
+				if ok && strings.HasPrefix(d.Name, "llgointernal:") {
+					return fmt.Errorf("%s: //%s is only allowed in the Go standard library or %s", fset.Position(d.Pos), d.Name, env.LLGoRuntimePkg)
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/cl/import_coverage_test.go
+++ b/cl/import_coverage_test.go
@@ -80,7 +80,7 @@ func (A) StackedHidden() {}
 	if !prog.PackageSyntaxParsed(pkg) {
 		t.Fatal("package syntax was not marked as parsed")
 	}
-	badFile, err := parser.ParseFile(fset, "bad.go", "package p\n//llgo:tls\nfunc Bad() {}\n", parser.ParseComments)
+	badFile, err := parser.ParseFile(fset, "bad.go", "package p\n//llgointernal:tls\nfunc Bad() {}\n", parser.ParseComments)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,24 +95,33 @@ func TestParsePkgSyntaxReportsLocalityErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	tests := []struct {
-		name string
-		src  string
-		want string
+		name  string
+		src   string
+		want  string
+		allow bool
 	}{
 		{
-			name: "function body",
-			src:  "package p\nfunc f() {\n//llgo:gls\nvar value int\n_ = value\n}\n",
-			want: "package-level var",
+			name: "external package",
+			src:  "package p\n//llgointernal:tls\nvar value int\n",
+			want: "only allowed in the Go standard library",
 		},
 		{
-			name: "package var",
-			src:  "package p\n//llgo:tls extra\nvar Value int\n",
-			want: "does not accept arguments",
+			name:  "function body",
+			src:   "package p\nfunc f() {\n//llgointernal:gls\nvar value int\n_ = value\n}\n",
+			want:  "package-level var",
+			allow: true,
 		},
 		{
-			name: "non-var declaration",
-			src:  "package p\n//llgo:gls\nconst Value = 1\n",
-			want: "package-level var",
+			name:  "package var",
+			src:   "package p\n//llgointernal:tls extra\nvar Value int\n",
+			want:  "does not accept arguments",
+			allow: true,
+		},
+		{
+			name:  "non-var declaration",
+			src:   "package p\n//llgointernal:gls\nconst Value = 1\n",
+			want:  "package-level var",
+			allow: true,
 		},
 	}
 	for _, test := range tests {
@@ -123,7 +132,7 @@ func TestParsePkgSyntaxReportsLocalityErrors(t *testing.T) {
 				t.Fatal(err)
 			}
 			pkg := types.NewPackage("example.com/"+strings.ReplaceAll(test.name, " ", "-"), "p")
-			err = ParsePkgSyntax(llssa.NewProgram(nil), fset, pkg, []*ast.File{file})
+			err = ParsePkgSyntaxWithOptions(llssa.NewProgram(nil), fset, pkg, []*ast.File{file}, Options{AllowInternalDirectives: test.allow})
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("ParsePkgSyntax error = %v, want %q", err, test.want)
 			}
@@ -361,7 +370,7 @@ func TestCollectDeclarationDirectivesIgnoresOtherDirectives(t *testing.T) {
 	prog := llssa.NewProgram(nil)
 	doc := &ast.CommentGroup{List: []*ast.Comment{
 		{Text: "//go:noinline"},
-		{Text: "//llgo:tls"},
+		{Text: "//llgointernal:tls"},
 	}}
 	const fullName = "example.com/p.Value"
 	collectDeclarationDirectives(prog, nil, doc, fullName, "Value", token.NoPos)

--- a/cl/locality_test.go
+++ b/cl/locality_test.go
@@ -22,6 +22,7 @@ func compileLocalitySource(t *testing.T, src string) (llssa.Program, string) {
 
 func compileLocalitySourceWithOptions(t *testing.T, src string, options Options) (llssa.Program, string) {
 	t.Helper()
+	options.AllowInternalDirectives = true
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "locality.go", src, parser.ParseComments)
 	if err != nil {
@@ -53,6 +54,14 @@ func compileLocalitySourceWithOptions(t *testing.T, src string, options Options)
 		t.Fatal(err)
 	}
 	return prog, compiled.String()
+}
+
+func newLocalityTestPackage(prog llssa.Program, pkg *ssa.Package, files []*ast.File) (llssa.Package, error) {
+	compiled, _, err := NewPackageExWithEmbedMetaOptions(
+		prog, nil, nil, nil, pkg, files, nil, false,
+		Options{AllowInternalDirectives: true},
+	)
+	return compiled, err
 }
 
 func newLocalityTypeInfo() *types.Info {
@@ -106,7 +115,7 @@ func localityRuntimePackage() *types.Package {
 func TestLocalPackageAccessorUsesDirectTLSCache(t *testing.T) {
 	const src = `package locality
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func value() *int { return pointer }
@@ -156,13 +165,13 @@ var backing int
 func scalar() int { return 42 }
 func pointer() *int { return &backing }
 
-//llgo:tls
+//llgointernal:tls
 var tlsScalar = scalar()
-//llgo:tls
+//llgointernal:tls
 var tlsPointer = pointer()
-//llgo:gls
+//llgointernal:gls
 var glsScalar = scalar()
-//llgo:gls
+//llgointernal:gls
 var glsPointer = pointer()
 
 func values() (int, *int, int, *int) {
@@ -219,10 +228,10 @@ func values() (int, *int, int, *int) {
 func TestLocalityDebugInfoOnlyUsesFixedGlobals(t *testing.T) {
 	_, ir := compileLocalitySourceWithOptions(t, `package locality
 
-//llgo:tls
+//llgointernal:tls
 var direct int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func values() (int, *int) { return direct, pointer }
@@ -246,11 +255,11 @@ func TestLocalityInitializersPreserveGoOrderPerKind(t *testing.T) {
 	_, ir := compileLocalitySource(t, `package locality
 
 func mark(value int) int { return value }
-//llgo:tls
+//llgointernal:tls
 var t0 = mark(0)
-//llgo:gls
+//llgointernal:gls
 var g0 = mark(1)
-//llgo:tls
+//llgointernal:tls
 var t1 = mark(2)
 func values() (int, int, int) { return t0, t1, g0 }
 `)
@@ -275,7 +284,7 @@ func values() (int, int, int) { return t0, t1, g0 }
 func TestDirectInitializerStillRequiresFailureContext(t *testing.T) {
 	prog, ir := compileLocalitySource(t, `package locality
 func value() int { return 1 }
-//llgo:tls
+//llgointernal:tls
 var localValue = value()
 func get() int { return localValue }
 `)
@@ -292,9 +301,9 @@ func get() int { return localValue }
 
 func TestZeroValueDirectLocalsNeedNoContext(t *testing.T) {
 	prog, ir := compileLocalitySource(t, `package locality
-//llgo:tls
+//llgointernal:tls
 var threadValue int
-//llgo:gls
+//llgointernal:gls
 var goroutineValue uintptr
 func values() (int, uintptr) { return threadValue, goroutineValue }
 `)
@@ -308,7 +317,7 @@ func values() (int, uintptr) { return threadValue, goroutineValue }
 
 func TestExportedFunctionInstallsLocalContext(t *testing.T) {
 	_, ir := compileLocalitySource(t, `package locality
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 //export Exported
 func Exported(useLocal bool) *int {
@@ -333,7 +342,7 @@ func Exported(useLocal bool) *int {
 
 func TestExportedNativeTLSNeedsNoLocalContext(t *testing.T) {
 	prog, ir := compileLocalitySource(t, `package locality
-//llgo:tls
+//llgointernal:tls
 var scalar int
 //export Exported
 func Exported() int { return scalar }
@@ -362,7 +371,7 @@ func assertTextOrder(t *testing.T, text string, wants ...string) {
 func TestLocalityRejectsLinknameAlias(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "locality.go", `package locality
-//llgo:gls
+//llgointernal:gls
 var target *int
 //go:linkname alias example.com/locality.target
 var alias *int
@@ -376,7 +385,7 @@ var alias *int
 		t.Fatal(err)
 	}
 	prog := ssatest.NewProgram(t, nil)
-	if err := ParsePkgSyntax(prog, fset, pkg, []*ast.File{file}); err != nil {
+	if err := ParsePkgSyntaxWithOptions(prog, fset, pkg, []*ast.File{file}, Options{AllowInternalDirectives: true}); err != nil {
 		t.Fatal(err)
 	}
 	if err := prog.ValidateLocalities(pkg.Path()); err == nil || !strings.Contains(err.Error(), "cannot reference local variable") {
@@ -395,9 +404,9 @@ func TestLocalityCrossPackageAccessUsesFunctions(t *testing.T) {
 	}
 	depFile := parse("dep.go", `package dep
 func initialScalar() int { return 1 }
-//llgo:tls
+//llgointernal:tls
 var scalar = initialScalar()
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 func Values() (int, *int) { return scalar, pointer }
 `)
@@ -432,7 +441,7 @@ func Values() (int, *int) { return dep.Values() }
 		{depPkg, depInfo, []*ast.File{depFile}},
 		{rootPkg, rootInfo, []*ast.File{rootFile}},
 	} {
-		if err := ParsePkgSyntax(prog, fset, input.pkg, input.files); err != nil {
+		if err := ParsePkgSyntaxWithOptions(prog, fset, input.pkg, input.files, Options{AllowInternalDirectives: true}); err != nil {
 			t.Fatal(err)
 		}
 		if err := PrepareLocalVariables(prog, fset, input.pkg, input.info, input.files); err != nil {
@@ -444,10 +453,10 @@ func Values() (int, *int) { return dep.Values() }
 	depSSA := goProg.CreatePackage(depPkg, []*ast.File{depFile}, depInfo, true)
 	rootSSA := goProg.CreatePackage(rootPkg, []*ast.File{rootFile}, rootInfo, true)
 	goProg.Build()
-	if _, err := NewPackage(prog, depSSA, []*ast.File{depFile}); err != nil {
+	if _, err := newLocalityTestPackage(prog, depSSA, []*ast.File{depFile}); err != nil {
 		t.Fatal(err)
 	}
-	root, err := NewPackage(prog, rootSSA, []*ast.File{rootFile})
+	root, err := newLocalityTestPackage(prog, rootSSA, []*ast.File{rootFile})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,10 +474,10 @@ func Values() (int, *int) { return dep.Values() }
 func TestParseRejectsLocalAliasInitializer(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "locality.go", `package locality
-//llgo:tls
+//llgointernal:tls
 var target int
 //go:linkname alias example.com/locality.target
-//llgo:tls
+//llgointernal:tls
 var alias = 1
 `, parser.ParseComments)
 	if err != nil {
@@ -480,7 +489,7 @@ var alias = 1
 		t.Fatal(err)
 	}
 	prog := llssa.NewProgram(nil)
-	if err := ParsePkgSyntax(prog, fset, pkg, files); err == nil || !strings.Contains(err.Error(), "cannot apply to a //go:linkname variable") {
+	if err := ParsePkgSyntaxWithOptions(prog, fset, pkg, files, Options{AllowInternalDirectives: true}); err == nil || !strings.Contains(err.Error(), "cannot apply to a //go:linkname variable") {
 		t.Fatalf("ParsePkgSyntax error = %v", err)
 	}
 }
@@ -544,7 +553,7 @@ func TestNewPackageReportsLocalityPreparationErrors(t *testing.T) {
 		{
 			name: "invalid directive",
 			src: `package locality
-//llgo:tls
+//llgointernal:tls
 func invalid() {}
 `,
 			wantError: "applies only to package-level var declarations",
@@ -553,7 +562,7 @@ func invalid() {}
 			name: "unprepared initializer",
 			src: `package locality
 func initialValue() int { return 1 }
-//llgo:tls
+//llgointernal:tls
 var value = initialValue()
 `,
 			parseSyntax: true,
@@ -562,10 +571,10 @@ var value = initialValue()
 		{
 			name: "linkname locality",
 			src: `package locality
-//llgo:tls
+//llgointernal:tls
 var target int
 //go:linkname alias example.com/locality.target
-//llgo:gls
+//llgointernal:gls
 var alias int
 `,
 			wantError: "cannot apply to a //go:linkname variable",
@@ -590,11 +599,11 @@ var alias int
 			ssaPkg.Build()
 			prog := ssatest.NewProgram(t, nil)
 			if tt.parseSyntax {
-				if err := ParsePkgSyntax(prog, fset, pkg, files); err != nil {
+				if err := ParsePkgSyntaxWithOptions(prog, fset, pkg, files, Options{AllowInternalDirectives: true}); err != nil {
 					t.Fatal(err)
 				}
 			}
-			if _, err := NewPackage(prog, ssaPkg, files); err == nil || !strings.Contains(err.Error(), tt.wantError) {
+			if _, err := newLocalityTestPackage(prog, ssaPkg, files); err == nil || !strings.Contains(err.Error(), tt.wantError) {
 				t.Fatalf("NewPackage error = %v, want %q", err, tt.wantError)
 			}
 		})
@@ -623,7 +632,7 @@ var value int
 	name := llssa.FullName(pkg, "value")
 	prog.SetLocalityInfo(name, llssa.LocalityInfo{Locality: llssa.ThreadLocal})
 	prog.SetLinkname(name, name+"Alias")
-	if _, err := NewPackage(prog, ssaPkg, files); err == nil || !strings.Contains(err.Error(), "cannot use go:linkname") {
+	if _, err := newLocalityTestPackage(prog, ssaPkg, files); err == nil || !strings.Contains(err.Error(), "cannot use go:linkname") {
 		t.Fatalf("NewPackage locality validation error = %v", err)
 	}
 }
@@ -631,7 +640,7 @@ var value int
 func TestParseRejectsExportedLocalVariable(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "locality.go", `package locality
-//llgo:tls
+//llgointernal:tls
 var Value int
 `, parser.ParseComments)
 	if err != nil {
@@ -643,7 +652,7 @@ var Value int
 		t.Fatal(err)
 	}
 	prog := ssatest.NewProgram(t, nil)
-	if err := ParsePkgSyntax(prog, fset, pkg, files); err == nil || !strings.Contains(err.Error(), "requires an unexported package variable") {
+	if err := ParsePkgSyntaxWithOptions(prog, fset, pkg, files, Options{AllowInternalDirectives: true}); err == nil || !strings.Contains(err.Error(), "requires an unexported package variable") {
 		t.Fatalf("ParsePkgSyntax error = %v", err)
 	}
 }
@@ -719,7 +728,7 @@ func TestPlanLocalPackageDiagnostics(t *testing.T) {
 func TestLocalInitializerNameCollision(t *testing.T) {
 	prog, _ := compileLocalitySource(t, `package locality
 func __llgo_local_init_0() {}
-//llgo:tls
+//llgointernal:tls
 var value = 1
 `)
 	info, ok := prog.VariableLocality("example.com/locality.value")
@@ -732,7 +741,7 @@ func TestNamedPointerLocalUsesPackageStorage(t *testing.T) {
 	prog, ir := compileLocalitySource(t, `package locality
 type Handle struct { Pointer *int }
 func makeHandle() Handle { return Handle{} }
-//llgo:tls
+//llgointernal:tls
 var value = makeHandle()
 func get() Handle { return value }
 `)

--- a/doc/defer-tls-gc.md
+++ b/doc/defer-tls-gc.md
@@ -17,7 +17,7 @@ Prior experiments (`test-defer-dont-free` branch) confirmed the crash disappeare
      goroutine's defer-chain head.
    - The context is allocated with `AllocRoot`, so pointers reachable through
      `g` remain visible to the collector.
-   - A pointer-free `//llgo:tls` `uintptr` slot locates the current `g`. The
+   - A pointer-free `//llgointernal:tls` `uintptr` slot locates the current `g`. The
      slot is only an address cache; the `runtimeContext` allocation is the GC
      root.
    - Bare-metal targets keep the same state in ordinary globals because they
@@ -34,9 +34,9 @@ Prior experiments (`test-defer-dont-free` branch) confirmed the crash disappeare
    - Defer argument nodes and the `runtime.Defer` struct itself are allocated with `aggregateAllocU`, ensuring new memory comes from GC-managed heaps, and nodes are released via `runtime.FreeDeferNode`.
 
 3. **Locality directives**
-   - Runtime state that belongs to a logical goroutine uses `//llgo:gls`.
+   - Runtime state that belongs to a logical goroutine uses `//llgointernal:gls`.
    - Physical scheduler and execution-resource slots that must be available
-     before goroutine-local context setup use `//llgo:tls`.
+     before goroutine-local context setup use `//llgointernal:tls`.
    - TLS and GLS currently share one physical owner because LLGo binds one
      goroutine/P/M to one OS thread. The directive still records the intended
      lifetime so a future scheduler can keep GLS with a migrating goroutine

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -642,6 +642,8 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 		defer syntaxErrMu.Unlock()
 		return syntaxErr
 	}
+	// Assigned before package loading invokes the preload callback.
+	var sourcePatchGOROOT string
 	dedup.SetPreload(func(pkg *packages.Package) {
 		if llruntime.SkipToBuild(pkg.PkgPath) {
 			return
@@ -649,7 +651,9 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 		if pkg.Name == "main" && pkg.ForTest != "" {
 			pkg.Types.Scope().Insert(types.NewConst(0, pkg.Types, abi.ForTestMarker, types.Typ[types.UntypedBool], constant.MakeBool(true)))
 		}
-		if err := cl.ParsePkgSyntaxWithOptions(prog, cfg.Fset, pkg.Types, pkg.Syntax, preloadOptions); err != nil {
+		options := preloadOptions
+		options.AllowInternalDirectives = isStandardLibraryPackage(pkg, sourcePatchGOROOT)
+		if err := cl.ParsePkgSyntaxWithOptions(prog, cfg.Fset, pkg.Types, pkg.Syntax, options); err != nil {
 			recordSyntaxErr(err)
 		}
 	})
@@ -771,7 +775,7 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 	patches := make(cl.Patches, len(altPkgPaths))
 	altEntries := registerAltSSAPkgs(progSSA, patches, altPkgs[1:], conf, verbose)
 	prepareSpan := buildTrace.startCoordinator("prepare shared backend state", nil)
-	if err := preloadPatchedPackageSyntax(prog, patches, dedup, preloadOptions); err != nil {
+	if err := preloadPatchedPackageSyntax(prog, patches, dedup, preloadOptions, sourcePatchGOROOT); err != nil {
 		prepareSpan.done()
 		return nil, err
 	}
@@ -1529,13 +1533,14 @@ func (c *context) newBackendSession() backendSession {
 // preloadPatchedPackageSyntax prepares the effective types.Package used by
 // patched lowering. Normal and alternate packages are already covered by the
 // packages loader's preload callback, but patch.Types has a distinct identity.
-func preloadPatchedPackageSyntax(prog llssa.Program, patches cl.Patches, dedup packages.Deduper, options cl.Options) error {
+func preloadPatchedPackageSyntax(prog llssa.Program, patches cl.Patches, dedup packages.Deduper, options cl.Options, goroot string) error {
 	paths := make([]string, 0, len(patches))
 	for pkgPath := range patches {
 		paths = append(paths, pkgPath)
 	}
 	slices.Sort(paths)
 	for _, pkgPath := range paths {
+		packageOptions := options
 		patch := patches[pkgPath]
 		alt := dedup.Check(altPkgPathPrefix + pkgPath)
 		if alt == nil || len(alt.Syntax) == 0 || patch.Types == nil {
@@ -1546,12 +1551,22 @@ func preloadPatchedPackageSyntax(prog llssa.Program, patches cl.Patches, dedup p
 		if original := dedup.Check(pkgPath); original != nil {
 			fset = original.Fset
 			files = append(slices.Clone(original.Syntax), files...)
+			packageOptions.AllowInternalDirectives = isStandardLibraryPackage(original.Package, goroot)
 		}
-		if err := cl.ParsePkgSyntaxWithOptions(prog, fset, patch.Types, files, options); err != nil {
+		if err := cl.ParsePkgSyntaxWithOptions(prog, fset, patch.Types, files, packageOptions); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func isStandardLibraryPackage(pkg *packages.Package, goroot string) bool {
+	if pkg == nil || pkg.Module != nil || pkg.PkgPath == "" || pkg.Dir == "" || goroot == "" {
+		return false
+	}
+	first := strings.SplitN(pkg.PkgPath, "/", 2)[0]
+	rel, err := filepath.Rel(filepath.Join(goroot, "src"), pkg.Dir)
+	return err == nil && !strings.Contains(first, ".") && rel != "." && rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (c *context) compiler() *clang.Cmd {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1058,7 +1058,7 @@ func TestBaremetalRuntimeAvoidsLocalityDirectives(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if bytes.Contains(content, []byte("//llgo:tls")) || bytes.Contains(content, []byte("//llgo:gls")) {
+				if bytes.Contains(content, []byte("//llgointernal:tls")) || bytes.Contains(content, []byte("//llgointernal:gls")) {
 					t.Fatalf("bare-metal runtime selected locality directive in %s", name)
 				}
 			}
@@ -1864,10 +1864,10 @@ func TestPrepareLocalVariablesKeepsAltDeclarationOwners(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "runtime.go", `package runtime
 
-//llgo:gls
+//llgointernal:gls
 var goroutineState *uint32
 
-//llgo:tls
+//llgointernal:tls
 var threadState uintptr
 `, parser.ParseComments)
 	if err != nil {
@@ -2454,38 +2454,59 @@ func TestDoOptimizesUnreachableBodylessCalls(t *testing.T) {
 	}
 }
 
-func TestDoReportsLocalityDirectiveError(t *testing.T) {
+func TestDoRejectsInternalDirectiveOutsideRuntime(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "invalid_locality.go")
 	if err := os.WriteFile(file, []byte(`package invalidlocality
 
-//llgo:tls
+//llgointernal:tls
 func Invalid() {}
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	conf := NewDefaultConf(ModeGen)
-	if _, err := Do([]string{file}, conf); err == nil || !strings.Contains(err.Error(), "applies only to package-level var declarations") {
-		t.Fatalf("Do error = %v, want locality directive diagnostic", err)
+	if _, err := Do([]string{file}, conf); err == nil || !strings.Contains(err.Error(), "only allowed in the Go standard library or "+env.LLGoRuntimePkg) {
+		t.Fatalf("Do error = %v, want internal-directive scope diagnostic", err)
+	}
+}
+
+func TestIsStandardLibraryPackage(t *testing.T) {
+	goroot := t.TempDir()
+	src := filepath.Join(goroot, "src")
+	for _, test := range []struct {
+		pkg  *packages.Package
+		want bool
+	}{
+		{pkg: &packages.Package{PkgPath: "fmt", Dir: filepath.Join(src, "fmt")}, want: true},
+		{pkg: &packages.Package{PkgPath: "example.com/pkg", Dir: filepath.Join(src, "example.com", "pkg")}},
+		{pkg: &packages.Package{PkgPath: "fmt", Dir: filepath.Join(goroot, "elsewhere", "fmt")}},
+	} {
+		if got := isStandardLibraryPackage(test.pkg, goroot); got != test.want {
+			t.Fatalf("isStandardLibraryPackage(%+v, %q) = %v, want %v", test.pkg, goroot, got, test.want)
+		}
 	}
 }
 
 func TestDoRejectsLocalityLinkname(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "invalid_locality_alias.go")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module "+env.LLGoRuntimePkg+"/_test/invalidalias\n\ngo 1.27.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(dir, "invalid_locality_alias.go")
 	if err := os.WriteFile(file, []byte(`package invalidlocalityalias
 
 import _ "unsafe"
 
-//llgo:tls
+//llgointernal:tls
 var target int
 
 //go:linkname alias example.com/target.value
-//llgo:tls
+//llgointernal:tls
 var alias = 1
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	conf := NewDefaultConf(ModeGen)
-	if _, err := Do([]string{file}, conf); err == nil || !strings.Contains(err.Error(), "cannot apply to a //go:linkname variable") {
+	if _, err := Build(Invocation{Args: []string{"."}, Config: conf, Dir: dir}); err == nil || !strings.Contains(err.Error(), "cannot apply to a //go:linkname variable") {
 		t.Fatalf("Do error = %v, want locality linkname diagnostic", err)
 	}
 }
@@ -2502,7 +2523,7 @@ func TestDoReportsAltPackageLocalityDirectiveError(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(runtimePkgDir, "runtime.go"), []byte(`package runtime
 
-//llgo:gls
+//llgointernal:gls
 func Invalid() {}
 `), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/directive/directive.go
+++ b/internal/directive/directive.go
@@ -42,6 +42,8 @@ func Parse(comment *ast.Comment) (Directive, bool) {
 	switch {
 	case strings.HasPrefix(raw, "//go:"):
 		namespace, body = "go:", raw[len("//go:"):]
+	case strings.HasPrefix(raw, "//llgointernal:"):
+		namespace, body = "llgointernal:", raw[len("//llgointernal:"):]
 	case strings.HasPrefix(raw, "//llgo:"):
 		namespace, body = "llgo:", raw[len("//llgo:"):]
 	case strings.HasPrefix(raw, "// llgo:"):

--- a/internal/directive/directive_test.go
+++ b/internal/directive/directive_test.go
@@ -15,7 +15,7 @@ func TestParse(t *testing.T) {
 		{text: "// ordinary"},
 		{text: "//go:"},
 		{text: "//go:noinline", name: "go:noinline", ok: true},
-		{text: "//llgo:tls", name: "llgo:tls", ok: true},
+		{text: "//llgointernal:tls", name: "llgointernal:tls", ok: true},
 		{text: "// llgo:type C", name: "llgo:type", args: "C", ok: true},
 		{text: "//llgo:link\tF C.f", name: "llgo:link", args: "F C.f", ok: true},
 		{text: "//export F", name: "export", args: "F", ok: true},
@@ -38,10 +38,10 @@ func TestParseGroupPreservesSourceOrder(t *testing.T) {
 	doc := &ast.CommentGroup{List: []*ast.Comment{
 		{Text: "// ordinary"},
 		{Text: "//go:noinline"},
-		{Text: "//llgo:tls"},
+		{Text: "//llgointernal:tls"},
 	}}
 	got := ParseGroup(doc)
-	if len(got) != 2 || got[0].Name != "go:noinline" || got[1].Name != "llgo:tls" {
+	if len(got) != 2 || got[0].Name != "go:noinline" || got[1].Name != "llgointernal:tls" {
 		t.Fatalf("ParseGroup = %+v", got)
 	}
 }

--- a/internal/llgen/llgenf_test.go
+++ b/internal/llgen/llgenf_test.go
@@ -97,7 +97,8 @@ func TestApplyFlagsFileTargetForms(t *testing.T) {
 }
 
 func TestGeneratePostABIIsExplicit(t *testing.T) {
-	const pkg = "../../cl/_testgo/localitycodegen"
+	t.Chdir("../../runtime")
+	const pkg = "./_test/codegen/localitycodegen"
 	preABI := GenFrom(pkg)
 	postABI := GeneratePostABI(pkg)
 	if preABI == postABI.Text {

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -21,8 +21,8 @@ package locality
 import "fmt"
 
 const (
-	ThreadDirective    = "//llgo:tls"
-	GoroutineDirective = "//llgo:gls"
+	ThreadDirective    = "//llgointernal:tls"
+	GoroutineDirective = "//llgointernal:gls"
 	InitPrefix         = "__llgo_local_init_"
 )
 

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -60,10 +60,10 @@ func TestMerge(t *testing.T) {
 func TestScanPackageVar(t *testing.T) {
 	fset, file := parseFile(t, `package p
 
-//llgo:tls
+//llgointernal:tls
 var (
 	first int
-	//llgo:gls
+	//llgointernal:gls
 	second int
 )
 `)
@@ -75,7 +75,7 @@ var (
 	fset, file = parseFile(t, `package p
 
 var (
-	//llgo:tls
+	//llgointernal:tls
 	first, second = 1, 2
 )
 `)
@@ -103,32 +103,32 @@ func TestScanPackageVarBranches(t *testing.T) {
 	}{
 		{
 			name: "declaration error",
-			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgo:tls extra")},
+			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgointernal:tls extra")},
 			want: "does not accept arguments",
 		},
 		{
 			name: "spec error",
-			decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Doc: comment("//llgo:gls extra")}}},
+			decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Doc: comment("//llgointernal:gls extra")}}},
 			want: "does not accept arguments",
 		},
 		{
 			name: "embed conflict",
-			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgo:tls\n//go:embed value.txt"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("Value")}}}},
+			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgointernal:tls\n//go:embed value.txt"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("Value")}}}},
 			want: "//go:embed",
 		},
 		{
 			name: "blank name",
-			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgo:tls"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("_")}}}},
+			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgointernal:tls"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("_")}}}},
 			want: "blank identifier",
 		},
 		{
 			name: "exported name",
-			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgo:gls"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("Value")}}}},
+			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//llgointernal:gls"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("Value")}}}},
 			want: "requires an unexported package variable",
 		},
 		{
 			name: "linkname",
-			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//go:linkname value example.com/p.value\n//llgo:tls"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("value")}}}},
+			decl: &ast.GenDecl{Tok: token.VAR, Doc: comment("//go:linkname value example.com/p.value\n//llgointernal:tls"), Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("value")}}}},
 			want: "cannot apply to a //go:linkname variable",
 		},
 	}
@@ -159,7 +159,7 @@ func TestDirectivePlacementDiagnostics(t *testing.T) {
 			name: "grouped import spec",
 			src: `package p
 import (
-	//llgo:tls
+	//llgointernal:tls
 	"unsafe"
 )
 var _ = unsafe.Sizeof(0)
@@ -170,7 +170,7 @@ var _ = unsafe.Sizeof(0)
 			name: "local var",
 			src: `package p
 func f() {
-	//llgo:gls
+	//llgointernal:gls
 	var value int
 	_ = value
 }
@@ -182,7 +182,7 @@ func f() {
 			src: `package p
 func f() {
 	_ = func() {
-		//llgo:tls extra
+		//llgointernal:tls extra
 		var value int
 		_ = value
 	}
@@ -195,7 +195,7 @@ func f() {
 			src: `package p
 func f() {
 	var nested = func() {
-		//llgo:gls
+		//llgointernal:gls
 		var value int
 		_ = value
 	}
@@ -207,7 +207,7 @@ func f() {
 		{
 			name: "function",
 			src: `package p
-//llgo:tls
+//llgointernal:tls
 func f() {}
 `,
 			want: "package-level var",
@@ -229,10 +229,10 @@ func TestDirectiveDiagnostics(t *testing.T) {
 		comment string
 		want    string
 	}{
-		{"//llgo:threadlocal", "use //llgo:tls"},
-		{"//llgo:goroutinelocal", "use //llgo:gls"},
-		{"//llgo:tls extra", "does not accept arguments"},
-		{"//llgo:tls\n//llgo:gls", "cannot apply to the same variable declaration"},
+		{"//llgo:threadlocal", "use //llgointernal:tls"},
+		{"//llgo:goroutinelocal", "use //llgointernal:gls"},
+		{"//llgointernal:tls extra", "does not accept arguments"},
+		{"//llgointernal:tls\n//llgointernal:gls", "cannot apply to the same variable declaration"},
 	}
 	for _, test := range tests {
 		doc := &ast.CommentGroup{}
@@ -253,7 +253,7 @@ func TestDirectiveDiagnostics(t *testing.T) {
 		t.Fatal(err)
 	}
 	typeDecl := &ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{
-		&ast.TypeSpec{Name: ast.NewIdent("T"), Doc: &ast.CommentGroup{List: []*ast.Comment{{Text: "//llgo:tls"}}}},
+		&ast.TypeSpec{Name: ast.NewIdent("T"), Doc: &ast.CommentGroup{List: []*ast.Comment{{Text: "//llgointernal:tls"}}}},
 	}}
 	if err := ValidateNonPackageVar(nil, typeDecl); err == nil || !strings.Contains(err.Error(), "package-level var") {
 		t.Fatalf("type spec validation error = %v", err)
@@ -294,7 +294,7 @@ func TestInitializerLocalityDiagnostics(t *testing.T) {
 func TestPrepareIsIdempotentAcrossPrograms(t *testing.T) {
 	fset, file := parseFile(t, `package p
 func makeValue() *int { value := 42; return &value }
-//llgo:tls
+//llgointernal:tls
 var value = makeValue()
 `)
 	files := []*ast.File{file}

--- a/internal/locality/scan.go
+++ b/internal/locality/scan.go
@@ -135,9 +135,9 @@ func FromDoc(fset *token.FileSet, doc *ast.CommentGroup) (Kind, token.Pos, error
 	for _, directive := range directive.ParseGroup(doc) {
 		var next Kind
 		switch directive.Name {
-		case "llgo:tls":
+		case "llgointernal:tls":
 			next = Thread
-		case "llgo:gls":
+		case "llgointernal:gls":
 			next = Goroutine
 		case legacyThread:
 			return None, token.NoPos, errorAt(fset, directive.Pos, "//%s is not supported; use %s", legacyThread, ThreadDirective)

--- a/runtime/_test/codegen/localitycodegen/in.go
+++ b/runtime/_test/codegen/localitycodegen/in.go
@@ -45,13 +45,13 @@ func newPointer() *int {
 	return &backing
 }
 
-//llgo:tls
+//llgointernal:tls
 var scalar int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
-//llgo:tls
+//llgointernal:tls
 var initialized = newPointer()
 
 func values() (int, *int, *int) {

--- a/runtime/_test/locality/locality.go
+++ b/runtime/_test/locality/locality.go
@@ -16,16 +16,16 @@
  * limitations under the License.
  */
 
-package llgoext
+package locality
 
 import (
 	"runtime"
 	"sync/atomic"
 	"testing"
 
-	"github.com/xgo-dev/llgo/test/llgoext/testdata/localitybench"
-	"github.com/xgo-dev/llgo/test/llgoext/testdata/localityfailure"
-	"github.com/xgo-dev/llgo/test/llgoext/testdata/localityscope"
+	"github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localitybench"
+	"github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityfailure"
+	"github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityscope"
 )
 
 var initializerSequence int
@@ -35,16 +35,16 @@ func nextLocalValue(base int) int {
 	return base + initializerSequence
 }
 
-//llgo:tls
+//llgointernal:tls
 var tlsCounter int
 
-//llgo:gls
+//llgointernal:gls
 var glsCounter int
 
-//llgo:tls
+//llgointernal:tls
 var initializedTLS = nextLocalValue(100)
 
-//llgo:gls
+//llgointernal:gls
 var initializedGLS = nextLocalValue(200)
 
 type localitySnapshot struct {
@@ -170,7 +170,7 @@ func (recursiveSourceValue) value() int {
 
 var recursiveSource recursiveInitializer = recursiveSourceValue{}
 
-//llgo:gls
+//llgointernal:gls
 var recursiveValue = recursiveSource.value()
 
 func TestRecursiveInitializerObservesPartialValue(t *testing.T) {
@@ -191,7 +191,7 @@ func nextLateValue() int {
 
 // zLate sorts after the package init function in SSA member order.
 //
-//llgo:tls
+//llgointernal:tls
 var zLate = nextLateValue()
 
 func TestLateSortedInitializer(t *testing.T) {
@@ -213,7 +213,7 @@ func newRootedValue() *rootedValue {
 	return &rootedValue{value: 73}
 }
 
-//llgo:gls
+//llgointernal:gls
 var rootedPointer = newRootedValue()
 
 //go:noinline
@@ -257,7 +257,7 @@ func TestLocalContextCleanupAfterThreadExit(t *testing.T) {
 	runtime.GC()
 }
 
-//llgo:gls
+//llgointernal:gls
 var atomicGLS int64
 
 func TestLocalAddressAndAtomicSemantics(t *testing.T) {
@@ -299,7 +299,7 @@ type escapedBlockValue struct {
 	value   int
 }
 
-//llgo:gls
+//llgointernal:gls
 var escapedBlock escapedBlockValue
 
 func TestEscapedPackageBlockAddressSurvivesOwnerExit(t *testing.T) {
@@ -351,7 +351,7 @@ func TestEscapedPackageBlockAddressSurvivesGoexit(t *testing.T) {
 	}
 }
 
-//llgo:gls
+//llgointernal:gls
 var zeroSizedGLS struct{}
 
 func TestZeroSizedNativeLocalAddressIsStable(t *testing.T) {
@@ -449,10 +449,10 @@ func TestCrossPackageMixedInitializerGroup(t *testing.T) {
 
 var benchmarkOrdinary int
 
-//llgo:tls
+//llgointernal:tls
 var benchmarkTLS int
 
-//llgo:gls
+//llgointernal:gls
 var benchmarkGLS int
 
 var benchmarkSink int
@@ -481,10 +481,10 @@ type benchmarkPackageValue struct {
 	value   int
 }
 
-//llgo:tls
+//llgointernal:tls
 var benchmarkTLSPackage benchmarkPackageValue
 
-//llgo:gls
+//llgointernal:gls
 var benchmarkGLSPackage benchmarkPackageValue
 
 //go:noinline

--- a/runtime/_test/locality/testdata/localitybench/bench.go
+++ b/runtime/_test/locality/testdata/localitybench/bench.go
@@ -16,16 +16,42 @@
  * limitations under the License.
  */
 
-package p0
+package localitybench
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+var ordinaryPointer *int
+
+//llgointernal:tls
+var nativePointerBits uintptr
+
+//llgointernal:gls
 var pointer *int
 
-func Prepare() { pointer = &backing }
+//go:noinline
+func Touch() {
+	pointer = &backing
+}
+
+func PrepareReads() {
+	ordinaryPointer = &backing
+	nativePointerBits = uintptr(unsafe.Pointer(&backing))
+	pointer = &backing
+}
 
 //go:noinline
-func Read() uintptr { return uintptr(unsafe.Pointer(pointer)) }
+func ReadOrdinaryGlobal() uintptr {
+	return uintptr(unsafe.Pointer(ordinaryPointer))
+}
+
+//go:noinline
+func ReadNativeTLS() uintptr {
+	return nativePointerBits
+}
+
+//go:noinline
+func ReadGLSPackage() uintptr {
+	return uintptr(unsafe.Pointer(pointer))
+}

--- a/runtime/_test/locality/testdata/localityblocks/p0/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p0/block.go
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package p4
+package p0
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func Prepare() { pointer = &backing }

--- a/runtime/_test/locality/testdata/localityblocks/p1/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p1/block.go
@@ -16,42 +16,16 @@
  * limitations under the License.
  */
 
-package localitybench
+package p1
 
 import "unsafe"
 
 var backing int
 
-var ordinaryPointer *int
-
-//llgo:tls
-var nativePointerBits uintptr
-
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
-//go:noinline
-func Touch() {
-	pointer = &backing
-}
-
-func PrepareReads() {
-	ordinaryPointer = &backing
-	nativePointerBits = uintptr(unsafe.Pointer(&backing))
-	pointer = &backing
-}
+func Prepare() { pointer = &backing }
 
 //go:noinline
-func ReadOrdinaryGlobal() uintptr {
-	return uintptr(unsafe.Pointer(ordinaryPointer))
-}
-
-//go:noinline
-func ReadNativeTLS() uintptr {
-	return nativePointerBits
-}
-
-//go:noinline
-func ReadGLSPackage() uintptr {
-	return uintptr(unsafe.Pointer(pointer))
-}
+func Read() uintptr { return uintptr(unsafe.Pointer(pointer)) }

--- a/runtime/_test/locality/testdata/localityblocks/p2/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p2/block.go
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package p6
+package p2
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func Prepare() { pointer = &backing }

--- a/runtime/_test/locality/testdata/localityblocks/p3/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p3/block.go
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package p5
+package p3
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func Prepare() { pointer = &backing }

--- a/runtime/_test/locality/testdata/localityblocks/p4/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p4/block.go
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package p2
+package p4
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func Prepare() { pointer = &backing }

--- a/runtime/_test/locality/testdata/localityblocks/p5/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p5/block.go
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package p3
+package p5
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func Prepare() { pointer = &backing }

--- a/runtime/_test/locality/testdata/localityblocks/p6/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p6/block.go
@@ -16,42 +16,16 @@
  * limitations under the License.
  */
 
-package localityfailure
+package p6
 
-const Failure = "locality initializer failed"
+import "unsafe"
 
-var attempts int
+var backing int
 
-func initialize() int {
-	attempts++
-	if attempts > 1 {
-		panic(Failure)
-	}
-	return attempts
-}
+//llgointernal:gls
+var pointer *int
 
-//llgo:tls
-var value = initialize()
+func Prepare() { pointer = &backing }
 
 //go:noinline
-func Value() int { return value }
-
-func Attempts() int { return attempts }
-
-var nilAttempts int
-
-func initializeNil() int {
-	nilAttempts++
-	if nilAttempts > 1 {
-		panic(nil)
-	}
-	return nilAttempts
-}
-
-//llgo:gls
-var nilValue = initializeNil()
-
-//go:noinline
-func NilValue() int { return nilValue }
-
-func NilAttempts() int { return nilAttempts }
+func Read() uintptr { return uintptr(unsafe.Pointer(pointer)) }

--- a/runtime/_test/locality/testdata/localityblocks/p7/block.go
+++ b/runtime/_test/locality/testdata/localityblocks/p7/block.go
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package p1
+package p7
 
 import "unsafe"
 
 var backing int
 
-//llgo:gls
+//llgointernal:gls
 var pointer *int
 
 func Prepare() { pointer = &backing }

--- a/runtime/_test/locality/testdata/localityfailure/failure.go
+++ b/runtime/_test/locality/testdata/localityfailure/failure.go
@@ -16,16 +16,42 @@
  * limitations under the License.
  */
 
-package p7
+package localityfailure
 
-import "unsafe"
+const Failure = "locality initializer failed"
 
-var backing int
+var attempts int
 
-//llgo:gls
-var pointer *int
+func initialize() int {
+	attempts++
+	if attempts > 1 {
+		panic(Failure)
+	}
+	return attempts
+}
 
-func Prepare() { pointer = &backing }
+//llgointernal:tls
+var value = initialize()
 
 //go:noinline
-func Read() uintptr { return uintptr(unsafe.Pointer(pointer)) }
+func Value() int { return value }
+
+func Attempts() int { return attempts }
+
+var nilAttempts int
+
+func initializeNil() int {
+	nilAttempts++
+	if nilAttempts > 1 {
+		panic(nil)
+	}
+	return nilAttempts
+}
+
+//llgointernal:gls
+var nilValue = initializeNil()
+
+//go:noinline
+func NilValue() int { return nilValue }
+
+func NilAttempts() int { return nilAttempts }

--- a/runtime/_test/locality/testdata/localityscope/scope.go
+++ b/runtime/_test/locality/testdata/localityscope/scope.go
@@ -31,10 +31,10 @@ func initSecond() int {
 	return 200 + secondCalls
 }
 
-//llgo:gls
+//llgointernal:gls
 var first = initFirst()
 
-//llgo:gls
+//llgointernal:gls
 var second = initSecond()
 
 func FirstCalls() int  { return firstCalls }
@@ -56,7 +56,7 @@ func initPair() (int, int) {
 	return 300 + pairCalls, 400 + pairCalls
 }
 
-//llgo:gls
+//llgointernal:gls
 var pairFirst, pairSecond = initPair()
 
 func PairCalls() int { return pairCalls }
@@ -72,7 +72,7 @@ func initMixed() (int, *int) {
 	return 600 + mixedCalls, &mixedBacking
 }
 
-//llgo:tls
+//llgointernal:tls
 var mixedScalar, mixedPointer = initMixed()
 
 func MixedCalls() int { return mixedCalls }

--- a/runtime/internal/lib/runtime/fipsbypass_state_gls.go
+++ b/runtime/internal/lib/runtime/fipsbypass_state_gls.go
@@ -5,5 +5,5 @@ package runtime
 // fipsBypassDepth is part of the calling goroutine's cryptographic state. It
 // must follow that goroutine if a future scheduler moves it between OS threads.
 //
-//llgo:gls
+//llgointernal:gls
 var fipsBypassDepth uint32

--- a/runtime/internal/runtime/caller_gls.go
+++ b/runtime/internal/runtime/caller_gls.go
@@ -22,5 +22,5 @@ package runtime
 // and synthetic PCs must move with that goroutine when the backend eventually
 // permits migration between OS threads.
 //
-//llgo:gls
+//llgointernal:gls
 var callerLocationStoreCurrent *callerLocationStore

--- a/runtime/internal/runtime/g_tls.go
+++ b/runtime/internal/runtime/g_tls.go
@@ -33,13 +33,13 @@ import (
 // GC root; making this a pointer-bearing local variable would require the
 // LocalContext that getg helps bootstrap.
 //
-//llgo:tls
+//llgointernal:tls
 var currentG uintptr
 
 // currentGHasLifecycle records whether the current G was installed in the
 // host TLS destructor sidecar. Runtime-owned M threads leave this false.
 //
-//llgo:tls
+//llgointernal:tls
 var currentGHasLifecycle bool
 
 // gLifecycleKey is not used to locate the current G. It only retains the

--- a/runtime/internal/runtime/local_context_tls.go
+++ b/runtime/internal/runtime/local_context_tls.go
@@ -22,5 +22,5 @@ package runtime
 // the outer entry frame, so this native TLS slot intentionally has no GC-visible
 // pointer type.
 //
-//llgo:tls
+//llgointernal:tls
 var currentLocalContext uintptr

--- a/test/llgoext/locality_runtime_test.go
+++ b/test/llgoext/locality_runtime_test.go
@@ -1,0 +1,69 @@
+//go:build llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package llgoext
+
+import (
+	"testing"
+
+	l "github.com/xgo-dev/llgo/runtime/_test/locality"
+)
+
+func TestTLSAndGLSIsolation(t *testing.T)              { l.TestTLSAndGLSIsolation(t) }
+func TestLocalPackageDirectCaches(t *testing.T)        { l.TestLocalPackageDirectCaches(t) }
+func TestPanickingInitializerIsSticky(t *testing.T)    { l.TestPanickingInitializerIsSticky(t) }
+func TestNilPanickingInitializerIsSticky(t *testing.T) { l.TestNilPanickingInitializerIsSticky(t) }
+func TestRecursiveInitializerObservesPartialValue(t *testing.T) {
+	l.TestRecursiveInitializerObservesPartialValue(t)
+}
+func TestLateSortedInitializer(t *testing.T) { l.TestLateSortedInitializer(t) }
+func TestLocalPointerIsGCRoot(t *testing.T)  { l.TestLocalPointerIsGCRoot(t) }
+func TestLocalContextCleanupAfterThreadExit(t *testing.T) {
+	l.TestLocalContextCleanupAfterThreadExit(t)
+}
+func TestLocalAddressAndAtomicSemantics(t *testing.T) { l.TestLocalAddressAndAtomicSemantics(t) }
+func TestClosureUsesInvocationContext(t *testing.T)   { l.TestClosureUsesInvocationContext(t) }
+func TestEscapedPackageBlockAddressSurvivesOwnerExit(t *testing.T) {
+	l.TestEscapedPackageBlockAddressSurvivesOwnerExit(t)
+}
+func TestEscapedPackageBlockAddressSurvivesGoexit(t *testing.T) {
+	l.TestEscapedPackageBlockAddressSurvivesGoexit(t)
+}
+func TestZeroSizedNativeLocalAddressIsStable(t *testing.T) {
+	l.TestZeroSizedNativeLocalAddressIsStable(t)
+}
+func TestInitializerScopeRunsOncePerPackageKind(t *testing.T) {
+	l.TestInitializerScopeRunsOncePerPackageKind(t)
+}
+func TestMultiValueInitializerUsesOneGroup(t *testing.T) { l.TestMultiValueInitializerUsesOneGroup(t) }
+func TestCrossPackageMixedInitializerGroup(t *testing.T) { l.TestCrossPackageMixedInitializerGroup(t) }
+func TestComparableLocalityReads(t *testing.T)           { l.TestComparableLocalityReads(t) }
+
+func BenchmarkOrdinaryGlobal(b *testing.B)               { l.BenchmarkOrdinaryGlobal(b) }
+func BenchmarkNativeTLS(b *testing.B)                    { l.BenchmarkNativeTLS(b) }
+func BenchmarkNativeGLS(b *testing.B)                    { l.BenchmarkNativeGLS(b) }
+func BenchmarkTLSPackageBlock(b *testing.B)              { l.BenchmarkTLSPackageBlock(b) }
+func BenchmarkGLSPackageBlock(b *testing.B)              { l.BenchmarkGLSPackageBlock(b) }
+func BenchmarkComparableOrdinaryGlobalRead(b *testing.B) { l.BenchmarkComparableOrdinaryGlobalRead(b) }
+func BenchmarkComparableNativeTLSRead(b *testing.B)      { l.BenchmarkComparableNativeTLSRead(b) }
+func BenchmarkComparableGLSPackageRead(b *testing.B)     { l.BenchmarkComparableGLSPackageRead(b) }
+func BenchmarkAlternatingGLSPackageRead(b *testing.B)    { l.BenchmarkAlternatingGLSPackageRead(b) }
+func BenchmarkGoroutineEntry(b *testing.B)               { l.BenchmarkGoroutineEntry(b) }
+func BenchmarkGoroutinePackageBlockFirstTouch(b *testing.B) {
+	l.BenchmarkGoroutinePackageBlockFirstTouch(b)
+}

--- a/test/llgoext/localitymulti/locality_test.go
+++ b/test/llgoext/localitymulti/locality_test.go
@@ -21,14 +21,14 @@ package localitymulti
 import (
 	"testing"
 
-	localityblock0 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p0"
-	localityblock1 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p1"
-	localityblock2 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p2"
-	localityblock3 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p3"
-	localityblock4 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p4"
-	localityblock5 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p5"
-	localityblock6 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p6"
-	localityblock7 "github.com/xgo-dev/llgo/test/llgoext/testdata/localityblocks/p7"
+	localityblock0 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p0"
+	localityblock1 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p1"
+	localityblock2 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p2"
+	localityblock3 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p3"
+	localityblock4 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p4"
+	localityblock5 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p5"
+	localityblock6 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p6"
+	localityblock7 "github.com/xgo-dev/llgo/runtime/_test/locality/testdata/localityblocks/p7"
 )
 
 var benchmarkSink uintptr


### PR DESCRIPTION
Fixes #2532.

#2077 introduced `//llgo:tls` and `//llgo:gls` so the compiler can initialize per-owner package state and preserve its GC reachability. Exposing those names to arbitrary packages also made the mechanism a user-visible LLGo source dialect.

This change renames them to `//llgointernal:tls` and `//llgointernal:gls`, then limits the internal namespace to `github.com/xgo-dev/llgo/runtime`, its subpackages, and packages verified by the loader as part of the selected Go standard library. The standard-library allowance is required because LLGo applies runtime source patches there.

Directive-bearing compiler and runtime fixtures move under the runtime module as Git renames; a small forwarding test file preserves the existing `test/llgoext` test and benchmark names. The old short spellings have no compatibility alias or added reverse test. TLS/GLS lowering, initialization, storage selection, and GC-root behavior are unchanged.

The proposal records compiler inference from `PkgPath + Type` as a possible follow-up that could remove even these internal directives.

Validation was intentionally limited to the affected surfaces:

- `go test ./internal/directive ./internal/locality`
- targeted `./cl`, `./internal/build`, `./internal/llgen`, and `./chore/litgen` tests
- `go run ./cmd/llgo test -run '^TestTLSAndGLSIsolation$' ./test/llgoext`
- `go run ./cmd/llgo test -run '^TestGLSPackageWorkingSet$' ./test/llgoext/localitymulti`
