### PR TITLE
fix(pclnpost): prevent Linux executable writer inheritance across fork

### DIFF
--- a/doc/design/pclntab-linkphase.md
+++ b/doc/design/pclntab-linkphase.md
@@ -88,6 +88,23 @@ not PCLN properties and must not introduce function-class-specific sections.
      An unfamiliar segment shape, overlapping relocation/fixup range, signing
      failure, or verification failure leaves the original executable intact.
 
+### Parallel executable publication on Linux
+
+The test DAG waits for linking and postprocessing before executing each image,
+but other roots may start subprocesses while that image is being staged.
+`O_CLOEXEC` does not prevent a forked child from temporarily inheriting its
+writable descriptor. Closing the parent's descriptor and atomically renaming
+the file do not release the child's reference, so execution can fail with
+`ETXTBSY` (see [Go issue 22315](https://go.dev/issue/22315)).
+
+`pclnpost.stageBinary` holds `syscall.ForkLock` for reading from before opening
+the staged image through closing its writable descriptor on Linux. Go takes
+the write side when forking, so no child can inherit that descriptor. Multiple
+image writers can still overlap, and already-running subprocesses are unaffected.
+The guard must end before verification or signing, which may start subprocesses
+themselves. Parsing, table generation, linking, and test execution remain outside
+the guard; no execution retry is needed for this publication race.
+
 ### ASLR
 
 Stored table entries are offsets from the first function PC. The header keeps

--- a/doc/design/pclntab-linkphase.md
+++ b/doc/design/pclntab-linkphase.md
@@ -101,7 +101,13 @@ the file do not release the child's reference, so execution can fail with
 the staged image through closing its writable descriptor on Linux. Go takes
 the write side when forking, so no child can inherit that descriptor. Multiple
 image writers can still overlap, and already-running subprocesses are unaffected.
-The guard must end before verification or signing, which may start subprocesses
+After closing the writer, Linux releases the guard and uses a read-only handle
+for `fsync`, so slow storage cannot hold up process creation during the flush.
+That handle is opened before applying the output mode, which may be execute-only.
+The file is still synced before publication; directory `fsync` alone does
+not ensure file-data durability. The write itself must stay guarded while its
+writable descriptor exists. Other hosts retain sync-before-close behavior.
+The guard also ends before verification or signing, which may start subprocesses
 themselves. Parsing, table generation, linking, and test execution remain outside
 the guard; no execution retry is needed for this publication race.
 

--- a/internal/pclnpost/executable_linux.go
+++ b/internal/pclnpost/executable_linux.go
@@ -1,0 +1,16 @@
+package pclnpost
+
+import "syscall"
+
+// A concurrent fork can inherit a writable executable descriptor until exec,
+// even with O_CLOEXEC. Closing our copy and renaming the file cannot release
+// that inherited writer, so executing the published inode can fail with
+// ETXTBSY (https://go.dev/issue/22315).
+//
+// Exclude Go's forks from before opening the file until after closing it. A
+// read lock permits concurrent executable writers; existing child processes
+// continue running. No subprocess may be started while this lock is held.
+func lockExecutableWrite() func() {
+	syscall.ForkLock.RLock()
+	return syscall.ForkLock.RUnlock
+}

--- a/internal/pclnpost/executable_linux_test.go
+++ b/internal/pclnpost/executable_linux_test.go
@@ -1,0 +1,141 @@
+package pclnpost
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+func TestExecutableWriteExcludesFork(t *testing.T) {
+	unlock := lockExecutableWrite()
+	if syscall.ForkLock.TryLock() {
+		syscall.ForkLock.Unlock()
+		unlock()
+		t.Fatal("executable writes do not exclude fork")
+	}
+	// Writers share the read side; only starting a child must be excluded.
+	if !syscall.ForkLock.TryRLock() {
+		unlock()
+		t.Fatal("executable writes cannot overlap")
+	}
+	syscall.ForkLock.RUnlock()
+	unlock()
+	if !syscall.ForkLock.TryLock() {
+		t.Fatal("fork remains excluded after the executable is closed")
+	}
+	syscall.ForkLock.Unlock()
+}
+
+func TestStageBinaryReleasesForkLock(t *testing.T) {
+	for _, name := range []string{"success", "create-error"} {
+		t.Run(name, func(t *testing.T) {
+			fail := name == "create-error"
+			dir := t.TempDir()
+			if fail {
+				dir = filepath.Join(dir, "missing")
+			}
+			path, err := stageBinary(dir, "image-*", []byte("image"), 0751)
+			if (err != nil) != fail {
+				t.Fatalf("stageBinary error = %v, want failure %v", err, fail)
+			}
+			if !syscall.ForkLock.TryLock() {
+				t.Fatal("stageBinary left fork excluded")
+			}
+			syscall.ForkLock.Unlock()
+			if !fail {
+				data, err := os.ReadFile(path)
+				if err != nil || string(data) != "image" {
+					t.Fatalf("staged image = %q, %v", data, err)
+				}
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != 0751 {
+					t.Fatalf("staged mode = %v, want 0751", info.Mode())
+				}
+			}
+		})
+	}
+}
+
+func TestStageBinaryWriteFailure(t *testing.T) {
+	// This test must not run in parallel: RLIMIT_FSIZE is process-wide.
+	dir := t.TempDir()
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &limit); err != nil {
+		t.Fatal(err)
+	}
+	err := func() error {
+		zero := limit
+		zero.Cur = 0
+		if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &zero); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &limit); err != nil {
+				t.Error(err)
+			}
+		}()
+		_, err := stageBinary(dir, "image-*", []byte("image"), 0755)
+		return err
+	}()
+	if !errors.Is(err, syscall.EFBIG) {
+		t.Fatalf("stageBinary error = %v, want EFBIG", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("failed write left staged images: %v, %v", entries, err)
+	}
+	if !syscall.ForkLock.TryLock() {
+		t.Fatal("failed write left fork excluded")
+	}
+	syscall.ForkLock.Unlock()
+}
+
+func TestReplaceBinaryConcurrentExec(t *testing.T) {
+	// Exercise the production publisher while other workers start binaries.
+	// Use a script to check contents and execution, not just successful exec.
+	const workers, iterations = 8, 16
+	raw := []byte("#!/bin/sh\nprintf 'published executable\\n'\n")
+	dir := t.TempDir()
+	paths := make([]string, workers)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("image-%d", i))
+		if err := os.WriteFile(paths[i], raw, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var wg sync.WaitGroup
+	for _, path := range paths {
+		wg.Go(func() {
+			for range iterations {
+				err := replaceBinary(path, raw, false, func(staged string) error {
+					// Verification must run after the write guard is released:
+					// a verifier (or codesign on macOS) may start a process.
+					output, err := exec.Command("/bin/sh", "-n", staged).CombinedOutput()
+					if err != nil {
+						return fmt.Errorf("verify: %v: %s", err, output)
+					}
+					return nil
+				})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				output, err := exec.Command(path).CombinedOutput()
+				if err != nil || !bytes.Equal(output, []byte("published executable\n")) {
+					t.Errorf("execute published image: %v, output %q", err, output)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/internal/pclnpost/executable_linux_test.go
+++ b/internal/pclnpost/executable_linux_test.go
@@ -2,7 +2,6 @@ package pclnpost
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +11,8 @@ import (
 	"testing"
 )
 
+// These lock checks must not run in parallel with tests that start processes:
+// they inspect the process-global ForkLock, not a package-local mutex.
 func TestExecutableWriteExcludesFork(t *testing.T) {
 	unlock := lockExecutableWrite()
 	if syscall.ForkLock.TryLock() {
@@ -63,40 +64,6 @@ func TestStageBinaryReleasesForkLock(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestStageBinaryWriteFailure(t *testing.T) {
-	// This test must not run in parallel: RLIMIT_FSIZE is process-wide.
-	dir := t.TempDir()
-	var limit syscall.Rlimit
-	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &limit); err != nil {
-		t.Fatal(err)
-	}
-	err := func() error {
-		zero := limit
-		zero.Cur = 0
-		if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &zero); err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &limit); err != nil {
-				t.Error(err)
-			}
-		}()
-		_, err := stageBinary(dir, "image-*", []byte("image"), 0755)
-		return err
-	}()
-	if !errors.Is(err, syscall.EFBIG) {
-		t.Fatalf("stageBinary error = %v, want EFBIG", err)
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil || len(entries) != 0 {
-		t.Fatalf("failed write left staged images: %v, %v", entries, err)
-	}
-	if !syscall.ForkLock.TryLock() {
-		t.Fatal("failed write left fork excluded")
-	}
-	syscall.ForkLock.Unlock()
 }
 
 func TestReplaceBinaryConcurrentExec(t *testing.T) {

--- a/internal/pclnpost/executable_other.go
+++ b/internal/pclnpost/executable_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package pclnpost
+
+func lockExecutableWrite() func() { return func() {} }

--- a/internal/pclnpost/external.go
+++ b/internal/pclnpost/external.go
@@ -289,30 +289,11 @@ func replaceBinary(path string, raw []byte, sign bool, verify func(string) error
 		return err
 	}
 	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".pclnpost-*")
+	tmpPath, err := stageBinary(dir, "."+filepath.Base(path)+".pclnpost-*", raw, st.Mode())
 	if err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
-	defer func() {
-		if tmp != nil {
-			_ = tmp.Close()
-		}
-		_ = os.Remove(tmpPath)
-	}()
-	if err := tmp.Chmod(st.Mode()); err != nil {
-		return err
-	}
-	if _, err := tmp.Write(raw); err != nil {
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	tmp = nil
+	defer os.Remove(tmpPath)
 	if sign {
 		if output, err := exec.Command("codesign", "-f", "-s", "-", tmpPath).CombinedOutput(); err != nil {
 			return fmt.Errorf("codesign: %v: %s", err, output)
@@ -339,4 +320,34 @@ func replaceBinary(path string, raw []byte, sign bool, verify func(string) error
 		_ = d.Close()
 	}
 	return nil
+}
+
+// stageBinary returns a closed executable image. Keep the writable descriptor's
+// entire lifetime inside the fork exclusion, but leave signing, verification,
+// and publication outside it: those operations may themselves start processes.
+func stageBinary(dir, pattern string, raw []byte, mode os.FileMode) (path string, err error) {
+	unlock := lockExecutableWrite()
+	defer unlock()
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	path = tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		if err != nil {
+			_ = os.Remove(path)
+		}
+	}()
+	if err = tmp.Chmod(mode); err != nil {
+		return path, err
+	}
+	if _, err = tmp.Write(raw); err != nil {
+		return path, err
+	}
+	if err = tmp.Sync(); err != nil {
+		return path, err
+	}
+	err = tmp.Close()
+	return path, err
 }

--- a/internal/pclnpost/external.go
+++ b/internal/pclnpost/external.go
@@ -322,32 +322,90 @@ func replaceBinary(path string, raw []byte, sign bool, verify func(string) error
 	return nil
 }
 
-// stageBinary returns a closed executable image. Keep the writable descriptor's
-// entire lifetime inside the fork exclusion, but leave signing, verification,
-// and publication outside it: those operations may themselves start processes.
+type binaryStageFile interface {
+	Name() string
+	Chmod(os.FileMode) error
+	Write([]byte) (int, error)
+	Sync() error
+	Close() error
+}
+
+// Per-call file operations let tests exercise I/O failures without changing
+// process-wide resource limits or installing mutable global test hooks.
+type binaryStageFiles struct {
+	createTemp   func(string, string) (binaryStageFile, error)
+	openReadOnly func(string) (binaryStageFile, error)
+}
+
+// stageBinary returns a closed, synced executable image. Keep the writable
+// descriptor's entire lifetime inside the fork exclusion. On Linux, fsync uses
+// a read-only descriptor after releasing the guard, so a slow flush does not
+// block subprocess creation. Signing and verification also remain outside it.
 func stageBinary(dir, pattern string, raw []byte, mode os.FileMode) (path string, err error) {
+	return stageBinaryWithFiles(dir, pattern, raw, mode, binaryStageFiles{
+		createTemp: func(dir, pattern string) (binaryStageFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		openReadOnly: func(path string) (binaryStageFile, error) {
+			return os.Open(path)
+		},
+	})
+}
+
+func stageBinaryWithFiles(dir, pattern string, raw []byte, mode os.FileMode, files binaryStageFiles) (path string, err error) {
 	unlock := lockExecutableWrite()
-	defer unlock()
-	tmp, err := os.CreateTemp(dir, pattern)
-	if err != nil {
-		return "", err
-	}
-	path = tmp.Name()
+	var tmp, reader binaryStageFile
 	defer func() {
-		_ = tmp.Close()
-		if err != nil {
+		if tmp != nil {
+			_ = tmp.Close() // Preserve the original I/O error during cleanup.
+		}
+		if unlock != nil {
+			unlock()
+		}
+		if reader != nil {
+			_ = reader.Close()
+		}
+		if err != nil && path != "" {
 			_ = os.Remove(path)
 		}
 	}()
+	tmp, err = files.createTemp(dir, pattern)
+	if err != nil {
+		tmp = nil
+		return "", err
+	}
+	path = tmp.Name()
+	if runtime.GOOS == "linux" {
+		// Open before Chmod: the preserved output mode may be execute-only.
+		reader, err = files.openReadOnly(path)
+		if err != nil {
+			reader = nil
+			return path, err
+		}
+	}
 	if err = tmp.Chmod(mode); err != nil {
 		return path, err
 	}
 	if _, err = tmp.Write(raw); err != nil {
 		return path, err
 	}
+	if runtime.GOOS == "linux" {
+		err = tmp.Close()
+		tmp = nil
+		if err != nil {
+			return path, err
+		}
+		unlock()
+		unlock = nil
+		// A read-only descriptor cannot keep an executable write-busy, even
+		// if another child inherits it. Directory fsync is not a substitute
+		// for syncing file data, so retain the file flush before publication.
+		tmp, reader = reader, nil
+	}
 	if err = tmp.Sync(); err != nil {
 		return path, err
 	}
 	err = tmp.Close()
+	tmp = nil
 	return path, err
 }

--- a/internal/pclnpost/stage_binary_linux_test.go
+++ b/internal/pclnpost/stage_binary_linux_test.go
@@ -1,0 +1,206 @@
+package pclnpost
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type stageTestFile struct {
+	*os.File
+	kind   string
+	before func(string) error
+	closes int
+}
+
+func (f *stageTestFile) Chmod(mode os.FileMode) error {
+	if err := f.before("chmod"); err != nil {
+		return err
+	}
+	return f.File.Chmod(mode)
+}
+
+func (f *stageTestFile) Write(data []byte) (int, error) {
+	if err := f.before("write"); err != nil {
+		n, _ := f.File.Write(data[:len(data)/2])
+		return n, err // Leave a partial image to exercise cleanup.
+	}
+	return f.File.Write(data)
+}
+
+func (f *stageTestFile) Sync() error {
+	if err := f.before("sync"); err != nil {
+		return err
+	}
+	return f.File.Sync()
+}
+
+func (f *stageTestFile) Close() error {
+	f.closes++
+	err := f.before("close-" + f.kind)
+	closeErr := f.File.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func TestStageBinaryIOFailuresAndForkWindow(t *testing.T) {
+	// Do not parallelize: the assertions observe the process-global ForkLock.
+	for _, fail := range []string{"", "create", "chmod", "write", "close-writer", "open-reader", "sync", "close-reader"} {
+		name := fail
+		if name == "" {
+			name = "success"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			wantErr := errors.New("injected " + fail)
+			cleanupErr := errors.New("cleanup close failed")
+			var calls []string
+			before := func(op string) error {
+				calls = append(calls, op)
+				wantLocked := slices.Contains([]string{"create", "open-reader", "chmod", "write", "close-writer"}, op)
+				locked := !syscall.ForkLock.TryLock()
+				if !locked {
+					syscall.ForkLock.Unlock()
+				}
+				if locked != wantLocked {
+					t.Errorf("%s: fork excluded = %v, want %v", op, locked, wantLocked)
+				}
+				if op == fail {
+					return wantErr
+				}
+				if fail == "write" && op == "close-writer" {
+					return cleanupErr // Must not replace the original write error.
+				}
+				return nil
+			}
+			var opened []*stageTestFile
+			wrap := func(f *os.File, err error, kind string) (binaryStageFile, error) {
+				if err != nil {
+					return nil, err
+				}
+				file := &stageTestFile{File: f, kind: kind, before: before}
+				opened = append(opened, file)
+				return file, nil
+			}
+			files := binaryStageFiles{
+				createTemp: func(dir, pattern string) (binaryStageFile, error) {
+					if err := before("create"); err != nil {
+						return nil, err
+					}
+					f, err := os.CreateTemp(dir, pattern)
+					return wrap(f, err, "writer")
+				},
+				openReadOnly: func(path string) (binaryStageFile, error) {
+					if err := before("open-reader"); err != nil {
+						return nil, err
+					}
+					f, err := os.Open(path)
+					if err == nil {
+						flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), syscall.F_GETFL, 0)
+						if errno != 0 || flags&syscall.O_ACCMODE != syscall.O_RDONLY {
+							t.Errorf("sync descriptor flags = %#x, errno = %v; want read-only", flags, errno)
+						}
+					}
+					return wrap(f, err, "reader")
+				},
+			}
+			raw := []byte("staged executable")
+			path, err := stageBinaryWithFiles(dir, "image-*", raw, 0751, files)
+			if fail == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := strings.Join(calls, ","); got != "create,open-reader,chmod,write,close-writer,sync,close-reader" {
+					t.Errorf("I/O order = %s", got)
+				}
+				if got, err := os.ReadFile(path); err != nil || !bytes.Equal(got, raw) {
+					t.Errorf("staged contents = %q, %v", got, err)
+				}
+			} else {
+				if !errors.Is(err, wantErr) {
+					t.Errorf("stage error = %v, want %v", err, wantErr)
+				}
+				if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+					t.Errorf("failed staging left files: %v, %v", entries, err)
+				}
+			}
+			for _, f := range opened {
+				if f.closes != 1 {
+					t.Errorf("%s closed %d times, want once", f.kind, f.closes)
+				}
+			}
+			if !syscall.ForkLock.TryLock() {
+				t.Fatal("stage left fork excluded")
+			}
+			syscall.ForkLock.Unlock()
+		})
+	}
+}
+
+func TestStageBinaryExecuteOnlyMode(t *testing.T) {
+	path, err := stageBinary(t.TempDir(), "image-*", []byte("image"), 0111)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0111 {
+		t.Fatalf("execute-only staged image: %v, %v", info, err)
+	}
+}
+
+func TestStageBinarySlowSyncAllowsExec(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	staged := make(chan error, 1)
+	dir := t.TempDir()
+	go func() {
+		_, err := stageBinaryWithFiles(dir, "image-*", []byte("image"), 0755, binaryStageFiles{
+			createTemp: func(dir, pattern string) (binaryStageFile, error) {
+				return os.CreateTemp(dir, pattern)
+			},
+			openReadOnly: func(path string) (binaryStageFile, error) {
+				f, err := os.Open(path)
+				if err != nil {
+					return nil, err
+				}
+				return &stageTestFile{File: f, kind: "reader", before: func(op string) error {
+					if op == "sync" {
+						close(entered)
+						<-release
+					}
+					return nil
+				}}, nil
+			},
+		})
+		staged <- err
+	}()
+	select {
+	case <-entered:
+	case err := <-staged:
+		t.Fatalf("staging ended before sync: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	started := make(chan error, 1)
+	go func() { started <- exec.CommandContext(ctx, "/bin/true").Run() }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Error(err)
+		}
+	case <-ctx.Done():
+		t.Error("subprocess creation blocked behind the file sync")
+	}
+	close(release)
+	if err := <-staged; err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2533.

Prevent writable executable descriptors from leaking into concurrently forked subprocesses during Linux post-link publication. This removes the underlying `ETXTBSY` race; it does not retry execution or skip tests.

`pclnpost.replaceBinary` already closes and atomically renames its staged image. That is insufficient when another child has inherited the writable descriptor and has not reached `exec` yet: the descriptor refers to the same inode after the rename. The DAG's link-before-run dependency is correct but cannot account for this unrelated child's inherited writer.

## Changes

- Hold the read side of `syscall.ForkLock` on Linux while creating, writing, and closing the staged executable's writable descriptor.
- Flush through a read-only handle after releasing the guard. Slow `fsync` no longer blocks other subprocess launches; file durability is preserved. Open the reader before applying output permissions, including execute-only modes. Other platforms retain sync-before-close behavior.
- Keep writers concurrent. Already-running compilers, linkers, and tests continue running; parsing and metadata generation are outside the guard.
- Release the guard before verification, signing, or publication. Verification and signing may themselves start subprocesses.
- Test fork exclusion at each I/O operation, every staging error path, exactly-once closes, preservation of the original error during cleanup, subprocess progress during a blocked flush, and concurrent publication and execution with checked output. File-operation injection is per call, with no mutable global hooks or process-wide resource-limit changes.
- Document the invariant beside the post-link design.

No changes to DAG scheduling, test-runner retries, or CI workflows.

## Verification

On Linux arm64, an out-of-tree diagnostic exercised the actual publisher with 16 concurrent writers and other subprocess launches. `strace` delayed only unrelated exec calls by 100 ms, widening the inherited-FD window without injecting errors. `/proc` inspection captured children holding the published inode open as `O_RDWR | O_CLOEXEC` after the parent had closed it.

| Publisher | Executions | ETXTBSY failures |
| --- | ---: | ---: |
| Unmodified main, first run | 1,600 | 776 |
| Unmodified main, second run | 1,600 | 347 |
| Fixed, same delay | 1,600 | 0 |
| Fixed, extended run | 8,000 | 0 |
| Fixed after moving fsync outside the guard | 8,000 | 0 |

Additional checks passed:

- Original Go 1.25.11 compatibility selection: all 21 packages, including `test/goroot`, passed locally (36 seconds initially, 42 seconds after the review update; these are separate runs, not controlled performance data).
- The same 21-package selection passed with delayed clang exec calls.
- Linux and macOS: `go test ./internal/pclnpost -count=1` and race checks.
- Linux regression tests repeated 10 times under `-race`.
- Linux `internal/build` integration tests covering native execution, DAG, PCLN, funcinfo, and prebuilt metadata.
- Windows amd64 cross-compilation of the `pclnpost` tests.
- Linux `pclnpost` statement coverage: 93.2%; the staging functions and Linux fork guard each have 100% statement coverage after the review update.
- The initial revision's Qiniu Linux amd64 Go 1.20-1.26 compatibility job passed: https://github.com/xgo-dev/llgo/actions/runs/34201117617/job/101996890989

The original failed CI runner was Linux amd64; its historical holder PID is not recoverable from the job log. The FD trace and fault-injection diagnostics are outside this PR; only ordinary regression tests are added.
