### PR TITLE
reflect: canonicalize function pointer descriptors

### DIFF
--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -510,16 +510,6 @@ func (t *rtype) Out(i int) Type {
 func toPublicType(typ *abi.Type) Type {
 	if typ.IsClosure() {
 		typ = &toFuncType((*abi.StructType)(unsafe.Pointer(typ))).Type
-	} else if typ.Kind() == abi.Pointer {
-		elem := typ.Elem()
-		if elem == nil || !elem.IsClosure() {
-			return toType(typ)
-		}
-		// A pointer to a function uses a pointer to LLGo's closure struct in
-		// its physical signature. Canonicalize the element before exposing
-		// the reflect.Type, otherwise *NamedFunc from a function parameter is
-		// not identical to PointerTo(TypeOf(NamedFunc)).
-		return PointerTo(toPublicType(elem))
 	}
 	return toType(typ)
 }
@@ -1008,6 +998,17 @@ func PointerTo(t Type) Type {
 
 func (t *rtype) ptrTo() *abi.Type {
 	at := &t.t
+	// Match the element identity used by the compiler's abi.PublicType.
+	// Named functions keep their closure descriptor, which owns PtrToThis_
+	// and its pointer method set. Unnamed closures use the public signature.
+	// Normalize before either static lookup or caching so Addr, New, and
+	// PointerTo cannot synthesize competing descriptors for the same *T.
+	if at.Kind() == abi.Func && at.HasName() {
+		at = closureOf(at.FuncType())
+	} else if at.IsClosure() && !at.HasName() {
+		at = &toFuncType(at.StructType()).Type
+	}
+	t = toRType(at)
 	if at.PtrToThis_ != nil {
 		return at.PtrToThis_
 	}

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -389,14 +389,7 @@ func (v Value) Addr() Value {
 	// Preserve flagRO instead of using v.flag.ro() so that
 	// v.Addr().Elem() is equivalent to v (#32772)
 	fl := v.flag & flagRO
-	typ := v.typ()
-	if v.typ_.IsClosure() {
-		// Function values use a closure struct as their physical LLGo
-		// representation. Addr must expose the pointer to the semantic Go
-		// function type, just as Type does, rather than *$closure.
-		typ = v.Type().common()
-	}
-	return Value{ptrTo(typ), v.ptr, fl | flag(Pointer)}
+	return Value{ptrTo(v.typ()), v.ptr, fl | flag(Pointer)}
 }
 
 // Bool returns v's underlying value.

--- a/test/go/reflect_function_pointer_test.go
+++ b/test/go/reflect_function_pointer_test.go
@@ -1,0 +1,173 @@
+package gotest
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+type reflectPointerEncoder func() string
+
+func (f reflectPointerEncoder) Encode() string { return f() }
+
+func (f *reflectPointerEncoder) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*f = func() string { return value }
+	return nil
+}
+
+type reflectPointerPlainFunc func() string
+
+type reflectPointerOnlyFunc func()
+
+func (*reflectPointerOnlyFunc) PointerOnly() {}
+
+func TestReflectFunctionPointerOnlyMethod(t *testing.T) {
+	// No value method or statically used pointer value should be necessary
+	// to retain the compiler-emitted pointer method descriptor.
+	typ := reflect.TypeOf(reflectPointerOnlyFunc(nil))
+	ptr := reflect.New(typ)
+	if typ.NumMethod() != 0 || reflect.PointerTo(typ).NumMethod() != 1 {
+		t.Fatal("incorrect value or pointer method set")
+	}
+	u, ok := ptr.Interface().(interface{ PointerOnly() })
+	if !ok {
+		t.Fatal("reflected pointer lost its pointer-only method")
+	}
+	u.PointerOnly()
+}
+
+func TestReflectFunctionPointerIdentity(t *testing.T) {
+	for _, ptr := range []any{
+		new(reflectPointerEncoder),
+		new(reflectPointerPlainFunc),
+		new(func() string),
+	} {
+		value := reflect.ValueOf(ptr).Elem()
+		typ := value.Type()
+		want := reflect.TypeOf(ptr)
+		for name, got := range map[string]reflect.Type{
+			"PointerTo": reflect.PointerTo(typ),
+			"Addr":      value.Addr().Type(),
+			"New":       reflect.New(typ).Type(),
+			"NewAt":     reflect.NewAt(typ, value.Addr().UnsafePointer()).Type(),
+		} {
+			if got != want || got.Elem() != typ {
+				t.Errorf("%s(%v) = %v, want canonical %v with element %v", name, typ, got, want, typ)
+			}
+		}
+		if got := reflect.TypeOf(value.Addr().Interface()); got != want {
+			t.Errorf("Addr().Interface() type = %v, want %v", got, want)
+		}
+	}
+
+	var f reflectPointerEncoder
+	want := reflect.TypeOf(&f)
+	for name, got := range map[string]reflect.Type{
+		"parameter": reflect.TypeOf(func(*reflectPointerEncoder) {}).In(0),
+		"field":     reflect.TypeOf(struct{ F *reflectPointerEncoder }{}).Field(0).Type,
+		"slice":     reflect.TypeOf([]*reflectPointerEncoder{}).Elem(),
+		"map":       reflect.TypeOf(map[int]*reflectPointerEncoder{}).Elem(),
+	} {
+		if got != want {
+			t.Errorf("%s pointer type = %v, want canonical %v", name, got, want)
+		}
+	}
+	if got, want := reflect.PointerTo(want), reflect.TypeOf((**reflectPointerEncoder)(nil)); got != want {
+		t.Errorf("pointer to function pointer = %v, want canonical %v", got, want)
+	}
+}
+
+func TestReflectFunctionPointerMethods(t *testing.T) {
+	var f reflectPointerEncoder
+	typ := reflect.TypeOf(f)
+	unmarshaler := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+	if typ.Implements(unmarshaler) {
+		t.Fatal("value type unexpectedly implements pointer-receiver interface")
+	}
+	for name, ptr := range map[string]reflect.Value{
+		"Addr":  reflect.ValueOf(&f).Elem().Addr(),
+		"New":   reflect.New(typ),
+		"NewAt": reflect.NewAt(typ, unsafe.Pointer(&f)),
+	} {
+		if got := ptr.Type().NumMethod(); got != 2 {
+			t.Fatalf("%s pointer has %d methods, want 2", name, got)
+		}
+		if !ptr.Type().Implements(unmarshaler) {
+			t.Fatalf("%s pointer does not implement json.Unmarshaler", name)
+		}
+		u, ok := ptr.Interface().(json.Unmarshaler)
+		if !ok {
+			t.Fatalf("%s pointer interface assertion failed", name)
+		}
+		if err := u.UnmarshalJSON([]byte(`"interface"`)); err != nil {
+			t.Fatal(err)
+		}
+		if got := ptr.MethodByName("Encode").Call(nil)[0].String(); got != "interface" {
+			t.Fatalf("%s inherited value method returned %q", name, got)
+		}
+		out := ptr.MethodByName("UnmarshalJSON").Call([]reflect.Value{reflect.ValueOf([]byte(`"method"`))})
+		if !out[0].IsNil() || ptr.Elem().Interface().(reflectPointerEncoder)() != "method" {
+			t.Fatalf("%s reflected pointer method did not update the function", name)
+		}
+	}
+}
+
+func TestReflectFunctionPointerJSON(t *testing.T) {
+	var config struct{ Encoder reflectPointerEncoder }
+	if err := json.Unmarshal([]byte(`{"Encoder":"iso8601"}`), &config); err != nil {
+		t.Fatal(err)
+	}
+	if got := config.Encoder(); got != "iso8601" {
+		t.Fatalf("decoded encoder returned %q", got)
+	}
+}
+
+func TestReflectDynamicFunctionPointer(t *testing.T) {
+	typ := reflect.FuncOf(nil, []reflect.Type{reflect.TypeOf("")}, false)
+	ptr := reflect.New(typ)
+	want := reflect.TypeOf((*func() string)(nil))
+	if ptr.Type() != want || reflect.PointerTo(typ) != want {
+		t.Fatalf("dynamic function pointer = %v, want canonical %v", ptr.Type(), want)
+	}
+	captured := "captured"
+	ptr.Elem().Set(reflect.ValueOf(func() string { return captured }))
+	f, ok := ptr.Interface().(*func() string)
+	if !ok || (*f)() != captured {
+		t.Fatal("dynamic function pointer did not preserve its closure")
+	}
+}
+
+func TestReflectDynamicFunctionPointerConcurrent(t *testing.T) {
+	// This signature and its pointer types have no static descriptors.
+	array := reflect.ArrayOf(13, reflect.TypeOf(""))
+	typ := reflect.FuncOf([]reflect.Type{array}, []reflect.Type{array}, false)
+	const workers = 16
+	results := make(chan reflect.Type, workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			if i%2 == 0 {
+				results <- reflect.PointerTo(typ)
+			} else {
+				results <- reflect.New(typ).Type()
+			}
+		}(i)
+	}
+	want := <-results
+	for i := 1; i < workers; i++ {
+		if got := <-results; got != want {
+			t.Fatalf("concurrent function pointers are not canonical: %v != %v", got, want)
+		}
+	}
+	ptr := reflect.New(typ)
+	if want.Elem() != typ || ptr.Elem().Type() != typ || !ptr.Elem().IsNil() {
+		t.Fatal("dynamic pointer does not describe a nil function of the requested type")
+	}
+	if got := reflect.New(want).Type(); got != reflect.PointerTo(want) || got.Elem() != want {
+		t.Fatal("dynamic pointer-to-pointer identity was not preserved")
+	}
+}


### PR DESCRIPTION
## Summary

Fix the zapcore v1.27.0 compatibility failures in `TestTimeEncoders` and `TestTimeEncodersParseFromJSON` by preserving the canonical pointer descriptor for named function types.

LLGo exposes function values through a public `FuncType`, while named functions retain a closure descriptor in compiler-emitted pointer metadata. Previously, `Value.Addr` converted a named closure to its public function type before calling `ptrTo`. The synthesized pointer then had neither the canonical type identity nor the pointer method set. Consequently, a pointer to a named function could implement `json.Unmarshaler` directly but lose that interface after reflection.

## Design

- Normalize pointer elements centrally in `ptrTo`, before static descriptor lookup or cache access, following the compiler's `abi.PublicType` convention.
- Map named public function types back to their canonical closure descriptor, preserving `PtrToThis_` and pointer methods.
- Map unnamed closures to their public signature so `PointerTo`, `Addr`, `New`, and `NewAt` share the same cache key and descriptor.
- Remove the separate pointer conversion paths in `Value.Addr` and `toPublicType`.
- Preserve the existing lazy-pointer boundary: method-bearing pointers are emitted by the compiler; methodless pointers may be synthesized by reflection. No method-table copying, compiler ABI changes, or zap-specific special cases.

## Regression coverage

Six new tests cover pointer-only methods, inherited value methods, interface assertions, reflected method calls, JSON decoding, named and unnamed function pointer identity, nested pointers, captured closures, and concurrent first-time synthesis of entirely dynamic function pointers. The initial identity, method-set, JSON, and dynamic-pointer regressions fail without the fix and pass with it.

## Validation

Local macOS arm64 with LLVM 22.1.8 (and matching lld 22 for Full LTO):

- Native Go: `go test -run TestReflect -count=1 ./test/go`
- LLGo: `llgo test -run TestReflect -count=1 ./test/go`
- LLGo O2: `llgo test -O2 -run TestReflect -count=3 ./test/go`
- LLGo O2 + Full LTO: `llgo test -O2 -lto=full -run TestReflect -count=1 ./test/go`
- `llgo test -count=1 ./test/std/reflect ./test/go/reflectmethod`
- `llgo run ./cl/_testrt/ptrtothislazy`
- `go test ./ssa -run 'Test.*(PtrToThis|Pointer)' -count=1`
- Full `go.uber.org/zap/zapcore@v1.27.0` test suite using LLGo
- zapcore `TestTimeEncoders*` using LLGo O2 + Full LTO
- `git diff --check`

Repository tests used Go 1.27.0; the external zapcore tests used the installed Go 1.26.5 toolchain. Cross-platform validation is pending PR CI.
