### PR TITLE
fix(runtime): resolve goroutine stack size inside NewProc

### DIFF
--- a/cl/_testgo/chan/in.go
+++ b/cl/_testgo/chan/in.go
@@ -21,7 +21,7 @@ package main
 // CHECK: store ptr [[CH1_SLOT]], ptr {{%.*}}
 // CHECK: [[SEND_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr [[SEND_ENV]], 1
 // CHECK: store { ptr, ptr } [[SEND_CLOSURE]], ptr {{%.*}}
-// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$1", ptr {{%.*}}, i64 0)
+// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$1", ptr {{%.*}})
 // CHECK: [[CH1_RECV:%.*]] = load ptr, ptr [[CH1_SLOT]]
 // CHECK: [[CH1_RECV_BUF:%.*]] = alloca i64
 // CHECK: call i1 @"{{.*}}ChanRecv"(ptr [[CH1_RECV]], ptr [[CH1_RECV_BUF]], i64 8)
@@ -36,7 +36,7 @@ package main
 // CHECK: store ptr [[CH2_SLOT]], ptr {{%.*}}
 // CHECK: [[CLOSE_CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"main.main$2", ptr undef }, ptr [[CLOSE_ENV]], 1
 // CHECK: store { ptr, ptr } [[CLOSE_CLOSURE]], ptr {{%.*}}
-// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$2", ptr {{%.*}}, i64 0)
+// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$2", ptr {{%.*}})
 // CHECK: [[CH2_RECV:%.*]] = load ptr, ptr [[CH2_SLOT]]
 // CHECK: [[CH2_RECV_BUF:%.*]] = alloca i64
 // CHECK: [[CH2_OK:%.*]] = call i1 @"{{.*}}ChanRecv"(ptr [[CH2_RECV]], ptr [[CH2_RECV_BUF]], i64 8)

--- a/cl/_testgo/select/in.go
+++ b/cl/_testgo/select/in.go
@@ -13,8 +13,8 @@ package main
 // CHECK-LABEL: define void @main.recv(){{.*}} {
 // CHECK: [[RECV_CH1_OBJ:%[0-9]+]] = call ptr @"{{.*}}NewChan"(i64 16, i64 0)
 // CHECK: [[RECV_CH2_OBJ:%[0-9]+]] = call ptr @"{{.*}}NewChan"(i64 16, i64 0)
-// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$1", ptr %{{[0-9]+}}, i64 0)
-// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$2", ptr %{{[0-9]+}}, i64 0)
+// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$1", ptr %{{[0-9]+}})
+// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$2", ptr %{{[0-9]+}})
 // CHECK: [[RECV_CH1:%[0-9]+]] = load ptr, ptr %{{[0-9]+}}
 // CHECK-NEXT: [[RECV_CH2:%[0-9]+]] = load ptr, ptr %{{[0-9]+}}
 // CHECK: [[RECV_BUF1:%[0-9]+]] = alloca %"{{.*}}String"

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -403,6 +403,10 @@ func (p *context) compileGlobal(pkg llssa.Package, gbl *ssa.Global) {
 	if skip {
 		return
 	}
+	if define && name == llssa.RuntimeGoroutineStackSizeVar {
+		p.prog.InitPthreadStackSize(g)
+		return
+	}
 	if p.tryEmbedGlobalInit(pkg, gbl, g, name) {
 		return
 	}

--- a/cl/runtime_stack_test.go
+++ b/cl/runtime_stack_test.go
@@ -1,0 +1,96 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"fmt"
+	"go/types"
+	"strings"
+	"testing"
+
+	llssa "github.com/xgo-dev/llgo/ssa"
+	"github.com/xgo-dev/llgo/ssa/ssatest"
+	"github.com/xgo-dev/llvm"
+)
+
+func TestCompileRuntimeGoroutineStackSize(t *testing.T) {
+	for _, tc := range []struct {
+		name, path string
+		size       uint64
+		injected   bool
+	}{
+		{"default", llssa.PkgRuntime, 0, true},
+		{"configured", llssa.PkgRuntime, 32 << 20, true},
+		{"ordinary_package", "example.com/runtime", 32 << 20, false},
+		{"public_runtime", "runtime", 32 << 20, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Even the negative cases use the package name runtime: injection
+			// must match the full core-runtime path, not its name or suffix.
+			ssaPkg, files := buildCallerFrameSSAPackage(t, tc.path, `package runtime
+var goroutineStackSize uintptr
+func Size() uintptr { return goroutineStackSize }
+`)
+			prog := ssatest.NewProgram(t, &llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+			defer prog.Dispose()
+			prog.TypeSizes(types.SizesFor("gc", "amd64"))
+			prog.SetPthreadStackSize(tc.size)
+			pkg, err := NewPackage(prog, ssaPkg, files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mod := pkg.Module()
+			global := mod.NamedGlobal(tc.path + ".goroutineStackSize")
+			if global.IsNil() {
+				t.Fatalf("missing stack-size global:\n%s", mod.String())
+			}
+			if got := global.IsGlobalConstant(); got != tc.injected {
+				t.Fatalf("global constant = %v, want %v: %s", got, tc.injected, global.String())
+			}
+			want := uint64(0)
+			if tc.injected {
+				want = tc.size
+			}
+			if initializer := global.Initializer(); initializer.IsNil() || initializer.ZExtValue() != want {
+				t.Fatalf("global initializer = %s, want %d", global.String(), want)
+			}
+			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+			if !tc.injected {
+				return
+			}
+
+			// No package init execution or whole-program LTO is needed: a
+			// normal function pass folds the immutable configuration load.
+			options := llvm.NewPassBuilderOptions()
+			defer options.Dispose()
+			if err := mod.RunPasses("function(instcombine)", prog.TargetMachine(), options); err != nil {
+				t.Fatal(err)
+			}
+			body := mod.NamedFunction(tc.path + ".Size").String()
+			if strings.Contains(body, "load ") || !strings.Contains(body, fmt.Sprintf("ret i64 %d", want)) {
+				t.Fatalf("stack-size load did not fold to %d:\n%s", want, body)
+			}
+			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -30,6 +30,7 @@ import (
 	"github.com/xgo-dev/llgo/internal/env"
 	"github.com/xgo-dev/llgo/internal/meta"
 	"github.com/xgo-dev/llgo/internal/packages"
+	llssa "github.com/xgo-dev/llgo/ssa"
 	gopackages "golang.org/x/tools/go/packages"
 )
 
@@ -209,6 +210,11 @@ func (c *context) collectPackageInputs(m *manifestBuilder, pkg *aPackage) error 
 
 	m.pkg.PkgPath = p.PkgPath
 	m.pkg.PkgID = p.ID
+	if p.PkgPath == llssa.PkgRuntime {
+		// Only the runtime embeds this setting; goroutine callers have a
+		// configuration-independent ABI. Match SetPthreadStackSize in Build.
+		m.pkg.PthreadStackSize = max(0, c.buildConf.PthreadStackSize)
+	}
 
 	// Go source files
 	goFilesList, err := digestFilesWithOverlay(packageGoSourceInputs(p, c.patchFiles[p.PkgPath]), c.buildConf.Overlay)

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -365,6 +365,57 @@ func TestCollectFingerprintDisablesCycles(t *testing.T) {
 	}
 }
 
+func TestCollectFingerprintIncludesPthreadStackSize(t *testing.T) {
+	for _, target := range []struct{ goos, goarch string }{
+		{"linux", "amd64"}, {"windows", "amd64"}, {"js", "wasm"}, {"wasip1", "wasm"},
+	} {
+		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
+			for _, pkgPath := range []string{llssa.PkgRuntime, "runtime", "test/stack"} {
+				fingerprints := make(map[int64]string)
+				for _, size := range []int64{0, 256 << 10, 512 << 10, -1} {
+					ctx := &context{
+						conf: &packages.Config{},
+						buildConf: &Config{Goos: target.goos, Goarch: target.goarch,
+							BuildMode: BuildModeExe, PthreadStackSize: size},
+					}
+					pkg := &aPackage{Package: &packages.Package{PkgPath: pkgPath}}
+					if err := ctx.collectFingerprint(pkg); err != nil {
+						t.Fatal(err)
+					}
+					data, err := decodeManifest(pkg.Manifest)
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantSize := max(0, size)
+					if pkgPath != llssa.PkgRuntime {
+						wantSize = 0
+					}
+					if data.Package == nil || data.Package.PthreadStackSize != wantSize {
+						t.Fatalf("stack size %d missing from manifest:\n%s", size, pkg.Manifest)
+					}
+					if got := strings.Contains(pkg.Manifest, "pthread_stack_size:"); got != (wantSize > 0) {
+						t.Fatalf("package stack input presence = %v, want %v:\n%s", got, wantSize > 0, pkg.Manifest)
+					}
+					fingerprints[size] = pkg.Fingerprint
+				}
+				if fingerprints[0] != fingerprints[-1] {
+					t.Fatal("equivalent default stack settings have different fingerprints")
+				}
+				if pkgPath != llssa.PkgRuntime {
+					if fingerprints[0] != fingerprints[256<<10] || fingerprints[0] != fingerprints[512<<10] {
+						t.Fatal("changing the stack size invalidated an unrelated package")
+					}
+				} else if fingerprints[0] == fingerprints[256<<10] || fingerprints[256<<10] == fingerprints[512<<10] || fingerprints[0] == fingerprints[512<<10] {
+					t.Fatal("changing the goroutine stack size did not invalidate cached packages")
+				}
+			}
+		})
+	}
+	if (&packageSection{PthreadStackSize: 256 << 10}).empty() {
+		t.Fatal("non-default stack size must not be omitted from the manifest")
+	}
+}
+
 func TestCollectFingerprintIncludesEmitDWARF(t *testing.T) {
 	td := t.TempDir()
 	goFile := filepath.Join(td, "main.go")

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -168,18 +168,19 @@ func (s *commonSection) empty() bool {
 }
 
 type packageSection struct {
-	PkgPath     string           `yaml:"pkg_path,omitempty"`
-	PkgID       string           `yaml:"pkg_id,omitempty"`
-	GoFiles     []fileDigest     `yaml:"go_files,omitempty"`
-	AltGoFiles  []fileDigest     `yaml:"alt_go_files,omitempty"`
-	OtherFiles  []fileDigest     `yaml:"other_files,omitempty"`
-	LLGoFiles   []llgoFileDigest `yaml:"llgo_files,omitempty"`
-	RewriteVars orderedStringMap `yaml:"rewrite_vars,omitempty"`
+	PthreadStackSize int64            `yaml:"pthread_stack_size,omitempty"`
+	PkgPath          string           `yaml:"pkg_path,omitempty"`
+	PkgID            string           `yaml:"pkg_id,omitempty"`
+	GoFiles          []fileDigest     `yaml:"go_files,omitempty"`
+	AltGoFiles       []fileDigest     `yaml:"alt_go_files,omitempty"`
+	OtherFiles       []fileDigest     `yaml:"other_files,omitempty"`
+	LLGoFiles        []llgoFileDigest `yaml:"llgo_files,omitempty"`
+	RewriteVars      orderedStringMap `yaml:"rewrite_vars,omitempty"`
 }
 
 func (s *packageSection) empty() bool {
 	return s.PkgPath == "" && s.PkgID == "" && len(s.GoFiles) == 0 && len(s.AltGoFiles) == 0 &&
-		len(s.OtherFiles) == 0 && len(s.LLGoFiles) == 0 && len(s.RewriteVars) == 0
+		len(s.OtherFiles) == 0 && len(s.LLGoFiles) == 0 && len(s.RewriteVars) == 0 && s.PthreadStackSize == 0
 }
 
 // manifestBuilder builds manifest text with sorted sections.

--- a/internal/build/stack_cache_test.go
+++ b/internal/build/stack_cache_test.go
@@ -1,0 +1,219 @@
+//go:build !llgo
+
+package build
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xgo-dev/llgo/internal/packages"
+	llssa "github.com/xgo-dev/llgo/ssa"
+	"github.com/xgo-dev/llvm"
+)
+
+func TestPthreadStackSizeRuntimeDependencyFingerprint(t *testing.T) {
+	fingerprints := make(map[int64]string)
+	for _, size := range []int64{0, 256 << 10} {
+		dep := &aPackage{Package: &packages.Package{ID: llssa.PkgRuntime, PkgPath: llssa.PkgRuntime}}
+		pkg := &aPackage{Package: &packages.Package{ID: "example/caller", PkgPath: "example/caller", Imports: map[string]*packages.Package{dep.PkgPath: dep.Package}}}
+		ctx := &context{conf: &packages.Config{}, buildConf: &Config{PthreadStackSize: size}, pkgByID: map[string]*aPackage{dep.ID: dep, pkg.ID: pkg}, llvmVersion: "test"}
+		if err := ctx.collectFingerprint(pkg); err != nil {
+			t.Fatal(err)
+		}
+		data, err := decodeManifest(pkg.Manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if data.Package.PthreadStackSize != 0 {
+			t.Fatal("ordinary caller got a direct stack input")
+		}
+		if len(data.Deps) != 1 || data.Deps[0].Fingerprint != dep.Fingerprint {
+			t.Fatal("missing runtime dependency fingerprint")
+		}
+		fingerprints[size] = pkg.Fingerprint
+	}
+	if fingerprints[0] == fingerprints[256<<10] {
+		t.Fatal("direct runtime importer failed to invalidate conservatively")
+	}
+}
+
+// checkStackCacheNewProc verifies the configuration-independent caller ABI
+// before TransformModule can inline NewProc or eliminate its declaration.
+func checkStackCacheNewProc(t *testing.T, pkg Package) bool {
+	t.Helper()
+	fn := pkg.LPkg.Module().NamedFunction(llssa.PkgRuntime + ".NewProc")
+	if fn.IsNil() {
+		t.Errorf("%s did not declare NewProc", pkg.PkgPath)
+		return false
+	}
+	if typ := fn.GlobalValueType(); typ.ParamTypesCount() != 2 || typ.IsFunctionVarArg() {
+		t.Errorf("%s NewProc ABI = %s, want exactly two parameters", pkg.PkgPath, typ.String())
+	}
+	calls := 0
+	for use := fn.FirstUse(); !use.IsNil(); use = use.NextUse() {
+		call := use.User().IsACallInst()
+		if call.IsNil() || call.CalledValue() != fn {
+			continue
+		}
+		calls++
+		if call.CalledFunctionType().ParamTypesCount() != 2 || call.OperandsCount() != 3 {
+			t.Errorf("%s NewProc call still embeds stack configuration: %s", pkg.PkgPath, call.String())
+		}
+	}
+	return calls > 0
+}
+
+func checkStackCacheRuntimeConstant(t *testing.T, pkg Package, size int64) {
+	t.Helper()
+	mod := pkg.LPkg.Module()
+	global := mod.NamedGlobal(llssa.RuntimeGoroutineStackSizeVar)
+	if global.IsNil() {
+		t.Error("runtime did not emit goroutineStackSize")
+		return
+	}
+	if !global.IsGlobalConstant() {
+		t.Error("runtime goroutineStackSize is not an LLVM constant")
+	}
+	init := global.Initializer()
+	if init.IsNil() || init.IsAConstantInt().IsNil() {
+		t.Errorf("runtime goroutineStackSize has no integer initializer: %s", global.String())
+	} else if got := init.ZExtValue(); got != uint64(size) {
+		t.Errorf("runtime goroutineStackSize = %d, want %d", got, size)
+	}
+	fn := mod.NamedFunction(llssa.PkgRuntime + ".NewProc")
+	if fn.IsNil() || fn.IsDeclaration() {
+		t.Error("runtime did not define NewProc")
+		return
+	}
+	backendCalls := 0
+	for block := fn.FirstBasicBlock(); !block.IsNil(); block = llvm.NextBasicBlock(block) {
+		for inst := block.FirstInstruction(); !inst.IsNil(); inst = llvm.NextInstruction(inst) {
+			call := inst.IsACallInst()
+			if call.IsNil() || call.CalledValue().Name() != llssa.PkgRuntime+".newprocBackend" {
+				continue
+			}
+			backendCalls++
+			if call.CalledFunctionType().ParamTypesCount() != 4 {
+				t.Errorf("unexpected scheduler backend ABI: %s", call.String())
+				continue
+			}
+			// The backend's stack argument must come from the configured
+			// runtime global (or its already-folded constant), not an ABI arg.
+			stack := call.Operand(2)
+			if integer := stack.IsAConstantInt(); !integer.IsNil() {
+				if integer.ZExtValue() != uint64(size) {
+					t.Errorf("NewProc passes stack size %d, want %d", integer.ZExtValue(), size)
+				}
+			} else if load := stack.IsALoadInst(); load.IsNil() || load.Operand(0) != global {
+				t.Errorf("NewProc stack size does not use its runtime constant: %s", stack.String())
+			}
+		}
+	}
+	if backendCalls != 1 {
+		t.Errorf("NewProc calls scheduler backend %d times, want once", backendCalls)
+	}
+}
+
+func TestPthreadStackSizePackageCache(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LLGO_ROOT", repoRoot)
+	t.Setenv(llgoBuildCache, "1")
+	oldCacheRoot := cacheRootFunc
+	cacheDir := t.TempDir()
+	cacheRootFunc = func() string { return cacheDir }
+	defer func() { cacheRootFunc = oldCacheRoot }()
+	const fixturePath = "github.com/xgo-dev/llgo/internal/build/testdata/stackcache/"
+	seenSize := make(map[int64]bool)
+	for phase, tc := range []struct {
+		size  int64
+		force bool
+	}{
+		{0, false}, {256 << 10, false}, {512 << 10, false}, {0, false}, {256 << 10, true}, {-1, false},
+	} {
+		t.Run(fmt.Sprintf("%d-size%d-force%v", phase, tc.size, tc.force), func(t *testing.T) {
+			conf := NewDefaultConf(ModeBuild)
+			conf.PthreadStackSize = tc.size
+			conf.ForceRebuild = tc.force
+			conf.OutFile = filepath.Join(t.TempDir(), "stackcache")
+			if runtime.GOOS == "windows" {
+				conf.OutFile += ".exe"
+			}
+			conf.BuildParallelism = 2
+			normalizedSize := max(0, tc.size)
+			generated := make(map[string]bool)
+			runtimeChecked := false
+			var hookMu sync.Mutex
+			conf.ModuleHook = func(pkg Package) {
+				if pkg.CacheHit || pkg.LPkg == nil {
+					return
+				}
+				hookMu.Lock()
+				defer hookMu.Unlock()
+				switch pkg.PkgPath {
+				case llssa.PkgRuntime:
+					checkStackCacheNewProc(t, pkg)
+					checkStackCacheRuntimeConstant(t, pkg, normalizedSize)
+					runtimeChecked = true
+				case fixturePath + "spawn", fixturePath + "instance":
+					generated[pkg.PkgPath] = checkStackCacheNewProc(t, pkg)
+				}
+			}
+			pkgs, err := Build(Invocation{Args: []string{"."}, Config: conf, Dir: filepath.Join(repoRoot, "internal", "build", "testdata", "stackcache")})
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := make(map[string]bool)
+			for _, pkg := range pkgs {
+				if pkg.PkgPath == llssa.PkgRuntime {
+					found["runtime"] = true
+					wantHit := seenSize[normalizedSize] && !tc.force
+					if pkg.CacheHit != wantHit {
+						t.Errorf("runtime CacheHit = %v, want %v", pkg.CacheHit, wantHit)
+					}
+					if !wantHit && !runtimeChecked {
+						t.Error("runtime stack constant was not checked on a cache miss")
+					}
+					continue
+				}
+				if pkg.PkgPath == strings.TrimSuffix(fixturePath, "/") {
+					found["main"] = true
+					if pkg.CacheHit {
+						t.Error("main package must not use the package cache")
+					}
+					continue
+				}
+				name, ok := strings.CutPrefix(pkg.PkgPath, fixturePath)
+				if !ok {
+					continue
+				}
+				found[name] = true
+				// Neither ordinary nor instantiated generic go statements
+				// embed the stack size. They share the plain package's hits.
+				wantHit := phase > 0 && !tc.force
+				if pkg.CacheHit != wantHit {
+					t.Errorf("%s CacheHit = %v, want %v", name, pkg.CacheHit, wantHit)
+				}
+				if !wantHit && (name == "spawn" || name == "instance") && !generated[pkg.PkgPath] {
+					t.Errorf("%s did not emit a two-argument goroutine entry call", name)
+				}
+			}
+			for _, name := range []string{"main", "runtime", "plain", "spawn", "generic", "instance"} {
+				if !found[name] {
+					t.Errorf("missing package %s", name)
+				}
+			}
+			if out, err := exec.Command(conf.OutFile).CombinedOutput(); err != nil {
+				t.Fatalf("run: %v\n%s", err, out)
+			}
+			seenSize[normalizedSize] = true
+		})
+	}
+}

--- a/internal/build/testdata/stackcache/generic/launch.go
+++ b/internal/build/testdata/stackcache/generic/launch.go
@@ -1,0 +1,7 @@
+package generic
+
+func Launch[T any](value T) T {
+	done := make(chan T)
+	go func() { done <- value }()
+	return <-done
+}

--- a/internal/build/testdata/stackcache/instance/instance.go
+++ b/internal/build/testdata/stackcache/instance/instance.go
@@ -1,0 +1,5 @@
+package instance
+
+import "github.com/xgo-dev/llgo/internal/build/testdata/stackcache/generic"
+
+func Value() int { return generic.Launch(42) }

--- a/internal/build/testdata/stackcache/main.go
+++ b/internal/build/testdata/stackcache/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/xgo-dev/llgo/internal/build/testdata/stackcache/instance"
+	"github.com/xgo-dev/llgo/internal/build/testdata/stackcache/plain"
+	"github.com/xgo-dev/llgo/internal/build/testdata/stackcache/spawn"
+)
+
+func main() {
+	if plain.Value() != 42 || spawn.Value() != 42 || instance.Value() != 42 {
+		panic("stack cache regression")
+	}
+}

--- a/internal/build/testdata/stackcache/plain/plain.go
+++ b/internal/build/testdata/stackcache/plain/plain.go
@@ -1,0 +1,3 @@
+package plain
+
+func Value() int { return 42 }

--- a/internal/build/testdata/stackcache/spawn/spawn.go
+++ b/internal/build/testdata/stackcache/spawn/spawn.go
@@ -1,0 +1,7 @@
+package spawn
+
+func Value() int {
+	done := make(chan int)
+	go func() { done <- 42 }()
+	return <-done
+}

--- a/runtime/internal/runtime/proc.go
+++ b/runtime/internal/runtime/proc.go
@@ -52,13 +52,20 @@ var sched struct {
 	gstate uint64
 }
 
+// goroutineStackSize is initialized by the compiler as a read-only constant in
+// this package, before any package init or goroutine can run. Zero preserves
+// the backend's default. Keep it without a Go initializer so init cannot
+// overwrite the configured value. The compiler names this symbol through
+// ssa.RuntimeGoroutineStackSizeVar; update both when renaming it.
+var goroutineStackSize uintptr
+
 // NewProc creates a new G running fn.
 //
 // The compiler turns a go statement into a call to NewProc. Unlike the old
 // lowering, this ABI contains no host-thread types: the selected runtime backend
 // decides how to provide an M and execute the G.
-func NewProc(fn goroutineFunc, arg unsafe.Pointer, stackSize uintptr) {
-	newprocBackend(fn, arg, stackSize, getg())
+func NewProc(fn goroutineFunc, arg unsafe.Pointer) {
+	newprocBackend(fn, arg, goroutineStackSize, getg())
 }
 
 // newproc1 creates target-independent runnable G state. The selected backend

--- a/ssa/goroutine.go
+++ b/ssa/goroutine.go
@@ -72,8 +72,20 @@ func (b Builder) Go(fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, args .
 	dataPtr := b.Call(pkg.rtFunc("AllocRoot"), prog.IntVal(prog.SizeOf(t), prog.Uintptr())).impl
 	aggregateInit(b.impl, dataPtr, t.ll, flds...)
 	data := Expr{dataPtr, voidPtr}
-	stackSize := prog.IntVal(prog.pthreadStackSize, prog.Uintptr())
-	b.Call(pkg.rtFunc("NewProc"), pkg.routine(t, fn, buildCall, len(args)), data, stackSize)
+	b.Call(pkg.rtFunc("NewProc"), pkg.routine(t, fn, buildCall, len(args)), data)
+}
+
+// RuntimeGoroutineStackSizeVar names the private configuration global declared
+// in runtime/internal/runtime/proc.go. Keep that declaration in sync; the build
+// cache integration test checks injection into the actual runtime package.
+const RuntimeGoroutineStackSizeVar = PkgRuntime + ".goroutineStackSize"
+
+// InitPthreadStackSize initializes the runtime's private stack configuration.
+// Keeping the immutable value in the runtime module lets LLVM fold it into
+// NewProc without baking build configuration into every goroutine caller.
+func (p Program) InitPthreadStackSize(g Global) {
+	g.Init(p.IntVal(p.pthreadStackSize, p.Uintptr()))
+	g.impl.SetGlobalConstant(true)
 }
 
 func (p Package) routineName() string {

--- a/ssa/goroutine_patch_test.go
+++ b/ssa/goroutine_patch_test.go
@@ -102,7 +102,7 @@ func TestGoPanicRoutineDoesNotReturnAfterUnreachable(t *testing.T) {
 	}
 }
 
-func TestGoPassesConfiguredStackSizeToRuntime(t *testing.T) {
+func TestGoDoesNotPassConfiguredStackSizeToRuntime(t *testing.T) {
 	prog := ssatest.NewProgram(t, nil)
 	prog.SetPthreadStackSize(32 << 20)
 	pkg := prog.NewPackage("bar", "foo/bar")
@@ -118,15 +118,18 @@ func TestGoPassesConfiguredStackSizeToRuntime(t *testing.T) {
 	if !strings.Contains(ir, `"github.com/xgo-dev/llgo/runtime/internal/runtime.NewProc"`) {
 		t.Fatalf("goroutine should delegate startup to the runtime:\n%s", ir)
 	}
-	if !strings.Contains(ir, "33554432") {
-		t.Fatalf("goroutine should pass the configured stack size:\n%s", ir)
+	if strings.Contains(ir, "33554432") {
+		t.Fatalf("goroutine caller must not embed the configured stack size:\n%s", ir)
+	}
+	if fn := pkg.Module().NamedFunction(ssa.PkgRuntime + ".NewProc"); fn.ParamsCount() != 2 {
+		t.Fatalf("NewProc takes %d parameters, want two", fn.ParamsCount())
 	}
 	if strings.Contains(ir, "pthread") {
 		t.Fatalf("compiler IR should not depend on the pthread backend:\n%s", ir)
 	}
 }
 
-func TestGoPassesZeroStackSizeToRuntimeByDefault(t *testing.T) {
+func TestGoUsesTwoArgumentRuntimeEntryByDefault(t *testing.T) {
 	prog := ssatest.NewProgram(t, nil)
 	pkg := prog.NewPackage("bar", "foo/bar")
 
@@ -143,5 +146,32 @@ func TestGoPassesZeroStackSizeToRuntimeByDefault(t *testing.T) {
 	}
 	if strings.Contains(ir, "pthread") {
 		t.Fatalf("compiler IR should not depend on the pthread backend:\n%s", ir)
+	}
+	if fn := pkg.Module().NamedFunction(ssa.PkgRuntime + ".NewProc"); fn.ParamsCount() != 2 {
+		t.Fatalf("NewProc takes %d parameters, want two", fn.ParamsCount())
+	}
+}
+
+func TestRuntimePthreadStackSizeConstant(t *testing.T) {
+	for _, target := range []*ssa.Target{
+		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "wasip1", GOARCH: "wasm"},
+		{GOOS: "js", GOARCH: "wasm", LLVMTarget: "wasm64-unknown-emscripten"},
+	} {
+		for _, size := range []uint64{0, 32 << 20} {
+			prog := ssatest.NewProgram(t, target)
+			prog.SetPthreadStackSize(size)
+			pkg := prog.NewPackage("runtime", ssa.PkgRuntime)
+			name := ssa.RuntimeGoroutineStackSizeVar
+			g := pkg.NewVarEx(name, prog.Pointer(prog.Uintptr()))
+			prog.InitPthreadStackSize(g)
+			global := pkg.Module().NamedGlobal(name)
+			if !global.IsGlobalConstant() || global.Initializer().ZExtValue() != size {
+				t.Fatalf("runtime stack size: got %s, want constant %d", global.String(), size)
+			}
+			if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -417,6 +417,8 @@ func (p Program) DisableBoundsChecks(disable bool) {
 	p.disableBoundsChecks = disable
 }
 
+// SetPthreadStackSize configures the runtime module's goroutine stack size.
+// Goroutine call sites do not embed this value.
 func (p Program) SetPthreadStackSize(size uint64) {
 	p.pthreadStackSize = size
 }


### PR DESCRIPTION
## Problem

`-pthread-stack-size` was embedded in every compiler-generated `NewProc` call, but absent from package cache fingerprints. Changing the option could silently reuse callers with the old size; an `-a` build could contaminate a later default build in the other direction.

This is a main-branch bug exposed during WASM R4 stack investigation. The original configurable-stack feature came from #2038; #2166 moved creation into `NewProc` while retaining the per-call stack argument.

## Change

- Make the internal compiler/runtime entry `NewProc(fn, arg)`: **no stack-size argument at any goroutine call site**.
- Initialize the private `goroutineStackSize` variable in `github.com/xgo-dev/llgo/runtime/internal/runtime` as an LLVM read-only constant. `NewProc` supplies it to the selected backend. It is available before any package initialization, and ordinary module optimization folds away the load, including the default zero.
- Add `pthread_stack_size` only to that exact internal runtime package's manifest/fingerprint. The public standard-library `runtime` and all other packages omit the field. Existing dependency-fingerprint propagation is unchanged; explicit runtime importers may still invalidate conservatively.
- Preserve default/platform behavior and non-positive Build API normalization. No new ABI-version cache salt, cache-wide size key, SSA goroutine detection, generic-emission analysis, scheduler API, or default-stack-size change is introduced.
- Replace the earlier intermediate approach; this PR is amended into one focused commit.

## Validation

LLVM 22 focused tests cover:

- exact runtime-package matching and same-named-variable negative controls;
- static constant initialization and ordinary LLVM constant folding;
- native, wasm32 and memory64 constant generation;
- two-argument entry declarations/calls and updated chan/select/goroutine IR goldens;
- six real native cache/build/run phases: default → 256 KiB → 512 KiB → default → forced 256 KiB → equivalent default (`-1`). Plain, ordinary-goroutine, generic-definition and instantiated-goroutine packages retain cache hits when only the size changes. The internal runtime misses for a new size and reuses an existing size. Each regenerated runtime's initializer and `NewProc` backend argument are checked, and all six executables run successfully.

The six cache phases take about 6–9 seconds locally. Tests use existing host CI/coverage jobs, with no new matrix or long stress loop. Final-head CI/coverage must still pass. R4 will use this same isolated main-branch fix.
