### PR TITLE
runtime/tls: fix stale Windows GC roots and diagnose goroot stalls

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -149,6 +149,11 @@ jobs:
           export CHECK_STD_SYMBOLS="$RUNNER_TEMP/llgo-bin/check_std_symbols${tool_suffix}"
           dev/test_go_version.sh 1.27
 
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            # The TLS regression lives in the runtime submodule, outside test/.
+            (cd runtime && "$LLGO" test -v -run '^TestSlotGCAllocation$' -count=20 -timeout=2m ./internal/clite/tls)
+          fi
+
       - name: Check std symbol coverage
         # Split profiles leave this profile-wide check on shard 1. Unsharded
         # non-amd64 profiles run it here after their full package test.

--- a/runtime/internal/clite/bdwgc/bdwgc.go
+++ b/runtime/internal/clite/bdwgc/bdwgc.go
@@ -68,16 +68,15 @@ func Realloc(ptr c.Pointer, size uintptr) c.Pointer
 //go:linkname Free C.GC_free
 func Free(ptr c.Pointer)
 
-// AddRoots registers a memory region [start, end) as a GC root. The caller
-// must ensure that the range remains valid until RemoveRoots is invoked with
-// the same boundaries. This is typically used for TLS slots that store Go
-// pointers.
+// AddRoots registers [start, end) as a GC root. BDWGC may merge adjacent or
+// overlapping regions, so RemoveRoots is not necessarily its inverse. Use
+// MallocUncollectable for allocations that must be released independently.
 //
 //go:linkname AddRoots C.GC_add_roots
 func AddRoots(start, end c.Pointer)
 
-// RemoveRoots unregisters a region previously registered with AddRoots. The
-// start and end pointers must exactly match the earlier AddRoots call.
+// RemoveRoots unregisters root regions wholly contained in [start, end).
+// It does not split a larger region formed by merging earlier AddRoots calls.
 //
 //go:linkname RemoveRoots C.GC_remove_roots
 func RemoveRoots(start, end c.Pointer)

--- a/runtime/internal/clite/tls/tls_common.go
+++ b/runtime/internal/clite/tls/tls_common.go
@@ -17,10 +17,11 @@
  */
 
 // Package tls provides generic storage backed by the host thread-local
-// storage API. When built with the GC-enabled configuration (llgo && !nogc),
-// TLS slots use scanned, uncollectable BDWGC allocations so their pointers stay
-// visible until the thread-local destructor releases the slot. Builds without
-// GC integration (llgo && nogc) use ordinary calloc/free allocations.
+// storage API. GC-enabled builds (llgo && !baremetal && !wasm && !nogc) use
+// scanned, uncollectable BDWGC slots so their pointers stay visible until the
+// thread-local destructor releases the slot. Non-baremetal llgo builds with nogc or
+// wasm use ordinary calloc/free allocations. Baremetal builds and builds
+// without llgo use no-op handles.
 //
 // Basic usage:
 //
@@ -37,8 +38,9 @@
 //	})
 //
 // Build tags:
-//   - llgo && !nogc: Enables GC-managed slots via BDWGC
-//   - llgo && nogc:  Disables GC integration; TLS acts as plain host TLS
+//   - llgo && !baremetal && !wasm && !nogc: GC-managed slots via BDWGC
+//   - llgo && !baremetal && (nogc || wasm): Plain host TLS via calloc/free
+//   - !llgo || baremetal: No-op handles
 package tls
 
 import (

--- a/runtime/internal/clite/tls/tls_common.go
+++ b/runtime/internal/clite/tls/tls_common.go
@@ -18,10 +18,9 @@
 
 // Package tls provides generic storage backed by the host thread-local
 // storage API. When built with the GC-enabled configuration (llgo && !nogc),
-// TLS slots are automatically registered with the BDWGC garbage collector so
-// pointers stored in thread-local state remain visible to the collector.
-// Builds without GC integration (llgo && nogc) simply use host TLS without
-// root registration.
+// TLS slots use scanned, uncollectable BDWGC allocations so their pointers stay
+// visible until the thread-local destructor releases the slot. Builds without
+// GC integration (llgo && nogc) use ordinary calloc/free allocations.
 //
 // Basic usage:
 //
@@ -38,7 +37,7 @@
 //	})
 //
 // Build tags:
-//   - llgo && !nogc: Enables GC-aware slot registration via BDWGC
+//   - llgo && !nogc: Enables GC-managed slots via BDWGC
 //   - llgo && nogc:  Disables GC integration; TLS acts as plain host TLS
 package tls
 
@@ -93,22 +92,22 @@ func (h Handle[T]) ensureSlot() *slot[T] {
 		return (*slot[T])(ptr)
 	}
 	size := unsafe.Sizeof(slot[T]{})
-	mem := c.Calloc(1, size)
+	mem := allocSlot(size)
 	if mem == nil {
 		panic("tls: failed to allocate thread slot")
 	}
 	s := (*slot[T])(mem)
 	s.destructor = h.destructor
+	// Collector allocation can run finalizers that re-enter this handle.
 	if existing := h.key.Get(); existing != nil {
-		c.Free(mem)
+		freeSlot(mem)
 		return (*slot[T])(existing)
 	}
 	if ret := h.key.Set(mem); ret != 0 {
-		c.Free(mem)
+		freeSlot(mem)
 		c.Fprintf(c.Stderr, c.Str("tls: thread-local value installation failed (error=%d)\n"), ret)
 		panic("tls: failed to set thread local storage value")
 	}
-	registerSlot(s)
 	return s
 }
 
@@ -120,9 +119,8 @@ func slotDestructor[T any](ptr c.Pointer) {
 	if s.destructor != nil {
 		s.destructor(&s.value)
 	}
-	deregisterSlot(s)
 	var zero T
 	s.value = zero
 	s.destructor = nil
-	c.Free(ptr)
+	freeSlot(ptr)
 }

--- a/runtime/internal/clite/tls/tls_gc.go
+++ b/runtime/internal/clite/tls/tls_gc.go
@@ -19,56 +19,24 @@
 package tls
 
 import (
-	"unsafe"
-
 	c "github.com/xgo-dev/llgo/runtime/internal/clite"
 	"github.com/xgo-dev/llgo/runtime/internal/clite/bdwgc"
 )
 
-const slotRegistered = 1 << iota
-
-const maxSlotSize = 1 << 20 // 1 MiB sanity cap
-
 type slot[T any] struct {
 	value      T
-	state      uintptr
 	destructor func(*T)
 }
 
-func registerSlot[T any](s *slot[T]) {
-	if s.state&slotRegistered != 0 {
-		return
-	}
-	start, end := s.rootRange()
-	size := uintptr(end) - uintptr(start)
-	if size == 0 {
-		return
-	}
-	if size > maxSlotSize {
-		panic("tls: slot size exceeds maximum")
-	}
-	bdwgc.AddRoots(start, end)
-	s.state |= slotRegistered
+func allocSlot(size uintptr) c.Pointer {
+	// FLS/pthread slots are not collector roots. Keep the slot scanned and
+	// uncollectable until its destructor, including the Go callback closure.
+	// Do not register individual calloc ranges: on Windows BDWGC merges
+	// adjacent roots, but RemoveRoots does not split the merged range when
+	// one slot is freed, leaving a dangling root that can stall collection.
+	return bdwgc.MallocUncollectable(size)
 }
 
-func deregisterSlot[T any](s *slot[T]) {
-	if s == nil || s.state&slotRegistered == 0 {
-		return
-	}
-	s.state &^= slotRegistered
-	start, end := s.rootRange()
-	if uintptr(end) > uintptr(start) {
-		bdwgc.RemoveRoots(start, end)
-	}
-}
-
-func (s *slot[T]) rootRange() (start, end c.Pointer) {
-	begin := unsafe.Pointer(s)
-	size := unsafe.Sizeof(*s)
-	beginAddr := uintptr(begin)
-	if beginAddr > ^uintptr(0)-size {
-		panic("tls: pointer arithmetic overflow in rootRange")
-	}
-	endPtr := unsafe.Pointer(beginAddr + size)
-	return c.Pointer(begin), c.Pointer(endPtr)
+func freeSlot(ptr c.Pointer) {
+	bdwgc.Free(ptr)
 }

--- a/runtime/internal/clite/tls/tls_gc_test.go
+++ b/runtime/internal/clite/tls/tls_gc_test.go
@@ -1,0 +1,92 @@
+//go:build llgo && !baremetal && !wasm && !nogc
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"testing"
+	"unsafe"
+
+	c "github.com/xgo-dev/llgo/runtime/internal/clite"
+	"github.com/xgo-dev/llgo/runtime/internal/clite/bdwgc"
+)
+
+//go:linkname gcBase C.GC_base
+func gcBase(ptr unsafe.Pointer) unsafe.Pointer
+
+//go:linkname gcKindAndSize C.GC_get_kind_and_size
+func gcKindAndSize(ptr unsafe.Pointer, size *uintptr) c.Int
+
+func TestSlotGCAllocation(t *testing.T) {
+	var destroyed, wantDestroyed uint64
+	h := Alloc[*[8]uint64](func(value **[8]uint64) {
+		if value != nil && *value != nil {
+			destroyed = (*value)[0]
+		}
+	})
+	s := h.ensureSlot()
+	t.Cleanup(func() {
+		// Remove the FLS sidecar first so manual destruction cannot run twice.
+		if ret := h.key.Set(nil); ret != 0 {
+			t.Errorf("clear TLS slot: %d", ret)
+			return
+		}
+		slotDestructor[*[8]uint64](unsafe.Pointer(s))
+		if destroyed != wantDestroyed {
+			t.Errorf("destructor value = %#x, want %#x", destroyed, wantDestroyed)
+		}
+		if ret := h.key.Delete(); ret != 0 {
+			t.Errorf("delete TLS key: %d", ret)
+		}
+	})
+	if base := gcBase(unsafe.Pointer(s)); base != unsafe.Pointer(s) {
+		t.Fatalf("slot base = %p, want GC-managed allocation %p", base, s)
+	}
+	// Compare with the collector's own scanned-uncollectable allocation kind,
+	// rather than depending on private numeric kind constants.
+	reference := bdwgc.MallocUncollectable(unsafe.Sizeof(*s))
+	if reference == nil {
+		t.Fatal("failed to allocate reference object")
+	}
+	defer bdwgc.Free(reference)
+	var size uintptr
+	if got, want := gcKindAndSize(unsafe.Pointer(s), &size), gcKindAndSize(reference, nil); got != want {
+		t.Fatalf("slot allocation kind = %d, want scanned-uncollectable %d", got, want)
+	}
+	if size < unsafe.Sizeof(*s) {
+		t.Fatalf("slot allocation size = %d, need %d", size, unsafe.Sizeof(*s))
+	}
+	if s.value != nil || h.Get() != nil {
+		t.Fatal("new slot value is not zero-initialized")
+	}
+	if h.ensureSlot() != s {
+		t.Fatal("ensureSlot replaced an installed slot")
+	}
+	value := new([8]uint64)
+	value[0] = 0x12345678
+	h.Set(value)
+	wantDestroyed = value[0]
+	value = nil
+	bdwgc.Gcollect()
+	if got := h.Get(); got == nil || got[0] != 0x12345678 {
+		t.Fatalf("slot value after GC = %v", got)
+	}
+	if destroyed != 0 {
+		t.Error("slot destructor ran before release")
+	}
+}

--- a/runtime/internal/clite/tls/tls_nogc.go
+++ b/runtime/internal/clite/tls/tls_nogc.go
@@ -18,11 +18,17 @@
 
 package tls
 
+import c "github.com/xgo-dev/llgo/runtime/internal/clite"
+
 type slot[T any] struct {
 	value      T
 	destructor func(*T)
 }
 
-func registerSlot[T any](s *slot[T]) {}
+func allocSlot(size uintptr) c.Pointer {
+	return c.Calloc(1, size)
+}
 
-func deregisterSlot[T any](s *slot[T]) {}
+func freeSlot(ptr c.Pointer) {
+	c.Free(ptr)
+}

--- a/test/goroot/README.md
+++ b/test/goroot/README.md
@@ -6,6 +6,8 @@ copying the upstream source files into this repository.
 The source of truth is an external `GOROOT`. Upstream files stay read-only;
 each case runs in a temporary workspace.
 
+The runner's own unit tests each have a three-minute watchdog, including their subtests and cleanup. Each case logs `goroot case START` and `goroot case END` with its name and elapsed time to stderr; external GOROOT cases also log their path and position in the suite. Helper subprocesses keep their original output contracts. A timeout fails the test process and reports the test name; it is not retried or ignored. This limit does not apply to the external `TestGoRootRunCases` suite, whose individual build/run steps use the budgets below. Child output pipes have a five-second drain limit after exit, and termination is followed by at most ten seconds of waiting before failing the runner. These guards depend on the runner's runtime timers working; they do not replace an external process/job timeout for runtime-wide hangs.
+
 Directive modes:
 
 - `legacy`: `run`

--- a/test/goroot/memory_darwin_test.go
+++ b/test/goroot/memory_darwin_test.go
@@ -92,6 +92,7 @@ func parseDarwinMemorySize(value string) (uint64, error) {
 }
 
 func TestParseDarwinSwapUsage(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name        string
 		output      string

--- a/test/goroot/memory_windows_test.go
+++ b/test/goroot/memory_windows_test.go
@@ -54,6 +54,7 @@ func windowsSystemMemoryState(status windowsMemoryStatus) (systemMemoryState, er
 }
 
 func TestWindowsSystemMemoryState(t *testing.T) {
+	guardTestTimeout(t)
 	state, err := readSystemMemoryState()
 	if err != nil {
 		t.Fatal(err)
@@ -64,6 +65,7 @@ func TestWindowsSystemMemoryState(t *testing.T) {
 }
 
 func TestWindowsSystemMemoryStateRejectsInvalidTotals(t *testing.T) {
+	guardTestTimeout(t)
 	_, err := windowsSystemMemoryState(windowsMemoryStatus{
 		totalPhysical:     1024,
 		availablePhysical: 2048,

--- a/test/goroot/proc_unix_test.go
+++ b/test/goroot/proc_unix_test.go
@@ -5,10 +5,15 @@ package goroot
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"syscall"
+	"testing"
+	"time"
 )
 
 func configureProcessGroup(cmd *exec.Cmd) {
@@ -50,4 +55,67 @@ func processGroupRSS(processGroupID int) (uint64, error) {
 		return 0, err
 	}
 	return totalKiB << 10, nil
+}
+
+func TestRunProgramWaitDelayCleansDescendant(t *testing.T) {
+	guardTestTimeout(t)
+	disableSystemMemoryLimits(t)
+
+	oldWaitDelay := runProgramWaitDelay
+	runProgramWaitDelay = 100 * time.Millisecond
+	t.Cleanup(func() { runProgramWaitDelay = oldWaitDelay })
+
+	for _, exitCode := range []int{0, 7} {
+		t.Run(fmt.Sprintf("exit-%d", exitCode), func(t *testing.T) {
+			pidFile := filepath.Join(t.TempDir(), "descendant.pid")
+			script := `sleep 60 & echo $! > "$1"; exit "$2"`
+			_, _, gotExitCode, elapsed, err := runProgram(
+				t.TempDir(),
+				"/bin/sh",
+				os.Environ(),
+				5*time.Second,
+				"-c", script, "sh", pidFile, strconv.Itoa(exitCode),
+			)
+			if exitCode == 0 {
+				if !errors.Is(err, exec.ErrWaitDelay) {
+					t.Fatalf("runProgram error = %v, want exec.ErrWaitDelay", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("runProgram error = %v, want nil ExitError wrapper", err)
+				}
+				if gotExitCode != exitCode {
+					t.Fatalf("exit code = %d, want %d", gotExitCode, exitCode)
+				}
+			}
+			if elapsed >= 5*time.Second {
+				t.Fatalf("runProgram took %s, want bounded WaitDelay return", elapsed)
+			}
+
+			pidBytes, readErr := os.ReadFile(pidFile)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			pid, parseErr := strconv.Atoi(string(bytes.TrimSpace(pidBytes)))
+			if parseErr != nil {
+				t.Fatalf("parse descendant PID %q: %v", pidBytes, parseErr)
+			}
+			t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				probeErr := syscall.Kill(pid, 0)
+				if errors.Is(probeErr, syscall.ESRCH) {
+					break
+				}
+				if probeErr != nil {
+					t.Fatalf("probe descendant %d: %v", pid, probeErr)
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("descendant %d is still running after runProgram returned", pid)
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		})
+	}
 }

--- a/test/goroot/proc_windows_test.go
+++ b/test/goroot/proc_windows_test.go
@@ -139,6 +139,7 @@ func terminateWindowsProcess(pid uint32) {
 }
 
 func TestWindowsProcessTree(t *testing.T) {
+	guardTestTimeout(t)
 	processes := map[uint32]windowsProcessInfo{
 		10: {parentPID: 1},
 		11: {parentPID: 10},

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -902,6 +902,8 @@ func restoreProcessEnv(env []string, key string) []string {
 	return out
 }
 
+var runProgramWaitDelay = 5 * time.Second
+
 func runProgram(dir, app string, env []string, timeout time.Duration, args ...string) ([]byte, []byte, int, time.Duration, error) {
 	start := time.Now()
 	if err := checkSystemMemoryPressure(); err != nil {
@@ -910,7 +912,7 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 	cmd := exec.Command(app, args...)
 	// A descendant may keep stdout/stderr open after the direct child exits.
 	// Do not let the pipe-copy goroutines make Wait unbounded in that case.
-	cmd.WaitDelay = 5 * time.Second
+	cmd.WaitDelay = runProgramWaitDelay
 	configureProcessGroup(cmd)
 	cmd.Dir = dir
 	cmd.Env = upsertEnv(append([]string{}, env...), "PWD="+dir)
@@ -962,6 +964,12 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 	for {
 		select {
 		case err = <-waitCh:
+			// ErrWaitDelay identifies a pipe-copy timeout after a successful
+			// direct child, but an ExitError masks it after a non-zero exit.
+			// Either error can therefore leave descendants alive.
+			if err != nil {
+				killProcessTree(cmd)
+			}
 			goto finished
 		case <-timeoutCh:
 			terminationErr = fmt.Errorf("timed out after %s", timeout)

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -218,6 +218,7 @@ func (p *gorootProgress) StartCase(index int, casePath string) {
 	p.caseStart = time.Now()
 	p.done = false
 	p.mu.Unlock()
+	fmt.Fprintf(os.Stderr, "goroot case START %d/%d: %s\n", index, p.total, casePath)
 }
 
 func (p *gorootProgress) FinishCase(casePath string) {
@@ -234,9 +235,7 @@ func (p *gorootProgress) FinishCase(casePath string) {
 	p.done = current >= total
 	p.mu.Unlock()
 
-	if *flagProgress > 0 && elapsed >= *flagProgress {
-		fmt.Fprintf(os.Stderr, "goroot case %d/%d done after %s: %s\n", current, total, elapsed.Round(time.Millisecond), casePath)
-	}
+	fmt.Fprintf(os.Stderr, "goroot case END %d/%d: %s (%s)\n", current, total, casePath, elapsed.Round(time.Millisecond))
 }
 
 func (p *gorootProgress) Log() {
@@ -909,6 +908,9 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 		return nil, nil, 0, time.Since(start), err
 	}
 	cmd := exec.Command(app, args...)
+	// A descendant may keep stdout/stderr open after the direct child exits.
+	// Do not let the pipe-copy goroutines make Wait unbounded in that case.
+	cmd.WaitDelay = 5 * time.Second
 	configureProcessGroup(cmd)
 	cmd.Dir = dir
 	cmd.Env = upsertEnv(append([]string{}, env...), "PWD="+dir)
@@ -964,7 +966,7 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 		case <-timeoutCh:
 			terminationErr = fmt.Errorf("timed out after %s", timeout)
 			killProcessTree(cmd)
-			err = <-waitCh
+			err = waitTerminatedProgram(cmd, waitCh, 10*time.Second)
 			goto finished
 		case <-rssCh:
 			rssBytes, rssErr := processGroupRSS(cmd.Process.Pid)
@@ -978,14 +980,14 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 			if *flagMaxRSSMiB > 0 && rssBytes > limitBytes {
 				terminationErr = &resourceLimitError{message: fmt.Sprintf("process-group RSS %s exceeded limit %s", formatBytes(rssBytes), formatBytes(limitBytes))}
 				killProcessTree(cmd)
-				err = <-waitCh
+				err = waitTerminatedProgram(cmd, waitCh, 10*time.Second)
 				goto finished
 			}
 		case <-memoryCh:
 			if memoryErr := checkSystemMemoryPressure(); memoryErr != nil {
 				terminationErr = memoryErr
 				killProcessTree(cmd)
-				err = <-waitCh
+				err = waitTerminatedProgram(cmd, waitCh, 10*time.Second)
 				goto finished
 			}
 		}
@@ -1013,6 +1015,19 @@ finished:
 		return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, terminationErr
 	}
 	return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, nil
+}
+
+func waitTerminatedProgram(cmd *exec.Cmd, waitCh <-chan error, grace time.Duration) error {
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case err := <-waitCh:
+		return err
+	case <-timer.C:
+		// Returning captured buffers here would race with a still-running pipe
+		// copier. Fail the runner instead of abandoning a live Wait goroutine.
+		panic(fmt.Sprintf("goroot command %q (pid %d) did not finish within %s after termination", cmd.Args, cmd.Process.Pid, grace))
+	}
 }
 
 func formatBytes(bytes uint64) string {

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestPrepareCaseWorkspaceUsesRepositoryModulePath(t *testing.T) {
+	guardTestTimeout(t)
 	repo := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/owner/project\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -39,6 +40,7 @@ func TestPrepareCaseWorkspaceUsesRepositoryModulePath(t *testing.T) {
 }
 
 func TestParseDirective(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	file := filepath.Join(dir, "case.go")
 	if err := os.WriteFile(file, []byte("// run\n\npackage main\n"), 0644); err != nil {
@@ -57,6 +59,7 @@ func TestParseDirective(t *testing.T) {
 }
 
 func TestParseDirectiveWithArgs(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	file := filepath.Join(dir, "case.go")
 	if err := os.WriteFile(file, []byte("// errorcheckandrundir -1\n\npackage ignored\n"), 0644); err != nil {
@@ -75,6 +78,7 @@ func TestParseDirectiveWithArgs(t *testing.T) {
 }
 
 func TestParseDirectiveQuotedArgs(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	file := filepath.Join(dir, "case.go")
 	src := `// runindir -gomodversion "1.23" -gcflags='all=-N -l'
@@ -98,6 +102,7 @@ package ignored
 }
 
 func TestReleaseTagsFor(t *testing.T) {
+	guardTestTimeout(t)
 	got := releaseTagsFor("go1.24.11")
 	want := []string{
 		"go1.1", "go1.2", "go1.3", "go1.4", "go1.5", "go1.6", "go1.7", "go1.8",
@@ -110,6 +115,7 @@ func TestReleaseTagsFor(t *testing.T) {
 }
 
 func TestXFailMatch(t *testing.T) {
+	guardTestTimeout(t)
 	cfg := xfailConfig{
 		Entries: []xfailEntry{{
 			Version:   "go1.24",
@@ -130,6 +136,7 @@ func TestXFailMatch(t *testing.T) {
 }
 
 func TestNotApplicableMatch(t *testing.T) {
+	guardTestTimeout(t)
 	cfg := notApplicableConfig{
 		Entries: []xfailEntry{{
 			Version:   "go1.26",
@@ -149,6 +156,7 @@ func TestNotApplicableMatch(t *testing.T) {
 }
 
 func TestRepositoryExpectationsAreSeparated(t *testing.T) {
+	guardTestTimeout(t)
 	repo := repoRoot(t)
 	xfails := loadXFailConfig(t, repo, filepath.Join("test", "goroot", "xfail.yaml"))
 	notApplicable := loadNotApplicableConfig(t, repo, filepath.Join("test", "goroot", "notapplicable.yaml"))
@@ -187,6 +195,7 @@ func TestRepositoryExpectationsAreSeparated(t *testing.T) {
 }
 
 func TestFlakyMatch(t *testing.T) {
+	guardTestTimeout(t)
 	cfg := xfailConfig{
 		Flakes: []xfailEntry{{
 			Version:   "go1.25",
@@ -207,6 +216,7 @@ func TestFlakyMatch(t *testing.T) {
 }
 
 func TestMatchGoVersion(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		version   string
 		goVersion string
@@ -227,6 +237,7 @@ func TestMatchGoVersion(t *testing.T) {
 }
 
 func TestHostSkipMatch(t *testing.T) {
+	guardTestTimeout(t)
 	cfg := xfailConfig{
 		HostSkips: []xfailEntry{{
 			Version:   "go1.24",
@@ -247,6 +258,7 @@ func TestHostSkipMatch(t *testing.T) {
 }
 
 func TestTimeoutMatch(t *testing.T) {
+	guardTestTimeout(t)
 	cfg := xfailConfig{
 		Timeouts: []timeoutEntry{{
 			Version:   "go1.24",
@@ -271,6 +283,7 @@ func TestTimeoutMatch(t *testing.T) {
 }
 
 func TestEffectiveBuildTimeout(t *testing.T) {
+	guardTestTimeout(t)
 	if got := effectiveBuildTimeout(3*time.Minute, 20*time.Second); got != 3*time.Minute {
 		t.Fatalf("effectiveBuildTimeout()=%s, want 3m", got)
 	}
@@ -280,6 +293,7 @@ func TestEffectiveBuildTimeout(t *testing.T) {
 }
 
 func TestRunProgramTimeout(t *testing.T) {
+	guardTestTimeout(t)
 	if os.Getenv("LLGO_GOROOT_HELPER") == "sleep" {
 		// Leave ample margin for a loaded CI worker to service the 50ms timer.
 		time.Sleep(5 * time.Second)
@@ -315,6 +329,7 @@ func TestRunProgramTimeout(t *testing.T) {
 }
 
 func TestRunProgramRSSLimit(t *testing.T) {
+	guardTestTimeout(t)
 	if !resourceMonitoringSupported() {
 		t.Skip("process-group RSS monitoring is unavailable")
 	}
@@ -354,6 +369,7 @@ func TestRunProgramRSSLimit(t *testing.T) {
 }
 
 func TestValidateSystemMemoryState(t *testing.T) {
+	guardTestTimeout(t)
 	oldMemory := *flagMinMemPct
 	oldSwap := *flagMinSwapMiB
 	*flagMinMemPct = 15
@@ -378,6 +394,7 @@ func TestValidateSystemMemoryState(t *testing.T) {
 }
 
 func TestRunGeneratedProgramUsesProvidedTimeout(t *testing.T) {
+	guardTestTimeout(t)
 	disableSystemMemoryLimits(t)
 	dir := t.TempDir()
 	tool := fakeToolPath(dir, "fake-timeout-tool")
@@ -402,6 +419,7 @@ func TestRunGeneratedProgramUsesProvidedTimeout(t *testing.T) {
 }
 
 func TestNormalizeOutputStripsLogTimestamp(t *testing.T) {
+	guardTestTimeout(t)
 	in := []byte("2026/03/13 00:56:11 listing stdlib export files: open : no such file or directory\n")
 	got := string(normalizeOutput(in))
 	want := "listing stdlib export files: open : no such file or directory\n"
@@ -411,6 +429,7 @@ func TestNormalizeOutputStripsLogTimestamp(t *testing.T) {
 }
 
 func TestShardCases(t *testing.T) {
+	guardTestTimeout(t)
 	cases := []testCase{
 		{RelPath: "a.go"},
 		{RelPath: "b.go"},
@@ -429,6 +448,7 @@ func TestShardCases(t *testing.T) {
 }
 
 func TestDiscoverCasesSkipsMissingDir(t *testing.T) {
+	guardTestTimeout(t)
 	testRoot := t.TempDir()
 	existingDir := filepath.Join(testRoot, "fixedbugs")
 	if err := os.MkdirAll(existingDir, 0o755); err != nil {
@@ -457,6 +477,7 @@ func TestDiscoverCasesSkipsMissingDir(t *testing.T) {
 }
 
 func TestDiscoverCasesRunLikeModeIncludesDirectiveArgs(t *testing.T) {
+	guardTestTimeout(t)
 	testRoot := t.TempDir()
 	dir := filepath.Join(testRoot, "fixedbugs")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -487,6 +508,7 @@ func TestDiscoverCasesRunLikeModeIncludesDirectiveArgs(t *testing.T) {
 }
 
 func TestDiscoverCasesCIModeExcludesBuildrundir(t *testing.T) {
+	guardTestTimeout(t)
 	testRoot := t.TempDir()
 	dir := filepath.Join(testRoot, "fixedbugs")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -530,6 +552,7 @@ func TestDiscoverCasesCIModeExcludesBuildrundir(t *testing.T) {
 }
 
 func TestParseDirectiveOptions(t *testing.T) {
+	guardTestTimeout(t)
 	opts, err := parseDirectiveOptions("runindir", []string{"-gomodversion", "1.23", "-goexperiment", "fieldtrack", "-ldflags", "-strictdups=2", "-w=0", "arg1"}, 20*time.Second)
 	if err != nil {
 		t.Fatal(err)
@@ -549,6 +572,7 @@ func TestParseDirectiveOptions(t *testing.T) {
 }
 
 func TestParseCompilerDirectiveOptions(t *testing.T) {
+	guardTestTimeout(t)
 	opts, err := parseDirectiveOptions("errorcheck", []string{
 		"-0", "-lang=go1.17", "-N", "-goexperiment", "fieldtrack",
 	}, 20*time.Second)
@@ -570,6 +594,7 @@ func TestParseCompilerDirectiveOptions(t *testing.T) {
 }
 
 func TestParseRundirCompilerAndLinkerFlags(t *testing.T) {
+	guardTestTimeout(t)
 	opts, err := parseDirectiveOptions("rundir", []string{"-N", "-ldflags", "-w", "-strictdups=2"}, 20*time.Second)
 	if err != nil {
 		t.Fatal(err)
@@ -583,6 +608,7 @@ func TestParseRundirCompilerAndLinkerFlags(t *testing.T) {
 }
 
 func TestDirectoryBuildFlagsMatchGoFlagShape(t *testing.T) {
+	guardTestTimeout(t)
 	goFlags, llgoFlags := directoryBuildFlags(directiveOptions{
 		CompilerFlags: []string{"-N", "-l=4"},
 		LinkerFlags:   []string{"-strictdups=2", "-w=0"},
@@ -597,6 +623,7 @@ func TestDirectoryBuildFlagsMatchGoFlagShape(t *testing.T) {
 }
 
 func TestCheckExpectedErrors(t *testing.T) {
+	guardTestTimeout(t)
 	file := filepath.Join(t.TempDir(), "case.go")
 	src := `package p
 var _ = missing // ERROR "undefined: missing"
@@ -611,6 +638,7 @@ var _ = missing // ERROR "undefined: missing"
 }
 
 func TestCheckExpectedErrorsReportsMissingDiagnostic(t *testing.T) {
+	guardTestTimeout(t)
 	file := filepath.Join(t.TempDir(), "case.go")
 	src := `package p
 var _ = missing // ERROR "undefined: missing"
@@ -625,6 +653,7 @@ var _ = missing // ERROR "undefined: missing"
 }
 
 func TestCheckExpectedErrorsNormalizesLexicalDiagnostics(t *testing.T) {
+	guardTestTimeout(t)
 	file := filepath.Join(t.TempDir(), "case.go")
 	src := `package p
 var _ = 0 // ERROR "newline in string"
@@ -671,6 +700,7 @@ var _ = 0 // ERROR "mantissa requires a 'p' exponent"
 }
 
 func TestCheckExpectedErrorsDiscardsPairedMissingCommaDiagnostics(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name      string
 		source    string
@@ -726,6 +756,7 @@ func f(x int /* // GC_ERROR "unexpected newline"
 }
 
 func TestCheckExpectedErrorsKeepsUnrelatedDiagnostics(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name   string
 		src    string
@@ -770,6 +801,7 @@ func TestCheckExpectedErrorsKeepsUnrelatedDiagnostics(t *testing.T) {
 }
 
 func TestCheckExpectedErrorsDiscardsExactParserPair(t *testing.T) {
+	guardTestTimeout(t)
 	file := filepath.Join(t.TempDir(), "case.go")
 	src := "package p\nfunc f() {\n\tif a := 10 { // ERROR \"cannot use a := 10 as value\"\n\t}\n}\n"
 	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
@@ -794,6 +826,7 @@ func TestCheckExpectedErrorsDiscardsExactParserPair(t *testing.T) {
 }
 
 func TestCheckExpectedErrorsScopesImportAlias(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name, src string
 		wantOK    bool
@@ -816,6 +849,7 @@ func TestCheckExpectedErrorsScopesImportAlias(t *testing.T) {
 }
 
 func TestDiscardPairedParserDiagnosticsIsExactMultiset(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	fileA := filepath.Join(dir, "a", "case.go")
 	fileB := filepath.Join(dir, "b", "case.go")
@@ -838,6 +872,7 @@ func TestDiscardPairedParserDiagnosticsIsExactMultiset(t *testing.T) {
 }
 
 func TestPreferSpecificDiagnostics(t *testing.T) {
+	guardTestTimeout(t)
 	got := preferSpecificDiagnostics([]string{
 		"case.go:18:16: requires go1.22 or later (file declares go1.21)",
 		"/tmp/case.go:18: requires go1.22 or later",
@@ -857,6 +892,7 @@ func TestPreferSpecificDiagnostics(t *testing.T) {
 }
 
 func TestNormalizeCompilerDiagnosticMessage(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name string
 		in   string
@@ -917,6 +953,7 @@ func TestNormalizeCompilerDiagnosticMessage(t *testing.T) {
 }
 
 func TestMatchesExpectedDiagnosticGoTypesAliases(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name     string
 		expected string
@@ -943,6 +980,7 @@ func TestMatchesExpectedDiagnosticGoTypesAliases(t *testing.T) {
 }
 
 func TestCheckExpectedErrorsFiltersDeterministicSecondaryDiagnostics(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name   string
 		source string
@@ -1048,6 +1086,7 @@ func f(s uint) {
 }
 
 func TestCheckExpectedErrorsKeepsUnrelatedTypeDiagnostics(t *testing.T) {
+	guardTestTimeout(t)
 	tests := []struct {
 		name   string
 		source string
@@ -1152,6 +1191,7 @@ func f(s uint) {
 }
 
 func TestCheckExpectedErrorsSeparatesSameBasenameSources(t *testing.T) {
+	guardTestTimeout(t)
 	root := t.TempDir()
 	leftDir := filepath.Join(root, "left")
 	rightDir := filepath.Join(root, "right")
@@ -1180,6 +1220,7 @@ func TestCheckExpectedErrorsSeparatesSameBasenameSources(t *testing.T) {
 }
 
 func TestSecondaryDiagnosticsDoNotCrossSameBasenameSources(t *testing.T) {
+	guardTestTimeout(t)
 	root := t.TempDir()
 	left := filepath.Join(root, "left", "case.go")
 	right := filepath.Join(root, "right", "case.go")
@@ -1220,6 +1261,7 @@ var _ = missing // ERROR "undefined: missing"
 }
 
 func TestSplitSourceFiles(t *testing.T) {
+	guardTestTimeout(t)
 	files, args := splitSourceFiles("index0.go", []string{"./index.go", "arg1", "arg2"})
 	if !reflect.DeepEqual(files, []string{"index0.go", "index.go"}) {
 		t.Fatalf("files=%v, want [index0.go index.go]", files)
@@ -1230,6 +1272,7 @@ func TestSplitSourceFiles(t *testing.T) {
 }
 
 func TestToolchainGoCommand(t *testing.T) {
+	guardTestTimeout(t)
 	goroot := filepath.Join("toolchains", "go1.26.5")
 	for _, tc := range []struct {
 		goos string
@@ -1248,6 +1291,7 @@ func TestToolchainGoCommand(t *testing.T) {
 }
 
 func TestNeedsExternalCgoBaseline(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	cgoFile := filepath.Join(dir, "cgo.go")
 	if err := os.WriteFile(cgoFile, []byte("package main\nimport _ \"runtime/cgo\"\n"), 0o644); err != nil {
@@ -1292,6 +1336,7 @@ func TestNeedsExternalCgoBaseline(t *testing.T) {
 }
 
 func TestRunSingleFileCaseExcludesUnlistedSiblings(t *testing.T) {
+	guardTestTimeout(t)
 	disableSystemMemoryLimits(t)
 	repoRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/llgo\n"), 0o644); err != nil {
@@ -1366,6 +1411,7 @@ func main() {
 }
 
 func TestEnsureModuleWorkspace(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	if err := ensureModuleWorkspace(dir, "llgo-goroot-runoutput", "1.14"); err != nil {
 		t.Fatal(err)
@@ -1381,6 +1427,7 @@ func TestEnsureModuleWorkspace(t *testing.T) {
 }
 
 func TestRunOutputCaseGeneratesWithBaselineGoOnly(t *testing.T) {
+	guardTestTimeout(t)
 	disableSystemMemoryLimits(t)
 	dir := t.TempDir()
 	repoRoot := filepath.Join(dir, "repo")
@@ -1458,6 +1505,7 @@ func disableSystemMemoryLimits(t *testing.T) {
 }
 
 func TestToolchainGoModVersion(t *testing.T) {
+	guardTestTimeout(t)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("go1.24.11\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -1472,6 +1520,7 @@ func TestToolchainGoModVersion(t *testing.T) {
 }
 
 func TestStageRundirLayoutRewritesRelativeImports(t *testing.T) {
+	guardTestTimeout(t)
 	srcDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcDir, "a.go"), []byte("package a\nconst X = 1\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/test/goroot/timeout_test.go
+++ b/test/goroot/timeout_test.go
@@ -1,0 +1,93 @@
+package goroot
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// guardTestTimeout bounds one runner unit test, including its subtests and
+// cleanup. The external GOROOT/test suite has separate build/run budgets and
+// must not use this unit-test limit. A runtime-wide timer failure still needs
+// an external process watchdog; this is not a substitute for that watchdog.
+func guardTestTimeout(t *testing.T) {
+	t.Helper()
+	armTestTimeout(t, 3*time.Minute)
+	// Helper subprocesses have their own output contracts (including empty
+	// output in the termination tests). Log their parent case, not the helper.
+	if os.Getenv("LLGO_GOROOT_HELPER") != "" || os.Getenv("LLGO_GOROOT_TIMEOUT_HELPER") != "" {
+		return
+	}
+	name, start := t.Name(), time.Now()
+	fmt.Fprintf(os.Stderr, "goroot case START %s (timeout 3m)\n", name)
+	t.Cleanup(func() {
+		fmt.Fprintf(os.Stderr, "goroot case END %s (%s)\n", name, time.Since(start).Round(time.Millisecond))
+	})
+}
+
+func armTestTimeout(t *testing.T, timeout time.Duration) *time.Timer {
+	t.Helper()
+	name := t.Name()
+	timer := time.AfterFunc(timeout, func() {
+		// Fatal cannot stop the test from another goroutine. Panic deliberately
+		// fails the process, retaining the case name even without verbose output.
+		panic(fmt.Sprintf("goroot unit test %s timed out after %s", name, timeout))
+	})
+	// Register first so later test cleanups also run within the timeout.
+	t.Cleanup(func() { timer.Stop() })
+	return timer
+}
+
+func TestCaseTimeout(t *testing.T) {
+	guardTestTimeout(t)
+	switch os.Getenv("LLGO_GOROOT_TIMEOUT_HELPER") {
+	case "expire":
+		armTestTimeout(t, 50*time.Millisecond)
+		select {}
+	case "cleanup":
+		armTestTimeout(t, 50*time.Millisecond)
+		t.Cleanup(func() { select {} })
+		return
+	case "cancel":
+		var timer *time.Timer
+		t.Run("finished", func(t *testing.T) {
+			timer = armTestTimeout(t, 3*time.Minute)
+		})
+		if timer.Stop() {
+			t.Fatal("test cleanup did not stop its timer")
+		}
+		return
+	case "wait":
+		cmd := exec.Command("blocked-helper")
+		cmd.Process = &os.Process{Pid: 123}
+		waitTerminatedProgram(cmd, make(chan error), 50*time.Millisecond)
+		return
+	}
+	disableSystemMemoryLimits(t)
+	for _, mode := range []string{"expire", "cleanup", "cancel", "wait"} {
+		t.Run(mode, func(t *testing.T) {
+			env := upsertEnv(os.Environ(), "LLGO_GOROOT_TIMEOUT_HELPER="+mode)
+			stdout, stderr, code, _, err := runProgram(t.TempDir(), os.Args[0], env, 10*time.Second,
+				"-test.run=^TestCaseTimeout$", "-test.count=1", "-test.timeout=5s")
+			if err != nil {
+				t.Fatalf("timeout helper: %v\n%s\n%s", err, stdout, stderr)
+			}
+			if mode == "cancel" {
+				if code != 0 {
+					t.Fatalf("completed test retained its timer: exit %d\n%s\n%s", code, stdout, stderr)
+				}
+				return
+			}
+			want := "goroot unit test TestCaseTimeout timed out after 50ms"
+			if mode == "wait" {
+				want = `goroot command ["blocked-helper"] (pid 123) did not finish within 50ms after termination`
+			}
+			if code == 0 || !strings.Contains(string(stderr), want) {
+				t.Fatalf("missing case timeout failure: exit %d\n%s\n%s", code, stdout, stderr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Rebased onto main after #2534 was merged (`1e41ad3ff`). The inherited Linux publication changes are no longer part of this PR's diff; this contribution contains the TLS fix, goroot diagnostics, regression tests, and related documentation only.

Fix a Windows TLS root-lifetime bug that can leave BDWGC retrying an invalid root scan indefinitely with the world stopped. Record each goroot case and bound individual cases and post-termination waits, without retrying or ignoring test failures.

## Root cause

The previous GC-enabled TLS implementation allocated each slot with `calloc`, registered it with `GC_add_roots`, and removed the same interval before freeing it. On Windows, BDWGC merges adjacent root intervals, but `GC_remove_roots` only removes whole root records contained in the requested interval; it does not split a merged record. Removing each original allocation can therefore leave a permanent root pointing into freed memory. See [BDWGC 8.2.12 root registration/removal](https://github.com/ivmai/bdwgc/blob/v8.2.12/mark_rts.c).

A local Windows ARM64 stress run stalled in `TestRWMutexHighContention`. Live debugger snapshots and a retained full dump showed an unchanged GC cycle, suspended timer/worker threads, and repeated access violations while scanning the same permanent 64-byte root in a decommitted Windows heap page. BDWGC invalidated the mark state and retried the root scan, so neither the test's own timer nor `-test.timeout` could run. This establishes the immediate cause of that reproduced hang; without a dump of the original goroot CI timeout, it does not establish that every earlier CI timeout had the same cause.

A separate, bounded C probe confirmed the lifetime mismatch on the same collector DLL: registering two adjacent 32-byte ranges produced one 64-byte root; removing both original ranges left it registered; removing the whole 64-byte range removed it. The probe released memory only after removing the complete root and exited normally.

## Windows TLS allocation model

`Alloc` creates one FLS key per `Handle`, but does not allocate a value slot immediately. On the first `Set` in a Windows FLS context, `ensureSlot` observes that context’s empty key value, allocates one scanned-uncollectable BDWGC slot, and installs it through `FlsSetValue`; subsequent access in the same context reuses that slot, while another thread receives a separate slot. Windows also allocates one small FLS sidecar per populated context to retain the destructor and slot pointer; the FLS callback releases the GC-managed slot through `GC_free` and then frees the sidecar. Because llgo does not create or switch Windows fibers, this currently means one slot per `Handle` per host thread; the API’s precise Windows isolation unit remains the FLS context. The post-allocation `Get` is intentional: collector allocation may run finalizers that re-enter the same handle, so a redundantly allocated slot is freed if reentry has already installed one, preserving at most one installed slot per key and context.

## Changes

- Allocate GC-enabled TLS slots with scanned `GC_malloc_uncollectable` storage and release them through `GC_free`. Both the stored value and destructor closure remain visible to the collector until native TLS destruction. Preserve the post-allocation reentry check and all failure-path cleanup; `nogc` keeps `calloc/free`.
- Add a deterministic regression that checks collector ownership, scanned-uncollectable allocation kind, zero initialization, slot reuse, value preservation across collection, and destructor behavior. The old allocation fails the ownership check immediately. Run it for 20 rounds in each existing Windows compiler job; no new CI job is added.
- Give individual goroot runner tests a three-minute watchdog covering subtests and cleanup, and print START/END with the case name and elapsed time. External GOROOT source cases also print progress while keeping their existing build/run budgets. Helper subprocess output contracts remain unchanged.
- Bound child pipe draining and post-termination waits. When a delayed Wait returns an error, clean the process tree before interpreting either ErrWaitDelay or a masking ExitError, so descendants cannot survive a successful or non-zero direct-child exit. Test output retains the existing buffered behavior on every platform; this PR does not add a Windows-specific streaming path.

No test retries, skipped failures, GC disabling, DAG changes, or `sync.Cond` changes. Timer guards remain diagnostic protection, not a cure for a runtime-wide stop-the-world stall.

## Validation

- Windows ARM64/MSVC, x64 LLGo/LLVM host, Go 1.27, build cache disabled: the fixed TLS regression passed 30 rounds; complete goroot passed 10 rounds with all 530 START/END pairs matched; `TestRWMutexHighContention` passed 100 rounds. All three native processes exited with status 0 under an independent external watchdog. An additional earlier 100-round RWMutex stress run also passed while goroot compilation was active.
- Windows amd64/MSVC target: the TLS regression passed 20 rounds with exit status 0. The executable was verified as COFF-x86-64 and ran through Windows ARM64's x64 compatibility layer on the local VM; this is distinct from the ARM64 target tested above. An additional 100-round RWMutex experiment completed 35 rounds with continuous progress before its two-minute test alarm fired normally during round 36; it is not counted as a passed stress run, and was not rerun. Hardware-native amd64 verification remains part of CI.
- macOS LLGo: the old TLS allocation fails the new regression; the fix passes 20 rounds, the complete TLS package passes, and `nogc` read/write and thread-isolation tests pass.
- macOS Go 1.27: race-enabled goroot tests pass. Watchdog regressions cover a blocked body, blocked cleanup, timer cancellation and a stalled post-termination wait.
- After rebasing onto main, removing the diagnostic streaming group and addressing review comments: the complete race-enabled goroot package passes, the macOS LLGo TLS allocation regression passes another 20 rounds, and `actionlint` plus `git diff --check` pass. The package documentation clarifies the exact GC/nogc/wasm/baremetal build modes.
- Before pushing the rebase and comment-only review follow-ups, the preceding head `c15c16313` completed its Linux and Windows MinGW main Go jobs and coverage uploads. Codecov patch coverage reached 100% (50 covered lines, no missing or partial lines; target 94.26%). This is evidence for that tested head, not a claim that the newly pushed revision has already finished CI.
- The WaitDelay descendant-cleanup regression passes for both direct-child exit 0 and exit 7; the complete goroot package and the race-enabled timeout/RSS/WaitDelay focus pass, and the new regression passes 10 consecutive rounds.
- `actionlint` and `git diff --check` pass. Full CI for the TLS-fix revision is still required.