### PR TITLE
fix(cl): preserve nil checks for pointer method receivers

### DIFF
--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -527,13 +527,19 @@ type I2 interface {
 
 // CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.Demo2"(ptr %0){{.*}} {
 // CHECK: [[SPP2_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK: [[SPP2_T:%[0-9]+]] = load ptr, ptr [[SPP2_FIELD]]
+// CHECK: [[SPP2_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[SPP2_NIL]])
+// CHECK: [[SPP2_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SPP2_FIELD]])
+// CHECK: [[SPP2_T:%[0-9]+]] = load ptr, ptr [[SPP2_SAFE]]
 // CHECK: [[SPP2_RES:%[0-9]+]] = call i64 @"main.(*T).Demo2"(ptr [[SPP2_T]])
 // CHECK: ret i64 [[SPP2_RES]]
 
 // CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.demo3"(ptr %0){{.*}} {
 // CHECK: [[SPP3_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK: [[SPP3_T:%[0-9]+]] = load ptr, ptr [[SPP3_FIELD]]
+// CHECK: [[SPP3_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[SPP3_NIL]])
+// CHECK: [[SPP3_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SPP3_FIELD]])
+// CHECK: [[SPP3_T:%[0-9]+]] = load ptr, ptr [[SPP3_SAFE]]
 // CHECK: [[SPP3_RES:%[0-9]+]] = call i64 @"main.(*T).demo3"(ptr [[SPP3_T]])
 // CHECK: ret i64 [[SPP3_RES]]
 
@@ -590,7 +596,10 @@ type I2 interface {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.*struct{m int; *bytes.Buffer}.String"(ptr %0){{.*}} {
 // CHECK: [[BSP_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK: [[BSP_BUFFER:%[0-9]+]] = load ptr, ptr [[BSP_FIELD]]
+// CHECK: [[BSP_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[BSP_NIL]])
+// CHECK: [[BSP_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[BSP_FIELD]])
+// CHECK: [[BSP_BUFFER:%[0-9]+]] = load ptr, ptr [[BSP_SAFE]]
 // CHECK: [[BSP_STRING:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr [[BSP_BUFFER]])
 // CHECK: ret %"{{.*}}/runtime/internal/runtime.String" [[BSP_STRING]]
 

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -520,26 +520,28 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.Demo1"(ptr %0){{.*}} {
 // CHECK: [[SPP1_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK: [[SPP1_T:%[0-9]+]] = load ptr, ptr [[SPP1_FIELD]]
-// CHECK: [[SPP1_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SPP1_T]])
-// CHECK: [[SPP1_VALUE:%[0-9]+]] = load %main.T, ptr [[SPP1_SAFE]]
+// CHECK: [[SPP1_NIL:%[0-9]+]] = icmp eq ptr [[SPP1_T]], null
+// CHECK: br i1 [[SPP1_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[SPP1_VALUE:%[0-9]+]] = load %main.T, ptr [[SPP1_T]]
 // CHECK: [[SPP1_RES:%[0-9]+]] = call i64 @main.T.Demo1(%main.T [[SPP1_VALUE]])
 // CHECK: ret i64 [[SPP1_RES]]
 
 // CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.Demo2"(ptr %0){{.*}} {
 // CHECK: [[SPP2_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK: [[SPP2_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[SPP2_NIL]])
-// CHECK: [[SPP2_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SPP2_FIELD]])
-// CHECK: [[SPP2_T:%[0-9]+]] = load ptr, ptr [[SPP2_SAFE]]
+// CHECK: br i1 [[SPP2_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[SPP2_T:%[0-9]+]] = load ptr, ptr [[SPP2_FIELD]]
 // CHECK: [[SPP2_RES:%[0-9]+]] = call i64 @"main.(*T).Demo2"(ptr [[SPP2_T]])
 // CHECK: ret i64 [[SPP2_RES]]
 
 // CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.demo3"(ptr %0){{.*}} {
 // CHECK: [[SPP3_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK: [[SPP3_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[SPP3_NIL]])
-// CHECK: [[SPP3_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SPP3_FIELD]])
-// CHECK: [[SPP3_T:%[0-9]+]] = load ptr, ptr [[SPP3_SAFE]]
+// CHECK: br i1 [[SPP3_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[SPP3_T:%[0-9]+]] = load ptr, ptr [[SPP3_FIELD]]
 // CHECK: [[SPP3_RES:%[0-9]+]] = call i64 @"main.(*T).demo3"(ptr [[SPP3_T]])
 // CHECK: ret i64 [[SPP3_RES]]
 
@@ -548,8 +550,10 @@ type I2 interface {
 // CHECK: store { i64, ptr } %0, ptr [[SVP1_ADDR]]
 // CHECK-NEXT: [[SVP1_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr [[SVP1_ADDR]], i32 0, i32 1
 // CHECK: [[SVP1_T:%[0-9]+]] = load ptr, ptr [[SVP1_FIELD]]
-// CHECK: [[SVP1_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SVP1_T]])
-// CHECK: [[SVP1_VALUE:%[0-9]+]] = load %main.T, ptr [[SVP1_SAFE]]
+// CHECK: [[SVP1_NIL:%[0-9]+]] = icmp eq ptr [[SVP1_T]], null
+// CHECK: br i1 [[SVP1_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[SVP1_VALUE:%[0-9]+]] = load %main.T, ptr [[SVP1_T]]
 // CHECK: [[SVP1_RES:%[0-9]+]] = call i64 @main.T.Demo1(%main.T [[SVP1_VALUE]])
 // CHECK: ret i64 [[SVP1_RES]]
 
@@ -579,8 +583,10 @@ type I2 interface {
 
 // CHECK-LABEL: define i64 @"main.*struct{m int; main.T}.Demo1"(ptr %0){{.*}} {
 // CHECK: [[SPV1_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, %main.T }, ptr %0, i32 0, i32 1
-// CHECK: [[SPV1_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[SPV1_FIELD]])
-// CHECK: [[SPV1_T:%[0-9]+]] = load %main.T, ptr [[SPV1_SAFE]]
+// CHECK: [[SPV1_NIL:%[0-9]+]] = icmp eq ptr %0, null
+// CHECK: br i1 [[SPV1_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[SPV1_T:%[0-9]+]] = load %main.T, ptr [[SPV1_FIELD]]
 // CHECK: [[SPV1_RES:%[0-9]+]] = call i64 @main.T.Demo1(%main.T [[SPV1_T]])
 // CHECK: ret i64 [[SPV1_RES]]
 
@@ -597,22 +603,24 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.*struct{m int; *bytes.Buffer}.String"(ptr %0){{.*}} {
 // CHECK: [[BSP_FIELD:%[0-9]+]] = getelementptr inbounds nuw { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK: [[BSP_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[BSP_NIL]])
-// CHECK: [[BSP_SAFE:%[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[BSP_FIELD]])
-// CHECK: [[BSP_BUFFER:%[0-9]+]] = load ptr, ptr [[BSP_SAFE]]
+// CHECK: br i1 [[BSP_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[BSP_BUFFER:%[0-9]+]] = load ptr, ptr [[BSP_FIELD]]
 // CHECK: [[BSP_STRING:%[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr [[BSP_BUFFER]])
 // CHECK: ret %"{{.*}}/runtime/internal/runtime.String" [[BSP_STRING]]
 
 // Atomic Load and Store must address Pointer[any].v and preserve seq_cst ordering.
 // CHECK-LABEL: define linkonce ptr @"main.(*Pointer{{\[.*\]}}).Load"(ptr %0){{.*}} {
 // CHECK: [[LOAD_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[LOAD_NIL]])
+// CHECK: br i1 [[LOAD_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: [[LOAD_V:%[0-9]+]] = getelementptr inbounds nuw %"main.Pointer{{\[.*\]}}", ptr %0, i32 0, i32 1
 // CHECK: [[LOAD_VALUE:%[0-9]+]] = load atomic ptr, ptr [[LOAD_V]] seq_cst
 // CHECK: ret ptr [[LOAD_VALUE]]
 
 // CHECK-LABEL: define linkonce void @"main.(*Pointer{{\[.*\]}}).Store"(ptr %0, ptr %1){{.*}} {
 // CHECK: [[STORE_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[STORE_NIL]])
+// CHECK: br i1 [[STORE_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: [[STORE_V:%[0-9]+]] = getelementptr inbounds nuw %"main.Pointer{{\[.*\]}}", ptr %0, i32 0, i32 1
 // CHECK: store atomic ptr %1, ptr [[STORE_V]] seq_cst

--- a/cl/_testgo/chan/in.go
+++ b/cl/_testgo/chan/in.go
@@ -25,7 +25,8 @@ package main
 // CHECK: [[CH1_RECV:%.*]] = load ptr, ptr [[CH1_SLOT]]
 // CHECK: [[CH1_RECV_BUF:%.*]] = alloca i64
 // CHECK: call i1 @"{{.*}}ChanRecv"(ptr [[CH1_RECV]], ptr [[CH1_RECV_BUF]], i64 8)
-// CHECK-NEXT: [[CH1_VALUE:%.*]] = load i64, ptr [[CH1_RECV_BUF]]
+// CHECK-NEXT: [[CH1_VALUE:%.*]] = load volatile i64, ptr [[CH1_RECV_BUF]]
+// CHECK-NEXT: call void @llvm.stackrestore
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[CH1_VALUE]])
 // Second channel: capture it in a closer goroutine and preserve the receive ok
 // bit alongside the zero value returned after close.
@@ -40,7 +41,8 @@ package main
 // CHECK: [[CH2_RECV:%.*]] = load ptr, ptr [[CH2_SLOT]]
 // CHECK: [[CH2_RECV_BUF:%.*]] = alloca i64
 // CHECK: [[CH2_OK:%.*]] = call i1 @"{{.*}}ChanRecv"(ptr [[CH2_RECV]], ptr [[CH2_RECV_BUF]], i64 8)
-// CHECK-NEXT: [[CH2_VALUE:%.*]] = load i64, ptr [[CH2_RECV_BUF]]
+// CHECK-NEXT: [[CH2_VALUE:%.*]] = load volatile i64, ptr [[CH2_RECV_BUF]]
+// CHECK-NEXT: call void @llvm.stackrestore
 // CHECK: [[CH2_PAIR0:%.*]] = insertvalue { i64, i1 } undef, i64 [[CH2_VALUE]], 0
 // CHECK-NEXT: [[CH2_PAIR:%.*]] = insertvalue { i64, i1 } [[CH2_PAIR0]], i1 [[CH2_OK]], 1
 // CHECK-NEXT: [[CH2_PRINT_VALUE:%.*]] = extractvalue { i64, i1 } [[CH2_PAIR]], 0

--- a/cl/_testgo/embedunexport-1598/in.go
+++ b/cl/_testgo/embedunexport-1598/in.go
@@ -48,7 +48,10 @@ func main() {
 // CHECK-SAME: ptr %[[TMP0:[0-9]+]]){{.*}} {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP1:[0-9]+]] = getelementptr inbounds nuw %main.Wrapped, ptr %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = load ptr, ptr %[[TMP1]], align 8
+// CHECK-NEXT:   %[[NIL:[0-9]+]] = icmp eq ptr %[[TMP0]], null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[NIL]])
+// CHECK-NEXT:   %[[SAFE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %[[TMP1]])
+// CHECK-NEXT:   %[[TMP2:[0-9]+]] = load ptr, ptr %[[SAFE]], align 8
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testdata/embedunexport.(*Base).Name"(ptr %[[TMP2]])
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %[[TMP3]]
 // CHECK-NEXT: }
@@ -57,7 +60,10 @@ func main() {
 // CHECK-SAME: ptr %[[TMP0:[0-9]+]], %"{{.*}}/runtime/internal/runtime.String" %[[TMP1:[0-9]+]]){{.*}} {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = getelementptr inbounds nuw %main.Wrapped, ptr %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:   %[[TMP3:[0-9]+]] = load ptr, ptr %[[TMP2]], align 8
+// CHECK-NEXT:   %[[NIL:[0-9]+]] = icmp eq ptr %[[TMP0]], null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[NIL]])
+// CHECK-NEXT:   %[[SAFE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %[[TMP2]])
+// CHECK-NEXT:   %[[TMP3:[0-9]+]] = load ptr, ptr %[[SAFE]], align 8
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/embedunexport.(*Base).setName"(ptr %[[TMP3]], %"{{.*}}/runtime/internal/runtime.String" %[[TMP1]])
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/embedunexport-1598/in.go
+++ b/cl/_testgo/embedunexport-1598/in.go
@@ -49,9 +49,9 @@ func main() {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP1:[0-9]+]] = getelementptr inbounds nuw %main.Wrapped, ptr %[[TMP0]], i32 0, i32 0
 // CHECK-NEXT:   %[[NIL:[0-9]+]] = icmp eq ptr %[[TMP0]], null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[NIL]])
-// CHECK-NEXT:   %[[SAFE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %[[TMP1]])
-// CHECK-NEXT:   %[[TMP2:[0-9]+]] = load ptr, ptr %[[SAFE]], align 8
+// CHECK-NEXT:   br i1 %[[NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK:   %[[TMP2:[0-9]+]] = load ptr, ptr %[[TMP1]], align 8
 // CHECK-NEXT:   %[[TMP3:[0-9]+]] = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testdata/embedunexport.(*Base).Name"(ptr %[[TMP2]])
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %[[TMP3]]
 // CHECK-NEXT: }
@@ -61,9 +61,9 @@ func main() {
 // CHECK-NEXT: _llgo_[[BB0:[0-9]+]]:
 // CHECK-NEXT:   %[[TMP2:[0-9]+]] = getelementptr inbounds nuw %main.Wrapped, ptr %[[TMP0]], i32 0, i32 0
 // CHECK-NEXT:   %[[NIL:[0-9]+]] = icmp eq ptr %[[TMP0]], null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[NIL]])
-// CHECK-NEXT:   %[[SAFE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %[[TMP2]])
-// CHECK-NEXT:   %[[TMP3:[0-9]+]] = load ptr, ptr %[[SAFE]], align 8
+// CHECK-NEXT:   br i1 %[[NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK:   %[[TMP3:[0-9]+]] = load ptr, ptr %[[TMP2]], align 8
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/embedunexport.(*Base).setName"(ptr %[[TMP3]], %"{{.*}}/runtime/internal/runtime.String" %[[TMP1]])
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/genericembediface/in.go
+++ b/cl/_testgo/genericembediface/in.go
@@ -82,7 +82,8 @@ func main() {
 // CHECK: [[SERVER_NIL:%.*]] = icmp eq ptr %0, null
 // CHECK: call void @"{{.*}}PanicWrapNilPointer"(i1 [[SERVER_NIL]], %"{{.*}}String" {{.*}}, %"{{.*}}String" {{.*}})
 // CHECK: [[SERVER_DEREF_NIL:%.*]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}AssertNilDeref"(i1 [[SERVER_DEREF_NIL]])
+// CHECK: br i1 [[SERVER_DEREF_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}AssertNilDeref"(i1 true)
 // CHECK: [[SERVER_RESULT:%.*]] = call %"{{.*}}iface" @main.server.ServerReflectionInfo(%main.server zeroinitializer, %"{{.*}}iface" %1)
 // CHECK: ret %"{{.*}}iface" [[SERVER_RESULT]]
 
@@ -94,7 +95,8 @@ func main() {
 // CHECK: [[STREAM_NIL:%.*]] = icmp eq ptr %0, null
 // CHECK: call void @"{{.*}}PanicWrapNilPointer"(i1 [[STREAM_NIL]], %"{{.*}}String" {{.*}}, %"{{.*}}String" { ptr [[CONTEXT]], i64 7 })
 // CHECK: [[STREAM_DEREF_NIL:%.*]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}AssertNilDeref"(i1 [[STREAM_DEREF_NIL]])
+// CHECK: br i1 [[STREAM_DEREF_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}AssertNilDeref"(i1 true)
 // CHECK: [[STREAM_RESULT:%.*]] = call %"{{.*}}String" @main.stream.Context(%main.stream zeroinitializer)
 // CHECK: ret %"{{.*}}String" [[STREAM_RESULT]]
 

--- a/cl/_testgo/ifaceconv/in.go
+++ b/cl/_testgo/ifaceconv/in.go
@@ -92,7 +92,8 @@ func main() {
 // CHECK: [[C1_NIL:%.*]] = icmp eq ptr %0, null
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 [[C1_NIL]], %"{{.*}}String" {{.*}}, %"{{.*}}String" {{.*}})
 // CHECK: [[C1_DEREF_NIL:%.*]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[C1_DEREF_NIL]])
+// CHECK: br i1 [[C1_DEREF_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: call void @main.C1.f(%main.C1 zeroinitializer)
 
 // CHECK-LABEL: define void @main.C2.f(%main.C2 %0){{.*}} {

--- a/cl/_testgo/invoke/in.go
+++ b/cl/_testgo/invoke/in.go
@@ -161,7 +161,8 @@ type M interface {
 // preserves the signed int8 conversion.
 // CHECK-LABEL: define i64 @"main.(*T3).Invoke"(ptr %0){{.*}} {
 // CHECK: %[[T3_NIL:[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[T3_NIL]])
+// CHECK: br i1 %[[T3_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: %[[T3_VALUE:[0-9]+]] = load i8, ptr %0
 // CHECK: %[[T3_WIDE:[0-9]+]] = sext i8 %[[T3_VALUE]] to i64
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %[[T3_WIDE]])

--- a/cl/_testgo/reflectmkfn/in.go
+++ b/cl/_testgo/reflectmkfn/in.go
@@ -40,15 +40,19 @@ func main() {
 // CHECK: [[ARG0_LEN:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK: call void @"g{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 [[ARG0_LEN]])
 // CHECK: [[ARG0_PTR:%[0-9]+]] = getelementptr inbounds %reflect.Value, ptr [[ARG0_DATA]], i64 0
-// CHECK: [[ARG0_SAFE:%[0-9]+]] = call ptr @"g{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[ARG0_PTR]])
-// CHECK-NEXT: [[ARG0:%[0-9]+]] = load %reflect.Value, ptr [[ARG0_SAFE]]
+// CHECK: [[ARG0_IS_NIL:%[0-9]+]] = icmp eq ptr [[ARG0_PTR]], null
+// CHECK: br i1 [[ARG0_IS_NIL]], label %{{.*}}, label %{{.*}}
+// CHECK: call void @"g{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[ARG0:%[0-9]+]] = load %reflect.Value, ptr [[ARG0_PTR]]
 // CHECK-NEXT: [[TEXT:%[0-9]+]] = call %"g{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value [[ARG0]])
 // CHECK: [[ARG1_DATA:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK: [[ARG1_LEN:%[0-9]+]] = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK: call void @"g{{.*}}/runtime/internal/runtime.PanicIndex"(i64 1, i64 [[ARG1_LEN]])
 // CHECK: [[ARG1_PTR:%[0-9]+]] = getelementptr inbounds %reflect.Value, ptr [[ARG1_DATA]], i64 1
-// CHECK: [[ARG1_SAFE:%[0-9]+]] = call ptr @"g{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[ARG1_PTR]])
-// CHECK-NEXT: [[ARG1:%[0-9]+]] = load %reflect.Value, ptr [[ARG1_SAFE]]
+// CHECK: [[ARG1_IS_NIL:%[0-9]+]] = icmp eq ptr [[ARG1_PTR]], null
+// CHECK: br i1 [[ARG1_IS_NIL]], label %{{.*}}, label %{{.*}}
+// CHECK: call void @"g{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: [[ARG1:%[0-9]+]] = load %reflect.Value, ptr [[ARG1_PTR]]
 // CHECK-NEXT: [[COUNT:%[0-9]+]] = call i64 @reflect.Value.Int(%reflect.Value [[ARG1]])
 // CHECK-NEXT: [[REPEATED:%[0-9]+]] = call %"g{{.*}}/runtime/internal/runtime.String" @strings.Repeat(%"g{{.*}}/runtime/internal/runtime.String" [[TEXT]], i64 [[COUNT]])
 // CHECK: store %"g{{.*}}/runtime/internal/runtime.String" [[REPEATED]], ptr [[RESULT_TEXT:%[0-9]+]]

--- a/cl/_testgo/select/in.go
+++ b/cl/_testgo/select/in.go
@@ -36,9 +36,9 @@ package main
 // CHECK-NEXT: [[TRY_SELECTED:%[0-9]+]] = extractvalue { i64, i1, i1 } [[TRY_SELECT]], 2
 // CHECK-NEXT: [[TRY_DISPATCH:%[0-9]+]] = select i1 [[TRY_SELECTED]], i64 [[TRY_INDEX]], i64 -1
 // CHECK: [[RECV_DATA1:%[0-9]+]] = extractvalue %"{{.*}}ChanOp" [[RECV_OP1]], 1
-// CHECK-NEXT: [[RECV_VALUE1:%[0-9]+]] = load %"{{.*}}String", ptr [[RECV_DATA1]]
+// CHECK-NEXT: [[RECV_VALUE1:%[0-9]+]] = load volatile %"{{.*}}String", ptr [[RECV_DATA1]]
 // CHECK-NEXT: [[RECV_DATA2:%[0-9]+]] = extractvalue %"{{.*}}ChanOp" [[RECV_OP2]], 1
-// CHECK-NEXT: [[RECV_VALUE2:%[0-9]+]] = load %"{{.*}}String", ptr [[RECV_DATA2]]
+// CHECK-NEXT: [[RECV_VALUE2:%[0-9]+]] = load volatile %"{{.*}}String", ptr [[RECV_DATA2]]
 // CHECK: [[RECV_RESULT0:%[0-9]+]] = insertvalue { i64, i1, %"{{.*}}String", %"{{.*}}String" } undef, i64 [[TRY_DISPATCH]], 0
 // CHECK-NEXT: [[RECV_RESULT1:%[0-9]+]] = insertvalue { i64, i1, %"{{.*}}String", %"{{.*}}String" } [[RECV_RESULT0]], i1 [[TRY_OK]], 1
 // CHECK-NEXT: [[RECV_RESULT2:%[0-9]+]] = insertvalue { i64, i1, %"{{.*}}String", %"{{.*}}String" } [[RECV_RESULT1]], %"{{.*}}String" [[RECV_VALUE1]], 2

--- a/cl/_testgo/select/in.go
+++ b/cl/_testgo/select/in.go
@@ -94,7 +94,7 @@ package main
 // CHECK-NEXT: [[SEND1_CH_SLOT:%[0-9]+]] = extractvalue { ptr } [[SEND1_ENV]], 0
 // CHECK-NEXT: [[SEND1_CH:%[0-9]+]] = load ptr, ptr [[SEND1_CH_SLOT]]
 // CHECK: call i1 @"{{.*}}ChanRecv"(ptr [[SEND1_CH]], ptr [[SEND1_BUF:%[0-9]+]], i64 8)
-// CHECK-NEXT: [[SEND1_VALUE:%[0-9]+]] = load i64, ptr [[SEND1_BUF]]
+// CHECK-NEXT: [[SEND1_VALUE:%[0-9]+]] = load volatile i64, ptr [[SEND1_BUF]]
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[SEND1_VALUE]])
 // ARM64-LABEL: define void @"main.send$2"(ptr swiftself %0){{.*}} {
 // AMD64-LABEL: define void @"main.send$2"(ptr nest %0){{.*}} {
@@ -102,7 +102,7 @@ package main
 // CHECK-NEXT: [[SEND2_CH_SLOT:%[0-9]+]] = extractvalue { ptr } [[SEND2_ENV]], 0
 // CHECK-NEXT: [[SEND2_CH:%[0-9]+]] = load ptr, ptr [[SEND2_CH_SLOT]]
 // CHECK: call i1 @"{{.*}}ChanRecv"(ptr [[SEND2_CH]], ptr [[SEND2_BUF:%[0-9]+]], i64 8)
-// CHECK-NEXT: [[SEND2_VALUE:%[0-9]+]] = load i64, ptr [[SEND2_BUF]]
+// CHECK-NEXT: [[SEND2_VALUE:%[0-9]+]] = load volatile i64, ptr [[SEND2_BUF]]
 // CHECK: call void @"{{.*}}PrintInt"(i64 [[SEND2_VALUE]])
 
 func main() {

--- a/cl/_testgo/tpnamed/in.go
+++ b/cl/_testgo/tpnamed/in.go
@@ -49,7 +49,8 @@ func RunIO[T any](call IO[T]) T {
 // CHECK-NEXT: [[FUTURE_ENV:%[0-9]+]] = extractvalue %"main.Future{{\[\[0\]uint8\]}}" [[FUTURE]], 1
 // CHECK-NEXT: [[FUTURE_CODE:%[0-9]+]] = extractvalue %"main.Future{{\[\[0\]uint8\]}}" [[FUTURE]], 0
 // CHECK-NEXT: [[FUTURE_NIL:%[0-9]+]] = icmp eq ptr [[FUTURE_CODE]], null
-// CHECK-NEXT: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[FUTURE_NIL]])
+// CHECK-NEXT: br i1 [[FUTURE_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // ARM64: [[IO_RESULT:%[0-9]+]] = call [0 x i8] %__llgo_funcval_code1(ptr swiftself [[FUTURE_ENV]])
 // AMD64: [[IO_RESULT:%[0-9]+]] = call [0 x i8] %__llgo_funcval_code1(ptr nest [[FUTURE_ENV]])
 // CHECK-NEXT: ret [0 x i8] [[IO_RESULT]]

--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -12,9 +12,9 @@ import (
 // runtime type descriptors; the test body then exercises lazy pointer-to-this
 // and element links from those descriptors.
 // CHECK-LABEL: define void @main.checkBasicNames(){{.*}} {
-// CHECK: insertvalue %"{{.*}}eface" { ptr @_llgo_int32,
+// CHECK-DAG: insertvalue %"{{.*}}eface" { ptr @_llgo_int32,
+// CHECK-DAG: insertvalue %"{{.*}}eface" { ptr @_llgo_uint8,
 // CHECK: call %"{{.*}}String" @"{{.*}}/runtime/abi.(*Type).String"
-// CHECK: insertvalue %"{{.*}}eface" { ptr @_llgo_uint8,
 // CHECK: call %"{{.*}}String" @"{{.*}}/runtime/abi.(*Type).String"
 // CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: insertvalue %"{{.*}}eface" { ptr @_llgo_main.T,

--- a/cl/_testrt/closurebound/in.go
+++ b/cl/_testrt/closurebound/in.go
@@ -49,12 +49,14 @@ func main() {
 
 // ARM64-LABEL: define i64 @"main.demo2.encode$bound"(ptr swiftself %0){{.*}} {
 // AMD64-LABEL: define i64 @"main.demo2.encode$bound"(ptr nest %0){{.*}} {
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %{{[0-9]+}})
+// CHECK: br i1 %{{[0-9]+}}, label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: %[[D2_RESULT:[0-9]+]] = call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
 // CHECK: ret i64 %[[D2_RESULT]]
 
 // ARM64-LABEL: define i64 @"main.demo1.encode$bound"(ptr swiftself %0){{.*}} {
 // AMD64-LABEL: define i64 @"main.demo1.encode$bound"(ptr nest %0){{.*}} {
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %{{[0-9]+}})
+// CHECK: br i1 %{{[0-9]+}}, label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: %[[D1_RESULT:[0-9]+]] = call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
 // CHECK: ret i64 %[[D1_RESULT]]

--- a/cl/_testrt/reflectclosureenv/in.go
+++ b/cl/_testrt/reflectclosureenv/in.go
@@ -15,8 +15,10 @@ type receiver struct {
 // CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.PanicIndex"(i64 0, i64 [[CHECK_RESULTS_LEN]])
 // CHECK-DAG: br label %{{_llgo_[0-9]+}}
 // CHECK-DAG: [[CHECK_FIRST_PTR:%.*]] = getelementptr inbounds %reflect.Value, ptr [[CHECK_RESULTS_PTR]], i64 0
-// CHECK-DAG: [[CHECK_FIRST_SAFE:%.*]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr [[CHECK_FIRST_PTR]])
-// CHECK-DAG: [[CHECK_FIRST:%.*]] = load %reflect.Value, ptr [[CHECK_FIRST_SAFE]]
+// CHECK-DAG: [[CHECK_FIRST_IS_NIL:%.*]] = icmp eq ptr [[CHECK_FIRST_PTR]], null
+// CHECK-DAG: br i1 [[CHECK_FIRST_IS_NIL]], label %{{.*}}, label %{{.*}}
+// CHECK-DAG: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK-DAG: [[CHECK_FIRST:%.*]] = load %reflect.Value, ptr [[CHECK_FIRST_PTR]]
 // CHECK-DAG: [[CHECK_GOT:%.*]] = call i64 @reflect.Value.Int(%reflect.Value [[CHECK_FIRST]])
 // CHECK-DAG: [[CHECK_BAD:%.*]] = icmp ne i64 [[CHECK_GOT]], 55
 // CHECK-DAG: br i1 [[CHECK_BAD]], label %{{.*}}, label %{{.*}}

--- a/cl/_testrt/tpfunc/in.go
+++ b/cl/_testrt/tpfunc/in.go
@@ -22,19 +22,22 @@ type Callback[T any] func(*T)
 // All three source literals still dereference and print the same *int argument.
 // CHECK-LABEL: define void @"main.main$1"(ptr %0){{.*}} {
 // CHECK: [[GO_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[GO_NIL]])
+// CHECK: br i1 [[GO_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: [[GO_VALUE:%[0-9]+]] = load i64, ptr %0
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[GO_VALUE]])
 
 // CHECK-LABEL: define void @"main.main$2"(ptr %0){{.*}} {
 // CHECK: [[C_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[C_NIL]])
+// CHECK: br i1 [[C_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: [[C_VALUE:%[0-9]+]] = load i64, ptr %0
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[C_VALUE]])
 
 // CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
 // CHECK: [[GENERIC_C_NIL:%[0-9]+]] = icmp eq ptr %0, null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 [[GENERIC_C_NIL]])
+// CHECK: br i1 [[GENERIC_C_NIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
 // CHECK: [[GENERIC_C_VALUE:%[0-9]+]] = load i64, ptr %0
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 [[GENERIC_C_VALUE]])
 

--- a/cl/_testrt/vamethod/in.go
+++ b/cl/_testrt/vamethod/in.go
@@ -63,7 +63,10 @@ func main() {
 // CHECK-LABEL: define i32 @"main.(*CFmt).Printf"(
 // CHECK-SAME: ptr %[[PTR:[0-9]+]], ...){{.*}} {
 // CHECK: %[[PTRFIELD:[0-9]+]] = getelementptr inbounds nuw %main.CFmt, ptr %[[PTR]], i32 0, i32 0
-// CHECK: %[[PTRFMT:[0-9]+]] = load ptr, ptr %[[PTRFIELD]], align 8
+// CHECK: %[[PTRNIL:[0-9]+]] = icmp eq ptr %[[PTR]], null
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[PTRNIL]])
+// CHECK: %[[PTRSAFE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %[[PTRFIELD]])
+// CHECK: %[[PTRFMT:[0-9]+]] = load ptr, ptr %[[PTRSAFE]], align 8
 // CHECK: %[[PTRRET:[0-9]+]] = call i32 (ptr, ...) @printf(ptr %[[PTRFMT]])
 // CHECK: ret i32 %[[PTRRET]]
 

--- a/cl/_testrt/vamethod/in.go
+++ b/cl/_testrt/vamethod/in.go
@@ -64,9 +64,9 @@ func main() {
 // CHECK-SAME: ptr %[[PTR:[0-9]+]], ...){{.*}} {
 // CHECK: %[[PTRFIELD:[0-9]+]] = getelementptr inbounds nuw %main.CFmt, ptr %[[PTR]], i32 0, i32 0
 // CHECK: %[[PTRNIL:[0-9]+]] = icmp eq ptr %[[PTR]], null
-// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %[[PTRNIL]])
-// CHECK: %[[PTRSAFE:[0-9]+]] = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %[[PTRFIELD]])
-// CHECK: %[[PTRFMT:[0-9]+]] = load ptr, ptr %[[PTRSAFE]], align 8
+// CHECK: br i1 %[[PTRNIL]], label %{{[^,]+}}, label %{{[^ ]+}}
+// CHECK: call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 true)
+// CHECK: %[[PTRFMT:[0-9]+]] = load ptr, ptr %[[PTRFIELD]], align 8
 // CHECK: %[[PTRRET:[0-9]+]] = call i32 (ptr, ...) @printf(ptr %[[PTRFMT]])
 // CHECK: ret i32 %[[PTRRET]]
 

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -217,11 +217,11 @@ func nested(pp **large) {
 }
 `)
 	ir := m.String()
-	if strings.Count(ir, "AssertNilDerefPtr") == 0 {
-		t.Fatalf("compiled IR missing nested AssertNilDerefPtr guard:\n%s", ir)
+	if got := strings.Count(ir, `runtime.AssertNilDeref"(i1 true)`); got < 2 {
+		t.Fatalf("compiled IR has %d cold nil-deref guards, want at least 2:\n%s", got, ir)
 	}
-	if !strings.Contains(ir, "AssertNilDeref") {
-		t.Fatalf("compiled IR missing outer AssertNilDeref guard:\n%s", ir)
+	if strings.Contains(ir, "AssertNilDerefPtr") {
+		t.Fatalf("compiled IR keeps a nil-deref runtime call on the success path:\n%s", ir)
 	}
 }
 

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -403,8 +403,8 @@ func TestCollectMethodNilDerefChecksSkipsDynamicDeferGo(t *testing.T) {
 			},
 		}},
 	}
-	if got := collectMethodNilDerefChecks(fn); len(got) != 0 {
-		t.Fatalf("collectMethodNilDerefChecks() = %v, want no static checks", got)
+	if got, receiverGot := collectMethodNilDerefChecks(fn, nil); len(got) != 0 || len(receiverGot) != 0 {
+		t.Fatalf("collectMethodNilDerefChecks() = %v, %v, want no static checks", got, receiverGot)
 	}
 }
 

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -154,35 +154,35 @@ type pkgInfo struct {
 type none = struct{}
 
 type context struct {
-	prog                   llssa.Program
-	pkg                    llssa.Package
-	fn                     llssa.Function
-	goFn                   *ssa.Function
-	fset                   *token.FileSet
-	goProg                 *ssa.Program
-	goTyps                 *types.Package
-	goPkg                  *ssa.Package
-	pyMod                  string
-	skips                  map[string]none
-	loaded                 map[*types.Package]*pkgInfo // loaded packages
-	bvals                  map[ssa.Value]llssa.Expr    // block values
-	methodNilDerefChecks   map[*ssa.UnOp]none
-	receiverNilDerefChecks map[*ssa.UnOp]token.Pos
-	vargs                  map[*ssa.Alloc][]llssa.Expr // varargs
-	funcs                  map[*ssa.Function]llssa.Function
-	linkOnceFns            map[*ssa.Function]none
-	stackDefers            map[*ssa.Function]bool
-	anonDefers             map[*ssa.Function]bool
-	recoverFacts           *recoverFacts
-	debugDIVars            map[*types.Var]llssa.DIVar
-	debugAllocVars         map[*ssa.Alloc]*types.Var
-	runtimeCallerFuncs     map[*ssa.Function]bool
-	panicSiteFuncs         map[*ssa.Function]bool
-	gcRoots                map[ssa.Value][]llssa.Expr
-	gcClosureRoot          llssa.Expr
-	safepointEntry         bool
-	safepoints             map[ssa.Instruction]struct{}
-	pcLineSeq              uint64
+	prog                 llssa.Program
+	pkg                  llssa.Package
+	fn                   llssa.Function
+	goFn                 *ssa.Function
+	fset                 *token.FileSet
+	goProg               *ssa.Program
+	goTyps               *types.Package
+	goPkg                *ssa.Package
+	pyMod                string
+	skips                map[string]none
+	loaded               map[*types.Package]*pkgInfo // loaded packages
+	bvals                map[ssa.Value]llssa.Expr    // block values
+	methodNilDerefChecks map[*ssa.UnOp]none
+	recvNilDerefChecks   map[*ssa.UnOp]token.Pos
+	vargs                map[*ssa.Alloc][]llssa.Expr // varargs
+	funcs                map[*ssa.Function]llssa.Function
+	linkOnceFns          map[*ssa.Function]none
+	stackDefers          map[*ssa.Function]bool
+	anonDefers           map[*ssa.Function]bool
+	recoverFacts         *recoverFacts
+	debugDIVars          map[*types.Var]llssa.DIVar
+	debugAllocVars       map[*ssa.Alloc]*types.Var
+	runtimeCallerFuncs   map[*ssa.Function]bool
+	panicSiteFuncs       map[*ssa.Function]bool
+	gcRoots              map[ssa.Value][]llssa.Expr
+	gcClosureRoot        llssa.Expr
+	safepointEntry       bool
+	safepoints           map[ssa.Instruction]struct{}
+	pcLineSeq            uint64
 	// The runtime PC-line table stores file and line, but not column. Keep the
 	// last emitted position within one SSA basic block so repeated checks for a
 	// single source line can share an anchor.
@@ -697,7 +697,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		dbgSymsEnabled := p.options.DebugSymbols && (f == nil || f.Origin() == nil)
 		p.inits = append(p.inits, func() {
 			oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark := p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark
-			oldReceiverNilDerefChecks := p.receiverNilDerefChecks
+			oldRecvNilDerefChecks := p.recvNilDerefChecks
 			oldLocalityFunction := p.locality.function
 			oldRecoverSlots, oldImplicitDeferResults := p.recoverSlots, p.implicitDeferResults
 			oldGCRoots, oldGCClosureRoot := p.gcRoots, p.gcClosureRoot
@@ -714,7 +714,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			}
 			defer func() {
 				p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark = oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark
-				p.receiverNilDerefChecks = oldReceiverNilDerefChecks
+				p.recvNilDerefChecks = oldRecvNilDerefChecks
 				p.locality.function = oldLocalityFunction
 				p.recoverSlots = oldRecoverSlots
 				p.implicitDeferResults = oldImplicitDeferResults
@@ -739,8 +739,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			}
 			p.prepareExportedLocalContext(f)
 			p.bvals = make(map[ssa.Value]llssa.Expr)
-			p.methodNilDerefChecks = collectMethodNilDerefChecks(f)
-			p.receiverNilDerefChecks = collectReceiverNilDerefChecks(f, p.options.ReceiverNilChecks)
+			p.methodNilDerefChecks, p.recvNilDerefChecks = collectMethodNilDerefChecks(f, p.options.ReceiverNilChecks)
 			p.prepareCooperativeSafepoints(f, isCgo)
 			p.prepareGCRoots(f, hasCtx)
 			p.initGCRoots(b, f)
@@ -1560,7 +1559,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		}
 	case *ssa.UnOp:
 		if v.Op == token.MUL {
-			if pos, ok := p.receiverNilDerefChecks[v]; ok {
+			if pos, ok := p.recvNilDerefChecks[v]; ok {
 				p.recordPanicSite(b, pos)
 				return p.compileCheckedDeref(b, v)
 			}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -2148,6 +2148,9 @@ func instructionPrecedes(before, after ssa.Instruction) bool {
 	return false
 }
 
+// assertNilDerefBase uses pointer-returning checks to rewrite p.bvals. Keep its
+// traversal in sync with emitNilDerefBaseCheck, which emits cold failure
+// branches without replacing cached addresses for delayed receiver checks.
 func (p *context) assertNilDerefBase(b llssa.Builder, addr ssa.Value) {
 	switch addr := addr.(type) {
 	case *ssa.UnOp:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -74,6 +74,9 @@ type Options struct {
 	// PreloadedSyntax means all Program-side source metadata was collected
 	// before lowering and is now shared read-only by backend Programs.
 	PreloadedSyntax bool
+	// ReceiverNilChecks retains pointer-method selection semantics erased
+	// during Go SSA construction. It is collected from checked source info.
+	ReceiverNilChecks *ReceiverNilChecks
 }
 
 // SetDebug sets debug flags.
@@ -151,34 +154,35 @@ type pkgInfo struct {
 type none = struct{}
 
 type context struct {
-	prog                 llssa.Program
-	pkg                  llssa.Package
-	fn                   llssa.Function
-	goFn                 *ssa.Function
-	fset                 *token.FileSet
-	goProg               *ssa.Program
-	goTyps               *types.Package
-	goPkg                *ssa.Package
-	pyMod                string
-	skips                map[string]none
-	loaded               map[*types.Package]*pkgInfo // loaded packages
-	bvals                map[ssa.Value]llssa.Expr    // block values
-	methodNilDerefChecks map[*ssa.UnOp]none
-	vargs                map[*ssa.Alloc][]llssa.Expr // varargs
-	funcs                map[*ssa.Function]llssa.Function
-	linkOnceFns          map[*ssa.Function]none
-	stackDefers          map[*ssa.Function]bool
-	anonDefers           map[*ssa.Function]bool
-	recoverFacts         *recoverFacts
-	debugDIVars          map[*types.Var]llssa.DIVar
-	debugAllocVars       map[*ssa.Alloc]*types.Var
-	runtimeCallerFuncs   map[*ssa.Function]bool
-	panicSiteFuncs       map[*ssa.Function]bool
-	gcRoots              map[ssa.Value][]llssa.Expr
-	gcClosureRoot        llssa.Expr
-	safepointEntry       bool
-	safepoints           map[ssa.Instruction]struct{}
-	pcLineSeq            uint64
+	prog                   llssa.Program
+	pkg                    llssa.Package
+	fn                     llssa.Function
+	goFn                   *ssa.Function
+	fset                   *token.FileSet
+	goProg                 *ssa.Program
+	goTyps                 *types.Package
+	goPkg                  *ssa.Package
+	pyMod                  string
+	skips                  map[string]none
+	loaded                 map[*types.Package]*pkgInfo // loaded packages
+	bvals                  map[ssa.Value]llssa.Expr    // block values
+	methodNilDerefChecks   map[*ssa.UnOp]none
+	receiverNilDerefChecks map[*ssa.UnOp]token.Pos
+	vargs                  map[*ssa.Alloc][]llssa.Expr // varargs
+	funcs                  map[*ssa.Function]llssa.Function
+	linkOnceFns            map[*ssa.Function]none
+	stackDefers            map[*ssa.Function]bool
+	anonDefers             map[*ssa.Function]bool
+	recoverFacts           *recoverFacts
+	debugDIVars            map[*types.Var]llssa.DIVar
+	debugAllocVars         map[*ssa.Alloc]*types.Var
+	runtimeCallerFuncs     map[*ssa.Function]bool
+	panicSiteFuncs         map[*ssa.Function]bool
+	gcRoots                map[ssa.Value][]llssa.Expr
+	gcClosureRoot          llssa.Expr
+	safepointEntry         bool
+	safepoints             map[ssa.Instruction]struct{}
+	pcLineSeq              uint64
 	// The runtime PC-line table stores file and line, but not column. Keep the
 	// last emitted position within one SSA basic block so repeated checks for a
 	// single source line can share an anchor.
@@ -693,6 +697,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		dbgSymsEnabled := p.options.DebugSymbols && (f == nil || f.Origin() == nil)
 		p.inits = append(p.inits, func() {
 			oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark := p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark
+			oldReceiverNilDerefChecks := p.receiverNilDerefChecks
 			oldLocalityFunction := p.locality.function
 			oldRecoverSlots, oldImplicitDeferResults := p.recoverSlots, p.implicitDeferResults
 			oldGCRoots, oldGCClosureRoot := p.gcRoots, p.gcClosureRoot
@@ -709,6 +714,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			}
 			defer func() {
 				p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark = oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark
+				p.receiverNilDerefChecks = oldReceiverNilDerefChecks
 				p.locality.function = oldLocalityFunction
 				p.recoverSlots = oldRecoverSlots
 				p.implicitDeferResults = oldImplicitDeferResults
@@ -734,6 +740,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			p.prepareExportedLocalContext(f)
 			p.bvals = make(map[ssa.Value]llssa.Expr)
 			p.methodNilDerefChecks = collectMethodNilDerefChecks(f)
+			p.receiverNilDerefChecks = collectReceiverNilDerefChecks(f, p.options.ReceiverNilChecks)
 			p.prepareCooperativeSafepoints(f, isCgo)
 			p.prepareGCRoots(f, hasCtx)
 			p.initGCRoots(b, f)
@@ -1489,6 +1496,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 	}
 	switch v := iv.(type) {
 	case *ssa.Call:
+		p.checkMethodCallReceiver(b, &v.Call)
 		ret = p.call(b, llssa.Call, &v.Call)
 		if p.rangeFuncCallNeedsDeferDrain(&v.Call) {
 			b.DeferStackDrain()
@@ -1552,6 +1560,10 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		}
 	case *ssa.UnOp:
 		if v.Op == token.MUL {
+			if pos, ok := p.receiverNilDerefChecks[v]; ok {
+				p.recordPanicSite(b, pos)
+				return p.compileCheckedDeref(b, v)
+			}
 			if _, ok := p.methodNilDerefChecks[v]; ok {
 				return p.compileCheckedDeref(b, v)
 			}
@@ -1764,6 +1776,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		}
 		ret = b.MakeMap(t, nReserve)
 	case *ssa.MakeClosure:
+		p.checkBoundMethodReceiver(b, v)
 		fn := p.compileValue(b, v.Fn)
 		var bindings []llssa.Expr
 		goFn, _ := v.Fn.(*ssa.Function)
@@ -2282,12 +2295,14 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		p.recordPanicSite(b, v.Pos())
 		b.MapUpdate(m, key, val)
 	case *ssa.Defer:
+		p.checkMethodCallReceiver(b, &v.Call)
 		if v.DeferStack != nil {
 			p.callDeferStack(b, p.blkInfos[v.Block().Index].Kind, &v.Call, v.DeferStack, v.Parent())
 			return
 		}
 		p.call(b, p.blkInfos[v.Block().Index].Kind, &v.Call)
 	case *ssa.Go:
+		p.checkMethodCallReceiver(b, &v.Call)
 		p.call(b, llssa.Go, &v.Call)
 	case *ssa.RunDefers:
 		p.recordPanicLocation(b, v.Pos())

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -2355,6 +2355,9 @@ func isWrapNilCheckCall(v ssa.Value) bool {
 	return ok && builtin.Name() == "ssa:wrapnilchk"
 }
 
+// emitNilDerefBaseCheck emits cold failure branches without replacing cached
+// addresses. Keep its traversal in sync with assertNilDerefBase, whose checks
+// instead return safe addresses and rewrite p.bvals for ordinary compilation.
 func (p *context) emitNilDerefBaseCheck(b llssa.Builder, addr ssa.Value) {
 	switch addr := addr.(type) {
 	case *ssa.UnOp:
@@ -2383,8 +2386,13 @@ func (p *context) emitCheckedDerefCheck(b llssa.Builder, arg *ssa.UnOp) {
 func (p *context) compileCheckedDeref(b llssa.Builder, arg *ssa.UnOp) llssa.Expr {
 	p.emitNilDerefBaseCheck(b, arg.X)
 	ptr := p.compileValue(b, arg.X)
-	checked := b.NilDerefCheck(ptr)
-	ret := b.UnOp(token.MUL, checked)
+	// A field address is non-nil once emitNilDerefBaseCheck has validated its
+	// pointer base. Checking the derived address again does not protect the
+	// embedded pointer value loaded from that address.
+	if _, ok := arg.X.(*ssa.FieldAddr); !ok {
+		b.AssertNilDeref(ptr)
+	}
+	ret := b.UnOp(token.MUL, ptr)
 	p.bvals[arg] = ret
 	return ret
 }

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -2421,7 +2421,7 @@ func boundValueReceiverNilDerefArg(fn *ssa.Function, bindings []ssa.Value) (*ssa
 	return arg, true
 }
 
-func collectMethodNilDerefChecks(fn *ssa.Function) map[*ssa.UnOp]none {
+func collectMethodNilDerefChecks(fn *ssa.Function, receiverChecks *ReceiverNilChecks) (map[*ssa.UnOp]none, map[*ssa.UnOp]token.Pos) {
 	var checks map[*ssa.UnOp]none
 	mark := func(arg *ssa.UnOp, ok bool) {
 		if !ok {
@@ -2432,9 +2432,41 @@ func collectMethodNilDerefChecks(fn *ssa.Function) map[*ssa.UnOp]none {
 		}
 		checks[arg] = none{}
 	}
+	// Receiver selections may already contain pointer loads. Protect them
+	// before LLVM can treat the load as non-nil; checking only at the later
+	// call would be too late. Fold this into the existing per-function scan.
+	var receiverDerefChecks map[*ssa.UnOp]token.Pos
+	var markReceiver func(ssa.Value, token.Pos)
+	markReceiver = func(value ssa.Value, pos token.Pos) {
+		switch value := value.(type) {
+		case *ssa.UnOp:
+			if value.Op != token.MUL {
+				return
+			}
+			if !isKnownNonNilAddr(value.X) && !isWrapNilCheckCall(value.X) {
+				if receiverDerefChecks == nil {
+					receiverDerefChecks = make(map[*ssa.UnOp]token.Pos)
+				}
+				receiverDerefChecks[value] = pos
+			}
+			markReceiver(value.X, pos)
+		case *ssa.FieldAddr:
+			markReceiver(value.X, pos)
+		}
+	}
 	markCall := func(call *ssa.CallCommon) {
 		if fn, ok := call.Value.(*ssa.Function); ok {
 			mark(valueReceiverNilDerefArg(fn, call.Args))
+		}
+		if len(call.Args) == 0 {
+			return
+		}
+		if isPointerMethodWrapperCall(fn, call) {
+			markReceiver(call.Args[0], fn.Pos())
+		} else if receiverChecks != nil {
+			if check, ok := receiverChecks.calls[call.Pos()]; ok {
+				markReceiver(call.Args[0], check.pos)
+			}
 		}
 	}
 	for _, block := range fn.Blocks {
@@ -2450,10 +2482,15 @@ func collectMethodNilDerefChecks(fn *ssa.Function) map[*ssa.UnOp]none {
 				if bound, ok := instr.Fn.(*ssa.Function); ok {
 					mark(boundValueReceiverNilDerefArg(bound, instr.Bindings))
 				}
+				if receiverChecks != nil && len(instr.Bindings) != 0 {
+					if check, ok := receiverChecks.values[instr.Pos()]; ok {
+						markReceiver(instr.Bindings[0], check.pos)
+					}
+				}
 			}
 		}
 	}
-	return checks
+	return checks, receiverDerefChecks
 }
 
 func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon, ds *explicitDeferStack) (ret llssa.Expr) {

--- a/cl/receiver_nil.go
+++ b/cl/receiver_nil.go
@@ -15,6 +15,9 @@ import (
 // with FieldAddr, neither of which retains the required nil dereference.
 // The maps are immutable after collection and shared by package lowering.
 type ReceiverNilChecks struct {
+	// AST CallExpr.Lparen matches ssa.CallCommon.Pos; SelectorExpr.Sel.Pos
+	// matches the position of SSA MakeClosure for a bound method value.
+	// NoPos belongs to synthesized SSA, never to either source lookup table.
 	calls  map[token.Pos]receiverNilCheck
 	values map[token.Pos]receiverNilCheck
 }
@@ -32,7 +35,7 @@ func CollectReceiverNilChecks(files []*ast.File, infos ...*types.Info) *Receiver
 	for _, info := range infos {
 		if info != nil {
 			for expr, sel := range info.Selections {
-				if isPointerMethodSelection(sel) {
+				if isPointerMethodSelection(sel) && expr.Pos().IsValid() && expr.Sel.Pos().IsValid() {
 					selections[expr] = receiverNilCheck{expr.Pos(), receiverNeedsAddressCheck(sel)}
 				}
 			}
@@ -52,7 +55,7 @@ func CollectReceiverNilChecks(files []*ast.File, infos ...*types.Info) *Receiver
 				return true
 			}
 			selector, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr)
-			if check, found := selections[selector]; ok && found {
+			if check, found := selections[selector]; ok && found && call.Lparen.IsValid() {
 				checks.calls[call.Lparen] = check
 			}
 			return true
@@ -117,11 +120,15 @@ func (p *context) checkMethodCallReceiver(b llssa.Builder, call *ssa.CallCommon)
 }
 
 func isPointerMethodWrapperCall(owner *ssa.Function, call *ssa.CallCommon) bool {
-	if owner == nil || !(strings.HasPrefix(owner.Synthetic, "wrapper for ") || strings.HasPrefix(owner.Synthetic, "thunk for ")) {
+	if !isMethodReceiverWrapper(owner) {
 		return false
 	}
 	fn := call.StaticCallee()
 	return fn != nil && fn.Signature.Recv() != nil && isPointerGoType(fn.Signature.Recv().Type())
+}
+
+func isMethodReceiverWrapper(fn *ssa.Function) bool {
+	return fn != nil && (strings.HasPrefix(fn.Synthetic, "wrapper for ") || strings.HasPrefix(fn.Synthetic, "thunk for "))
 }
 
 // collectReceiverNilDerefChecks protects pre-existing pointer loads in the
@@ -129,6 +136,11 @@ func isPointerMethodWrapperCall(owner *ssa.Function, call *ssa.CallCommon) bool 
 // checking at the later method call would leave an earlier null load as UB.
 // Address-only selections have no load and keep their check at call/creation.
 func collectReceiverNilDerefChecks(fn *ssa.Function, checks *ReceiverNilChecks) map[*ssa.UnOp]token.Pos {
+	// Without source metadata only promoted wrappers/thunks can add checks.
+	// Do not scan ordinary bodies when neither source can produce a result.
+	if checks == nil && !isMethodReceiverWrapper(fn) {
+		return nil
+	}
 	var loads map[*ssa.UnOp]token.Pos
 	var mark func(ssa.Value, token.Pos)
 	mark = func(value ssa.Value, pos token.Pos) {

--- a/cl/receiver_nil.go
+++ b/cl/receiver_nil.go
@@ -1,0 +1,217 @@
+package cl
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	llssa "github.com/xgo-dev/llgo/ssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+// ReceiverNilChecks preserves implicit address-taking in pointer method
+// selections. SSA folds (*p).M into p.M and represents promoted value fields
+// with FieldAddr, neither of which retains the required nil dereference.
+// The maps are immutable after collection and shared by package lowering.
+type ReceiverNilChecks struct {
+	calls  map[token.Pos]receiverNilCheck
+	values map[token.Pos]receiverNilCheck
+}
+
+type receiverNilCheck struct {
+	pos     token.Pos
+	address bool
+}
+
+// CollectReceiverNilChecks uses checked selections, not selector spelling:
+// (*T).M is a method expression, whereas (*p).M selects a method value.
+// infos may include both an original package and its runtime source overlay.
+func CollectReceiverNilChecks(files []*ast.File, infos ...*types.Info) *ReceiverNilChecks {
+	selections := make(map[*ast.SelectorExpr]receiverNilCheck)
+	for _, info := range infos {
+		if info != nil {
+			for expr, sel := range info.Selections {
+				if isPointerMethodSelection(sel) {
+					selections[expr] = receiverNilCheck{expr.Pos(), receiverNeedsAddressCheck(sel)}
+				}
+			}
+		}
+	}
+	if len(selections) == 0 {
+		return nil
+	}
+	checks := &ReceiverNilChecks{calls: make(map[token.Pos]receiverNilCheck), values: make(map[token.Pos]receiverNilCheck)}
+	for expr, check := range selections {
+		checks.values[expr.Sel.Pos()] = check
+	}
+	for _, file := range files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr)
+			if check, found := selections[selector]; ok && found {
+				checks.calls[call.Lparen] = check
+			}
+			return true
+		})
+	}
+	return checks
+}
+
+func isPointerMethodSelection(sel *types.Selection) bool {
+	if sel == nil || sel.Kind() != types.MethodVal {
+		return false
+	}
+	sig, ok := sel.Obj().Type().(*types.Signature)
+	return ok && sig.Recv() != nil && isPointerGoType(sig.Recv().Type())
+}
+
+func receiverNeedsAddressCheck(sel *types.Selection) bool {
+	if !isPointerMethodSelection(sel) {
+		return false
+	}
+	// An embedded pointer is already a pointer receiver and may legally be
+	// nil. A value field, in contrast, requires the address of the field;
+	// selecting it through a nil enclosing pointer must panic.
+	typ := sel.Recv()
+	indices := sel.Index()
+	for _, index := range indices[:len(indices)-1] {
+		if ptr, ok := types.Unalias(typ).Underlying().(*types.Pointer); ok {
+			typ = ptr.Elem()
+		}
+		st, ok := types.Unalias(typ).Underlying().(*types.Struct)
+		if !ok || index >= st.NumFields() {
+			return false
+		}
+		typ = st.Field(index).Type()
+	}
+	return !isPointerGoType(typ)
+}
+
+func (p *context) checkMethodCallReceiver(b llssa.Builder, call *ssa.CallCommon) {
+	if len(call.Args) == 0 {
+		return
+	}
+	// Promoted method expressions and interface adapters also contain
+	// implicit field-address arithmetic, but have no source selector or call
+	// position. Keep the required base checks in the generated wrapper itself
+	// so storing (*Outer).M in a function value cannot bypass them. The final
+	// declared pointer receiver may still legally be nil.
+	if isPointerMethodWrapperCall(p.goFn, call) {
+		p.checkAddressedMethodReceiver(b, call.Args[0], receiverNilCheck{pos: p.goFn.Pos()})
+	}
+	checks := p.options.ReceiverNilChecks
+	if checks == nil {
+		return
+	}
+	if check, ok := checks.calls[call.Pos()]; ok {
+		// SSA has evaluated the argument expressions by this instruction.
+		// Checking while compiling FieldAddr would move the panic before
+		// those side effects. The saved receiver also avoids re-reading a
+		// variable that an argument expression may have reassigned.
+		p.checkAddressedMethodReceiver(b, call.Args[0], check)
+	}
+}
+
+func isPointerMethodWrapperCall(owner *ssa.Function, call *ssa.CallCommon) bool {
+	if owner == nil || !(strings.HasPrefix(owner.Synthetic, "wrapper for ") || strings.HasPrefix(owner.Synthetic, "thunk for ")) {
+		return false
+	}
+	fn := call.StaticCallee()
+	return fn != nil && fn.Signature.Recv() != nil && isPointerGoType(fn.Signature.Recv().Type())
+}
+
+// collectReceiverNilDerefChecks protects pre-existing pointer loads in the
+// receiver expression before LLVM can assume their bases are non-nil. Merely
+// checking at the later method call would leave an earlier null load as UB.
+// Address-only selections have no load and keep their check at call/creation.
+func collectReceiverNilDerefChecks(fn *ssa.Function, checks *ReceiverNilChecks) map[*ssa.UnOp]token.Pos {
+	var loads map[*ssa.UnOp]token.Pos
+	var mark func(ssa.Value, token.Pos)
+	mark = func(value ssa.Value, pos token.Pos) {
+		switch value := value.(type) {
+		case *ssa.UnOp:
+			if value.Op != token.MUL {
+				return
+			}
+			if !isKnownNonNilAddr(value.X) && !isWrapNilCheckCall(value.X) {
+				if loads == nil {
+					loads = make(map[*ssa.UnOp]token.Pos)
+				}
+				loads[value] = pos
+			}
+			mark(value.X, pos)
+		case *ssa.FieldAddr:
+			mark(value.X, pos)
+		}
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			switch instr := instr.(type) {
+			case ssa.CallInstruction:
+				call := instr.Common()
+				if len(call.Args) == 0 {
+					continue
+				}
+				if isPointerMethodWrapperCall(fn, call) {
+					mark(call.Args[0], fn.Pos())
+				} else if checks != nil {
+					if check, ok := checks.calls[call.Pos()]; ok {
+						mark(call.Args[0], check.pos)
+					}
+				}
+			case *ssa.MakeClosure:
+				if checks != nil && len(instr.Bindings) != 0 {
+					if check, ok := checks.values[instr.Pos()]; ok {
+						mark(instr.Bindings[0], check.pos)
+					}
+				}
+			}
+		}
+	}
+	return loads
+}
+
+func (p *context) checkBoundMethodReceiver(b llssa.Builder, closure *ssa.MakeClosure) {
+	checks := p.options.ReceiverNilChecks
+	if checks == nil || len(closure.Bindings) == 0 {
+		return
+	}
+	if check, ok := checks.values[closure.Pos()]; ok {
+		// Method-value formation must panic now, even if the value is never
+		// invoked; there is no later argument-evaluation phase to preserve.
+		p.checkAddressedMethodReceiver(b, closure.Bindings[0], check)
+	}
+}
+
+func (p *context) checkAddressedMethodReceiver(b llssa.Builder, receiver ssa.Value, check receiverNilCheck) {
+	if isKnownNonNilAddr(receiver) || isWrapNilCheckCall(receiver) {
+		return
+	}
+	if load, ok := receiver.(*ssa.UnOp); ok && !check.address {
+		if _, protected := p.receiverNilDerefChecks[load]; protected {
+			return
+		}
+	}
+	if !check.address && !methodReceiverHasUncheckedBase(receiver) {
+		return
+	}
+	p.recordPanicSite(b, check.pos)
+	p.emitNilDerefBaseCheck(b, receiver)
+	if check.address {
+		b.AssertNilDeref(p.compileValue(b, receiver))
+	}
+}
+
+func methodReceiverHasUncheckedBase(receiver ssa.Value) bool {
+	switch receiver := receiver.(type) {
+	case *ssa.UnOp:
+		return receiver.Op == token.MUL && !isKnownNonNilAddr(receiver.X) && !isWrapNilCheckCall(receiver.X)
+	case *ssa.FieldAddr:
+		return !isKnownNonNilAddr(receiver.X) && !isWrapNilCheckCall(receiver.X)
+	}
+	return false
+}

--- a/cl/receiver_nil.go
+++ b/cl/receiver_nil.go
@@ -105,6 +105,7 @@ func (p *context) checkMethodCallReceiver(b llssa.Builder, call *ssa.CallCommon)
 	// declared pointer receiver may still legally be nil.
 	if isPointerMethodWrapperCall(p.goFn, call) {
 		p.checkAddressedMethodReceiver(b, call.Args[0], receiverNilCheck{pos: p.goFn.Pos()})
+		return
 	}
 	checks := p.options.ReceiverNilChecks
 	if checks == nil {

--- a/cl/receiver_nil.go
+++ b/cl/receiver_nil.go
@@ -131,62 +131,6 @@ func isMethodReceiverWrapper(fn *ssa.Function) bool {
 	return fn != nil && (strings.HasPrefix(fn.Synthetic, "wrapper for ") || strings.HasPrefix(fn.Synthetic, "thunk for "))
 }
 
-// collectReceiverNilDerefChecks protects pre-existing pointer loads in the
-// receiver expression before LLVM can assume their bases are non-nil. Merely
-// checking at the later method call would leave an earlier null load as UB.
-// Address-only selections have no load and keep their check at call/creation.
-func collectReceiverNilDerefChecks(fn *ssa.Function, checks *ReceiverNilChecks) map[*ssa.UnOp]token.Pos {
-	// Without source metadata only promoted wrappers/thunks can add checks.
-	// Do not scan ordinary bodies when neither source can produce a result.
-	if checks == nil && !isMethodReceiverWrapper(fn) {
-		return nil
-	}
-	var loads map[*ssa.UnOp]token.Pos
-	var mark func(ssa.Value, token.Pos)
-	mark = func(value ssa.Value, pos token.Pos) {
-		switch value := value.(type) {
-		case *ssa.UnOp:
-			if value.Op != token.MUL {
-				return
-			}
-			if !isKnownNonNilAddr(value.X) && !isWrapNilCheckCall(value.X) {
-				if loads == nil {
-					loads = make(map[*ssa.UnOp]token.Pos)
-				}
-				loads[value] = pos
-			}
-			mark(value.X, pos)
-		case *ssa.FieldAddr:
-			mark(value.X, pos)
-		}
-	}
-	for _, block := range fn.Blocks {
-		for _, instr := range block.Instrs {
-			switch instr := instr.(type) {
-			case ssa.CallInstruction:
-				call := instr.Common()
-				if len(call.Args) == 0 {
-					continue
-				}
-				if isPointerMethodWrapperCall(fn, call) {
-					mark(call.Args[0], fn.Pos())
-				} else if checks != nil {
-					if check, ok := checks.calls[call.Pos()]; ok {
-						mark(call.Args[0], check.pos)
-					}
-				}
-			case *ssa.MakeClosure:
-				if checks != nil && len(instr.Bindings) != 0 {
-					if check, ok := checks.values[instr.Pos()]; ok {
-						mark(instr.Bindings[0], check.pos)
-					}
-				}
-			}
-		}
-	}
-	return loads
-}
-
 func (p *context) checkBoundMethodReceiver(b llssa.Builder, closure *ssa.MakeClosure) {
 	checks := p.options.ReceiverNilChecks
 	if checks == nil || len(closure.Bindings) == 0 {
@@ -204,7 +148,7 @@ func (p *context) checkAddressedMethodReceiver(b llssa.Builder, receiver ssa.Val
 		return
 	}
 	if load, ok := receiver.(*ssa.UnOp); ok && !check.address {
-		if _, protected := p.receiverNilDerefChecks[load]; protected {
+		if _, protected := p.recvNilDerefChecks[load]; protected {
 			return
 		}
 	}

--- a/cl/receiver_nil_test.go
+++ b/cl/receiver_nil_test.go
@@ -91,3 +91,68 @@ func savedPromotedExpression(p *P) { f := (*P).M; f(p, arg()) }
 		t.Fatalf("method-value creation lost its nil check:\n%s", ir)
 	}
 }
+
+func TestImportedGenericPointerMethodReceiverNilChecks(t *testing.T) {
+	fset := token.NewFileSet()
+	check := func(path, source string, importer types.Importer) (*types.Package, *types.Info, *ast.File) {
+		t.Helper()
+		file, err := parser.ParseFile(fset, path+".go", source, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info := newLocalityTypeInfo()
+		pkg, err := (&types.Config{Importer: importer}).Check(path, fset, []*ast.File{file}, info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg, info, file
+	}
+	dep, depInfo, depFile := check("example.com/dep", `package dep
+type T struct{}
+func (*T) M(int) {}
+func Call[A any](p *T, arg func() int, _ A) { (*p).M(arg()) }
+func Bound[A any](p *T, _ A) func(int) { return (*p).M }
+`, nil)
+	root, rootInfo, rootFile := check("example.com/root", `package root
+import "example.com/dep"
+func Invoke(p *dep.T, arg func() int) { dep.Call(p, arg, 1); dep.Bound(p, 1)(arg()) }
+`, importerFunc(func(path string) (*types.Package, error) {
+		if path == dep.Path() {
+			return dep, nil
+		}
+		return nil, types.Error{Msg: "unexpected import " + path}
+	}))
+	goProg := gossa.NewProgram(fset, gossa.SanityCheckFunctions|gossa.InstantiateGenerics)
+	goProg.CreatePackage(dep, []*ast.File{depFile}, depInfo, true)
+	rootSSA := goProg.CreatePackage(root, []*ast.File{rootFile}, rootInfo, true)
+	goProg.Build()
+	if checks := CollectReceiverNilChecks([]*ast.File{rootFile}, rootInfo); checks != nil {
+		t.Fatal("the caller's syntax must not contain the dependency's receiver selections")
+	}
+	checks := CollectReceiverNilChecks([]*ast.File{rootFile, depFile}, rootInfo, depInfo)
+	prog := newLLSSAProg(t)
+	defer prog.Dispose()
+	pkg, _, err := newPackageEx(prog, nil, nil, nil, rootSSA, []*ast.File{rootFile}, nil, false, Options{ReceiverNilChecks: checks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod := pkg.Module()
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"Call", "Bound"} {
+		found := false
+		for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+			if !strings.HasPrefix(fn.Name(), "example.com/dep."+name+"[") {
+				continue
+			}
+			found = true
+			if !strings.Contains(fn.String(), "AssertNilDeref") {
+				t.Fatalf("imported generic %s lost its source receiver check:\n%s", name, fn.String())
+			}
+		}
+		if !found {
+			t.Fatalf("imported generic %s was not emitted in the caller module:\n%s", name, mod.String())
+		}
+	}
+}

--- a/cl/receiver_nil_test.go
+++ b/cl/receiver_nil_test.go
@@ -156,3 +156,110 @@ func Invoke(p *dep.T, arg func() int) { dep.Call(p, arg, 1); dep.Bound(p, 1)(arg
 		}
 	}
 }
+
+func TestReceiverNilChecksRejectNoPos(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		invalidate func(*ast.CallExpr, []*ast.SelectorExpr)
+		calls      int
+		values     int
+	}{
+		{"valid", func(*ast.CallExpr, []*ast.SelectorExpr) {}, 1, 2},
+		{"call", func(call *ast.CallExpr, _ []*ast.SelectorExpr) { call.Lparen = token.NoPos }, 0, 2},
+		{"selector", func(_ *ast.CallExpr, selectors []*ast.SelectorExpr) { selectors[0].Sel.NamePos = token.NoPos }, 0, 1},
+		{"receiver", func(_ *ast.CallExpr, selectors []*ast.SelectorExpr) {
+			selectors[0].X.(*ast.Ident).NamePos = token.NoPos
+		}, 0, 1},
+		{"bound", func(_ *ast.CallExpr, selectors []*ast.SelectorExpr) { selectors[1].Sel.NamePos = token.NoPos }, 1, 1},
+		{"all", func(call *ast.CallExpr, selectors []*ast.SelectorExpr) {
+			call.Lparen = token.NoPos
+			for _, selector := range selectors {
+				selector.Sel.NamePos = token.NoPos
+			}
+		}, 0, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "receiver.go", `package foo
+type T struct{}
+func (*T) M() {}
+func F(p *T) { p.M(); _ = p.M }
+`, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			info := &types.Info{Selections: make(map[*ast.SelectorExpr]*types.Selection)}
+			if _, err := new(types.Config).Check("foo", fset, []*ast.File{file}, info); err != nil {
+				t.Fatal(err)
+			}
+			var call *ast.CallExpr
+			var selectors []*ast.SelectorExpr
+			ast.Inspect(file, func(node ast.Node) bool {
+				switch node := node.(type) {
+				case *ast.CallExpr:
+					call = node
+				case *ast.SelectorExpr:
+					selectors = append(selectors, node)
+				}
+				return true
+			})
+			test.invalidate(call, selectors)
+			checks := CollectReceiverNilChecks([]*ast.File{file}, info)
+			if test.calls == 0 && test.values == 0 {
+				if checks != nil {
+					t.Fatalf("positionless selections produced checks: %#v", checks)
+				}
+				return
+			}
+			if checks == nil || len(checks.calls) != test.calls || len(checks.values) != test.values {
+				t.Fatalf("checks = %#v, want %d calls and %d values", checks, test.calls, test.values)
+			}
+			for _, table := range []map[token.Pos]receiverNilCheck{checks.calls, checks.values} {
+				for pos, check := range table {
+					if !pos.IsValid() || !check.pos.IsValid() {
+						t.Fatalf("source metadata contains invalid position: key=%v check=%#v", pos, check)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReceiverNilDerefChecksWithoutSourceMetadata(t *testing.T) {
+	// A nil block is a sentinel: an unnecessary instruction walk would panic.
+	// Neither an ordinary function nor an unrelated synthetic function needs
+	// that walk when no source receiver metadata exists.
+	for _, synthetic := range []string{"", "bound method wrapper for (*T).M"} {
+		fn := &gossa.Function{Synthetic: synthetic, Blocks: []*gossa.BasicBlock{nil}}
+		if checks := collectReceiverNilDerefChecks(fn, nil); checks != nil {
+			t.Fatalf("function %q without source metadata produced checks: %#v", synthetic, checks)
+		}
+	}
+	if checks := collectReceiverNilDerefChecks(nil, nil); checks != nil {
+		t.Fatalf("absent function produced checks: %#v", checks)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "wrapper.go", `package foo
+type T struct{}
+func (*T) M() {}
+type P struct { *T }
+func F(p *P) { (*P).M(p) }
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, _, err := ssautil.BuildPackage(new(types.Config), fset, types.NewPackage("foo", "foo"), []*ast.File{file}, gossa.SanityCheckFunctions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	protected := 0
+	for fn := range ssautil.AllFunctions(pkg.Prog) {
+		if !isMethodReceiverWrapper(fn) {
+			continue
+		}
+		protected += len(collectReceiverNilDerefChecks(fn, nil))
+	}
+	if protected == 0 {
+		t.Fatal("promoted pointer wrapper lost its receiver-load checks without source metadata")
+	}
+}

--- a/cl/receiver_nil_test.go
+++ b/cl/receiver_nil_test.go
@@ -1,0 +1,93 @@
+//go:build !llgo
+
+package cl
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/goplus/gogen/packages"
+	"github.com/xgo-dev/llvm"
+	gossa "golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestPointerMethodReceiverNilChecks(t *testing.T) {
+	const source = `package foo
+type T struct { x int }
+func (*T) M(int) {}
+type U struct { pad int; T }
+type P struct { *T }
+func arg() int { return 1 }
+func plain(p *T) { p.M(arg()) }
+func expression(p *T) { (*T).M(p, arg()) }
+func deref(p *T) { (*p).M(arg()) }
+func promoted(p *U) { p.M(arg()) }
+func pointer(p *P) { p.M(arg()) }
+func deferred(p *T) { defer (*p).M(arg()) }
+func started(p *T) { go (*p).M(arg()) }
+func bound(p *T) func(int) { return (*p).M }
+func shadowed(T *T) { (*T).M(arg()) }
+func promotedExpression(p *U) { (*U).M(p, arg()) }
+func savedPromotedExpression(p *P) { f := (*P).M; f(p, arg()) }
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "receiver.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []*ast.File{file}
+	ssaPkg, info, err := ssautil.BuildPackage(&types.Config{Importer: packages.NewImporter(fset)}, fset,
+		types.NewPackage("foo", "foo"), files, gossa.SanityCheckFunctions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := CollectReceiverNilChecks(files, nil, info)
+	if checks == nil || len(checks.calls) != 7 || len(checks.values) != 8 {
+		t.Fatalf("receiver check collection = %#v, want 7 calls and 8 selections", checks)
+	}
+	if CollectReceiverNilChecks(files, nil) != nil || receiverNeedsAddressCheck(nil) {
+		t.Fatal("absent type information must not invent receiver checks")
+	}
+	prog := newLLSSAProg(t)
+	defer prog.Dispose()
+	pkg, _, err := newPackageEx(prog, nil, nil, nil, ssaPkg, files, nil, false, Options{ReceiverNilChecks: checks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod := pkg.Module()
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"plain", "expression"} {
+		ir := mustNamedFunction(t, mod, "foo."+name).String()
+		if strings.Contains(ir, "AssertNilDeref") {
+			t.Fatalf("legal pointer receiver %s gained a nil check:\n%s", name, ir)
+		}
+	}
+	for _, name := range []string{"deref", "promoted", "deferred", "started", "shadowed"} {
+		ir := mustNamedFunction(t, mod, "foo."+name).String()
+		argument := strings.Index(ir, "@foo.arg(")
+		guard := strings.Index(ir, "AssertNilDeref")
+		if argument < 0 || guard < argument {
+			t.Fatalf("%s must check its receiver after evaluating arguments:\n%s", name, ir)
+		}
+	}
+	// An embedded-pointer receiver has a real load, unlike address-only
+	// promotion. Its guard must dominate that load even when optimization
+	// removes the eventual method's unused receiver argument.
+	pointerIR := mustNamedFunction(t, mod, "foo.pointer").String()
+	guard := strings.Index(pointerIR, "AssertNilDerefPtr")
+	load := strings.Index(pointerIR, "load ptr")
+	if guard < 0 || load < guard {
+		t.Fatalf("embedded receiver pointer load precedes its guard:\n%s", pointerIR)
+	}
+	ir := mustNamedFunction(t, mod, "foo.bound").String()
+	if !strings.Contains(ir, "AssertNilDeref") {
+		t.Fatalf("method-value creation lost its nil check:\n%s", ir)
+	}
+}

--- a/cl/receiver_nil_test.go
+++ b/cl/receiver_nil_test.go
@@ -263,3 +263,66 @@ func F(p *P) { (*P).M(p) }
 		t.Fatal("promoted pointer wrapper lost its receiver-load checks without source metadata")
 	}
 }
+
+func TestReceiverNilChecksNonLoadReceivers(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "received.go", `package foo
+type T struct{}
+func (*T) M() {}
+type U struct { T }
+func receive(ch <-chan *T) { (<-ch).M() }
+func receiveBound(ch <-chan *T) func() { return (<-ch).M }
+func local() { var value T; value.M(); _ = value.M }
+func promoted(value *U) { value.M() }
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []*ast.File{file}
+	ssaPkg, info, err := ssautil.BuildPackage(new(types.Config), fset, types.NewPackage("foo", "foo"), files, gossa.SanityCheckFunctions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := CollectReceiverNilChecks(files, info)
+	for _, name := range []string{"receive", "receiveBound", "local"} {
+		// A channel receive is also an SSA UnOp, but is not a pointer
+		// load. Its result can legally be a nil pointer-method receiver.
+		if loads := collectReceiverNilDerefChecks(ssaPkg.Func(name), checks); len(loads) != 0 {
+			t.Fatalf("%s invented receiver pointer loads: %v", name, loads)
+		}
+	}
+	prog := newLLSSAProg(t)
+	defer prog.Dispose()
+	pkg, _, err := newPackageEx(prog, nil, nil, nil, ssaPkg, files, nil, false, Options{ReceiverNilChecks: checks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"receive", "receiveBound", "local"} {
+		body := mustNamedFunction(t, pkg.Module(), "foo."+name).String()
+		if strings.Contains(body, "AssertNilDeref") {
+			t.Fatalf("%s must permit a received nil or known non-nil local receiver:\n%s", name, body)
+		}
+	}
+	// An unrelated closure with no source metadata requires neither a
+	// receiver check nor a builder. Keep that fast path independent of LLVM.
+	new(context).checkBoundMethodReceiver(nil, new(gossa.MakeClosure))
+	// Selection.Index exposes a mutable slice. Malformed metadata must be
+	// rejected by the existing guard instead of indexing outside the struct.
+	for _, selection := range info.Selections {
+		indices := selection.Index()
+		if len(indices) > 1 {
+			saved := indices[0]
+			indices[0] = 100
+			got := receiverNeedsAddressCheck(selection)
+			indices[0] = saved
+			if got {
+				t.Fatal("invalid embedded-field index produced a receiver check")
+			}
+			return
+		}
+	}
+	t.Fatal("missing promoted selection for the invalid-index guard")
+}

--- a/cl/receiver_nil_test.go
+++ b/cl/receiver_nil_test.go
@@ -226,18 +226,6 @@ func F(p *T) { p.M(); _ = p.M }
 }
 
 func TestReceiverNilDerefChecksWithoutSourceMetadata(t *testing.T) {
-	// A nil block is a sentinel: an unnecessary instruction walk would panic.
-	// Neither an ordinary function nor an unrelated synthetic function needs
-	// that walk when no source receiver metadata exists.
-	for _, synthetic := range []string{"", "bound method wrapper for (*T).M"} {
-		fn := &gossa.Function{Synthetic: synthetic, Blocks: []*gossa.BasicBlock{nil}}
-		if checks := collectReceiverNilDerefChecks(fn, nil); checks != nil {
-			t.Fatalf("function %q without source metadata produced checks: %#v", synthetic, checks)
-		}
-	}
-	if checks := collectReceiverNilDerefChecks(nil, nil); checks != nil {
-		t.Fatalf("absent function produced checks: %#v", checks)
-	}
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "wrapper.go", `package foo
 type T struct{}
@@ -257,7 +245,8 @@ func F(p *P) { (*P).M(p) }
 		if !isMethodReceiverWrapper(fn) {
 			continue
 		}
-		protected += len(collectReceiverNilDerefChecks(fn, nil))
+		_, checks := collectMethodNilDerefChecks(fn, nil)
+		protected += len(checks)
 	}
 	if protected == 0 {
 		t.Fatal("promoted pointer wrapper lost its receiver-load checks without source metadata")
@@ -287,7 +276,7 @@ func promoted(value *U) { value.M() }
 	for _, name := range []string{"receive", "receiveBound", "local"} {
 		// A channel receive is also an SSA UnOp, but is not a pointer
 		// load. Its result can legally be a nil pointer-method receiver.
-		if loads := collectReceiverNilDerefChecks(ssaPkg.Func(name), checks); len(loads) != 0 {
+		if _, loads := collectMethodNilDerefChecks(ssaPkg.Func(name), checks); len(loads) != 0 {
 			t.Fatalf("%s invented receiver pointer loads: %v", name, loads)
 		}
 	}

--- a/cl/receiver_nil_test.go
+++ b/cl/receiver_nil_test.go
@@ -79,12 +79,16 @@ func savedPromotedExpression(p *P) { f := (*P).M; f(p, arg()) }
 	}
 	// An embedded-pointer receiver has a real load, unlike address-only
 	// promotion. Its guard must dominate that load even when optimization
-	// removes the eventual method's unused receiver argument.
+	// removes the eventual method's unused receiver argument. Once the outer
+	// pointer is checked, the derived field address itself needs no second guard.
 	pointerIR := mustNamedFunction(t, mod, "foo.pointer").String()
-	guard := strings.Index(pointerIR, "AssertNilDerefPtr")
+	guard := strings.Index(pointerIR, "AssertNilDeref")
 	load := strings.Index(pointerIR, "load ptr")
 	if guard < 0 || load < guard {
 		t.Fatalf("embedded receiver pointer load precedes its guard:\n%s", pointerIR)
+	}
+	if strings.Contains(pointerIR, "AssertNilDerefPtr") {
+		t.Fatalf("embedded receiver pointer load rechecks its derived field address:\n%s", pointerIR)
 	}
 	ir := mustNamedFunction(t, mod, "foo.bound").String()
 	if !strings.Contains(ir, "AssertNilDeref") {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2820,6 +2820,11 @@ func preparePackageModule(ctx *context, aPkg *aPackage, verbose bool) ([]string,
 		return nil, fmt.Errorf("load go:embed directives for %s failed: %w", pkgPath, err)
 	}
 	options := ctx.frontendOptions
+	var altTypesInfo *types.Info
+	if aPkg.AltPkg != nil {
+		altTypesInfo = aPkg.AltPkg.TypesInfo
+	}
+	options.ReceiverNilChecks = cl.CollectReceiverNilChecks(syntax, pkg.TypesInfo, altTypesInfo)
 	// Library exports use final-link wrappers to register foreign caller threads
 	// with the collector; Windows shared libraries also initialize lazily. Only
 	// the command package needs alternate export symbols, and command packages

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -829,6 +829,7 @@ func Build(inv Invocation) (result []Package, resultErr error) {
 	callerSpan := buildTrace.startCoordinator("precompute caller tracking", nil)
 	ctx.callerTracking.Precompute(ctx.progSSA.AllPackages())
 	callerSpan.done()
+	ctx.frontendOptions.ReceiverNilChecks = collectReceiverNilChecks(initial, altPkgs)
 
 	allPkgs := append([]*aPackage{}, pkgs...)
 	allPkgs = append(allPkgs, depPkgs...)
@@ -2820,11 +2821,6 @@ func preparePackageModule(ctx *context, aPkg *aPackage, verbose bool) ([]string,
 		return nil, fmt.Errorf("load go:embed directives for %s failed: %w", pkgPath, err)
 	}
 	options := ctx.frontendOptions
-	var altTypesInfo *types.Info
-	if aPkg.AltPkg != nil {
-		altTypesInfo = aPkg.AltPkg.TypesInfo
-	}
-	options.ReceiverNilChecks = cl.CollectReceiverNilChecks(syntax, pkg.TypesInfo, altTypesInfo)
 	// Library exports use final-link wrappers to register foreign caller threads
 	// with the collector; Windows shared libraries also initialize lazily. Only
 	// the command package needs alternate export symbols, and command packages

--- a/internal/build/receiver_nil.go
+++ b/internal/build/receiver_nil.go
@@ -1,0 +1,30 @@
+package build
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/xgo-dev/llgo/cl"
+	"github.com/xgo-dev/llgo/internal/packages"
+)
+
+// collectReceiverNilChecks runs once on the coordinator, before any package
+// lowering. Imported generic bodies can be emitted in a caller's module while
+// retaining the defining package's source positions. Every backend therefore
+// shares this immutable table, including selections from runtime overlays.
+func collectReceiverNilChecks(groups ...[]*packages.Package) *cl.ReceiverNilChecks {
+	var files []*ast.File
+	var infos []*types.Info
+	seen := make(map[*types.Info]bool)
+	for _, roots := range groups {
+		packages.Visit(roots, nil, func(pkg *packages.Package) {
+			if pkg.TypesInfo == nil || seen[pkg.TypesInfo] {
+				return
+			}
+			seen[pkg.TypesInfo] = true
+			files = append(files, pkg.Syntax...)
+			infos = append(infos, pkg.TypesInfo)
+		})
+	}
+	return cl.CollectReceiverNilChecks(files, infos...)
+}

--- a/internal/build/receiver_nil_test.go
+++ b/internal/build/receiver_nil_test.go
@@ -1,0 +1,48 @@
+//go:build !llgo
+
+package build
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"reflect"
+	"testing"
+
+	"github.com/xgo-dev/llgo/cl"
+	"github.com/xgo-dev/llgo/internal/packages"
+)
+
+func TestCollectReceiverNilChecksAcrossPackages(t *testing.T) {
+	fset := token.NewFileSet()
+	checked := func(path string) *packages.Package {
+		t.Helper()
+		file, err := parser.ParseFile(fset, path+".go", `package p
+type T struct{}
+func (*T) M() {}
+func Invoke[A any](p *T, _ A) { (*p).M() }
+`, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info := &types.Info{Selections: make(map[*ast.SelectorExpr]*types.Selection)}
+		typ, err := new(types.Config).Check(path, fset, []*ast.File{file}, info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &packages.Package{ID: path, PkgPath: path, Types: typ, TypesInfo: info, Syntax: []*ast.File{file}}
+	}
+	dependency := checked("dep")
+	overlay := checked("overlay")
+	root := &packages.Package{ID: "root", Imports: map[string]*packages.Package{"dep": dependency}}
+	got := collectReceiverNilChecks([]*packages.Package{root}, []*packages.Package{overlay, dependency})
+	files := append(append([]*ast.File{}, dependency.Syntax...), overlay.Syntax...)
+	want := cl.CollectReceiverNilChecks(files, dependency.TypesInfo, overlay.TypesInfo)
+	if want == nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("shared receiver metadata = %#v, want dependency and overlay selections %#v", got, want)
+	}
+	if collectReceiverNilChecks() != nil {
+		t.Fatal("empty package graph must not invent receiver metadata")
+	}
+}

--- a/runtime/internal/runtime/z_error.go
+++ b/runtime/internal/runtime/z_error.go
@@ -81,6 +81,7 @@ func AssertDivideByZero(b bool) {
 	}
 }
 
+//go:noinline
 func AssertNilDeref(b bool) {
 	if b {
 		panic(errorString("invalid memory address or nil pointer dereference"))

--- a/ssa/channel_test.go
+++ b/ssa/channel_test.go
@@ -1,0 +1,74 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"go/importer"
+	"go/token"
+	"go/types"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestChannelReceiveBufferLoads(t *testing.T) {
+	rt, err := importer.For("source", nil).Import(PkgRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, elem := range []types.Type{
+		types.Typ[types.Int],
+		types.NewPointer(types.Typ[types.Int]),
+		types.NewArray(types.Typ[types.Int], 4),
+		types.NewInterfaceType(nil, nil).Complete(),
+		types.NewStruct(nil, nil),
+		types.NewArray(types.Typ[types.Int], 0),
+	} {
+		t.Run(elem.String(), func(t *testing.T) {
+			for _, mode := range []string{"direct", "comma-ok", "select", "try-select"} {
+				t.Run(mode, func(t *testing.T) {
+					prog := NewProgram(nil)
+					defer prog.Dispose()
+					prog.sizes = types.SizesFor("gc", runtime.GOARCH)
+					prog.SetRuntime(func() *types.Package { return rt })
+					pkg := prog.NewPackage("p", "example.com/receive")
+					params := types.NewTuple(types.NewVar(token.NoPos, nil, "ch", types.NewChan(types.SendRecv, elem)))
+					results := types.NewTuple(types.NewVar(token.NoPos, nil, "", elem))
+					fn := pkg.NewFunc("receive", types.NewSignatureType(nil, nil, nil, params, results, false), InGo)
+					b := fn.MakeBody(1)
+					var value Expr
+					switch mode {
+					case "direct":
+						value = b.Recv(fn.Param(0), false)
+					case "comma-ok":
+						value = b.Extract(b.Recv(fn.Param(0), true), 0)
+					default:
+						value = b.Extract(b.Select([]*SelectState{{Chan: fn.Param(0)}}, mode == "select"), 2)
+					}
+					b.Return(value)
+					b.EndBuild()
+					if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+						t.Fatal(err)
+					}
+					ir := fn.impl.String()
+					load := strings.Index(ir, "load volatile")
+					restore := strings.Index(ir, "call void @llvm.stackrestore")
+					if restore < 0 {
+						t.Fatalf("missing stack restoration:\n%s", ir)
+					}
+					if prog.SizeOf(prog.Type(elem, InGo)) == 0 {
+						// Comma-ok and select wrap the constant in a tuple with
+						// dynamic fields, so extraction need not be folded yet.
+						if load >= 0 || (mode == "direct" && !value.impl.IsConstant()) {
+							t.Fatalf("zero-sized receive must use a constant without a volatile load:\n%s", ir)
+						}
+					} else if load < 0 || load > restore {
+						t.Fatalf("receive buffer must be loaded before restoring the stack:\n%s", ir)
+					}
+				})
+			}
+		})
+	}
+}

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -995,7 +995,9 @@ func (b Builder) Recv(ch Expr, commaOk bool) (ret Expr) {
 	sp := b.StackSave()
 	ptr := b.Alloc(etyp, false)
 	ok := b.InlineCall(b.Pkg.rtFunc("ChanRecv"), ch, ptr, eltSize)
-	val := b.Load(ptr)
+	// The receive buffer becomes invalid at StackRestore. Keep its value load
+	// from being sunk past that lifetime boundary by a target backend.
+	val := b.Load(ptr).SetVolatile(true)
 	b.StackRestore(sp)
 	if commaOk {
 		t := prog.Struct(etyp, prog.Bool())

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -1077,8 +1077,10 @@ func (b Builder) Select(states []*SelectState, blocking bool) (ret Expr) {
 	for i, s := range states {
 		if !s.Send {
 			etyp := b.Prog.Elem(s.Chan.Type)
+			// The receive buffer was allocated after StackSave and becomes invalid
+			// at StackRestore. Keep its load from being sunk past that boundary.
 			typs = append(typs, etyp)
-			r := b.Load(Expr{b.impl.CreateExtractValue(ops[i].impl, 1, ""), prog.Pointer(etyp)})
+			r := b.Load(Expr{b.impl.CreateExtractValue(ops[i].impl, 1, ""), prog.Pointer(etyp)}).SetVolatile(true)
 			results = append(results, r.impl)
 		}
 	}

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -997,7 +997,10 @@ func (b Builder) Recv(ch Expr, commaOk bool) (ret Expr) {
 	ok := b.InlineCall(b.Pkg.rtFunc("ChanRecv"), ch, ptr, eltSize)
 	// The receive buffer becomes invalid at StackRestore. Keep its value load
 	// from being sunk past that lifetime boundary by a target backend.
-	val := b.Load(ptr).SetVolatile(true)
+	val := b.Load(ptr)
+	if prog.SizeOf(etyp) != 0 { // Zero-sized Load returns a constant, not an instruction.
+		val.SetVolatile(true)
+	}
 	b.StackRestore(sp)
 	if commaOk {
 		t := prog.Struct(etyp, prog.Bool())
@@ -1082,7 +1085,10 @@ func (b Builder) Select(states []*SelectState, blocking bool) (ret Expr) {
 			// The receive buffer was allocated after StackSave and becomes invalid
 			// at StackRestore. Keep its load from being sunk past that boundary.
 			typs = append(typs, etyp)
-			r := b.Load(Expr{b.impl.CreateExtractValue(ops[i].impl, 1, ""), prog.Pointer(etyp)}).SetVolatile(true)
+			r := b.Load(Expr{b.impl.CreateExtractValue(ops[i].impl, 1, ""), prog.Pointer(etyp)})
+			if prog.SizeOf(etyp) != 0 { // Zero-sized Load returns a constant.
+				r.SetVolatile(true)
+			}
 			results = append(results, r.impl)
 		}
 	}

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -366,7 +366,18 @@ func (b Builder) AssertNilDeref(ptr Expr) {
 	}
 	nilPtr := llvm.ConstNull(ptr.impl.Type())
 	isNil := Expr{llvm.CreateICmp(b.impl, llvm.IntEQ, ptr.impl, nilPtr), b.Prog.Bool()}
-	b.InlineCall(b.Pkg.rtFunc("AssertNilDeref"), isNil)
+	// Keep the successful path free of an opaque runtime call. In particular,
+	// field-address checks may fold to false only after LLVM optimization;
+	// calling AssertNilDeref(false) still forces spills across that call.
+	blks := b.Func.MakeBlocks(2)
+	b.If(isNil, blks[0], blks[1])
+	b.SetBlockEx(blks[0], AtEnd, false)
+	b.Call(b.Pkg.rtFunc("AssertNilDeref"), b.Prog.BoolVal(true))
+	// Like the bounds-check failure path, this cannot return normally. Keep
+	// a post-call instruction for panic return-address line information.
+	b.Jump(blks[0])
+	b.SetBlockEx(blks[1], AtEnd, false)
+	b.blk.last = blks[1].last
 }
 
 func (b Builder) NilDerefCheck(ptr Expr) Expr {

--- a/ssa/memory_test.go
+++ b/ssa/memory_test.go
@@ -1,8 +1,92 @@
 package ssa
 
-import "testing"
+import (
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
 
 func TestAssertNilDerefZeroExprNoPanic(t *testing.T) {
 	var b Builder
 	b.AssertNilDeref(Expr{})
+}
+
+func TestAssertNilDerefColdCall(t *testing.T) {
+	Initialize(InitAllTargets | InitAllTargetInfos | InitAllTargetMCs | InitAllAsmPrinters)
+	for _, target := range []*Target{
+		{GOOS: "linux", GOARCH: "amd64", LLVMTarget: "x86_64-unknown-linux"},
+		{GOOS: "js", GOARCH: "wasm", LLVMTarget: "wasm32-unknown-emscripten"},
+		{GOOS: "js", GOARCH: "wasm", LLVMTarget: "wasm64-unknown-emscripten"},
+		{GOOS: "wasip1", GOARCH: "wasm", LLVMTarget: "wasm32-unknown-wasip1"},
+	} {
+		t.Run(target.LLVMTarget, func(t *testing.T) {
+			prog := NewProgram(target)
+			defer prog.Dispose()
+			prog.SetRuntime(func() *types.Package {
+				rt := types.NewPackage(PkgRuntime, "runtime")
+				params := types.NewTuple(types.NewVar(token.NoPos, nil, "nil", types.Typ[types.Bool]))
+				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
+				rt.Scope().Insert(types.NewFunc(token.NoPos, rt, "AssertNilDeref", sig))
+				return rt
+			})
+			pkg := prog.NewPackage("p", "example.com/nilcheck")
+			params := types.NewTuple(types.NewVar(token.NoPos, nil, "p", types.Typ[types.UnsafePointer]))
+			sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
+			for _, name := range []string{"dynamic", "nil", "allocated", "constant"} {
+				fn := pkg.NewFunc(name, sig, InGo)
+				b := fn.MakeBody(1)
+				ptr := fn.Param(0)
+				switch name {
+				case "nil":
+					ptr = prog.Nil(prog.VoidPtr())
+				case "allocated":
+					allocator := pkg.NewFunc(PkgRuntime+".AllocU", prog.tyMalloc(), InGo)
+					ptr = b.Call(allocator.Expr, prog.IntVal(8, prog.Uintptr()))
+				case "constant":
+					ptr = b.Convert(prog.VoidPtr(), prog.IntVal(1, prog.Uintptr()))
+				}
+				b.AssertNilDeref(ptr)
+				b.Return()
+				b.EndBuild()
+				if name == "dynamic" {
+					entry := fn.impl.EntryBasicBlock()
+					branch := entry.LastInstruction()
+					if branch.InstructionOpcode() != llvm.Br || branch.SuccessorsCount() != 2 {
+						t.Fatalf("dynamic nil check must branch before calling runtime:\n%s", fn.impl.String())
+					}
+					for inst := entry.FirstInstruction(); !inst.IsNil(); inst = llvm.NextInstruction(inst) {
+						if inst.InstructionOpcode() == llvm.Call {
+							t.Fatalf("nil check calls runtime unconditionally:\n%s", fn.impl.String())
+						}
+					}
+					failure := branch.Successor(0)
+					back := failure.LastInstruction()
+					if back.InstructionOpcode() != llvm.Br || back.SuccessorsCount() != 1 || back.Successor(0) != failure {
+						t.Fatalf("nil failure must not return to the successful path:\n%s", fn.impl.String())
+					}
+				}
+			}
+			mod := pkg.Module()
+			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+			opts := llvm.NewPassBuilderOptions()
+			defer opts.Dispose()
+			if err := mod.RunPasses("function(instcombine,simplifycfg)", prog.TargetMachine(), opts); err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range []string{"dynamic", "nil", "allocated", "constant"} {
+				ir := mod.NamedFunction(name).String()
+				if got := strings.Contains(ir, "AssertNilDeref"); got != (name == "dynamic" || name == "nil") {
+					t.Fatalf("unexpected optimized %s check:\n%s", name, ir)
+				}
+			}
+			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }

--- a/test/go/receivernil/internal/receiverdep/receiver.go
+++ b/test/go/receivernil/internal/receiverdep/receiver.go
@@ -1,0 +1,22 @@
+package receiverdep
+
+type Leaf struct{ Value int }
+
+//go:noinline
+func (*Leaf) Invoke(callback func()) { callback() }
+
+// These instantiated bodies are emitted in an importing package's module,
+// but their nil-check source positions still belong to this package.
+//
+//go:noinline
+func Call[A any](p *Leaf, _ A, argument func() func()) {
+	(*p).Invoke(argument())
+}
+
+//go:noinline
+func Bound[A any](p *Leaf, _ A) func(func()) { return (*p).Invoke }
+
+//go:noinline
+func NilSafe[A any](p *Leaf, _ A, argument func() func()) {
+	p.Invoke(argument())
+}

--- a/test/go/receivernil/receiver_test.go
+++ b/test/go/receivernil/receiver_test.go
@@ -1,6 +1,10 @@
 package receivernil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/xgo-dev/llgo/test/go/receivernil/internal/receiverdep"
+)
 
 var trace string
 var called chan struct{}
@@ -156,5 +160,33 @@ func TestPointerMethodReceiverSavedBeforeArguments(t *testing.T) {
 		if trace != want || panicked != initiallyNil {
 			t.Fatalf("initially nil=%v: trace=%q panic=%v, want trace=%q panic=%v", initiallyNil, trace, panicked, want, initiallyNil)
 		}
+	}
+}
+
+func TestImportedGenericPointerMethodReceiver(t *testing.T) {
+	var nilLeaf *receiverdep.Leaf
+	argument := func() func() {
+		trace += "arg;"
+		return func() { trace += "method;" }
+	}
+	for _, test := range []struct {
+		name  string
+		call  func()
+		trace string
+		panic bool
+	}{
+		{"nil-call", func() { receiverdep.Call(nilLeaf, 1, argument) }, "arg;", true},
+		{"non-nil-call", func() { receiverdep.Call(&receiverdep.Leaf{}, 1, argument) }, "arg;method;", false},
+		{"nil-safe-call", func() { receiverdep.NilSafe(nilLeaf, 1, argument) }, "arg;method;", false},
+		{"nil-bound", func() { receiverdep.Bound(nilLeaf, 1)(argument()) }, "", true},
+		{"non-nil-bound", func() { receiverdep.Bound(&receiverdep.Leaf{}, 1)(argument()) }, "arg;method;", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			trace = ""
+			panicked := invokeAndRecover(test.call)
+			if trace != test.trace || panicked != test.panic {
+				t.Fatalf("trace=%q panic=%v, want trace=%q panic=%v", trace, panicked, test.trace, test.panic)
+			}
+		})
 	}
 }

--- a/test/go/receivernil/receiver_test.go
+++ b/test/go/receivernil/receiver_test.go
@@ -1,0 +1,160 @@
+package receivernil
+
+import "testing"
+
+var trace string
+var called chan struct{}
+
+type leaf struct{ value int }
+
+//go:noinline
+func (*leaf) Invoke(int) {
+	trace += "method;"
+	if called != nil {
+		called <- struct{}{}
+	}
+}
+
+type outer struct {
+	padding int
+	leaf
+}
+
+type pointerOuter struct{ *leaf }
+type nested struct{ *outer }
+
+//go:noinline
+func argument() int {
+	trace += "arg;"
+	return 1
+}
+
+//go:noinline
+func invokeAndRecover(fn func()) (panicked bool) {
+	defer func() { panicked = recover() != nil }()
+	fn()
+	return false
+}
+
+func TestPointerMethodReceiverEvaluation(t *testing.T) {
+	var p *leaf
+	var u *outer
+	var nilPointerOuter *pointerOuter
+	withNilLeaf := &pointerOuter{}
+	withNilOuter := &nested{}
+	var valueInvoker interface{ Invoke(int) } = u
+	var pointerInvoker interface{ Invoke(int) } = nilPointerOuter
+	var nilLeafInvoker interface{ Invoke(int) } = withNilLeaf
+	tests := []struct {
+		name  string
+		call  func()
+		trace string
+		panic bool
+	}{
+		{"nil-pointer", func() { p.Invoke(argument()) }, "arg;method;", false},
+		{"explicit-star", func() { (*p).Invoke(argument()) }, "arg;", true},
+		{"promoted-value", func() { u.Invoke(argument()) }, "arg;", true},
+		{"explicit-field", func() { u.leaf.Invoke(argument()) }, "arg;", true},
+		{"promoted-pointer", func() { withNilLeaf.Invoke(argument()) }, "arg;method;", false},
+		{"nil-promoted-pointer-base", func() { nilPointerOuter.Invoke(argument()) }, "optional-arg", true},
+		{"nested-nil-value-base", func() { withNilOuter.Invoke(argument()) }, "arg;", true},
+		{"method-expression", func() { (*leaf).Invoke(p, argument()) }, "arg;method;", false},
+		{"promoted-value-expression", func() { (*outer).Invoke(u, argument()) }, "arg;", true},
+		{"promoted-pointer-expression", func() { (*pointerOuter).Invoke(nilPointerOuter, argument()) }, "arg;", true},
+		{"nil-embedded-pointer-expression", func() { (*pointerOuter).Invoke(withNilLeaf, argument()) }, "arg;method;", false},
+		{"saved-promoted-value-expression", func() { f := (*outer).Invoke; f(u, argument()) }, "arg;", true},
+		{"saved-promoted-pointer-expression", func() { f := (*pointerOuter).Invoke; f(nilPointerOuter, argument()) }, "arg;", true},
+		{"promoted-value-interface", func() { valueInvoker.Invoke(argument()) }, "arg;", true},
+		{"promoted-pointer-interface", func() { pointerInvoker.Invoke(argument()) }, "arg;", true},
+		{"nil-embedded-pointer-interface", func() { nilLeafInvoker.Invoke(argument()) }, "arg;method;", false},
+		{"saved-promoted-interface", func() { f := valueInvoker.Invoke; trace += "bound;"; f(argument()) }, "bound;arg;", true},
+		{"explicit-address-expression", func() { (&*p).Invoke(argument()) }, "optional-arg", true},
+		{"explicit-star-bound", func() { f := (*p).Invoke; trace += "bound;"; f(argument()) }, "", true},
+		{"promoted-value-bound", func() { f := u.Invoke; trace += "bound;"; f(argument()) }, "", true},
+		{"nil-pointer-bound", func() { f := p.Invoke; f(argument()) }, "arg;method;", false},
+		{"promoted-pointer-bound", func() { f := withNilLeaf.Invoke; f(argument()) }, "arg;method;", false},
+		{"explicit-star-defer", func() { defer (*p).Invoke(argument()); trace += "registered;" }, "arg;", true},
+		{"promoted-value-defer", func() { defer u.Invoke(argument()); trace += "registered;" }, "arg;", true},
+		{"nil-pointer-defer", func() { defer p.Invoke(argument()); trace += "registered;" }, "arg;registered;method;", false},
+		{"promoted-expression-defer", func() { defer (*outer).Invoke(u, argument()); trace += "registered;" }, "arg;registered;", true},
+		{"nil-field-store", func() { p.value = argument() }, "arg;", true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			trace = ""
+			panicked := invokeAndRecover(test.call)
+			matches := trace == test.trace
+			if test.trace == "optional-arg" {
+				// Go does not order a pointer load relative to an argument's
+				// function call. Either nil-check schedule is valid, but the
+				// receiver load must not disappear just because M ignores it.
+				matches = trace == "" || trace == "arg;"
+			}
+			if !matches || panicked != test.panic {
+				t.Fatalf("trace=%q panic=%v, want trace=%q panic=%v", trace, panicked, test.trace, test.panic)
+			}
+		})
+	}
+}
+
+func TestPointerMethodGoReceiverEvaluation(t *testing.T) {
+	var p *leaf
+	var u *outer
+	called = make(chan struct{})
+	defer func() { called = nil }()
+	for _, test := range []struct {
+		name  string
+		start func()
+		panic bool
+	}{
+		{"nil-pointer", func() { go p.Invoke(argument()); <-called }, false},
+		{"explicit-star", func() { go (*p).Invoke(argument()); <-called }, true},
+		{"promoted-value", func() { go u.Invoke(argument()); <-called }, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			trace = ""
+			panicked := invokeAndRecover(test.start)
+			want := "arg;method;"
+			if test.panic {
+				want = "arg;"
+			}
+			if trace != want || panicked != test.panic {
+				t.Fatalf("trace=%q panic=%v, want trace=%q panic=%v", trace, panicked, want, test.panic)
+			}
+		})
+	}
+}
+
+//go:noinline
+func receiver(p *leaf) *leaf {
+	trace += "receiver;"
+	return p
+}
+
+func TestPointerMethodReceiverSavedBeforeArguments(t *testing.T) {
+	for _, initiallyNil := range []bool{true, false} {
+		var p *leaf
+		if !initiallyNil {
+			p = &leaf{}
+		}
+		trace = ""
+		panicked := invokeAndRecover(func() {
+			(*receiver(p)).Invoke(func() int {
+				trace += "arg;"
+				if initiallyNil {
+					p = &leaf{}
+				} else {
+					p = nil
+				}
+				return 1
+			}())
+		})
+		want := "receiver;arg;method;"
+		if initiallyNil {
+			want = "receiver;arg;"
+		}
+		if trace != want || panicked != initiallyNil {
+			t.Fatalf("initially nil=%v: trace=%q panic=%v, want trace=%q panic=%v", initiallyNil, trace, panicked, want, initiallyNil)
+		}
+	}
+}

--- a/test/goroot/proc_unix_test.go
+++ b/test/goroot/proc_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -104,12 +105,12 @@ func TestRunProgramWaitDelayCleansDescendant(t *testing.T) {
 
 			deadline := time.Now().Add(2 * time.Second)
 			for {
-				probeErr := syscall.Kill(pid, 0)
-				if errors.Is(probeErr, syscall.ESRCH) {
-					break
-				}
+				exited, probeErr := processHasExited(pid)
 				if probeErr != nil {
 					t.Fatalf("probe descendant %d: %v", pid, probeErr)
+				}
+				if exited {
+					break
 				}
 				if time.Now().After(deadline) {
 					t.Fatalf("descendant %d is still running after runProgram returned", pid)
@@ -117,5 +118,94 @@ func TestRunProgramWaitDelayCleansDescendant(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 			}
 		})
+	}
+}
+
+func processHasExited(pid int) (bool, error) {
+	err := syscall.Kill(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	if err != nil || runtime.GOOS != "linux" {
+		return false, err
+	}
+	// A container's PID 1 need not reap orphaned descendants. kill(pid, 0)
+	// still succeeds for a zombie, although SIGKILL has already stopped it.
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if os.IsNotExist(err) || errors.Is(err, syscall.ESRCH) {
+		return true, nil // Reaped between the signal probe and the proc read.
+	}
+	if err != nil {
+		return false, err
+	}
+	return procStatHasExited(stat)
+}
+
+func procStatHasExited(stat []byte) (bool, error) {
+	// comm may contain spaces and parentheses; state follows the last ')'.
+	end := bytes.LastIndexByte(stat, ')')
+	if end < 0 || end+3 >= len(stat) || stat[end+1] != ' ' || stat[end+3] != ' ' {
+		return false, fmt.Errorf("invalid process stat %q", stat)
+	}
+	return stat[end+2] == 'Z' || stat[end+2] == 'X', nil
+}
+
+func TestProcStatHasExited(t *testing.T) {
+	for _, tt := range []struct {
+		stat    string
+		exited  bool
+		invalid bool
+	}{
+		{"42 (sleep) S 1 42 0", false, false},
+		{"42 (sleep) R 1 42 0", false, false},
+		{"42 (sleep) Z 1 42 0", true, false},
+		{"42 (a name ) with parentheses) Z 1 42 0", true, false},
+		{"42 (sleep) X 1 42 0", true, false},
+		{"", false, true},
+		{"42 (sleep)", false, true},
+		{"42 (sleep) Z", false, true},
+	} {
+		t.Run(tt.stat, func(t *testing.T) {
+			got, err := procStatHasExited([]byte(tt.stat))
+			if got != tt.exited || (err != nil) != tt.invalid {
+				t.Fatalf("process stat = %v, %v; want exited=%v, invalid=%v", got, err, tt.exited, tt.invalid)
+			}
+		})
+	}
+}
+
+func TestProcessHasExited(t *testing.T) {
+	guardTestTimeout(t)
+	if exited, err := processHasExited(os.Getpid()); err != nil || exited {
+		t.Fatalf("live process: exited=%v, err=%v", exited, err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Wait() })
+	if runtime.GOOS == "linux" {
+		// Leave our child unreaped so this test does not depend on PID 1's
+		// behavior, even on a host with a fully functioning init process.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			exited, err := processHasExited(cmd.Process.Pid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exited {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("terminated but unreaped child was reported as running")
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if exited, err := processHasExited(cmd.Process.Pid); err != nil || !exited {
+		t.Fatalf("reaped child: exited=%v, err=%v", exited, err)
 	}
 }

--- a/test/goroot/proc_unix_test.go
+++ b/test/goroot/proc_unix_test.go
@@ -130,7 +130,7 @@ func processHasExited(pid int) (bool, error) {
 		return false, err
 	}
 	// A container's PID 1 need not reap orphaned descendants. kill(pid, 0)
-	// still succeeds for a zombie, although SIGKILL has already stopped it.
+	// still succeeds for a zombie, although the process has already terminated.
 	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if os.IsNotExist(err) || errors.Is(err, syscall.ESRCH) {
 		return true, nil // Reaped between the signal probe and the proc read.
@@ -160,6 +160,7 @@ func TestProcStatHasExited(t *testing.T) {
 		{"42 (sleep) R 1 42 0", false, false},
 		{"42 (sleep) Z 1 42 0", true, false},
 		{"42 (a name ) with parentheses) Z 1 42 0", true, false},
+		{"42 (foo)bar) Z 1 42 0", true, false},
 		{"42 (sleep) X 1 42 0", true, false},
 		{"", false, true},
 		{"42 (sleep)", false, true},

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -188,9 +188,6 @@ xfails:
     case: fixedbugs/issue34123.go
     reason: LLGo reports the deferred recovery frame two source lines earlier than cmd/compile
   - directive: run
-    case: fixedbugs/issue79762.go
-    reason: LLGo's runtime stack does not report the exact inlined source locations required by this test
-  - directive: run
     case: fixedbugs/issue80196.go
     reason: LLGo overflows its native stack while repeatedly assigning the escaped named result in this test
   - directive: run


### PR DESCRIPTION
## Problem

Selecting a pointer-receiver method through an explicit dereference or a promoted value field must still panic when that dereference is nil, even if the method itself accepts a nil receiver and never reads it. Go SSA can fold `(*p).M` into `p.M` or reduce promotion to field-address arithmetic, losing the required check during LLGo lowering.

This remains a main-branch language-semantics bug. With Go 1.27, `fixedbugs/issue79762.go` on current main reports the panic inside `(*T).foo` instead of at `(*t).foo()`, while this branch passes both direct and full-LTO builds without output.

## Change

- Retain checked method-selection metadata so lowering distinguishes `(*p).M` from the legal method expression `(*T).M` and from an ordinary nil-safe pointer receiver.
- Collect dependency and runtime-overlay selections once before lowering, and share the immutable table across backends. Imported generic bodies emitted in a caller module keep the defining package nil checks.
- Fold receiver-load discovery into the existing per-function method nil-check scan, avoiding a second traversal of all SSA instructions.
- Place address-only checks after argument evaluation, method-value checks at binding time, and existing pointer-load checks before the load.
- Protect promoted method-expression and interface wrappers inside their generated bodies. Deferred method expressions keep their promotion check at deferred execution rather than registration.
- Keep the nil-check success path free of opaque runtime calls, avoid rechecking a derived field address after its pointer base has been validated, and prevent the cold panic helper from being duplicated by full LTO.
- Keep direct and select receive-buffer loads before `llvm.stackrestore`; this prevents target code generation from reclaiming and overwriting a received value before it is consumed.
- Add executable regressions for direct calls, goroutines, defers, bound methods, promoted pointer and value fields, method expressions, interface dispatch, imported generic bodies, receiver side effects, malformed metadata, native targets, and Wasm targets.
- Remove the now-passing Go 1.27 GOROOT `fixedbugs/issue79762.go` xfail.

## Size audit

The original head added 22,676 B of native `fmtprintf` text locally and grew the complete-runtime Emscripten `println.wasm` by 1,446 B. The optimized rebased head reduces the native non-LTO text delta to 7,984 B and the full-LTO text delta to 1,688 B. Full LTO no longer duplicates either the panic body or the pointer-returning assertion helper at each checked receiver. The remaining text is principally the per-source-site branch required to retain precise panic locations; the native files and complete-runtime Emscripten module no longer grow in these same-toolchain measurements.

| artifact | main `76ac1f317` | head `90326800e` | delta |
| --- | ---: | ---: | ---: |
| darwin/arm64 `fmtprintf` file | 1,473,504 B | 1,473,312 B | -192 B |
| darwin/arm64 `fmtprintf` `__text` | 446,992 B | 454,976 B | +7,984 B |
| `fmtprintf -lto full` file | 1,159,456 B | 1,159,456 B | 0 B |
| `fmtprintf -lto full` `__text` | 410,916 B | 412,604 B | +1,688 B |
| Emscripten `println.wasm` file | 112,462 B | 112,359 B | -103 B |
| GOOS=js/GOARCH=wasm `println.wasm` file | 66,162 B | 66,749 B | +587 B |

These are local Go 1.27.0 and LLVM 22.1.8 comparisons with `LLGO_BUILD_CACHE=off`; fresh CI benchmark measurements remain authoritative for the CI toolchains.

## Validation

Rebased onto upstream main `76ac1f317` and tested with Go 1.27.0 and LLVM 22.1.8.

```
GOMAXPROCS=2 go test -tags=llvm22 ./ssa -count=1
GOMAXPROCS=2 go test -tags=llvm22 ./internal/build -run '^TestCollectReceiverNilChecksAcrossPackages$' -count=1
GOMAXPROCS=2 go test -tags=llvm22 ./cl -run '^Test(PointerMethodReceiverNilChecks|ImportedGenericPointerMethodReceiverNilChecks|ReceiverNilChecksRejectNoPos|ReceiverNilDerefChecksWithoutSourceMetadata|ReceiverNilChecksNonLoadReceivers|MethodNilDerefHelperBranches|CollectMethodNilDerefChecksSkipsDynamicDeferGo|CompilePromotedValueMethodNilDerefGuard|CompileValueReceiverNilDerefKeepsDominance)$' -count=1
GOMAXPROCS=2 go test -tags=llvm22 ./cl -run '^TestRunAndTestFromTestgo$/(abimethod|embedunexport-1598|genericembediface|ifaceconv|invoke|tpnamed)$|^TestRunAndTestFromTestrt$/(closurebound|tpfunc|vamethod)$' -count=1
go test ./cl -run '^TestRunAndTestFromTestgo$/(chan|select)$' -count=1
LLGO_ROOT=$PWD /tmp/llgo-pr2538-head-latest-bin test -timeout=2m ./test/go/receivernil
LLGO_ROOT=$PWD LLGO_BUILD_CACHE=off /tmp/llgo-pr2538-head-latest-bin build -lto full -o /tmp/issue79762 "$(go env GOROOT)/test/fixedbugs/issue79762.go" && /tmp/issue79762
```

The targeted local checks above pass. On a Windows 11 ARM64 VM targeting Windows/386 MinGW, the pre-fix head reproduced `TestConcurrentSelectProposeReplyStress` timeouts 20/20 times. Rebuilding the compiler with the latest receive-buffer fix passes 20/20 runs at 0.30-0.62 seconds each. The emitted x86 code was separately checked to load the received pointer before restoring the stack.

The receive-buffer follow-up also handles zero-sized elements: `Builder.Load` returns an LLVM constant for these elements, so only nonzero receive loads are marked volatile. `TestChannelReceiveBufferLoads` covers direct, comma-ok, blocking-select and nonblocking-select receives of scalar, pointer, array, interface and zero-sized types; it gives 100% local statement coverage for `Recv` and `Select`. The `chan` and `select` executable/FileCheck fixtures pass, including explicit load-before-stackrestore checks for direct receives. Native channel/select regressions pass 10 repetitions. The latest CI is still pending; these local results are not a claim that every CI job has passed.

The branch also carries the two independent test-only commits from #2563 to fix the inherited Linux container zombie-process false positive in `TestRunProgramWaitDelayCleansDescendant`. The failure was reproduced locally without an init reaper; with the fix the relevant tests pass 10 repetitions in that same container configuration.
