### PR TITLE
[Superseded by W1] fix(cl): retain wasm uintptr roots

### DIFF
--- a/cl/gcroot.go
+++ b/cl/gcroot.go
@@ -52,6 +52,9 @@ func (p *context) prepareGCRoots(fn *ssa.Function, hasClosureContext bool) {
 		typ := p.type_(value.Type(), llssa.InGo)
 		return p.prog.GCRootCount(typ) != 0
 	}, p.isGCSafepoint)
+	for value := range uintptrEscapesRoots(fn) {
+		planned[value] = struct{}{}
+	}
 	if p.safepointEntry {
 		for _, param := range fn.Params {
 			if !mayContainGCRoot(param.Type()) {
@@ -70,7 +73,12 @@ func (p *context) prepareGCRoots(fn *ssa.Function, hasClosureContext bool) {
 			return
 		}
 		typ := p.type_(value.Type(), llssa.InGo)
-		if n := p.prog.GCRootCount(typ); n != 0 {
+		n := p.prog.GCRootCount(typ)
+		if basicKind(value.Type()) == types.Uintptr {
+			// Only pragma-designated uintptr parameters enter planned.
+			n = 1
+		}
+		if n != 0 {
 			counts[value] = n
 			total += n
 		}
@@ -245,6 +253,10 @@ func basicKind(typ types.Type) types.BasicKind {
 func (p *context) publishGCRoot(b llssa.Builder, value ssa.Value, expr llssa.Expr) {
 	slots, ok := p.gcRoots[value]
 	if !ok || expr.IsNil() {
+		return
+	}
+	if basicKind(value.Type()) == types.Uintptr {
+		b.SetGCRoot(slots[0], expr)
 		return
 	}
 	roots := b.GCRootPointers(expr)

--- a/cl/uintptr_escapes.go
+++ b/cl/uintptr_escapes.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// uintptrEscapesRoots preserves the pointer semantics of //go:uintptrescapes
+// at both ends of a call. Ordinary uintptr values remain integers, not roots.
+// The source pointer must survive evaluation of subsequent arguments, before
+// the callee can publish its uintptr parameters. Go/defer argument records and
+// variadic backing arrays are scanned heap allocations and retain the values
+// while the call is pending; the callee roots cover the executing call.
+func uintptrEscapesRoots(fn *ssa.Function) map[ssa.Value]struct{} {
+	roots := make(map[ssa.Value]struct{})
+	if hasUintptrEscapesDirective(fn) {
+		for _, param := range fn.Params {
+			if basicKind(param.Type()) == types.Uintptr {
+				roots[param] = struct{}{}
+			}
+		}
+	}
+	seen := make(map[ssa.Value]bool)
+	var source func(ssa.Value)
+	source = func(value ssa.Value) {
+		if value == nil || seen[value] {
+			return
+		}
+		seen[value] = true
+		switch value := value.(type) {
+		case *ssa.Convert:
+			if basicKind(value.Type()) == types.Uintptr && basicKind(value.X.Type()) == types.UnsafePointer {
+				roots[value.X] = struct{}{}
+			}
+		case *ssa.ChangeType:
+			source(value.X)
+		case *ssa.Phi:
+			for _, edge := range value.Edges {
+				source(edge)
+			}
+		case *ssa.Slice:
+			source(value.X)
+		case *ssa.Alloc:
+			// SSA constructs f(uintptr(p), uintptr(q)) for ...uintptr as
+			// stores into a fresh array followed by a slice of that array.
+			if refs := value.Referrers(); refs != nil {
+				for _, ref := range *refs {
+					index, ok := ref.(*ssa.IndexAddr)
+					if !ok || index.X != value {
+						continue
+					}
+					if uses := index.Referrers(); uses != nil {
+						for _, use := range *uses {
+							if store, ok := use.(*ssa.Store); ok && store.Addr == index {
+								source(store.Val)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			call, ok := instr.(ssa.CallInstruction)
+			if !ok || !hasUintptrEscapesDirective(call.Common().StaticCallee()) {
+				continue
+			}
+			args := call.Common().Args
+			for i, arg := range args {
+				if basicKind(arg.Type()) == types.Uintptr {
+					source(arg)
+				} else if call.Common().Signature().Variadic() && i == len(args)-1 {
+					if slice, ok := arg.Type().Underlying().(*types.Slice); ok && basicKind(slice.Elem()) == types.Uintptr {
+						source(arg)
+					}
+				}
+			}
+		}
+	}
+	return roots
+}
+
+func hasUintptrEscapesDirective(fn *ssa.Function) bool {
+	seen := make(map[*ssa.Function]bool)
+	var visit func(*ssa.Function) bool
+	visit = func(fn *ssa.Function) bool {
+		if fn == nil || seen[fn] {
+			return false
+		}
+		seen[fn] = true
+		if hasFuncDirective(fn, "go:uintptrescapes") {
+			return true
+		}
+		if origin := fn.Origin(); origin != nil && visit(origin) {
+			return true
+		}
+		// SSA method expressions and bound methods have no FuncDecl of their
+		// own. Only these transparent adapters inherit the target's pragma;
+		// an ordinary function that happens to call it must not inherit it.
+		if !strings.HasPrefix(fn.Synthetic, "wrapper for ") &&
+			!strings.HasPrefix(fn.Synthetic, "thunk for ") &&
+			!strings.HasPrefix(fn.Synthetic, "bound method wrapper for ") {
+			return false
+		}
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				if call, ok := instr.(*ssa.Call); ok && visit(call.Call.StaticCallee()) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return visit(fn)
+}

--- a/cl/uintptr_escapes.go
+++ b/cl/uintptr_escapes.go
@@ -31,7 +31,18 @@ import (
 // while the call is pending; the callee roots cover the executing call.
 func uintptrEscapesRoots(fn *ssa.Function) map[ssa.Value]struct{} {
 	roots := make(map[ssa.Value]struct{})
-	if hasUintptrEscapesDirective(fn) {
+	// Repeated calls in one function share immutable directive facts, without
+	// introducing mutable state shared by parallel package backends.
+	directives := make(map[*ssa.Function]bool)
+	hasDirective := func(callee *ssa.Function) bool {
+		value, ok := directives[callee]
+		if !ok {
+			value = hasUintptrEscapesDirective(callee)
+			directives[callee] = value
+		}
+		return value
+	}
+	if hasDirective(fn) {
 		for _, param := range fn.Params {
 			if basicKind(param.Type()) == types.Uintptr {
 				roots[param] = struct{}{}
@@ -47,6 +58,9 @@ func uintptrEscapesRoots(fn *ssa.Function) map[ssa.Value]struct{} {
 		seen[value] = true
 		switch value := value.(type) {
 		case *ssa.Convert:
+			// Do not chase integer conversions (including truncation). Go's
+			// pragma applies to direct unsafe.Pointer-to-uintptr arguments,
+			// not pointers recovered through arbitrary integer expressions.
 			if basicKind(value.Type()) == types.Uintptr && basicKind(value.X.Type()) == types.UnsafePointer {
 				roots[value.X] = struct{}{}
 			}
@@ -61,6 +75,8 @@ func uintptrEscapesRoots(fn *ssa.Function) map[ssa.Value]struct{} {
 		case *ssa.Alloc:
 			// SSA constructs f(uintptr(p), uintptr(q)) for ...uintptr as
 			// stores into a fresh array followed by a slice of that array.
+			// This traces that compiler-created backing, not arbitrary saved
+			// []uintptr values or stores into a MakeSlice allocation.
 			if refs := value.Referrers(); refs != nil {
 				for _, ref := range *refs {
 					index, ok := ref.(*ssa.IndexAddr)
@@ -81,7 +97,9 @@ func uintptrEscapesRoots(fn *ssa.Function) map[ssa.Value]struct{} {
 	for _, block := range fn.Blocks {
 		for _, instr := range block.Instrs {
 			call, ok := instr.(ssa.CallInstruction)
-			if !ok || !hasUintptrEscapesDirective(call.Common().StaticCallee()) {
+			// Interface dispatch has no static callee and does not inherit
+			// an implementation's pragma, matching Go's call-site contract.
+			if !ok || !hasDirective(call.Common().StaticCallee()) {
 				continue
 			}
 			args := call.Common().Args
@@ -113,8 +131,9 @@ func hasUintptrEscapesDirective(fn *ssa.Function) bool {
 		if origin := fn.Origin(); origin != nil && visit(origin) {
 			return true
 		}
-		// SSA method expressions and bound methods have no FuncDecl of their
-		// own. Only these transparent adapters inherit the target's pragma;
+		// SSA promoted-method wrappers, thunks (method expressions), and
+		// bound-method wrappers have no FuncDecl of their own. Only these
+		// transparent adapters inherit the target's pragma;
 		// an ordinary function that happens to call it must not inherit it.
 		if !strings.HasPrefix(fn.Synthetic, "wrapper for ") &&
 			!strings.HasPrefix(fn.Synthetic, "thunk for ") &&

--- a/cl/uintptr_escapes.go
+++ b/cl/uintptr_escapes.go
@@ -125,10 +125,12 @@ func hasUintptrEscapesDirective(fn *ssa.Function) bool {
 			return false
 		}
 		seen[fn] = true
-		if hasFuncDirective(fn, "go:uintptrescapes") {
+		// Generic directives belong to the source declaration. Visit it
+		// first; an instantiated body may also retain the same syntax.
+		if origin := fn.Origin(); origin != nil && visit(origin) {
 			return true
 		}
-		if origin := fn.Origin(); origin != nil && visit(origin) {
+		if hasFuncDirective(fn, "go:uintptrescapes") {
 			return true
 		}
 		// SSA promoted-method wrappers, thunks (method expressions), and

--- a/cl/uintptr_escapes_internal_test.go
+++ b/cl/uintptr_escapes_internal_test.go
@@ -43,6 +43,16 @@ func forward(p uintptr, rest ...uintptr) { marked(p, rest...) }
 func unmarked() { ordinary(uintptr(unsafe.Pointer(new(int)))) }
 func integer(p uintptr) { ordinary(p) }
 func arithmetic(p unsafe.Pointer) { marked(uintptr(p) + 1) }
+type MyInt int
+func integerConversion(p unsafe.Pointer) { marked(uintptr(MyInt(uintptr(p)))) }
+func narrowConversion(p unsafe.Pointer) { marked(uintptr(uint32(uintptr(p)))) }
+func allocatedSlice(p unsafe.Pointer) {
+ rest := make([]uintptr, 1)
+ rest[0] = uintptr(p)
+ marked(0, rest...)
+}
+func savedSlice(rest []uintptr) { marked(0, rest...) }
+func repeated(p unsafe.Pointer) { marked(uintptr(p)); marked(uintptr(p)) }
 func merged(p, q unsafe.Pointer, choose bool) {
  value := uintptr(p)
  if choose { value = uintptr(q) }
@@ -59,6 +69,8 @@ func convert(p unsafe.Pointer) { named(Word(uintptr(p))) }
 	}{
 		{"marked", 1}, {"direct", 2}, {"goroutine", 1}, {"deferred", 1},
 		{"forward", 1}, {"unmarked", 0}, {"integer", 0}, {"arithmetic", 0},
+		{"integerConversion", 0}, {"narrowConversion", 0}, {"allocatedSlice", 0},
+		{"savedSlice", 0}, {"repeated", 1},
 		{"merged", 2}, {"named", 1}, {"convert", 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -116,6 +128,7 @@ func method() { Outer{}.Marked(uintptr(unsafe.Pointer(new(int)))) }
 func expression() { Outer.Marked(Outer{}, uintptr(unsafe.Pointer(new(int)))) }
 func bound() { f := Outer{}.Marked; f(uintptr(unsafe.Pointer(new(int)))) }
 func unmarkedBound() { f := Outer{}.Ordinary; f(uintptr(unsafe.Pointer(new(int)))) }
+func invoked(i interface{ Marked(uintptr) }, p unsafe.Pointer) { i.Marked(uintptr(p)) }
 `)
 	for _, name := range []string{"method", "expression", "bound"} {
 		if roots := uintptrEscapesRoots(pkg.Func(name)); len(roots) != 1 {
@@ -127,6 +140,9 @@ func unmarkedBound() { f := Outer{}.Ordinary; f(uintptr(unsafe.Pointer(new(int))
 	}
 	if roots := uintptrEscapesRoots(pkg.Func("unmarkedBound")); len(roots) != 0 {
 		t.Fatalf("ordinary bound method inherited pointer semantics: %v", roots)
+	}
+	if roots := uintptrEscapesRoots(pkg.Func("invoked")); len(roots) != 0 {
+		t.Fatalf("interface call inherited implementation pragma: %v", roots)
 	}
 }
 

--- a/cl/uintptr_escapes_internal_test.go
+++ b/cl/uintptr_escapes_internal_test.go
@@ -153,6 +153,7 @@ func Marked(p uintptr) {}
 //go:uintptrescapes
 func Generic[T any](p uintptr) {}
 func Ordinary(p uintptr) {}
+func OrdinaryGeneric[T any](p uintptr) {}
 `, "example.com/caller", `package caller
 import (
  "unsafe"
@@ -161,13 +162,16 @@ import (
 func direct() { dep.Marked(uintptr(unsafe.Pointer(new(int)))) }
 func generic() { dep.Generic[int](uintptr(unsafe.Pointer(new(int)))) }
 func ordinary() { dep.Ordinary(uintptr(unsafe.Pointer(new(int)))) }
+func ordinaryGeneric() { dep.OrdinaryGeneric[int](uintptr(unsafe.Pointer(new(int)))) }
 `)
 	for _, name := range []string{"direct", "generic"} {
 		if roots := uintptrEscapesRoots(pkg.Func(name)); len(roots) != 1 {
 			t.Errorf("cross-package %s roots = %v, want one conversion source", name, roots)
 		}
 	}
-	if roots := uintptrEscapesRoots(pkg.Func("ordinary")); len(roots) != 0 {
-		t.Fatalf("ordinary imported function inherited pointer semantics: %v", roots)
+	for _, name := range []string{"ordinary", "ordinaryGeneric"} {
+		if roots := uintptrEscapesRoots(pkg.Func(name)); len(roots) != 0 {
+			t.Fatalf("ordinary imported %s inherited pointer semantics: %v", name, roots)
+		}
 	}
 }

--- a/cl/uintptr_escapes_internal_test.go
+++ b/cl/uintptr_escapes_internal_test.go
@@ -1,0 +1,157 @@
+//go:build !llgo
+
+package cl
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func uintptrEscapesPackage(t *testing.T, src string) *ssa.Package {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "uintptr_escapes.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, _, err := ssautil.BuildPackage(&types.Config{Importer: importer.Default()}, fset,
+		types.NewPackage("uintptr_escapes", "p"), []*ast.File{file}, ssa.InstantiateGenerics|ssa.SanityCheckFunctions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkg
+}
+
+func TestUintptrEscapesRoots(t *testing.T) {
+	pkg := uintptrEscapesPackage(t, `package p
+import "unsafe"
+//go:uintptrescapes
+func marked(p uintptr, rest ...uintptr) {}
+func ordinary(p uintptr) {}
+func direct() { marked(uintptr(unsafe.Pointer(new(int))), uintptr(unsafe.Pointer(new(int)))) }
+func goroutine() { go marked(uintptr(unsafe.Pointer(new(int)))) }
+func deferred() { defer marked(uintptr(unsafe.Pointer(new(int)))) }
+//go:uintptrescapes
+func forward(p uintptr, rest ...uintptr) { marked(p, rest...) }
+func unmarked() { ordinary(uintptr(unsafe.Pointer(new(int)))) }
+func integer(p uintptr) { ordinary(p) }
+func arithmetic(p unsafe.Pointer) { marked(uintptr(p) + 1) }
+func merged(p, q unsafe.Pointer, choose bool) {
+ value := uintptr(p)
+ if choose { value = uintptr(q) }
+ marked(value, value)
+}
+type Word uintptr
+//go:uintptrescapes
+func named(Word) {}
+func convert(p unsafe.Pointer) { named(Word(uintptr(p))) }
+`)
+	for _, test := range []struct {
+		name string
+		want int
+	}{
+		{"marked", 1}, {"direct", 2}, {"goroutine", 1}, {"deferred", 1},
+		{"forward", 1}, {"unmarked", 0}, {"integer", 0}, {"arithmetic", 0},
+		{"merged", 2}, {"named", 1}, {"convert", 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fn := pkg.Func(test.name)
+			roots := uintptrEscapesRoots(fn)
+			if len(roots) != test.want {
+				t.Fatalf("roots = %v, want %d", roots, test.want)
+			}
+		})
+	}
+}
+
+func TestUintptrEscapesHeapAllocation(t *testing.T) {
+	pkg := uintptrEscapesPackage(t, `package p
+import "unsafe"
+//go:uintptrescapes
+func marked(p uintptr, rest ...uintptr) {}
+func escaping() {
+ var local int
+ var fields struct { n int }
+ var array [2]int
+ marked(uintptr(unsafe.Pointer(&local)), uintptr(unsafe.Pointer(&fields.n)), uintptr(unsafe.Pointer(&array[1])))
+ go marked(uintptr(unsafe.Pointer(&local)))
+ defer marked(uintptr(unsafe.Pointer(&local)))
+}
+`)
+	// The SSA builder conservatively escapes address-taken locals, including
+	// field/array bases and variadic arrays. Do not add a second escape pass or
+	// turn every ordinary uintptr argument into a pointer to satisfy this.
+	allocations := 0
+	for _, block := range pkg.Func("escaping").Blocks {
+		for _, instr := range block.Instrs {
+			if alloc, ok := instr.(*ssa.Alloc); ok {
+				allocations++
+				if !alloc.Heap {
+					t.Errorf("uintptr conversion source/backing array remains on stack: %s", alloc)
+				}
+			}
+		}
+	}
+	if allocations < 4 {
+		t.Fatalf("only %d allocations, want locals and the variadic backing array", allocations)
+	}
+}
+
+func TestUintptrEscapesMethodWrappers(t *testing.T) {
+	pkg := uintptrEscapesPackage(t, `package p
+import "unsafe"
+type Leaf struct{}
+//go:uintptrescapes
+func (Leaf) Marked(p uintptr) {}
+func (Leaf) Ordinary(p uintptr) {}
+type Outer struct { Leaf }
+func method() { Outer{}.Marked(uintptr(unsafe.Pointer(new(int)))) }
+func expression() { Outer.Marked(Outer{}, uintptr(unsafe.Pointer(new(int)))) }
+func bound() { f := Outer{}.Marked; f(uintptr(unsafe.Pointer(new(int)))) }
+func unmarkedBound() { f := Outer{}.Ordinary; f(uintptr(unsafe.Pointer(new(int)))) }
+`)
+	for _, name := range []string{"method", "expression", "bound"} {
+		if roots := uintptrEscapesRoots(pkg.Func(name)); len(roots) != 1 {
+			t.Errorf("%s roots = %v, want one conversion source", name, roots)
+		}
+	}
+	if hasUintptrEscapesDirective(nil) {
+		t.Fatal("nil callee has directive")
+	}
+	if roots := uintptrEscapesRoots(pkg.Func("unmarkedBound")); len(roots) != 0 {
+		t.Fatalf("ordinary bound method inherited pointer semantics: %v", roots)
+	}
+}
+
+func TestUintptrEscapesCrossPackageGeneric(t *testing.T) {
+	_, pkg := buildCallerFrameSSAProgram(t, "example.com/dep", `package dep
+//go:uintptrescapes
+func Marked(p uintptr) {}
+//go:uintptrescapes
+func Generic[T any](p uintptr) {}
+func Ordinary(p uintptr) {}
+`, "example.com/caller", `package caller
+import (
+ "unsafe"
+ "example.com/dep"
+)
+func direct() { dep.Marked(uintptr(unsafe.Pointer(new(int)))) }
+func generic() { dep.Generic[int](uintptr(unsafe.Pointer(new(int)))) }
+func ordinary() { dep.Ordinary(uintptr(unsafe.Pointer(new(int)))) }
+`)
+	for _, name := range []string{"direct", "generic"} {
+		if roots := uintptrEscapesRoots(pkg.Func(name)); len(roots) != 1 {
+			t.Errorf("cross-package %s roots = %v, want one conversion source", name, roots)
+		}
+	}
+	if roots := uintptrEscapesRoots(pkg.Func("ordinary")); len(roots) != 0 {
+		t.Fatalf("ordinary imported function inherited pointer semantics: %v", roots)
+	}
+}

--- a/cl/uintptr_escapes_test.go
+++ b/cl/uintptr_escapes_test.go
@@ -1,0 +1,71 @@
+//go:build !llgo
+
+package cl_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llgo/cl/cltest"
+	llssa "github.com/xgo-dev/llgo/ssa"
+)
+
+func TestCompileUintptrEscapesRoots(t *testing.T) {
+	const src = `package main
+import "unsafe"
+func collect()
+//go:uintptrescapes
+func marked(p uintptr) { collect(); _ = *(*int)(unsafe.Pointer(p)) }
+func integer(p uintptr) { collect() }
+func source() unsafe.Pointer
+func laterArgument() uintptr
+//go:uintptrescapes
+func two(uintptr, uintptr)
+func caller() { two(uintptr(source()), laterArgument()) }
+`
+	ir := cltest.CompileIREx(t, src, "uintptr_escapes.go", false, func(prog llssa.Program) {
+		prog.EnableGCRoots(true)
+	})
+	function := func(name string) string {
+		t.Helper()
+		start := strings.Index(ir, "define void @main."+name+"(")
+		if start < 0 {
+			t.Fatalf("missing %s:\n%s", name, ir)
+		}
+		body := ir[start:]
+		end := strings.Index(body, "\n}")
+		if end < 0 {
+			t.Fatalf("unterminated %s:\n%s", name, body)
+		}
+		return body[:end]
+	}
+	marked := function("marked")
+	if !strings.Contains(marked, "inttoptr i64 %0 to ptr") || !strings.Contains(marked, "@llvm_gc_root_chain") {
+		t.Fatalf("pragma uintptr parameter was not rooted:\n%s", marked)
+	}
+	if integer := function("integer"); strings.Contains(integer, "@llvm_gc_root_chain") {
+		t.Fatalf("ordinary integer parameter became a root:\n%s", integer)
+	}
+	caller := function("caller")
+	source := strings.Index(caller, "call ptr @main.source()")
+	if source < 0 {
+		t.Fatalf("missing pointer-producing call:\n%s", caller)
+	}
+	store := strings.Index(caller[source:], "store ptr ")
+	later := strings.Index(caller, "call i64 @main.laterArgument()")
+	if store < 0 || later < 0 || source+store > later {
+		t.Fatalf("source pointer not published before subsequent argument evaluation:\n%s", caller)
+	}
+}
+
+func TestCompileUintptrEscapesRootsDisabled(t *testing.T) {
+	const src = `package main
+func collect()
+//go:uintptrescapes
+func marked(p uintptr) { collect() }
+`
+	ir := cltest.CompileIREx(t, src, "uintptr_escapes_disabled.go", false, nil)
+	if strings.Contains(ir, "@llvm_gc_root_chain") || strings.Contains(ir, "inttoptr") {
+		t.Fatalf("pragma changed the native conservative collector path:\n%s", ir)
+	}
+}

--- a/internal/build/testdata/wasm-gc/main.go
+++ b/internal/build/testdata/wasm-gc/main.go
@@ -24,6 +24,7 @@ func main() {
 		panic("aligned allocation failed")
 	}
 	testRoots()
+	testUintptrEscapesRoots()
 	testCooperativeSafepoint()
 	testSuspendedGRoots()
 	testTimerWaitingRoot()

--- a/internal/build/testdata/wasm-gc/uintptr_escapes.go
+++ b/internal/build/testdata/wasm-gc/uintptr_escapes.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+type uintptrRootObject struct {
+	value   int
+	padding [32]byte
+}
+
+//go:noinline
+func newUintptrRoot() unsafe.Pointer {
+	p := &uintptrRootObject{value: 47}
+	runtime.SetFinalizer(p, func(p *uintptrRootObject) { p.value = -1 })
+	return unsafe.Pointer(p)
+}
+
+//go:noinline
+func laterUintptrRoot() unsafe.Pointer {
+	// The preceding argument has already become uintptr, but the marked
+	// callee has not entered and cannot publish its parameters yet.
+	runtime.GC()
+	runtime.GC()
+	return newUintptrRoot()
+}
+
+//go:noinline
+//go:uintptrescapes
+func checkUintptrRoots(first, second uintptr, rest ...uintptr) {
+	runtime.GC()
+	runtime.GC()
+	if (*uintptrRootObject)(unsafe.Pointer(first)).value != 47 ||
+		(*uintptrRootObject)(unsafe.Pointer(second)).value != 47 {
+		panic("pragma-designated uintptr root was finalized")
+	}
+	for _, p := range rest {
+		if (*uintptrRootObject)(unsafe.Pointer(p)).value != 47 {
+			panic("variadic uintptr root was finalized")
+		}
+	}
+}
+
+// This extends the existing three-profile GC fixture, so the regression runs
+// in CI without an additional test binary, workflow job, or dependency.
+func testUintptrEscapesRoots() {
+	checkUintptrRoots(uintptr(newUintptrRoot()), uintptr(laterUintptrRoot()),
+		uintptr(newUintptrRoot()), uintptr(laterUintptrRoot()))
+	func() {
+		for i := 0; i < 4; i++ {
+			defer checkUintptrRoots(uintptr(newUintptrRoot()), uintptr(newUintptrRoot()), uintptr(newUintptrRoot()))
+		}
+		runtime.GC()
+	}()
+}

--- a/test/go/uintptr_escapes_test.go
+++ b/test/go/uintptr_escapes_test.go
@@ -1,0 +1,134 @@
+package gotest
+
+import (
+	"runtime"
+	"testing"
+	"unsafe"
+)
+
+type uintptrEscapesObject struct {
+	value int
+	// Avoid depending on the collector's tiny-object/finalizer packing.
+	padding [32]byte
+}
+
+//go:noinline
+func newUintptrEscapesObject(value int) unsafe.Pointer {
+	obj := &uintptrEscapesObject{value: value}
+	runtime.SetFinalizer(obj, func(obj *uintptrEscapesObject) { obj.value = -1 })
+	return unsafe.Pointer(obj)
+}
+
+//go:noinline
+//go:uintptrescapes
+func checkUintptrEscapes(want int, first, second uintptr, rest ...uintptr) {
+	runtime.GC()
+	runtime.GC()
+	if (*uintptrEscapesObject)(unsafe.Pointer(first)).value != want {
+		panic("uintptrescapes: first object was finalized")
+	}
+	if (*uintptrEscapesObject)(unsafe.Pointer(second)).value != want {
+		panic("uintptrescapes: second object was finalized")
+	}
+	for _, ptr := range rest {
+		if (*uintptrEscapesObject)(unsafe.Pointer(ptr)).value != want {
+			panic("uintptrescapes: variadic object was finalized")
+		}
+	}
+}
+
+//go:noinline
+//go:uintptrescapes
+func forwardUintptrEscapes(want int, first, second uintptr, rest ...uintptr) {
+	runtime.GC()
+	checkUintptrEscapes(want, first, second, rest...)
+}
+
+//go:noinline
+func laterUintptrEscapesArgument(value int) unsafe.Pointer {
+	// The preceding argument's pointer-to-uintptr conversion has already
+	// happened, but the marked callee has not been entered yet.
+	runtime.GC()
+	runtime.GC()
+	return newUintptrEscapesObject(value)
+}
+
+func TestUintptrEscapesCalls(t *testing.T) {
+	checkUintptrEscapes(11,
+		uintptr(newUintptrEscapesObject(11)), uintptr(laterUintptrEscapesArgument(11)),
+		uintptr(newUintptrEscapesObject(11)), uintptr(laterUintptrEscapesArgument(11)))
+	forwardUintptrEscapes(23,
+		uintptr(newUintptrEscapesObject(23)), uintptr(newUintptrEscapesObject(23)),
+		uintptr(newUintptrEscapesObject(23)), uintptr(newUintptrEscapesObject(23)))
+}
+
+func TestUintptrEscapesDeferredCalls(t *testing.T) {
+	func() {
+		defer checkUintptrEscapes(31,
+			uintptr(newUintptrEscapesObject(31)), uintptr(newUintptrEscapesObject(31)),
+			uintptr(newUintptrEscapesObject(31)))
+		runtime.GC()
+	}()
+	func() {
+		// Each iteration overwrites the caller's temporary root slots. Older
+		// arguments must remain reachable through the deferred-call records.
+		for i := 0; i < 8; i++ {
+			defer checkUintptrEscapes(40+i,
+				uintptr(newUintptrEscapesObject(40+i)), uintptr(newUintptrEscapesObject(40+i)),
+				uintptr(newUintptrEscapesObject(40+i)))
+		}
+		runtime.GC()
+	}()
+}
+
+//go:noinline
+//go:uintptrescapes
+func consumeUintptrEscapes(gate <-chan struct{}, done chan<- int, ptr uintptr) {
+	<-gate
+	runtime.GC()
+	runtime.GC()
+	done <- (*uintptrEscapesObject)(unsafe.Pointer(ptr)).value
+}
+
+//go:noinline
+func startUintptrEscapes(gate <-chan struct{}, done chan<- int) {
+	var local uintptrEscapesObject
+	local.value = 71
+	runtime.SetFinalizer(&local, func(obj *uintptrEscapesObject) { obj.value = -1 })
+	go consumeUintptrEscapes(gate, done, uintptr(unsafe.Pointer(&local)))
+}
+
+func TestUintptrEscapesGoroutineOutlivesCaller(t *testing.T) {
+	gate := make(chan struct{})
+	done := make(chan int)
+	startUintptrEscapes(gate, done)
+	runtime.GC()
+	runtime.GC()
+	close(gate)
+	if got := <-done; got != 71 {
+		t.Fatalf("goroutine observed %d, want 71", got)
+	}
+}
+
+type uintptrEscapesLeaf struct{}
+
+//go:noinline
+//go:uintptrescapes
+func (uintptrEscapesLeaf) Check(first, second uintptr) {
+	checkUintptrEscapes(83, first, second)
+}
+
+type uintptrEscapesOuter struct{ uintptrEscapesLeaf }
+
+func TestUintptrEscapesMethodWrappers(t *testing.T) {
+	uintptrEscapesOuter{}.Check(uintptr(newUintptrEscapesObject(83)), uintptr(laterUintptrEscapesArgument(83)))
+	uintptrEscapesOuter.Check(uintptrEscapesOuter{}, uintptr(newUintptrEscapesObject(83)), uintptr(laterUintptrEscapesArgument(83)))
+	// Go does not propagate the directive through a saved function value.
+	// Preserve the ordinary unsafe conversion contract for this wrapper call.
+	bound := uintptrEscapesOuter{}.Check
+	first, second := newUintptrEscapesObject(83), newUintptrEscapesObject(83)
+	bound(uintptr(first), uintptr(second))
+	runtime.KeepAlive(first)
+	runtime.KeepAlive(second)
+	defer uintptrEscapesOuter{}.Check(uintptr(newUintptrEscapesObject(83)), uintptr(newUintptrEscapesObject(83)))
+}


### PR DESCRIPTION
> Consolidated into [cpunion/llgo#246, W1 (profiles and ABI foundation)](https://github.com/cpunion/llgo/pull/246). Its pushed head `9547397ab` contains all three commits from this PR plus new Go64-on-Memory32 root-storage regressions. Follow that contribution for combined target CI; the standalone results below remain historical evidence, not proof of the new combined head. No separate merge of this PR is required by the consolidated plan.

## Summary

Keep pointers passed through `//go:uintptrescapes` calls alive under the explicit-root collector. The directive affects both the marked callee's `uintptr` parameters and pointer-to-uintptr conversions while subsequent arguments are still being evaluated. Ordinary integer `uintptr` values remain non-roots; native conservative-GC lowering is unchanged.

This defect already exists on `main`. The broader WASM GOROOT acceptance exposed the failure in Go's unmodified `fixedbugs/issue24491a.go`; earlier CI did not cover this combination of pragma, finalizers, and explicit WASM roots. This main-branch fix is isolated from broader WebAssembly implementation work; the regression is not excluded or marked expected-failure.

## Changes

- Add the directive-designated values to the existing root analysis, including generic origins and transparent SSA method adapters.
- Keep argument pointers alive before a later argument can collect. Preserve pending go/defer/variadic values through their existing heap-backed argument storage.
- Cover ordinary integer/arithmetic/relay negative cases, variadic calls, imported generics, methods, and goroutines that outlive their caller.
- Extend the existing GC fixture with finalizer-sensitive normal/variadic/deferred calls. The existing `wasm-runtime (runtime)` job executes it on Emscripten wasm32, Memory64, and WASI, with no additional job or test binary.

This does not make arbitrary saved uintptrs into roots or propagate the directive through an arbitrary saved function value. The latter test retains the original typed pointer with `runtime.KeepAlive`, matching the ordinary unsafe conversion contract.

## Validation

- LLVM 22 focused compiler/root-analysis tests pass; `uintptrEscapesRoots` is 100% covered, and the new helper file is 98.3% covered by those tests.
- The four new runtime tests pass with official Go and LLGo's Emscripten Memory64 profile.
- Go 1.27's unchanged `fixedbugs/issue24491a.go` passes on the main-based branch under Emscripten Memory64 (6.86s for the case).
- The GC fixture covering the three named Emscripten wasm32, Emscripten Memory64, and WASI entries has been run locally on Emscripten Memory64 and prints `wasm gc ok`. This is historical local evidence; current-head CI results are recorded below.

No GOROOT exclusions, timeout increases, or changes to native GC behavior.


## Rebase validation (2026-09-11)

Rebased onto main `1d81439e8` (including #2531, #2536, and #2549), new head `7d5c6f35c`. `git range-diff` confirms all three PR commits are unchanged: this update carries current baseline fixes rather than unrelated implementation changes. Review requests remain addressed; the diff is still 7 files, 607 insertions and 1 deletion, primarily regression coverage, with no diagnostic probes, skip additions, or timeout changes.

- Go 1.27 / LLVM 22 focused compiler and directive-analysis tests pass after rebase. Both `uintptrEscapesRoots` and `hasUintptrEscapesDirective` now report **100% statement coverage** in the focused run; this is helper coverage, not coverage of the whole compiler or target runtime.
- All four executable uintptr-escape regressions pass three times with official Go after rebase.
- New-head [multi-platform and three-entry Wasm CI](https://github.com/xgo-dev/llgo/actions/runs/34542566186), [Go/coverage CI](https://github.com/xgo-dev/llgo/actions/runs/34542566016), and [baseline benchmarks](https://github.com/xgo-dev/llgo/actions/runs/34542566204) have completed on this unchanged head. As checked on 2026-09-11, the rollup has 64 successful checks and one conditional release skip, including the Codecov patch check. These are main-based results, not a replacement for future combined W1 acceptance.


