### PR TITLE
ci: use the stable Go archive extractor on Windows ARM64

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -13,16 +13,46 @@ runs:
   using: "composite"
   steps:
     - name: Configure Go environment
+      id: go_environment
       shell: bash
       run: |
         echo "GOPATH=${RUNNER_TEMP}/go" >> "$GITHUB_ENV"
         echo "GOBIN=${RUNNER_TEMP}/go/bin" >> "$GITHUB_ENV"
         echo "GOMODCACHE=${RUNNER_TEMP}/go/pkg/mod" >> "$GITHUB_ENV"
         echo "GOCACHE=${RUNNER_TEMP}/go-build-cache" >> "$GITHUB_ENV"
+        echo "path=$PATH" >> "$GITHUB_OUTPUT"
+
+    - name: Select Go archive extractor on Windows
+      if: runner.os == 'Windows'
+      id: windows_archive_path
+      shell: powershell
+      run: |
+        $ErrorActionPreference = "Stop"
+        $path = $env:PATH
+        if ("${{ runner.arch }}" -eq "ARM64") {
+          # Match setup-demo-deps' archive workaround. PowerShell 7 can abort
+          # inside ZipFile.ExtractToDirectory on Windows ARM64 before the
+          # tool-cache script's catch/fallback executes. Hide it only from
+          # setup-go so tool-cache selects Windows PowerShell instead.
+          # Use the runner architecture: the installed Go may be x64.
+          $pwsh = Get-Command pwsh.exe -ErrorAction SilentlyContinue
+          if ($pwsh) {
+            $pwshDir = (Split-Path -Parent $pwsh.Source).TrimEnd('\')
+            $path = (($env:PATH -split ';') | Where-Object {
+              $_ -and $_.Trim().Trim('"').TrimEnd('\') -ine $pwshDir
+            }) -join ';'
+            if ($path -eq $env:PATH) {
+              throw "Failed to remove PowerShell 7 from setup-go's PATH"
+            }
+          }
+        }
+        "path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Set up the LLGo build toolchain
       if: inputs.go-version == ''
       uses: actions/setup-go@v7
+      env:
+        PATH: ${{ steps.windows_archive_path.outputs.path || steps.go_environment.outputs.path }}
       with:
         go-version-file: .go-version
         architecture: ${{ inputs.architecture }}
@@ -33,6 +63,8 @@ runs:
     - name: Set up an explicit Go toolchain
       if: inputs.go-version != ''
       uses: actions/setup-go@v7
+      env:
+        PATH: ${{ steps.windows_archive_path.outputs.path || steps.go_environment.outputs.path }}
       with:
         go-version: ${{ inputs.go-version }}
         architecture: ${{ inputs.architecture }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -13,46 +13,43 @@ runs:
   using: "composite"
   steps:
     - name: Configure Go environment
-      id: go_environment
       shell: bash
       run: |
         echo "GOPATH=${RUNNER_TEMP}/go" >> "$GITHUB_ENV"
         echo "GOBIN=${RUNNER_TEMP}/go/bin" >> "$GITHUB_ENV"
         echo "GOMODCACHE=${RUNNER_TEMP}/go/pkg/mod" >> "$GITHUB_ENV"
         echo "GOCACHE=${RUNNER_TEMP}/go-build-cache" >> "$GITHUB_ENV"
-        echo "path=$PATH" >> "$GITHUB_OUTPUT"
 
     - name: Select Go archive extractor on Windows
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
       id: windows_archive_path
       shell: powershell
       run: |
         $ErrorActionPreference = "Stop"
-        $path = $env:PATH
-        if ("${{ runner.arch }}" -eq "ARM64") {
-          # Match setup-demo-deps' archive workaround. PowerShell 7 can abort
-          # inside ZipFile.ExtractToDirectory on Windows ARM64 before the
-          # tool-cache script's catch/fallback executes. Hide it only from
-          # setup-go so tool-cache selects Windows PowerShell instead.
-          # Use the runner architecture: the installed Go may be x64.
-          $pwsh = Get-Command pwsh.exe -ErrorAction SilentlyContinue
-          if ($pwsh) {
-            $pwshDir = (Split-Path -Parent $pwsh.Source).TrimEnd('\')
-            $path = (($env:PATH -split ';') | Where-Object {
-              $_ -and $_.Trim().Trim('"').TrimEnd('\') -ine $pwshDir
-            }) -join ';'
-            if ($path -eq $env:PATH) {
-              throw "Failed to remove PowerShell 7 from setup-go's PATH"
-            }
+        $overrides = @{}
+        # Match setup-demo-deps' archive policy. PowerShell 7 can abort inside
+        # ZipFile.ExtractToDirectory before tool-cache's catch/fallback runs.
+        # Hide it only from setup-go. Use the runner architecture above: the
+        # installed Go may be x64. If pwsh is absent, tool-cache already uses
+        # Windows PowerShell, so no PATH override is needed.
+        $pwsh = Get-Command pwsh.exe -ErrorAction SilentlyContinue
+        if ($pwsh) {
+          $pwshDir = (Split-Path -Parent $pwsh.Source).TrimEnd('\')
+          $path = (($env:PATH -split ';') | Where-Object {
+            $_ -and $_.Trim().Trim('"').TrimEnd('\') -ine $pwshDir
+          }) -join ';'
+          if ($path -eq $env:PATH) {
+            throw "Failed to remove PowerShell 7 from setup-go's PATH"
           }
+          $overrides.PATH = $path
         }
-        "path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $json = ConvertTo-Json -InputObject $overrides -Compress
+        "env=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Set up the LLGo build toolchain
       if: inputs.go-version == ''
       uses: actions/setup-go@v7
-      env:
-        PATH: ${{ steps.windows_archive_path.outputs.path || steps.go_environment.outputs.path }}
+      env: ${{ fromJSON(steps.windows_archive_path.outputs.env || '{}') }}
       with:
         go-version-file: .go-version
         architecture: ${{ inputs.architecture }}
@@ -63,8 +60,7 @@ runs:
     - name: Set up an explicit Go toolchain
       if: inputs.go-version != ''
       uses: actions/setup-go@v7
-      env:
-        PATH: ${{ steps.windows_archive_path.outputs.path || steps.go_environment.outputs.path }}
+      env: ${{ fromJSON(steps.windows_archive_path.outputs.env || '{}') }}
       with:
         go-version: ${{ inputs.go-version }}
         architecture: ${{ inputs.architecture }}


### PR DESCRIPTION
## Problem

The Windows ARM64 job for #2536 failed before compiling LLGo: both Go download sources succeeded, but PowerShell 7 aborted in `ZipFile.ExtractToDirectory` with `Internal CLR error (0x80131506)` / exit `3221225477`.

Evidence: [failed Go setup step](https://github.com/xgo-dev/llgo/actions/runs/34247371791/job/102133021324).

The same job successfully installed Python using the existing scoped Windows PowerShell workaround in `setup-demo-deps`. `setup-go` still selected PowerShell 7. This is a shared CI issue on current main, not part of #2536's runtime stack-size change.

## Change

- Apply the existing extractor-selection policy to both Go installation branches.
- Gate the workaround on the actual ARM64 runner, even when installing x64 Go for host builds.
- Override PATH only for the two `actions/setup-go` invocations; subsequent `pwsh` steps retain their normal PATH.
- Leave the live PATH untouched on all other runners (an empty environment override), and on ARM64 when `pwsh` is already absent. Do not snapshot PATH on unrelated platforms.

## Validation

- `actionlint` passed for Go, LLGo, and benchmark workflows.
- Parsed the composite-action YAML and passed its steps through an actionlint workflow-call schema probe, including both Go branches and their object-valued environment expressions.
- Existing Windows ARM64 CI exercises the real installation and Go-version/host-architecture checks. Actual hosted-Windows execution is pending; it is not claimed as locally verified.

No runtime, compiler, test exclusions, or timeout changes.
