### PR TITLE
perf(wasm): cache large object heads during GC marking

### DIFF
--- a/dev/test_wasm_single_worker.sh
+++ b/dev/test_wasm_single_worker.sh
@@ -125,6 +125,13 @@ run_llgo_test_compile_only() {
 	esac
 }
 
+if [[ "${suite}" == "all" || "${suite}" == "runtime" ]]; then
+# The runtime is a nested Go module and is not covered by root-level go test.
+# Exercise the collector's allocation-free interval helper on the host before
+# the target fixtures check marking, reclamation, and finalizer integration.
+go -C "${repo_root}/runtime" test -count=1 -cover ./internal/runtime/tinygogc
+fi
+
 if [[ "${suite}" != "test-command" ]]; then
 # Canonical C-ecosystem profiles exercise the same scheduler semantics under
 # Emscripten wasm32, Emscripten Memory64/LP64, and WASI Preview 1.

--- a/internal/build/wasm_gc_head_cache_test.go
+++ b/internal/build/wasm_gc_head_cache_test.go
@@ -1,0 +1,152 @@
+package build
+
+import (
+	"bytes"
+	stdctx "context"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Run the actual collector lookup functions against isolated metadata. This
+// exercises eviction and compares cached/uncached costs without mutating the
+// collector running the test. Timings describe host-compiled metadata lookup,
+// not end-to-end Wasm collections, and are deliberately not pass/fail limits.
+func TestWasmGCHeadCacheWorkloads(t *testing.T) {
+	fset := token.NewFileSet()
+	dir := filepath.Join("..", "..", "runtime", "internal", "runtime", "tinygogc")
+	functions := map[string]bool{
+		"gcFindHead": true, "gcFindHeadForMark": true,
+		"gcStateByteOf": true, "gcStateFromByte": true, "gcStateOf": true,
+	}
+	var source bytes.Buffer
+	source.WriteString(gcHeadCacheWorkloadSource)
+	for _, name := range []string{"gc_tinygo.go", "head_cache.go"} {
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, decl := range file.Decls {
+			if name == "gc_tinygo.go" {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || !functions[fn.Name.Name] {
+					continue
+				}
+				delete(functions, fn.Name.Name)
+			}
+			if err := format.Node(&source, fset, decl); err != nil {
+				t.Fatal(err)
+			}
+			source.WriteByte('\n')
+		}
+	}
+	if len(functions) != 0 {
+		t.Fatalf("missing collector operations: %v", functions)
+	}
+	path := filepath.Join(t.TempDir(), "head_cache_test.go")
+	if err := os.WriteFile(path, source.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "test", "-count=1", "-timeout=25s", "-bench=BenchmarkHeadLookup", "-benchtime=50ms", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("collector workload checks: %v\n%s", err, output)
+	}
+	t.Logf("actual metadata lookup workloads:\n%s", output)
+}
+
+const gcHeadCacheWorkloadSource = `package headcache
+import (
+  "fmt"
+  "runtime"
+  "testing"
+  "unsafe"
+)
+const (
+  blockStateFree uint8 = iota
+  blockStateHead
+  blockStateTail
+  blockStateMark
+  blockStateMask = 3
+  blockStateByteAllTails = 0xaa
+  stateBits = 2
+  blocksPerStateByte = 4
+)
+var metadataStart unsafe.Pointer
+var markHeads markHeadCache
+var c = struct { Str func(string) string }{func(s string) string { return s }}
+func gcPanic(message string) { panic(message) }
+
+func makeMetadata(objects int, blocks uintptr) []byte {
+  data := make([]byte, (uintptr(objects)*blocks+3)/4)
+  for i := range data { data[i] = blockStateByteAllTails }
+  for object := 0; object < objects; object++ {
+    head := uintptr(object)*blocks
+    // Cover both allocated and already-marked heads.
+    state := blockStateHead
+    if object%2 != 0 { state = blockStateMark }
+    data[head/4] = data[head/4] &^ (3 << ((head%4)*2)) | state << ((head%4)*2)
+  }
+  metadataStart = unsafe.Pointer(&data[0])
+  markHeads.reset()
+  return data
+}
+
+func TestInterleavedHeads(t *testing.T) {
+  for _, blocks := range []uintptr{1, 4, 16, 256, 4096} {
+    for _, objects := range []int{1, 4, 5, 10, 20} {
+      data := makeMetadata(objects, blocks)
+      for round := 0; round < 8; round++ {
+        for object := 0; object < objects; object++ {
+          head := uintptr(object)*blocks
+          for _, offset := range []uintptr{0, blocks/2, blocks-1} {
+            block := head+offset
+            if got := gcFindHeadForMark(block); got != head || got != gcFindHead(block) {
+              t.Fatalf("blocks=%d objects=%d round=%d block=%d head=%d want=%d", blocks, objects, round, block, got, head)
+            }
+          }
+        }
+      }
+      markHeads.reset()
+      runtime.KeepAlive(data)
+    }
+  }
+}
+
+var lookupSink uintptr
+func BenchmarkHeadLookup(b *testing.B) {
+  for _, workload := range []struct { name string; objects int; blocks, offset uintptr }{
+    {"small-heads", 256, 1, 0},
+    {"small-tails", 256, 16, 15},
+    // 327680 blocks represent a 5 MiB object in the wasm32 collector.
+    {"large-1", 1, 327680, 327679},
+    {"large-4", 4, 327680, 327679},
+    {"large-5", 5, 327680, 327679},
+    {"large-10", 10, 327680, 327679},
+    {"large-20", 20, 327680, 327679},
+  } {
+    for _, cached := range []bool{false, true} {
+      b.Run(fmt.Sprintf("%s/cached=%v", workload.name, cached), func(b *testing.B) {
+        data := makeMetadata(workload.objects, workload.blocks)
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+          head := uintptr(i%workload.objects)*workload.blocks
+          block := head+workload.offset
+          if cached { lookupSink = gcFindHeadForMark(block) } else { lookupSink = gcFindHead(block) }
+        }
+        b.StopTimer()
+        markHeads.reset()
+        runtime.KeepAlive(data)
+      })
+    }
+  }
+}
+`

--- a/internal/build/wasm_gc_head_cache_test.go
+++ b/internal/build/wasm_gc_head_cache_test.go
@@ -50,7 +50,7 @@ func TestWasmGCHeadCacheWorkloads(t *testing.T) {
 		t.Fatalf("missing collector operations: %v", functions)
 	}
 	path := filepath.Join(t.TempDir(), "head_cache_test.go")
-	if err := os.WriteFile(path, source.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(path, source.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
 	ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)

--- a/runtime/internal/runtime/tinygogc/gc_tinygo.go
+++ b/runtime/internal/runtime/tinygogc/gc_tinygo.go
@@ -77,6 +77,7 @@ var (
 	// stackOverflow is a flag which is set when the GC scans too deep while marking.
 	// After it is set, all marked allocations must be re-scanned.
 	markStackOverflow bool
+	markHeads         markHeadCache
 
 	// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
 	zeroSizedAlloc uint8
@@ -177,6 +178,21 @@ func gcFindHead(blockAddr uintptr) uintptr {
 		gcPanic(c.Str("gc: found tail without head"))
 	}
 	return blockAddr
+}
+
+// gcFindHeadForMark is valid only while object boundaries cannot change.
+// The collector clears this memoization before and after its complete mark
+// phase, including finalizer preservation. Free and Realloc use gcFindHead.
+func gcFindHeadForMark(block uintptr) uintptr {
+	if state := gcStateOf(block); state == blockStateHead || state == blockStateMark {
+		return block
+	}
+	if head, ok := markHeads.lookup(block); ok {
+		return head
+	}
+	head := gcFindHead(block)
+	markHeads.remember(head, block+1)
+	return head
 }
 
 // findNext returns the first block just past the end of the tail. This may or
@@ -430,10 +446,12 @@ func gc() (freeBytes uintptr) {
 	}
 
 	// Mark phase: mark all reachable objects, recursively.
+	markHeads.reset()
 	gcMarkReachable()
 
 	finishMark()
 	preserveFinalizableObjects()
+	markHeads.reset()
 
 	// If we're using threads, resume all other threads before starting the
 	// sweep.
@@ -475,7 +493,9 @@ func startMark(root uintptr) {
 		stackLen--
 		block := stack[stackLen]
 
-		start, end := gcAddressOf(block), gcAddressOf(gcFindNext(block))
+		endBlock := gcFindNext(block)
+		markHeads.remember(block, endBlock)
+		start, end := gcAddressOf(block), gcAddressOf(endBlock)
 
 		for addr := start; addr != end; addr += unsafe.Alignof(addr) {
 			// Load the word.
@@ -496,7 +516,7 @@ func startMark(root uintptr) {
 			}
 
 			// Move to the block's head.
-			referencedBlock = gcFindHead(referencedBlock)
+			referencedBlock = gcFindHeadForMark(referencedBlock)
 			noteFinalizerReference(referencedBlock)
 
 			if gcStateOf(referencedBlock) == blockStateMark {
@@ -551,7 +571,7 @@ func markRoot(addr, root uintptr) {
 			// just a false positive.
 			return
 		}
-		head := gcFindHead(block)
+		head := gcFindHeadForMark(block)
 
 		if gcStateOf(head) != blockStateMark {
 			startMark(head)

--- a/runtime/internal/runtime/tinygogc/head_cache.go
+++ b/runtime/internal/runtime/tinygogc/head_cache.go
@@ -21,6 +21,10 @@ type markHeadRange struct {
 	head, end uintptr // complemented indexes; end is exclusive
 }
 
+// Four KiB on wasm32 and eight KiB on wasm64 amortize interval lookup while
+// keeping cheap small-object lookups from displacing large allocations.
+const markHeadMinBlocks = 256
+
 func (c *markHeadCache) reset() { *c = markHeadCache{} }
 
 func (c *markHeadCache) lookup(block uintptr) (uintptr, bool) {
@@ -32,9 +36,11 @@ func (c *markHeadCache) lookup(block uintptr) (uintptr, bool) {
 	return 0, false
 }
 
+// remember accepts either a complete object range or a proven prefix ending
+// just after an interior pointer. Later observations may extend that prefix.
 func (c *markHeadCache) remember(head, end uintptr) {
-	// Small objects have cheap head lookup and must not displace stack ranges.
-	if end <= head || end-head < 256 || end == ^uintptr(0) {
+	// Favor large objects, including the GC-owned Fiber stack storage.
+	if end <= head || end-head < markHeadMinBlocks || end == ^uintptr(0) {
 		return
 	}
 	for i := range c.ranges {
@@ -47,5 +53,5 @@ func (c *markHeadCache) remember(head, end uintptr) {
 		}
 	}
 	c.ranges[c.next] = markHeadRange{head: ^head, end: ^end}
-	c.next = (c.next + 1) & 3
+	c.next = (c.next + 1) % uint8(len(c.ranges))
 }

--- a/runtime/internal/runtime/tinygogc/head_cache.go
+++ b/runtime/internal/runtime/tinygogc/head_cache.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package tinygogc
+
+// markHeadCache memoizes large object intervals during a single collection.
+// Store complemented block indexes, not raw heap addresses or indexes that
+// could accidentally look like heap addresses to conservative root scanning.
+// This follows weak-key encoding; conservative false positives remain possible.
+type markHeadCache struct {
+	ranges [4]markHeadRange
+	next   uint8
+}
+
+type markHeadRange struct {
+	head, end uintptr // complemented indexes; end is exclusive
+}
+
+func (c *markHeadCache) reset() { *c = markHeadCache{} }
+
+func (c *markHeadCache) lookup(block uintptr) (uintptr, bool) {
+	for _, r := range c.ranges {
+		if r.end != 0 && block >= ^r.head && block < ^r.end {
+			return ^r.head, true
+		}
+	}
+	return 0, false
+}
+
+func (c *markHeadCache) remember(head, end uintptr) {
+	// Small objects have cheap head lookup and must not displace stack ranges.
+	if end <= head || end-head < 256 || end == ^uintptr(0) {
+		return
+	}
+	for i := range c.ranges {
+		r := &c.ranges[i]
+		if r.end != 0 && ^r.head == head {
+			if end > ^r.end {
+				r.end = ^end
+			}
+			return
+		}
+	}
+	c.ranges[c.next] = markHeadRange{head: ^head, end: ^end}
+	c.next = (c.next + 1) & 3
+}

--- a/runtime/internal/runtime/tinygogc/head_cache_test.go
+++ b/runtime/internal/runtime/tinygogc/head_cache_test.go
@@ -45,8 +45,10 @@ func TestMarkHeadCache(t *testing.T) {
 	if c != (markHeadCache{}) {
 		t.Fatal("collection reset retained prior indexes")
 	}
-	c.remember(0, 256)
+	c.remember(0, markHeadMinBlocks-1)
+	check(0, 0, false)
+	c.remember(0, markHeadMinBlocks)
 	check(0, 0, true)
-	check(255, 0, true)
-	check(256, 0, false)
+	check(markHeadMinBlocks-1, 0, true)
+	check(markHeadMinBlocks, 0, false)
 }

--- a/runtime/internal/runtime/tinygogc/head_cache_test.go
+++ b/runtime/internal/runtime/tinygogc/head_cache_test.go
@@ -1,0 +1,52 @@
+package tinygogc
+
+import "testing"
+
+func TestMarkHeadCache(t *testing.T) {
+	var c markHeadCache
+	check := func(block, head uintptr, hit bool) {
+		t.Helper()
+		got, ok := c.lookup(block)
+		if ok != hit || (ok && got != head) {
+			t.Fatalf("lookup(%d)=(%d,%v), want (%d,%v)", block, got, ok, head, hit)
+		}
+	}
+	check(2000, 0, false) // Tail miss must fall back to the actual metadata.
+	c.remember(1000, 2000)
+	check(999, 0, false)
+	check(1000, 1000, true)
+	check(1999, 1000, true)
+	check(2000, 0, false)
+	c.remember(1000, 3000)
+	c.remember(1000, 2500) // Never shrink a previously proven interval.
+	check(2999, 1000, true)
+	c.remember(3000, 4000)
+	check(3000, 3000, true)
+	check(3999, 3000, true)
+	check(4000, 0, false)
+	for _, r := range c.ranges[:2] {
+		if r.head < 4000 || r.end < 4000 {
+			t.Fatal("stored unencoded heap block indexes")
+		}
+	}
+	c.remember(8, 8)
+	c.remember(9, 8)
+	c.remember(8, 9)
+	c.remember(1, ^uintptr(0))
+	check(8, 0, false)
+	c.remember(4000, 5000)
+	c.remember(5000, 6000)
+	c.remember(6000, 7000)
+	check(1000, 0, false) // Round-robin eviction, not an unbounded index.
+	check(3500, 3000, true)
+	check(6500, 6000, true)
+	c.reset()
+	check(3500, 0, false)
+	if c != (markHeadCache{}) {
+		t.Fatal("collection reset retained prior indexes")
+	}
+	c.remember(0, 256)
+	check(0, 0, true)
+	check(255, 0, true)
+	check(256, 0, false)
+}


### PR DESCRIPTION
## Problem

TinyGC recovers the allocation head of every interior pointer by walking backward through packed object metadata, even when that allocation has already been identified during the current mark phase. A pointer near the end of the existing 5 MiB Wasm main Fiber stack requires about 81,920 metadata-byte steps on wasm32. The Fiber stack and asyncify stack are persistent TinyGC allocations, and deep recursion, deferred calls, and conservative stack scanning can retain many interior pointers into them, so this is a real worst-case GC-latency problem rather than only a synthetic lookup benchmark. Current main `1d81439e8` still uses the uncached backward walk.

Expanded WebAssembly acceptance exposed this shared main-branch algorithmic cost: the original Go `issue16249.go` times out on an earlier integration build's `-target wasi` entry (wasm32 with a WASI Preview 1 host, using that revision's data model). This PR isolates the collector fix from broader profiling and compatibility changes.

## Change

- Memoize four proven large-object ranges only during the stop-the-world GC mark phase; ignore small ranges and keep direct head/marked pointers on the existing fast path.
- Clear the cache before marking and after finalizer preservation, before object boundaries may change or mutators resume.
- Preserve finalizer-reference accounting and mark-state checks on cache hits. Allocator, `Free`, `Realloc`, and finalizer-registration head lookup remain uncached.
- Store complemented block indexes rather than raw addresses or ordinary heap indexes, reducing the chance that conservative global scanning mistakes the cache contents for live heap pointers; this does not claim to eliminate every conservative false positive.

## Benefit and scope

This is a targeted worst-case latency fix, not a universal GC throughput optimization. Controlled lookup of 256 references near the end of a 5 MiB object takes about 86 ms without caching versus 0.37 ms with caching. Host-compiled measurements of the actual lookup functions show steady-state tail lookups for one to four reused 5 MiB-equivalent objects falling from roughly 67–73 µs to 2–3 ns after the cache is warm.

The original, unmodified Go 1.27 `issue16249.go` completes under the 15-second execution limit with this change. One validation environment recorded 0.72 seconds, while an independent local replay on the current branch completed consistently in about 4.5–4.7 seconds, so the exact elapsed time is environment-dependent and is not presented as a portable speedup ratio. A same-machine current-main end-to-end comparison was unavailable because that local baseline build hit an unrelated `runtime.NewProc` LLVM verifier error; the algorithmic lookup measurements and successful acceptance run are the performance evidence.

### Cache-capacity boundary

The bounded four-entry cache intentionally favors the persistent large Wasm stack allocations without adding an unbounded index. `TestWasmGCHeadCacheWorkloads` checks one, four, five, ten, and twenty interleaved objects using the actual collector lookup functions with isolated packed metadata. Five or more interleaved large objects thrash the four entries and provide no material improvement: both cached and uncached paths remain about 66–70 µs per tail lookup. Small 16-block tails add about 2.6 ns on a cache miss (approximately 4.47 ns to 7.05 ns), while small object heads retain the original fast path. Timings are recorded as evidence rather than flaky pass/fail thresholds.

## Cost

- Same-run main/head `println` Wasm sizes: Emscripten wasm32 112,483 → 113,710 B (+1,227, 1.09%); Memory64 118,028 → 119,267 B (+1,239, 1.05%); WASI 116,428 → 117,700 B (+1,272, 1.09%). The two raw no-GC profiles are unchanged.
- Emscripten build-time medians differ by +0.4% and +0.2%; these are build timings, not runtime throughput measurements.
- Linux native `cprintf`, `println`, `fmtprintf`, and all three LTO variants have identical file/text/data/BSS sizes against main `1d81439e8`.
- The production change is limited to the mark-only cache and its integration; most of the 293 added lines are correctness, workload, and capacity-boundary tests.

No enlarged timeout, test exclusion, growing stack, collector replacement, or new CI job is introduced.

## Validation and CI

- Pure cache helper boundary, growth, replacement, threshold, and reset tests report 100% statement coverage. They run in the existing single-worker runtime CI script because the nested runtime module is outside root `go test ./...`.
- The real-collector workload test is included in existing root Go-test CI and takes about 1.6 seconds locally.
- Focused Wasm weak-reference, finalizer, cleanup, and mixed-size live-buffer GC stress tests pass.
- [Wasm runtime and test-command CI](https://github.com/xgo-dev/llgo/actions/runs/34536009350), Linux Go coverage, compatibility, cross-compilation, and the [Wasm/native benchmark jobs](https://github.com/xgo-dev/llgo/actions/runs/34536009281) pass. Codecov reports coverage not affected; target-side collector execution is validated by the Wasm fixtures rather than inferred from host helper coverage.
- Final CI has 64 successful checks and one conditional release skip. The first [Linux dev-LTO attempt](https://github.com/xgo-dev/llgo/actions/runs/34536009371/job/103067666900) timed out waiting for `opt` in the pre-existing malformed-interface-metadata test; the same test passed on current main, in ten local LLVM 22 repetitions, and in a [single-job retry on unchanged code](https://github.com/xgo-dev/llgo/actions/runs/34536009371/job/103085323906). No retry, skip, or timeout workaround was added to this PR, and the intermittent timeout's cause is not established.

## Base

Rebased onto main `1d81439e8` (including #2549), head `69466825a`. The diff remains five files containing the mark-only cache, its tests, and integration into the existing runtime test script; it contains no diagnostic probes, skips, timeout increases, or unrelated changes.
