### PR TITLE
ci: capture Windows MinGW test-go crash evidence

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -167,8 +167,31 @@ jobs:
             -coverpkg=github.com/xgo-dev/llgo/cl,github.com/xgo-dev/llgo/ssa \
             -coverprofile="coverage-compiler.txt" -covermode=atomic \
             -bench '^BenchmarkGo126' -benchtime=1x ./cl
-          "${go_test[@]}" -timeout 45m \
-            -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
+          if [[ "$RUNNER_OS" == Windows && "${{ matrix.windows_abi }}" == mingw ]]; then
+            # Capture the first failure, without retrying or quarantining it.
+            bash dev/go_test_windows_diagnostics.sh "${go_test[@]}" -timeout 45m \
+              -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
+          else
+            "${go_test[@]}" -timeout 45m \
+              -coverprofile="coverage-test-go.txt" -covermode=atomic ./test/go
+          fi
+
+      - name: Restore Windows test-go crash reporting
+        id: restore_test_go_wer
+        if: always() && runner.os == 'Windows' && matrix.windows_abi == 'mingw'
+        shell: pwsh
+        run: |
+          # Also covers cancellation between registry setup and the bash trap.
+          & ./dev/go_test_windows_wer.ps1 -Mode Finish -Directory "$env:RUNNER_TEMP/llgo-windows-test-go-diagnostics"
+
+      - name: Upload Windows test-go failure evidence
+        if: always() && runner.os == 'Windows' && matrix.windows_abi == 'mingw' && (steps.test_coverage.outputs.windows_test_go_failed == 'true' || steps.restore_test_go_wer.outcome == 'failure')
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-mingw-test-go-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/llgo-windows-test-go-diagnostics/evidence/
+          if-no-files-found: error
+          retention-days: 3
 
       - name: Test with embedded emulator env
         env:

--- a/dev/go_test_windows_diagnostics.sh
+++ b/dev/go_test_windows_diagnostics.sh
@@ -34,11 +34,14 @@ if [[ "$target_count" -ne 1 || "$timeout_value" == true ]]; then
   exit 2
 fi
 : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
-command -v pwsh >/dev/null
+command -v pwsh >/dev/null || { echo 'pwsh is required for Windows diagnostics' >&2; exit 2; }
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 diagnostic_dir="$RUNNER_TEMP/llgo-windows-test-go-diagnostics"
 # Do not overwrite evidence or restoration state from an earlier invocation.
-mkdir "$diagnostic_dir"
+mkdir "$diagnostic_dir" || {
+  echo "Cannot create diagnostic directory: $diagnostic_dir; refusing to overwrite prior evidence" >&2
+  exit 2
+}
 evidence_dir="$diagnostic_dir/evidence"
 mkdir "$evidence_dir" "$diagnostic_dir/dumps"
 

--- a/dev/go_test_windows_diagnostics.sh
+++ b/dev/go_test_windows_diagnostics.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# One existing coverage execution, with bounded failure evidence. This is not
+# the synctest quarantine wrapper and must never retry or suppress a failure.
+set -euo pipefail
+
+if [[ "${RUNNER_OS:-}" != Windows || "${RUNNER_ARCH:-}" != X64 || "${LLGO_WINDOWS_ABI:-}" != mingw ]]; then
+  echo 'Windows test-go diagnostics require the MinGW x64 CI lane' >&2
+  exit 2
+fi
+if [[ $# -lt 3 || "$1" != go || "$2" != test ]]; then
+  echo 'usage: go_test_windows_diagnostics.sh go test <coverage flags> ./test/go' >&2
+  exit 2
+fi
+shift 2
+test_args=("$@")
+target_count=0
+timeout_value=false
+for arg in "$@"; do
+  if [[ "$timeout_value" == true ]]; then
+    [[ "$arg" == 45m ]] || { echo 'expected the existing 45m timeout' >&2; exit 2; }
+    timeout_value=false
+    continue
+  fi
+  case "$arg" in
+    -timeout) timeout_value=true ;;
+    -timeout=45m|-ldflags=*|-coverprofile=*|-covermode=atomic) ;;
+    ./test/go) target_count=$((target_count + 1)) ;;
+    *) echo "unsupported test-go diagnostic argument: $arg" >&2; exit 2 ;;
+  esac
+done
+if [[ "$target_count" -ne 1 || "$timeout_value" == true ]]; then
+  echo 'diagnostics require exactly one complete ./test/go execution' >&2
+  exit 2
+fi
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+command -v pwsh >/dev/null
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+diagnostic_dir="$RUNNER_TEMP/llgo-windows-test-go-diagnostics"
+# Do not overwrite evidence or restoration state from an earlier invocation.
+mkdir "$diagnostic_dir"
+evidence_dir="$diagnostic_dir/evidence"
+mkdir "$evidence_dir" "$diagnostic_dir/dumps"
+
+# shellcheck disable=SC2329 # Called by the EXIT trap.
+finish() {
+  local status=$? cleanup_status=0
+  trap - EXIT
+  pwsh -NoProfile -NonInteractive -File "$script_dir/go_test_windows_wer.ps1" \
+    -Mode Finish -Directory "$diagnostic_dir" >>"$evidence_dir/diagnostics.log" 2>&1 || cleanup_status=$?
+  if [[ "$cleanup_status" -ne 0 ]]; then
+    echo "Windows crash-reporting restoration failed (exit $cleanup_status); see diagnostics.log" >&2
+    # Preserve the original test/setup failure; a cleanup failure also fails
+    # an otherwise successful command and is retried by the workflow cleanup.
+    if [[ "$status" -eq 0 ]]; then status=$cleanup_status; fi
+  fi
+  if [[ "$status" -ne 0 && -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo 'windows_test_go_failed=true' >>"$GITHUB_OUTPUT" || echo 'Could not record the diagnostic failure output' >&2
+  fi
+  exit "$status"
+}
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+pwsh -NoProfile -NonInteractive -File "$script_dir/go_test_windows_wer.ps1" \
+  -Mode Prepare -Directory "$diagnostic_dir" >"$evidence_dir/diagnostics.log" 2>&1 || {
+    prepare_status=$?
+    tail -40 "$evidence_dir/diagnostics.log" >&2
+    exit "$prepare_status"
+  }
+
+# -o retains the exact executable (including symbols) even when the test fails.
+# cmd/go still executes its temporary go.test.exe, so WER uses that basename.
+command=(go test -v -count=1 "-o=$evidence_dir/go.test.exe" "${test_args[@]}")
+{
+  printf 'GOTRACEBACK=wer'
+  printf ' %q' "${command[@]}"
+  printf '\n'
+} >"$evidence_dir/command.txt"
+set +e
+GOTRACEBACK=wer "${command[@]}" 2>&1 | tee "$evidence_dir/test.log"
+statuses=("${PIPESTATUS[@]}")
+set -e
+log_status=0
+printf 'go_test_exit=%s\nlog_capture_exit=%s\n' "${statuses[0]}" "${statuses[1]}" >>"$evidence_dir/diagnostics.log" || log_status=$?
+if [[ "${statuses[0]}" -ne 0 ]]; then exit "${statuses[0]}"; fi
+if [[ "${statuses[1]}" -ne 0 ]]; then exit "${statuses[1]}"; fi
+exit "$log_status"

--- a/dev/go_test_windows_wer.ps1
+++ b/dev/go_test_windows_wer.ps1
@@ -1,0 +1,105 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('Prepare', 'Finish')]
+  [string]$Mode,
+  [Parameter(Mandatory = $true)]
+  [string]$Directory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+if (-not $IsWindows) { throw 'WER diagnostics require Windows' }
+
+# Never configure all-process dumping. cmd/go runs this basename even with -o.
+$nativeKey = 'HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\go.test.exe'
+$key = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\go.test.exe'
+$statePath = Join-Path $Directory 'wer-state.json'
+$backupPath = Join-Path $Directory 'wer-before.reg'
+$evidence = Join-Path $Directory 'evidence'
+$dumpDirectory = Join-Path $Directory 'dumps'
+
+function Invoke-Registry([string[]]$RegistryArguments) {
+  & reg.exe @RegistryArguments
+  if ($LASTEXITCODE -ne 0) { throw "reg.exe failed with exit code $LASTEXITCODE" }
+}
+
+function Read-NativeMetadata([string]$Executable, [string[]]$NativeArguments) {
+  & $Executable @NativeArguments
+  if ($LASTEXITCODE -ne 0) { throw "$Executable failed with exit code $LASTEXITCODE" }
+}
+
+if ($Mode -eq 'Prepare') {
+  if (Test-Path -LiteralPath $statePath) { throw 'WER restoration state already exists' }
+  $existed = Test-Path -LiteralPath $key
+  $addedValues = @('DumpFolder', 'DumpType', 'DumpCount')
+  if ($existed) {
+    # Export the entire exact key, including every value type and child key.
+    # The backup stays outside the uploaded evidence directory.
+    Invoke-Registry -RegistryArguments @('export', $nativeKey, $backupPath, '/y')
+    $oldNames = (Get-Item -LiteralPath $key).GetValueNames()
+    $addedValues = @($addedValues | Where-Object { $_ -notin $oldNames })
+  }
+  @{ Existed = $existed; Restored = $false; AddedValues = $addedValues } | ConvertTo-Json |
+    Set-Content -LiteralPath $statePath -Encoding utf8
+  if (-not $existed) { New-Item -Path $key -Force | Out-Null }
+  New-ItemProperty -LiteralPath $key -Name DumpFolder -Value $dumpDirectory -PropertyType ExpandString -Force | Out-Null
+  New-ItemProperty -LiteralPath $key -Name DumpType -Value 1 -PropertyType DWord -Force | Out-Null
+  New-ItemProperty -LiteralPath $key -Name DumpCount -Value 1 -PropertyType DWord -Force | Out-Null
+  Write-Output 'WER enabled only for go.test.exe: mini dump, maximum one file.'
+
+  # An explicit allowlist, never an environment dump or processor serial ID.
+  @(
+    "ImageOS=$env:ImageOS"
+    "ImageVersion=$env:ImageVersion"
+    "RUNNER_ARCH=$env:RUNNER_ARCH"
+    (Read-NativeMetadata -Executable go -NativeArguments @('version'))
+    (Read-NativeMetadata -Executable go -NativeArguments @('env', 'GOOS', 'GOARCH', 'GOVERSION', 'CC', 'CGO_ENABLED'))
+    (Read-NativeMetadata -Executable clang -NativeArguments @('--version'))
+  ) | Set-Content -LiteralPath (Join-Path $evidence 'metadata.txt') -Encoding utf8
+  Get-CimInstance Win32_Processor |
+    Select-Object Name, Manufacturer, NumberOfCores, NumberOfLogicalProcessors |
+    Format-List | Out-String |
+    Add-Content -LiteralPath (Join-Path $evidence 'metadata.txt') -Encoding utf8
+  exit 0
+}
+
+# Finish is idempotent, including when the coverage command was never reached.
+if (-not (Test-Path -LiteralPath $statePath)) { exit 0 }
+$state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+try {
+  if (-not $state.Restored) {
+    if ($state.Existed -and -not (Test-Path -LiteralPath $backupPath)) {
+      throw 'Cannot restore the pre-existing WER key: backup is missing'
+    }
+    if ($state.Existed) {
+      # Keep the original key and children in place: reg export/import preserves
+      # values and types, not ACLs. Deleting that key would lose custom ACLs.
+      if (-not (Test-Path -LiteralPath $key)) { throw 'The original WER key disappeared; cannot restore its permissions' }
+      $currentNames = (Get-Item -LiteralPath $key).GetValueNames()
+      foreach ($name in $state.AddedValues) {
+        if ($name -in $currentNames) { Remove-ItemProperty -LiteralPath $key -Name $name }
+      }
+      Invoke-Registry -RegistryArguments @('import', $backupPath)
+    } elseif (Test-Path -LiteralPath $key) {
+      Remove-Item -LiteralPath $key -Recurse -Force
+    }
+    $state.Restored = $true
+    $state | ConvertTo-Json | Set-Content -LiteralPath $statePath -Encoding utf8
+    Write-Output 'Original go.test.exe WER configuration restored.'
+  }
+} catch {
+  # Keep the restoration error visible even if collecting the dump also fails.
+  Write-Output "WER restoration failed: $($_.Exception.Message)"
+  throw
+} finally {
+  # Expected fatal-test children can also create dumps. Keep only the newest;
+  # do not label its cause without inspecting the dump and verbose test log.
+  $dump = Get-ChildItem -LiteralPath $dumpDirectory -Filter '*.dmp' -File |
+    Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+  if ($null -ne $dump) {
+    Copy-Item -LiteralPath $dump.FullName -Destination (Join-Path $evidence 'crash.dmp') -Force
+    Write-Output "Collected mini dump: $($dump.Name), $($dump.Length) bytes."
+  } else {
+    Write-Output 'No WER dump was produced; preserve the verbose log, without inferring a crash cause.'
+  }
+}

--- a/dev/go_test_windows_wer.ps1
+++ b/dev/go_test_windows_wer.ps1
@@ -24,11 +24,18 @@ function Invoke-Registry([string[]]$RegistryArguments) {
 }
 
 function Read-NativeMetadata([string]$Executable, [string[]]$NativeArguments) {
-  & $Executable @NativeArguments
-  if ($LASTEXITCODE -ne 0) { throw "$Executable failed with exit code $LASTEXITCODE" }
+  try {
+    & $Executable @NativeArguments 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "exit code $LASTEXITCODE" }
+  } catch {
+    "Metadata probe failed ($Executable): $($_.Exception.Message)"
+  }
 }
 
 if ($Mode -eq 'Prepare') {
+  # Missing build tools are configuration errors. Optional version/CPU probes
+  # below must not prevent the coverage command from running.
+  $null = Get-Command go, clang -CommandType Application -ErrorAction Stop
   if (Test-Path -LiteralPath $statePath) { throw 'WER restoration state already exists' }
   $existed = Test-Path -LiteralPath $key
   $addedValues = @('DumpFolder', 'DumpType', 'DumpCount')
@@ -56,10 +63,14 @@ if ($Mode -eq 'Prepare') {
     (Read-NativeMetadata -Executable go -NativeArguments @('env', 'GOOS', 'GOARCH', 'GOVERSION', 'CC', 'CGO_ENABLED'))
     (Read-NativeMetadata -Executable clang -NativeArguments @('--version'))
   ) | Set-Content -LiteralPath (Join-Path $evidence 'metadata.txt') -Encoding utf8
-  Get-CimInstance Win32_Processor |
-    Select-Object Name, Manufacturer, NumberOfCores, NumberOfLogicalProcessors |
-    Format-List | Out-String |
-    Add-Content -LiteralPath (Join-Path $evidence 'metadata.txt') -Encoding utf8
+  $processorMetadata = try {
+    Get-CimInstance Win32_Processor |
+      Select-Object Name, Manufacturer, NumberOfCores, NumberOfLogicalProcessors |
+      Format-List | Out-String
+  } catch {
+    "Processor metadata probe failed: $($_.Exception.Message)"
+  }
+  $processorMetadata | Add-Content -LiteralPath (Join-Path $evidence 'metadata.txt') -Encoding utf8
   exit 0
 }
 

--- a/internal/windowsdiagnostics/diagnostics_test.go
+++ b/internal/windowsdiagnostics/diagnostics_test.go
@@ -8,6 +8,7 @@
 package windowsdiagnostics
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -85,7 +86,8 @@ func (f fixture) run(t *testing.T, args ...string) (int, string) {
 	if err == nil {
 		return 0, string(out)
 	}
-	if e, ok := err.(*exec.ExitError); ok {
+	var e *exec.ExitError
+	if errors.As(err, &e) {
 		return e.ExitCode(), string(out)
 	}
 	t.Fatalf("run diagnostic script: %v\n%s", err, out)
@@ -229,10 +231,25 @@ func TestExistingEvidenceIsNotOverwritten(t *testing.T) {
 	if status, out := f.run(t, coverageArgs()...); status != 0 {
 		t.Fatalf("first exit %d: %s", status, out)
 	}
-	if status, out := f.run(t, coverageArgs()...); status == 0 {
-		t.Fatalf("existing evidence was overwritten: %s", out)
+	if status, out := f.run(t, coverageArgs()...); status != 2 || !strings.Contains(out, "refusing to overwrite prior evidence") {
+		t.Fatalf("existing evidence rejection: exit %d: %s", status, out)
 	}
 	if got := read(t, filepath.Join(f.dir, "modes")); got != "Prepare\nFinish\n" {
 		t.Fatalf("second invocation changed WER: %q", got)
+	}
+}
+
+func TestMissingPowerShellFailsBeforeChangingState(t *testing.T) {
+	f := newFixture(t)
+	// An empty PATH isolates the missing-tool case even when pwsh is installed
+	// on the host. f.shell is absolute; all preceding checks are bash builtins.
+	t.Setenv("PATH", t.TempDir())
+	if status, out := f.run(t, coverageArgs()...); status != 2 || !strings.Contains(out, "pwsh is required") {
+		t.Fatalf("missing-tool rejection: exit %d: %s", status, out)
+	}
+	for _, name := range []string{"modes", "args", "llgo-windows-test-go-diagnostics"} {
+		if _, err := os.Stat(filepath.Join(f.dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("missing tool changed %s: %v", name, err)
+		}
 	}
 }

--- a/internal/windowsdiagnostics/diagnostics_test.go
+++ b/internal/windowsdiagnostics/diagnostics_test.go
@@ -1,0 +1,238 @@
+//go:build !llgo
+
+// Copyright 2026 The XGo Authors (xgo.dev). All rights reserved.
+// Use of this source code is governed by the Apache 2.0 license.
+
+// These tests exercise shell control flow, not Windows exception handling or
+// WER. The existing MinGW job remains the real-platform integration check.
+package windowsdiagnostics
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fakeGo = `#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$@" > "$MOCK_ARGS"
+printf '%s\n' "${GOTRACEBACK:-}" > "$MOCK_TRACEBACK"
+echo '=== RUN   TestDiagnosticFixture'
+echo 'raw diagnostic stderr' >&2
+exit "${MOCK_GO_EXIT:-0}"
+`
+
+const fakePowerShell = `#!/usr/bin/env bash
+set -eu
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == -Mode ]]; then
+    printf '%s\n' "$2" >> "$MOCK_MODES"
+    case "$2" in
+      Prepare) exit "${MOCK_PREPARE_EXIT:-0}" ;;
+      Finish) exit "${MOCK_FINISH_EXIT:-0}" ;;
+    esac
+  fi
+  shift
+done
+exit 99
+`
+
+type fixture struct {
+	root, dir, shell string
+}
+
+func newFixture(t *testing.T) fixture {
+	t.Helper()
+	shell, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatalf("bash is required for workflow script tests: %v", err)
+	}
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(t.TempDir(), "runner with spaces")
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{"go": fakeGo, "pwsh": fakePowerShell} {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte(content), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for key, value := range map[string]string{
+		"RUNNER_OS": "Windows", "RUNNER_ARCH": "X64", "LLGO_WINDOWS_ABI": "mingw",
+		"RUNNER_TEMP": dir, "MOCK_ARGS": filepath.Join(dir, "args"),
+		"MOCK_MODES": filepath.Join(dir, "modes"), "MOCK_TRACEBACK": filepath.Join(dir, "traceback"),
+		"GITHUB_OUTPUT": filepath.Join(dir, "outputs"), "GOTRACEBACK": "original-parent-value",
+		"MOCK_GO_EXIT": "0", "MOCK_PREPARE_EXIT": "0", "MOCK_FINISH_EXIT": "0",
+	} {
+		t.Setenv(key, value)
+	}
+	return fixture{root: root, dir: dir, shell: shell}
+}
+
+func (f fixture) run(t *testing.T, args ...string) (int, string) {
+	t.Helper()
+	args = append([]string{filepath.Join(f.root, "dev", "go_test_windows_diagnostics.sh")}, args...)
+	cmd := exec.Command(f.shell, args...)
+	cmd.Dir = f.root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	if e, ok := err.(*exec.ExitError); ok {
+		return e.ExitCode(), string(out)
+	}
+	t.Fatalf("run diagnostic script: %v\n%s", err, out)
+	return 0, ""
+}
+
+func read(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.ReplaceAll(string(b), "\r\n", "\n")
+}
+
+func coverageArgs() []string {
+	return []string{"go", "test", "-ldflags=-linkmode=external -extldflags=-lsynchronization",
+		"-timeout", "45m", "-coverprofile=coverage-test-go.txt", "-covermode=atomic", "./test/go"}
+}
+
+func TestSingleRunPreservesArgumentsAndEvidence(t *testing.T) {
+	f := newFixture(t)
+	if status, out := f.run(t, coverageArgs()...); status != 0 {
+		t.Fatalf("exit %d: %s", status, out)
+	}
+	got := strings.Split(strings.TrimSpace(read(t, filepath.Join(f.dir, "args"))), "\n")
+	want := append([]string{"test", "-v", "-count=1", "-o=" + filepath.Join(f.dir, "llgo-windows-test-go-diagnostics", "evidence", "go.test.exe")}, coverageArgs()[2:]...)
+	// Git Bash normalizes separators on Windows; argument boundaries must stay.
+	normalize := func(s string) string { return strings.ReplaceAll(s, "\\", "/") }
+	if normalize(strings.Join(got, "\n")) != normalize(strings.Join(want, "\n")) {
+		t.Fatalf("arguments = %q, want %q", got, want)
+	}
+	if got := read(t, filepath.Join(f.dir, "modes")); got != "Prepare\nFinish\n" {
+		t.Fatalf("WER modes: %q", got)
+	}
+	if got := read(t, filepath.Join(f.dir, "traceback")); got != "wer\n" {
+		t.Fatalf("child GOTRACEBACK = %q", got)
+	}
+	if got := os.Getenv("GOTRACEBACK"); got != "original-parent-value" {
+		t.Fatalf("parent GOTRACEBACK changed: %q", got)
+	}
+	log := read(t, filepath.Join(f.dir, "llgo-windows-test-go-diagnostics", "evidence", "test.log"))
+	if !strings.Contains(log, "=== RUN   TestDiagnosticFixture") || !strings.Contains(log, "raw diagnostic stderr") {
+		t.Fatalf("incomplete raw log: %q", log)
+	}
+	if _, err := os.Stat(filepath.Join(f.dir, "outputs")); !os.IsNotExist(err) {
+		t.Fatalf("successful run signaled failure: %v", err)
+	}
+}
+
+func TestFailureAndRestorationExitStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name, goExit, prepareExit, finishExit, modes string
+		want                                         int
+	}{
+		{"test failure", "9", "0", "0", "Prepare\nFinish\n", 9},
+		{"cleanup after success", "0", "0", "7", "Prepare\nFinish\n", 7},
+		{"cleanup preserves test failure", "9", "0", "7", "Prepare\nFinish\n", 9},
+		{"partial setup", "0", "5", "0", "Prepare\nFinish\n", 5},
+		{"setup and cleanup failure", "0", "5", "7", "Prepare\nFinish\n", 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			t.Setenv("MOCK_GO_EXIT", tc.goExit)
+			t.Setenv("MOCK_PREPARE_EXIT", tc.prepareExit)
+			t.Setenv("MOCK_FINISH_EXIT", tc.finishExit)
+			if status, out := f.run(t, coverageArgs()...); status != tc.want {
+				t.Fatalf("exit = %d, want %d: %s", status, tc.want, out)
+			}
+			if got := read(t, filepath.Join(f.dir, "modes")); got != tc.modes {
+				t.Fatalf("modes = %q", got)
+			}
+			if got := read(t, filepath.Join(f.dir, "outputs")); got != "windows_test_go_failed=true\n" {
+				t.Fatalf("failure output = %q", got)
+			}
+			if tc.prepareExit != "0" {
+				if _, err := os.Stat(filepath.Join(f.dir, "args")); !os.IsNotExist(err) {
+					t.Fatalf("test ran after failed setup: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRejectOtherScopes(t *testing.T) {
+	for _, tc := range []struct {
+		name, env, value string
+		args             []string
+	}{
+		{"Linux", "RUNNER_OS", "Linux", coverageArgs()},
+		{"MSVC", "LLGO_WINDOWS_ABI", "msvc", coverageArgs()},
+		{"ARM64", "RUNNER_ARCH", "ARM64", coverageArgs()},
+		{"other package", "", "", []string{"go", "test", "./cl"}},
+		{"filtered tests", "", "", []string{"go", "test", "-run=TestOne", "./test/go"}},
+		{"compile only", "", "", []string{"go", "test", "-c", "./test/go"}},
+		{"missing timeout", "", "", []string{"go", "test", "./test/go", "-timeout"}},
+		{"duplicate package", "", "", []string{"go", "test", "./test/go", "./test/go"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			if tc.env != "" {
+				t.Setenv(tc.env, tc.value)
+			}
+			if status, out := f.run(t, tc.args...); status != 2 {
+				t.Fatalf("exit %d: %s", status, out)
+			}
+			if _, err := os.Stat(filepath.Join(f.dir, "modes")); !os.IsNotExist(err) {
+				t.Fatalf("WER changed for rejected command: %v", err)
+			}
+		})
+	}
+}
+
+func TestLogCaptureFailureStillRestoresWER(t *testing.T) {
+	for _, goExit := range []string{"0", "9"} {
+		t.Run(goExit, func(t *testing.T) {
+			f := newFixture(t)
+			t.Setenv("MOCK_GO_EXIT", goExit)
+			// Consume all output before failing, so the test process does not
+			// acquire an unrelated broken-pipe status from this test fixture.
+			tee := "#!/usr/bin/env bash\nwhile IFS= read -r line; do :; done\nexit 6\n"
+			if err := os.WriteFile(filepath.Join(f.dir, "bin", "tee"), []byte(tee), 0755); err != nil {
+				t.Fatal(err)
+			}
+			want := 6
+			if goExit == "9" {
+				want = 9
+			}
+			if status, out := f.run(t, coverageArgs()...); status != want {
+				t.Fatalf("exit %d, want %d: %s", status, want, out)
+			}
+			if got := read(t, filepath.Join(f.dir, "modes")); got != "Prepare\nFinish\n" {
+				t.Fatalf("WER modes: %q", got)
+			}
+		})
+	}
+}
+
+func TestExistingEvidenceIsNotOverwritten(t *testing.T) {
+	f := newFixture(t)
+	if status, out := f.run(t, coverageArgs()...); status != 0 {
+		t.Fatalf("first exit %d: %s", status, out)
+	}
+	if status, out := f.run(t, coverageArgs()...); status == 0 {
+		t.Fatalf("existing evidence was overwritten: %s", out)
+	}
+	if got := read(t, filepath.Join(f.dir, "modes")); got != "Prepare\nFinish\n" {
+		t.Fatalf("second invocation changed WER: %q", got)
+	}
+}

--- a/internal/windowsdiagnostics/powershell_windows_test.go
+++ b/internal/windowsdiagnostics/powershell_windows_test.go
@@ -21,10 +21,22 @@ func TestPowerShellHelperParses(t *testing.T) {
 	}
 	t.Setenv("LLGO_WER_SCRIPT_TO_PARSE", script)
 	cmd := exec.Command(shell, "-NoProfile", "-NonInteractive", "-Command", `
+$ErrorActionPreference = 'Stop'
 $tokens = $null
 $parseErrors = $null
-$null = [System.Management.Automation.Language.Parser]::ParseFile($env:LLGO_WER_SCRIPT_TO_PARSE, [ref]$tokens, [ref]$parseErrors)
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($env:LLGO_WER_SCRIPT_TO_PARSE, [ref]$tokens, [ref]$parseErrors)
 if ($parseErrors.Count -ne 0) { $parseErrors | Out-String | Write-Error; exit 1 }
+# Exercise only the metadata function, never the registry operations.
+$helper = $ast.Find({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Read-NativeMetadata' }, $true)
+if ($null -eq $helper) { throw 'metadata helper is missing' }
+. ([scriptblock]::Create($helper.Extent.Text))
+$result = Read-NativeMetadata -Executable $env:ComSpec -NativeArguments @('/d', '/c', 'echo fixture-ok') | Out-String
+if ($result -notmatch 'fixture-ok' -or $result -match 'probe failed') { throw "successful probe: $result" }
+$result = Read-NativeMetadata -Executable $env:ComSpec -NativeArguments @('/d', '/c', 'exit /b 7') | Out-String
+if ($result -notmatch 'Metadata probe failed' -or $result -notmatch 'exit code 7') { throw "failed probe: $result" }
+$result = Read-NativeMetadata -Executable '__llgo_missing_metadata_probe__' -NativeArguments @() | Out-String
+if ($result -notmatch 'Metadata probe failed') { throw "probe exception: $result" }
+exit 0
 `)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("parse WER helper: %v\n%s", err, out)

--- a/internal/windowsdiagnostics/powershell_windows_test.go
+++ b/internal/windowsdiagnostics/powershell_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows && !llgo
+
+package windowsdiagnostics
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestPowerShellHelperParses(t *testing.T) {
+	// Parse the production script on the real CI PowerShell. Do not execute its
+	// registry actions or mistake syntax validation for a WER integration test.
+	shell, err := exec.LookPath("pwsh")
+	if err != nil {
+		t.Fatalf("pwsh is required for Windows crash diagnostics: %v", err)
+	}
+	script, err := filepath.Abs(filepath.Join("..", "..", "dev", "go_test_windows_wer.ps1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LLGO_WER_SCRIPT_TO_PARSE", script)
+	cmd := exec.Command(shell, "-NoProfile", "-NonInteractive", "-Command", `
+$tokens = $null
+$parseErrors = $null
+$null = [System.Management.Automation.Language.Parser]::ParseFile($env:LLGO_WER_SCRIPT_TO_PARSE, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -ne 0) { $parseErrors | Out-String | Write-Error; exit 1 }
+`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("parse WER helper: %v\n%s", err, out)
+	}
+}

--- a/internal/windowsdiagnostics/workflow_test.go
+++ b/internal/windowsdiagnostics/workflow_test.go
@@ -1,0 +1,115 @@
+//go:build !llgo
+
+package windowsdiagnostics
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestWorkflowDiagnosticScope(t *testing.T) {
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				ID, Name, Run, If, Uses string
+				With                    map[string]string
+			}
+		}
+	}
+	data := read(t, filepath.Join("..", "..", ".github", "workflows", "go.yml"))
+	if err := yaml.Unmarshal([]byte(data), &workflow); err != nil {
+		t.Fatal(err)
+	}
+	var coverage, restore, upload bool
+	for jobName, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			if strings.Contains(step.Run, "bash dev/go_test_windows_diagnostics.sh") {
+				if jobName != "test" || step.ID != "test_coverage" {
+					t.Fatal("diagnostics escaped the existing coverage step")
+				}
+				guard := `if [[ "$RUNNER_OS" == Windows && "${{ matrix.windows_abi }}" == mingw ]]; then`
+				if !strings.Contains(step.Run, guard) || !strings.Contains(step.Run, "else\n  \"${go_test[@]}\" -timeout 45m") {
+					t.Fatal("non-MinGW execution is no longer preserved")
+				}
+				coverage = true
+			}
+			if step.ID == "restore_test_go_wer" {
+				if !strings.HasPrefix(step.If, "always()") || !strings.Contains(step.If, "matrix.windows_abi == 'mingw'") {
+					t.Fatalf("restoration scope: %s", step.If)
+				}
+				restore = true
+			}
+			if step.Name == "Upload Windows test-go failure evidence" {
+				for _, want := range []string{"always()", "runner.os == 'Windows'", "matrix.windows_abi == 'mingw'",
+					"steps.test_coverage.outputs.windows_test_go_failed == 'true'", "steps.restore_test_go_wer.outcome == 'failure'"} {
+					if !strings.Contains(step.If, want) {
+						t.Fatalf("artifact condition lacks %s", want)
+					}
+				}
+				if step.With["retention-days"] != "3" || step.With["if-no-files-found"] != "error" || !strings.HasSuffix(step.With["path"], "/evidence/") {
+					t.Fatal("artifact retention or private-state boundary changed")
+				}
+				upload = true
+			}
+		}
+	}
+	if !coverage || !restore || !upload {
+		t.Fatalf("incomplete workflow: coverage=%v restore=%v upload=%v", coverage, restore, upload)
+	}
+}
+
+func TestWERRestorationSourceContract(t *testing.T) {
+	// Static safety checks complement the Windows parser test. They do not
+	// claim that registry operations or dump generation ran on this host.
+	source := read(t, filepath.Join("..", "..", "dev", "go_test_windows_wer.ps1"))
+	prepareStart := strings.Index(source, "if ($Mode -eq 'Prepare')")
+	finishStart := strings.Index(source, "# Finish is idempotent")
+	if prepareStart < 0 || finishStart <= prepareStart {
+		t.Fatal("cannot identify preparation/restoration routes")
+	}
+	prepare, finish := source[prepareStart:finishStart], source[finishStart:]
+	for _, want := range []string{
+		"Invoke-Registry -RegistryArguments @('export', $nativeKey, $backupPath, '/y')",
+		"$addedValues = @($addedValues | Where-Object { $_ -notin $oldNames })",
+		"if (-not $existed) { New-Item -Path $key -Force | Out-Null }",
+		"-Name DumpType -Value 1", "-Name DumpCount -Value 1",
+	} {
+		if !strings.Contains(prepare, want) {
+			t.Fatalf("preparation safety contract missing %q", want)
+		}
+	}
+	if strings.Index(prepare, "@('export'") > strings.Index(prepare, "Set-Content -LiteralPath $statePath") ||
+		strings.Index(prepare, "Set-Content -LiteralPath $statePath") > strings.Index(prepare, "New-ItemProperty") {
+		t.Fatal("backup and recovery state must precede the first mutation")
+	}
+	existingStart := strings.Index(finish, "if ($state.Existed) {")
+	createdStart := strings.Index(finish, "} elseif (Test-Path -LiteralPath $key) {")
+	if existingStart < 0 || createdStart <= existingStart {
+		t.Fatal("missing distinct existing/new-key restoration routes")
+	}
+	existing := finish[existingStart:createdStart]
+	if strings.Contains(existing, "Remove-Item -LiteralPath") || strings.Contains(existing, "New-Item -Path") {
+		t.Fatal("pre-existing key must remain in place to preserve ACLs")
+	}
+	for _, want := range []string{
+		"if (-not (Test-Path -LiteralPath $key)) { throw",
+		"foreach ($name in $state.AddedValues)",
+		"Remove-ItemProperty -LiteralPath $key -Name $name",
+		"Invoke-Registry -RegistryArguments @('import', $backupPath)",
+	} {
+		if !strings.Contains(existing, want) {
+			t.Fatalf("existing-key restoration lacks %q", want)
+		}
+	}
+	if strings.Count(source, "Remove-Item -LiteralPath $key -Recurse -Force") != 1 ||
+		!strings.HasPrefix(finish[createdStart:], "} elseif (Test-Path -LiteralPath $key) {\n      Remove-Item -LiteralPath $key -Recurse -Force") {
+		t.Fatal("only a newly created exact key may be removed")
+	}
+	if !strings.Contains(finish, "Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1") ||
+		!strings.Contains(source, "Join-Path $Directory 'wer-before.reg'") {
+		t.Fatal("dump count or private registry backup boundary changed")
+	}
+}

--- a/test/go/caller_runtime_test.go
+++ b/test/go/caller_runtime_test.go
@@ -52,7 +52,8 @@ func callerPanicCaller() {
 
 func TestCallerPanicTraceback(t *testing.T) {
 	cmd := exec.Command(os.Args[0], "-test.run=^$")
-	cmd.Env = append(os.Environ(), callerPanicChild+"=1")
+	// Assert the default traceback format independently of parent crash diagnostics.
+	cmd.Env = append(os.Environ(), callerPanicChild+"=1", "GOTRACEBACK=single")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("panic child unexpectedly succeeded:\n%s", output)


### PR DESCRIPTION
## Summary

Capture the next intermittent Windows MinGW `test/go` coverage crash in its existing CI execution. This is a diagnostic change for a main-shared path, **not a claim that the access-violation root cause is fixed**.

In [#2536's MinGW job](https://github.com/xgo-dev/llgo/actions/runs/34247371526/job/102133191751), `internal/build` passed in 444.051s (including the stack/cache regression) and `cl` passed in 409.300s. The subsequent host-Go `test/go` process exited `0xc0000005` after 0.635s without a named failing test or exception stack. The same test/workflow/Go version is unchanged from main `1e41ad3ff`; the [main comparison job](https://github.com/xgo-dev/llgo/actions/runs/34239866833/job/102106964189) passed this coverage invocation in 0.470s.

These are Go test sources run by official Go 1.27 with external linking and atomic coverage. External linking also implicitly adds **official `runtime/cgo`**; this does not rule out its TLS/native startup paths. It does rule out executing LLGo's runtime, BDWGC, or LLVM in this test process. #2537 addresses a different LLGo/BDWGC path; #2502 retries the symptom without collecting an exception dump.

## Changes

- Only the existing Windows x64 MinGW standalone `test/go` coverage command gains `-v -count=1` and retains the exact executable with `-o`. Preserve existing linker flags, coverage, timeout, and original failure status.
- Use command-local `GOTRACEBACK=wer` and the Windows-provided per-application WER `LocalDumps/go.test.exe` configuration: mini dump, maximum one, no downloaded debugger or resident monitor. The actual temporary executable basename remains `go.test.exe` even with `go test -o`.
- Restore the prior typed values and preserve existing registry keys/ACLs in place. Remove only a key created by this invocation. An EXIT trap and an idempotent workflow cleanup cover normal failure and cancellation; restoration errors fail explicitly.
- Upload raw output, command/selected tool and CPU metadata, the same executable, and at most one dump **only on failure**, with three-day retention. Registry backups and the full environment are never uploaded.
- No new CI jobs, retries, quarantines, or changes to Linux/macOS/MSVC execution. Script boundary tests live under `internal/`, outside R4's wasm `test/` inventory, and run in existing Go CI.

## Validation

- `go test -count=1 ./internal/windowsdiagnostics` — pass; covers argument preservation, one-run behavior, child-only environment, failures, log-write failure, cleanup, existing evidence, workflow scope, and registry-restoration source contracts.
- Windows amd64 test binary cross-compilation — pass, **compile only**.
- `bash -n`, ShellCheck, actionlint, and `git diff --check` — pass.
- A Windows-only test parses the production PowerShell helper in the existing matrix. Actual registry execution and WER collection still require that Windows CI lane; mock/static tests do not claim to validate WER.

## Limits and next step

Expected fatal-test children use the same executable name and can also write a mini dump. Keep only the newest bounded artifact and correlate it with the verbose log; never infer its cause from its presence alone. A failure may still produce no WER dump, in which case retain the log and binary without declaring the crash diagnosed. Use the next exception stack to make a targeted follow-up fix rather than expanding retries or excluding tests.

References: [Go linker-induced dependencies](https://go.dev/src/cmd/go/internal/load/pkg.go), [Go Windows exception handling](https://go.dev/src/runtime/signal_windows.go), [Microsoft WER LocalDumps](https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps).
