### PR TITLE
fix(ssa): preserve floating min/max NaNs and signed zeros

### DIFF
--- a/cl/float_minmax_test.go
+++ b/cl/float_minmax_test.go
@@ -1,0 +1,93 @@
+//go:build !llgo
+
+package cl
+
+import (
+	"strings"
+	"testing"
+
+	llssa "github.com/xgo-dev/llgo/ssa"
+	"github.com/xgo-dev/llvm"
+)
+
+func TestFloatMinMaxLowering(t *testing.T) {
+	const src = `package minmax
+ type Float float64
+ func Min32(a, b, c float32) float32 { return min(a, b, c) }
+ func Max32(a, b, c float32) float32 { return max(a, b, c) }
+ func Min64(a, b, c Float) Float { return min(a, b, c) }
+ func Max64(a, b, c Float) Float { return max(a, b, c) }
+ func Identity(a Float) Float { return min(a) }
+ func Integer(a, b int) int { return min(a, b) }
+ `
+	for _, tt := range []struct {
+		target    llssa.Target
+		intrinsic bool
+	}{
+		{llssa.Target{GOOS: "linux", GOARCH: "arm64"}, true},
+		{llssa.Target{GOOS: "windows", GOARCH: "amd64"}, true},
+		{llssa.Target{GOOS: "windows", GOARCH: "386"}, true},
+		{llssa.Target{GOOS: "windows", GOARCH: "386", GO386: "softfloat"}, false},
+		{llssa.Target{GOOS: "wasip1", GOARCH: "wasm"}, true},
+		{llssa.Target{GOOS: "linux", GOARCH: "arm", GOARM: "7"}, false},
+		{llssa.Target{GOOS: "linux", GOARCH: "arm", GOARM: "5"}, false},
+		{llssa.Target{GOOS: "linux", GOARCH: "riscv64"}, false},
+		{llssa.Target{GOOS: "linux", GOARCH: "arm64", Target: "custom"}, false},
+	} {
+		target := tt.target
+		name := strings.Join([]string{target.GOARCH, target.GO386, target.GOARM, target.Target}, "-")
+		t.Run(strings.TrimRight(name, "-"), func(t *testing.T) {
+			ssapkg, _, files := buildGoSSAPkg(t, src)
+			prog := newLLSSAProgForTarget(t, &target)
+			defer prog.Dispose()
+			pkg, err := NewPackage(prog, ssapkg, files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+			for _, width := range []string{"32", "64"} {
+				for _, op := range []struct{ name, intrinsic string }{{"Min", "minimum"}, {"Max", "maximum"}} {
+					ir := mustNamedFunction(t, pkg.Module(), "minmax."+op.name+width).String()
+					want := "@llvm." + op.intrinsic + ".f" + width + "("
+					calls := 0
+					if tt.intrinsic {
+						calls = 2
+					}
+					if strings.Count(ir, want) != calls {
+						t.Errorf("want %d %s calls:\n%s", calls, want, ir)
+					}
+					if strings.Contains(ir, "fcmp") || (tt.intrinsic && strings.Contains(ir, "select")) {
+						t.Errorf("floating min/max still uses compare/select:\n%s", ir)
+					}
+				}
+			}
+			ir := mustNamedFunction(t, pkg.Module(), "minmax.Identity").String()
+			if strings.Contains(ir, "call") {
+				t.Errorf("one operand must remain unchanged:\n%s", ir)
+			}
+			ir = mustNamedFunction(t, pkg.Module(), "minmax.Integer").String()
+			if !strings.Contains(ir, "icmp slt") || strings.Contains(ir, "@llvm.minimum") {
+				t.Errorf("integer lowering changed:\n%s", ir)
+			}
+			mod := pkg.Module()
+			mod.SetDataLayout(prog.DataLayout())
+			mod.SetTarget(target.Spec().Triple)
+			opts := llvm.NewPassBuilderOptions()
+			defer opts.Dispose()
+			opts.SetVerifyEach(true)
+			if err := mod.RunPasses("default<O2>", prog.TargetMachine(), opts); err != nil {
+				t.Fatal(err)
+			}
+			asm, err := prog.TargetMachine().EmitToMemoryBuffer(mod, llvm.AssemblyFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer asm.Dispose()
+			if text := string(asm.Bytes()); strings.Contains(text, "fminimum") || strings.Contains(text, "fmaximum") {
+				t.Fatalf("min/max requires unavailable C23 libcalls:\n%s", text)
+			}
+		})
+	}
+}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1748,6 +1748,12 @@ func (b Builder) Do(da DoAction, fn Expr, buildCall func(Builder, Expr, ...Expr)
 // appropriate value based on the comparison.
 func (b Builder) compareSelect(op token.Token, x Expr, y ...Expr) Expr {
 	ret := x
+	if x.kind == vkFloat {
+		for _, v := range y {
+			ret.impl = b.floatMinMax(op, ret.impl, v.impl)
+		}
+		return ret
+	}
 	for _, v := range y {
 		cond := b.BinOp(op, ret, v)
 		sel := llvm.CreateSelect(b.impl, cond.impl, ret.impl, v.impl)

--- a/ssa/float_minmax.go
+++ b/ssa/float_minmax.go
@@ -1,0 +1,71 @@
+package ssa
+
+import (
+	"go/token"
+	"strings"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func (b Builder) floatMinMax(op token.Token, a, c llvm.Value) llvm.Value {
+	// Go propagates NaNs and orders -0 below +0. Neither compare/select nor
+	// LLVM minnum/maxnum implements both rules.
+	if b.Prog.Target().useFloatMinMaxIntrinsics() {
+		name := "llvm.minimum"
+		if op == token.GTR {
+			name = "llvm.maximum"
+		}
+		return b.impl.CreateIntrinsic(a.Type(), llvm.LookupIntrinsicID(name), []llvm.Value{a, c}, "")
+	}
+	return b.floatMinMaxBits(op, a, c)
+}
+
+func (p *Target) useFloatMinMaxIntrinsics() bool {
+	// Named targets may retarget the emitted IR in an external compiler with
+	// different floating-point features. Keep their lowering portable.
+	if p.Target != "" && p.WasmABI == "" {
+		return false
+	}
+	spec := p.Spec()
+	switch strings.SplitN(spec.Triple, "-", 2)[0] {
+	case "aarch64", "arm64", "x86_64", "wasm32", "wasm64":
+		return true
+	case "i386", "i686":
+		return strings.Contains(spec.Features, "+sse2") && !strings.Contains(spec.Features, "+soft-float")
+	}
+	// LLVM 22 can fail to select minimum.f64 on ARM32 without ARMv8 FP,
+	// or emit C23 fminimum/fmaximum libcalls on soft-float targets. Those
+	// functions are not available in all supported C libraries.
+	return false
+}
+
+// floatMinMaxBits orders IEEE float32/float64 encodings without floating-point
+// instructions or libcalls. Positive encodings sort upwards, negative ones
+// downwards; flipping the sign bit or complementing a negative encoding gives
+// unsigned keys with -0 immediately below +0. NaNs are handled separately.
+func (b Builder) floatMinMaxBits(op token.Token, a, c llvm.Value) llvm.Value {
+	width, infinity, ty := 64, uint64(0x7ff0000000000000), b.Prog.tyInt64()
+	if a.Type().TypeKind() == llvm.FloatTypeKind {
+		width, infinity, ty = 32, 0x7f800000, b.Prog.tyInt32()
+	}
+	sign := uint64(1) << (width - 1)
+	ua := b.impl.CreateBitCast(a, ty, "")
+	uc := b.impl.CreateBitCast(c, ty, "")
+	key := func(u llvm.Value) llvm.Value {
+		mask := b.impl.CreateAShr(u, llvm.ConstInt(ty, uint64(width-1), false), "")
+		mask = b.impl.CreateOr(mask, llvm.ConstInt(ty, sign, false), "")
+		return b.impl.CreateXor(u, mask, "")
+	}
+	pred := llvm.IntULT
+	if op == token.GTR {
+		pred = llvm.IntUGT
+	}
+	result := b.impl.CreateSelect(b.impl.CreateICmp(pred, key(ua), key(uc), ""), ua, uc, "")
+	isNaN := func(u llvm.Value) llvm.Value {
+		abs := b.impl.CreateAnd(u, llvm.ConstInt(ty, sign-1, false), "")
+		return b.impl.CreateICmp(llvm.IntUGT, abs, llvm.ConstInt(ty, infinity, false), "")
+	}
+	result = b.impl.CreateSelect(isNaN(uc), uc, result, "")
+	result = b.impl.CreateSelect(isNaN(ua), ua, result, "")
+	return b.impl.CreateBitCast(result, a.Type(), "")
+}

--- a/ssa/float_minmax_test.go
+++ b/ssa/float_minmax_test.go
@@ -1,0 +1,75 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"go/token"
+	"math"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestFloatMinMaxBits(t *testing.T) {
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	pkg := prog.NewPackage("minmaxbits", "minmaxbits")
+	fn := pkg.NewFunc("test", NoArgsNoRet, InC)
+	b := fn.MakeBody(1)
+	for _, width := range []int{32, 64} {
+		intType, floatType := prog.tyInt64(), prog.Float64().ll
+		values := []uint64{0, 0x8000000000000000, 0x7ff8000000000001, 0xfff8000000000042, 0x7ff0000000000001, 0x7ff0000000000000, 0xfff0000000000000, 1, 0x8000000000000001, 0x0010000000000000, 0x8010000000000000, 0x3ff0000000000000, 0xbff0000000000000, 0x7fefffffffffffff, 0xffefffffffffffff}
+		if width == 32 {
+			intType, floatType = prog.tyInt32(), prog.Float32().ll
+			values = []uint64{0, 0x80000000, 0x7fc00001, 0xffc00042, 0x7f800001, 0x7f800000, 0xff800000, 1, 0x80000001, 0x00800000, 0x80800000, 0x3f800000, 0xbf800000, 0x7f7fffff, 0xff7fffff}
+		}
+		check := func(x, y uint64) {
+			for _, op := range []token.Token{token.LSS, token.GTR} {
+				a := llvm.ConstBitCast(llvm.ConstInt(intType, x, false), floatType)
+				c := llvm.ConstBitCast(llvm.ConstInt(intType, y, false), floatType)
+				result := b.floatMinMaxBits(op, a, c)
+				raw := llvm.ConstBitCast(result, intType)
+				if raw.IsAConstantInt().IsNil() {
+					t.Fatalf("constant inputs did not fold: %s", raw.String())
+				}
+				got := raw.ZExtValue()
+				var want, actual float64
+				if width == 32 {
+					a, c := math.Float32frombits(uint32(x)), math.Float32frombits(uint32(y))
+					v := min(a, c)
+					if op == token.GTR {
+						v = max(a, c)
+					}
+					want, actual = float64(v), float64(math.Float32frombits(uint32(got)))
+				} else {
+					a, c := math.Float64frombits(x), math.Float64frombits(y)
+					want = min(a, c)
+					if op == token.GTR {
+						want = max(a, c)
+					}
+					actual = math.Float64frombits(got)
+				}
+				if math.IsNaN(want) {
+					if !math.IsNaN(actual) {
+						t.Fatalf("f%d %s(%x,%x) = %x, want NaN", width, op, x, y, got)
+					}
+				} else if math.Float64bits(actual) != math.Float64bits(want) {
+					t.Fatalf("f%d %s(%x,%x) = %x, want %g (sign=%v)", width, op, x, y, got, want, math.Signbit(want))
+				}
+			}
+		}
+		for _, a := range values {
+			for _, c := range values {
+				check(a, c)
+			}
+		}
+		// Exercise finite values across the exponent and mantissa ranges, as well
+		// as the exhaustive edge pairs above. The fixed seed keeps failures stable.
+		seed := uint64(0x123456789abcdef)
+		next := func() uint64 { seed ^= seed << 13; seed ^= seed >> 7; seed ^= seed << 17; return seed }
+		for i := 0; i < 2048; i++ {
+			check(next(), next())
+		}
+	}
+	b.Return()
+}

--- a/test/cmd/llgo/float_minmax_test.go
+++ b/test/cmd/llgo/float_minmax_test.go
@@ -1,0 +1,168 @@
+//go:build go1.21
+
+package llgocmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Keep the reference independent of min/max and ignore unspecified NaN payloads.
+const floatMinMaxProbe = `package main
+
+import (
+	"fmt"
+	"math"
+)
+
+type F32 float32
+type F64 float64
+
+//go:noinline
+func low[T ~float32 | ~float64](a, b T) T { return min(a, b) }
+
+//go:noinline
+func high[T ~float32 | ~float64](a, b T) T { return max(a, b) }
+
+//go:noinline
+func low3[T ~float32 | ~float64](a, b, c T) T { return min(a, b, c) }
+
+//go:noinline
+func high3[T ~float32 | ~float64](a, b, c T) T { return max(a, b, c) }
+
+//go:noinline
+func single[T ~float32 | ~float64](a T) T { return min(a) }
+func reference[T ~float32 | ~float64](a, b T, upper bool) T {
+	if a != a {
+		return a
+	}
+	if b != b {
+		return b
+	}
+	if a == 0 && b == 0 {
+		if upper {
+			if !math.Signbit(float64(a)) {
+				return a
+			}
+			return b
+		}
+		if math.Signbit(float64(a)) {
+			return a
+		}
+		return b
+	}
+	if upper {
+		if a > b {
+			return a
+		}
+		return b
+	}
+	if a < b {
+		return a
+	}
+	return b
+}
+
+var count int
+
+func check[T ~float32 | ~float64](got, want T) {
+	count++
+	if want != want {
+		if got != got {
+			return
+		}
+	} else if math.Float64bits(float64(got)) == math.Float64bits(float64(want)) {
+		return
+	}
+	panic(fmt.Sprintf("%T min/max: got %x want %x", got, math.Float64bits(float64(got)), math.Float64bits(float64(want))))
+}
+func test[T ~float32 | ~float64](values []T) {
+	for _, a := range values {
+		check(single(a), a)
+		for _, b := range values {
+			check(low(a, b), reference(a, b, false))
+			check(high(a, b), reference(a, b, true))
+			for _, c := range values {
+				check(low3(a, b, c), reference(reference(a, b, false), c, false))
+				check(high3(a, b, c), reference(reference(a, b, true), c, true))
+			}
+		}
+	}
+}
+
+var sequence int
+
+func next(n int, v float64) float64 {
+	if sequence != n {
+		panic("argument evaluation order")
+	}
+	sequence++
+	return v
+}
+func main() {
+	var a []float32
+	var b []float64
+	var an []F32
+	var bn []F64
+	for _, u := range []uint32{0, 0x80000000, 0x7fc00001, 0xffc00042, 0x7f800001, 0x7f800000, 0xff800000, 1, 0x80000001, 0x00800000, 0x80800000, 0x3f800000, 0xbf800000, 0x7f7fffff, 0xff7fffff} {
+		v := math.Float32frombits(u)
+		a = append(a, v)
+		an = append(an, F32(v))
+	}
+	for _, u := range []uint64{0, 0x8000000000000000, 0x7ff8000000000001, 0xfff8000000000042, 0x7ff0000000000001, 0x7ff0000000000000, 0xfff0000000000000, 1, 0x8000000000000001, 0x0010000000000000, 0x8010000000000000, 0x3ff0000000000000, 0xbff0000000000000, 0x7fefffffffffffff, 0xffefffffffffffff} {
+		v := math.Float64frombits(u)
+		b = append(b, v)
+		bn = append(bn, F64(v))
+	}
+	test(a)
+	test(b)
+	test(an)
+	test(bn)
+	check(min(next(0, 1), next(1, math.NaN()), next(2, 2)), math.NaN())
+	check(max(next(3, 1), next(4, math.NaN()), next(5, 2)), math.NaN())
+	if sequence != 6 {
+		panic("argument evaluation count")
+	}
+	x, y := -3, 4
+	s, t := "alpha", "beta"
+	if min(x, y) != x || max(x, y) != y || min(s, t) != s || max(s, t) != t {
+		panic("non-float min/max")
+	}
+	fmt.Println("PASS", count)
+}
+`
+
+func TestFloatMinMaxSemantics(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte(floatMinMaxProbe), 0644); err != nil {
+		t.Fatal(err)
+	}
+	want, err := runGoCompiler(t, dir, "run", file)
+	if err != nil {
+		t.Fatalf("gc min/max probe: %v\n%s", err, want)
+	}
+	modes := []struct {
+		name  string
+		flags []string
+	}{{name: "default"}}
+	if toolCompilerName == "llgo" {
+		modes = append(modes, struct {
+			name  string
+			flags []string
+		}{"O2", []string{"-O2"}})
+	}
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			args := append([]string{"run"}, mode.flags...)
+			got, err := runCompiler(t, dir, append(args, file)...)
+			if err != nil {
+				t.Fatalf("%s min/max probe: %v\n%s", toolCompilerName, err, got)
+			}
+			if got != want {
+				t.Fatalf("%s min/max differs from gc: got %q want %q", toolCompilerName, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Floating-point builtins currently use an ordered comparison followed by select: `min(NaN, 1)` returns `1`, `min(-0, +0)` returns `+0`, and `max(+0, -0)` returns `-0`. Preserve Go's NaN propagation and signed-zero ordering for float32/float64, including named types, generics, and multi-argument calls.

Use `llvm.minimum`/`llvm.maximum` on native ARM64, x64, SSE2 386, and Wasm targets. Other targets use integer ordering of IEEE encodings with explicit NaN selection: LLVM 22 can fail instruction selection for ARM32 minimum.f64 or emit unavailable C23 `fminimum`/`fmaximum` libcalls on soft-float targets. Named targets that may retarget IR externally also use the portable path. Integer and string lowering retain their existing behavior.

Validation on macOS ARM64 with Go 1.27.0 and LLVM/Clang/LLD 22.1.8:

- New IR and executable regressions fail against the previous implementation.
- Full `go test ./ssa ./cl -count=1` and `go vet ./ssa ./cl ./test/cmd/llgo` pass.
- Command regression passes 28,862 semantic checks in each of default and O2 modes; a separate full-LTO build and execution passes the same checks. Covers NaNs, signed zeros, infinities, subnormals, named types, generics, and argument evaluation order.
- Portable lowering passes 9,092 edge/random operation checks against host Go builtins. A separate production-Builder IR probe passes 676 float32/float64 cases under both native O2 and LTO execution.
- Nine target configurations pass O2 verification and assembly generation without C23 min/max libcalls, including Windows 386 softfloat, ARM5/7, RISC-V64, and Wasm. Cross-target checks establish code generation; platform linking and execution remain for CI.
