### PR TITLE
ci: remove manual GOROOT dispatch

### DIFF
--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -1,7 +1,6 @@
 name: GOROOT
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [labeled]
   schedule:

--- a/test/goroot/README.md
+++ b/test/goroot/README.md
@@ -31,8 +31,8 @@ The GOROOT workflow builds LLGo and this runner with the repository toolchain,
 then runs the `ci` directive set from the two most recent Go releases. Every run
 publishes the expectation-mismatch table in its Actions summary. The scheduled
 run in `xgo-dev/llgo` also replaces the previous `[GOROOT daily] YYYY-MM-DD`
-issue. A manual dispatch or adding the existing `go-test-compat` label to a
-pull request runs the same matrix without modifying issues.
+issue. Adding the existing `go-test-compat` label to a pull request runs the
+same matrix without modifying issues.
 
 Basic usage:
 


### PR DESCRIPTION
## Summary

Remove the GOROOT workflow's manual dispatch entry because a manually dispatched run cannot enter the schedule-only daily issue replacement path. Keep the scheduled daily report and the `go-test-compat` pull-request validation trigger, and update the runner documentation accordingly.

## Validation

- `actionlint .github/workflows/goroot.yml`
- `git diff --check`
