### PR TITLE
test(goroot): recognize terminated Linux descendants awaiting reaping

### DIFF
--- a/test/goroot/proc_unix_test.go
+++ b/test/goroot/proc_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -104,12 +105,12 @@ func TestRunProgramWaitDelayCleansDescendant(t *testing.T) {
 
 			deadline := time.Now().Add(2 * time.Second)
 			for {
-				probeErr := syscall.Kill(pid, 0)
-				if errors.Is(probeErr, syscall.ESRCH) {
-					break
-				}
+				exited, probeErr := processHasExited(pid)
 				if probeErr != nil {
 					t.Fatalf("probe descendant %d: %v", pid, probeErr)
+				}
+				if exited {
+					break
 				}
 				if time.Now().After(deadline) {
 					t.Fatalf("descendant %d is still running after runProgram returned", pid)
@@ -117,5 +118,94 @@ func TestRunProgramWaitDelayCleansDescendant(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 			}
 		})
+	}
+}
+
+func processHasExited(pid int) (bool, error) {
+	err := syscall.Kill(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	if err != nil || runtime.GOOS != "linux" {
+		return false, err
+	}
+	// A container's PID 1 need not reap orphaned descendants. kill(pid, 0)
+	// still succeeds for a zombie, although SIGKILL has already stopped it.
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if os.IsNotExist(err) || errors.Is(err, syscall.ESRCH) {
+		return true, nil // Reaped between the signal probe and the proc read.
+	}
+	if err != nil {
+		return false, err
+	}
+	return procStatHasExited(stat)
+}
+
+func procStatHasExited(stat []byte) (bool, error) {
+	// comm may contain spaces and parentheses; state follows the last ')'.
+	end := bytes.LastIndexByte(stat, ')')
+	if end < 0 || end+3 >= len(stat) || stat[end+1] != ' ' || stat[end+3] != ' ' {
+		return false, fmt.Errorf("invalid process stat %q", stat)
+	}
+	return stat[end+2] == 'Z' || stat[end+2] == 'X', nil
+}
+
+func TestProcStatHasExited(t *testing.T) {
+	for _, tt := range []struct {
+		stat    string
+		exited  bool
+		invalid bool
+	}{
+		{"42 (sleep) S 1 42 0", false, false},
+		{"42 (sleep) R 1 42 0", false, false},
+		{"42 (sleep) Z 1 42 0", true, false},
+		{"42 (a name ) with parentheses) Z 1 42 0", true, false},
+		{"42 (sleep) X 1 42 0", true, false},
+		{"", false, true},
+		{"42 (sleep)", false, true},
+		{"42 (sleep) Z", false, true},
+	} {
+		t.Run(tt.stat, func(t *testing.T) {
+			got, err := procStatHasExited([]byte(tt.stat))
+			if got != tt.exited || (err != nil) != tt.invalid {
+				t.Fatalf("process stat = %v, %v; want exited=%v, invalid=%v", got, err, tt.exited, tt.invalid)
+			}
+		})
+	}
+}
+
+func TestProcessHasExited(t *testing.T) {
+	guardTestTimeout(t)
+	if exited, err := processHasExited(os.Getpid()); err != nil || exited {
+		t.Fatalf("live process: exited=%v, err=%v", exited, err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Wait() })
+	if runtime.GOOS == "linux" {
+		// Leave our child unreaped so this test does not depend on PID 1's
+		// behavior, even on a host with a fully functioning init process.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			exited, err := processHasExited(cmd.Process.Pid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exited {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("terminated but unreaped child was reported as running")
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if exited, err := processHasExited(cmd.Process.Pid); err != nil || !exited {
+		t.Fatalf("reaped child: exited=%v, err=%v", exited, err)
 	}
 }

--- a/test/goroot/proc_unix_test.go
+++ b/test/goroot/proc_unix_test.go
@@ -130,7 +130,7 @@ func processHasExited(pid int) (bool, error) {
 		return false, err
 	}
 	// A container's PID 1 need not reap orphaned descendants. kill(pid, 0)
-	// still succeeds for a zombie, although SIGKILL has already stopped it.
+	// still succeeds for a zombie, although the process has already terminated.
 	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if os.IsNotExist(err) || errors.Is(err, syscall.ESRCH) {
 		return true, nil // Reaped between the signal probe and the proc read.
@@ -160,6 +160,7 @@ func TestProcStatHasExited(t *testing.T) {
 		{"42 (sleep) R 1 42 0", false, false},
 		{"42 (sleep) Z 1 42 0", true, false},
 		{"42 (a name ) with parentheses) Z 1 42 0", true, false},
+		{"42 (foo)bar) Z 1 42 0", true, false},
 		{"42 (sleep) X 1 42 0", true, false},
 		{"", false, true},
 		{"42 (sleep)", false, true},


### PR DESCRIPTION
## Summary

Fix a false failure in the existing Unix GOROOT runner regression, not the process cleanup itself. A Linux container's PID 1 may leave an already-killed descendant as a zombie. `kill(pid, 0)` then succeeds even though the process can no longer execute, so the test incorrectly reports a live leak.

On Linux, inspect `/proc/<pid>/stat` after a successful signal probe and accept only terminated states Z/X. Still reject running/sleeping processes, propagate unexpected probe errors, and handle ENOENT/ESRCH when reaping races with the proc read. The parser handles spaces/parentheses in the process name. Other Unix platforms retain the existing signal probe.

No production runner behavior, timeout, skip, or xfail changes. The existing Go and LLGo test matrices execute this file.

## Reproduction and verification

- The current main regression fails both exit-0 and exit-7 in an isolated Linux container without `--init`; the same binary passes with `--init`.
- Direct `ps` inspection shows the reported descendants as `PPID=1`, `STAT=Z`, command `sleep`, confirming they have terminated but were not reaped.
- Focused regressions cover a live process, an intentionally unreaped child, a reaped child, malformed stat records, and process names with parentheses.
- An overlay mutation removing `killProcessTree` still makes both original leak cases fail. The revised check does not mask a real surviving descendant.
- After handling the observed ESRCH race during a proc read, focused tests pass 20 repetitions each with and without a Linux init process, and 10 repetitions on macOS.
- This is the common failure observed in [#2541's Linux job](https://github.com/xgo-dev/llgo/actions/runs/34564365734/job/103153333167) and [#2539's compatibility job](https://github.com/xgo-dev/llgo/actions/runs/34554702162/job/103124768378). It is independent of the WASI initial-heap and Emscripten FS implementations.

Based on main `51864ab04`. All retained fork checks passed at `6139ac9df`: the native LLGo matrix, Linux/macOS/Windows Go tests, Go 1.20–1.26 compatibility, cross-compilation, both Wasm jobs, and formatting. Unrelated benchmark, release, installer, and cache workflows were deliberately cancelled. See the [LLGo run](https://github.com/cpunion/llgo/actions/runs/34566021361) and [Go run](https://github.com/cpunion/llgo/actions/runs/34566021389). Review follow-up `b32bb4168` generalizes the exit-probe comment and adds an explicit `foo)bar` process-name case; focused tests pass ten further local repetitions, and fresh upstream CI is pending. This focused contribution keeps the common runner-test correction separate from WebAssembly feature work.
