### PR TITLE
reflect: index named function conversions and pointer caches

### DIFF
--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -862,14 +862,43 @@ func TypeOf(i any) Type {
 	return toType((*abi.Type)(unsafe.Pointer(eface.typ)))
 }
 
-var namedFuncMap sync.Map // map[*abi.StructType]*abi.FuncType
+// Use typed maps: LLGo's sync.Map compatibility implementation performs linear
+// searches. Both directions must identify the same canonical descriptor pair.
+var namedFuncTypes struct {
+	sync.Mutex
+	funcs    map[*abi.StructType]*abi.FuncType
+	closures map[*abi.FuncType]*abi.StructType
+}
+
+// publishNamedFunc rechecks both directions after constructing a candidate
+// outside the lock. Losing candidates must never enter either index.
+func publishNamedFunc(ct *abi.StructType, ft *abi.FuncType) (*abi.StructType, *abi.FuncType) {
+	namedFuncTypes.Lock()
+	defer namedFuncTypes.Unlock()
+	if existing := namedFuncTypes.funcs[ct]; existing != nil {
+		return ct, existing
+	}
+	if existing := namedFuncTypes.closures[ft]; existing != nil {
+		return existing, ft
+	}
+	if namedFuncTypes.funcs == nil {
+		namedFuncTypes.funcs = make(map[*abi.StructType]*abi.FuncType)
+		namedFuncTypes.closures = make(map[*abi.FuncType]*abi.StructType)
+	}
+	namedFuncTypes.funcs[ct] = ft
+	namedFuncTypes.closures[ft] = ct
+	return ct, ft
+}
 
 func toFuncType(typ *abi.StructType) *abi.FuncType {
 	if !typ.HasName() {
 		return typ.Fields[0].Typ.FuncType()
 	}
-	if i, ok := namedFuncMap.Load(typ); ok {
-		return i.(*abi.FuncType)
+	namedFuncTypes.Lock()
+	cached := namedFuncTypes.funcs[typ]
+	namedFuncTypes.Unlock()
+	if cached != nil {
+		return cached
 	}
 	size := unsafe.Sizeof(abi.FuncType{})
 	u := typ.Uncommon()
@@ -910,8 +939,8 @@ func toFuncType(typ *abi.StructType) *abi.FuncType {
 			*(*abi.Method)(telemPtr) = *(*abi.Method)(uelemPtr)
 		}
 	}
-	tt, _ := namedFuncMap.LoadOrStore(typ, t)
-	return tt.(*abi.FuncType)
+	_, canonical := publishNamedFunc(typ, t)
+	return canonical
 }
 
 func toClosureType(typ *abi.FuncType) *abi.StructType {
@@ -970,7 +999,6 @@ func toClosureType(typ *abi.FuncType) *abi.StructType {
 			*(*abi.Method)(telemPtr) = *(*abi.Method)(uelemPtr)
 		}
 	}
-	namedFuncMap.Store(t, typ)
 	return t
 }
 
@@ -981,7 +1009,25 @@ func rtypeOf(i any) *abi.Type {
 }
 
 // ptrMap is the cache for PointerTo.
-var ptrMap sync.Map // map[*rtype]*ptrType
+// Keep it typed too: a linear sync.Map lookup here would negate the reverse
+// index's benefit for named functions without pointer methods.
+var ptrMap struct {
+	sync.Mutex
+	m map[*rtype]*ptrType
+}
+
+func cachePointer(t *rtype, p *ptrType) *abi.Type {
+	ptrMap.Lock()
+	defer ptrMap.Unlock()
+	if existing := ptrMap.m[t]; existing != nil {
+		return &existing.Type
+	}
+	if ptrMap.m == nil {
+		ptrMap.m = make(map[*rtype]*ptrType)
+	}
+	ptrMap.m[t] = p
+	return &p.Type
+}
 
 // PtrTo returns the pointer type with element t.
 // For example, if t represents type Foo, PtrTo(t) represents *Foo.
@@ -1013,8 +1059,11 @@ func (t *rtype) ptrTo() *abi.Type {
 		return at.PtrToThis_
 	}
 	// Check the cache.
-	if pi, ok := ptrMap.Load(t); ok {
-		return &pi.(*ptrType).Type
+	ptrMap.Lock()
+	cached := ptrMap.m[t]
+	ptrMap.Unlock()
+	if cached != nil {
+		return &cached.Type
 	}
 
 	// Look in known types.
@@ -1023,8 +1072,7 @@ func (t *rtype) ptrTo() *abi.Type {
 		if p.Elem != &t.t {
 			continue
 		}
-		pi, _ := ptrMap.LoadOrStore(t, p)
-		return &pi.(*ptrType).Type
+		return cachePointer(t, p)
 	}
 
 	// Create a new ptrType starting with the description
@@ -1050,8 +1098,7 @@ func (t *rtype) ptrTo() *abi.Type {
 
 	pp.Elem = at
 
-	pi, _ := ptrMap.LoadOrStore(t, &pp)
-	return &pi.(*ptrType).Type
+	return cachePointer(t, &pp)
 }
 
 func ptrTo(t *abi.Type) *abi.Type {
@@ -2298,18 +2345,15 @@ var closureLookupCache struct {
 // Struct returns a struct type.
 func closureOf(ftyp *abi.FuncType) *abi.Type {
 	if ftyp.HasName() {
-		var t *abi.StructType
-		namedFuncMap.Range(func(key interface{}, value interface{}) bool {
-			if value == ftyp {
-				t = key.(*abi.StructType)
-				return false
-			}
-			return true
-		})
-		if t != nil {
-			return &t.Type
+		namedFuncTypes.Lock()
+		cached := namedFuncTypes.closures[ftyp]
+		namedFuncTypes.Unlock()
+		if cached != nil {
+			return &cached.Type
 		}
-		return &toClosureType(ftyp).Type
+		t := toClosureType(ftyp)
+		canonical, _ := publishNamedFunc(t, ftyp)
+		return &canonical.Type
 	}
 
 	fields := []abi.StructField{

--- a/test/go/reflect_named_func_cache_llgo_test.go
+++ b/test/go/reflect_named_func_cache_llgo_test.go
@@ -1,0 +1,52 @@
+//go:build llgo
+
+package gotest
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/xgo-dev/llgo/runtime/abi"
+)
+
+// A public TypeOf already materializes the forward mapping. Exercise the
+// reverse cache's cold construction path directly, without that precondition.
+//
+//go:linkname reflectCacheClosureOf reflect.closureOf
+func reflectCacheClosureOf(*abi.FuncType) *abi.Type
+
+//go:linkname reflectCacheToFuncType reflect.toFuncType
+func reflectCacheToFuncType(*abi.StructType) *abi.FuncType
+
+func TestReflectNamedFuncReverseConcurrentPublication(t *testing.T) {
+	for round := 0; round < 20; round++ {
+		ft := &abi.FuncType{Type: abi.Type{
+			Kind_: uint8(abi.Func), TFlag: abi.TFlagNamed,
+			Str_: "gotest.reverseCacheFunc", Size_: 2 * unsafe.Sizeof(uintptr(0)),
+		}}
+		const workers = 32
+		start := make(chan struct{})
+		results := make(chan *abi.Type, workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				<-start
+				ct := reflectCacheClosureOf(ft)
+				if reflectCacheToFuncType(ct.StructType()) != ft {
+					results <- nil
+					return
+				}
+				results <- ct
+			}()
+		}
+		close(start)
+		want := <-results
+		if want == nil {
+			t.Fatal("reverse mapping was published without the canonical forward mapping")
+		}
+		for i := 1; i < workers; i++ {
+			if got := <-results; got != want {
+				t.Fatalf("round %d: competing named closure descriptors: %p != %p", round, got, want)
+			}
+		}
+	}
+}

--- a/test/go/reflect_named_func_cache_test.go
+++ b/test/go/reflect_named_func_cache_test.go
@@ -1,0 +1,82 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+type reflectColdNamedFunc func() int
+
+func (*reflectColdNamedFunc) Marker() {}
+
+func TestReflectNamedFuncConcurrentPublication(t *testing.T) {
+	const workers = 32
+	start := make(chan struct{})
+	results := make(chan reflect.Type, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			<-start
+			ft := reflect.TypeOf(reflectColdNamedFunc(nil))
+			pt := reflect.PointerTo(ft)
+			if reflect.New(ft).Type() != pt || pt.Elem() != ft {
+				results <- nil
+				return
+			}
+			results <- pt
+		}()
+	}
+	close(start)
+	want := reflect.TypeOf((*reflectColdNamedFunc)(nil))
+	for i := 0; i < workers; i++ {
+		if got := <-results; got != want {
+			t.Fatalf("concurrent named function pointer = %v, want canonical %v", got, want)
+		}
+	}
+	if !reflect.New(want.Elem()).Type().Implements(reflect.TypeOf((*interface{ Marker() })(nil)).Elem()) {
+		t.Fatal("published pointer lost its method set")
+	}
+}
+
+type reflectBenchNamedFunc[T any] func()
+
+func reflectBenchFuncTypes[T any]() []reflect.Type {
+	return []reflect.Type{
+		reflect.TypeOf(reflectBenchNamedFunc[T](nil)),
+		reflect.TypeOf(reflectBenchNamedFunc[*T](nil)),
+		reflect.TypeOf(reflectBenchNamedFunc[[]T](nil)),
+		reflect.TypeOf(reflectBenchNamedFunc[map[int]T](nil)),
+	}
+}
+
+var reflectBenchPointerSink reflect.Type
+
+func BenchmarkReflectNamedFuncPointer(b *testing.B) {
+	factories := []func() []reflect.Type{
+		reflectBenchFuncTypes[[1]byte], reflectBenchFuncTypes[[2]byte],
+		reflectBenchFuncTypes[[3]byte], reflectBenchFuncTypes[[4]byte],
+		reflectBenchFuncTypes[[5]byte], reflectBenchFuncTypes[[6]byte],
+		reflectBenchFuncTypes[[7]byte], reflectBenchFuncTypes[[8]byte],
+		reflectBenchFuncTypes[[9]byte], reflectBenchFuncTypes[[10]byte],
+		reflectBenchFuncTypes[[11]byte], reflectBenchFuncTypes[[12]byte],
+		reflectBenchFuncTypes[[13]byte], reflectBenchFuncTypes[[14]byte],
+		reflectBenchFuncTypes[[15]byte], reflectBenchFuncTypes[[16]byte],
+	}
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{{"4-types", 1}, {"16-types", 4}, {"64-types", 16}} {
+		b.Run(tc.name, func(b *testing.B) {
+			var typ reflect.Type
+			for _, factory := range factories[:tc.n] {
+				for _, ft := range factory() {
+					typ = ft
+					reflectBenchPointerSink = reflect.PointerTo(ft)
+				}
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reflectBenchPointerSink = reflect.PointerTo(typ)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow up on the performance and concurrent-publication review of #2535:
https://github.com/xgo-dev/llgo/pull/2535#discussion_r3956254114

- Replace the named-function reverse `Range` scan with an explicit `FuncType -> StructType` index.
- Publish the forward and reverse mappings as one canonical pair, rechecking both indexes under a mutex after constructing candidates outside the lock. Losing candidates never enter either index.
- Use typed maps for both directions and the pointer cache. LLGo's `runtime/_patch/internal/sync/hashtriemap.go` implements `sync.Map` with a mutex-protected slice, including linear `Load`; merely adding another `sync.Map` does not eliminate size-dependent lookup costs.
- Preserve #2535's element normalization, static pointer method metadata, and lazy methodless-pointer synthesis. No global changes to sync.Map or the type ABI.

The cache critical sections use plain mutexes, matching the existing compatibility cache's exclusion model. A trial RWMutex version stalled under extended contention and was discarded; the final mutex implementation passed the repeated stress test below.

## Tests

- Public named-function first-use publication across 32 goroutines, checking canonical pointer identity and pointer methods.
- LLGo-only cold reverse-cache test: fresh named FuncType descriptors, 20 rounds of 32 goroutines, checking both reverse identity and the forward round trip. A public TypeOf would prepopulate the forward index, so this test directly exercises the otherwise-hidden cold reverse path.
- Warm PointerTo benchmark after materializing 4, 16, and 64 named function types.

The cold reverse test fails on the parent (`daada50d22`) in round 0 with competing closure descriptors and passes with this change.

## Performance

Local Apple M4 Max, darwin/arm64, LLVM 22.1.8, default LLGo optimization; 10,000,000 iterations per case, no tests run during benchmarking. Parent and patched code use the same benchmark and compiler. Indicative local measurements, not cross-platform guarantees:

| Benchmark types materialized | Parent ns/op | Patched ns/op |
| --- | ---: | ---: |
| 4 | 165.9 | 56.53 |
| 16 | 267.8 | 61.62 |
| 64 | 762.5 | 61.70 |

Run each process with `-run '^$' -bench '^BenchmarkReflectNamedFuncPointer$' -benchtime=10000000x -count=1`; subcases intentionally materialize progressively more types. Other runtime types may already exist in the process.

## Validation

Local macOS arm64; repository tests use Go 1.27.0, external zapcore uses Go 1.26.5:

- `go test -run TestReflectNamedFunc -count=10 ./test/go`
- `llgo test -timeout=90s -run '^TestReflectNamedFunc' -count=10 ./test/go` (includes 200 fresh reverse-cache rounds / 6,400 worker invocations)
- `llgo test -run TestReflect -count=1 ./test/go`
- `llgo test -O2 -lto=full -run TestReflect -count=1 ./test/go`
- `llgo test -count=1 ./test/std/reflect ./test/go/reflectmethod`
- Full `go.uber.org/zap/zapcore@v1.27.0` test suite with LLGo
- `git diff --check`

Cross-platform validation is pending PR CI. The broader sync.Map compatibility implementation and the observed RWMutex stress stall are outside this patch.
