### PR TITLE
fix(runtime): preserve recovered panic source locations

### DIFF
--- a/cl/caller_frame_test.go
+++ b/cl/caller_frame_test.go
@@ -450,7 +450,7 @@ func pinnedPanicSite() {
 	}
 }
 
-func TestCompileRuntimeCallerStorePanicPCLineMetadataIsWindowsOnly(t *testing.T) {
+func TestCompileRuntimeCallerStorePanicPCLineMetadataOnNativeTargets(t *testing.T) {
 	const source = `package foo
 import "runtime"
 
@@ -471,10 +471,10 @@ func storePanicLeaf(p *int) {
 `
 	for _, test := range []struct {
 		goos string
-		want bool
 	}{
-		{goos: "linux", want: false},
-		{goos: "windows", want: true},
+		{goos: "linux"},
+		{goos: "darwin"},
+		{goos: "windows"},
 	} {
 		t.Run(test.goos, func(t *testing.T) {
 			ssapkg, files := buildCallerFrameSSAPackage(t, "example.com/foo", source)
@@ -494,8 +494,8 @@ func storePanicLeaf(p *int) {
 					break
 				}
 			}
-			if got != test.want {
-				t.Fatalf("store panic-site metadata present = %v, want %v for %s:\n%s", got, test.want, test.goos, ir)
+			if !got {
+				t.Fatalf("store panic-site metadata is missing for %s:\n%s", test.goos, ir)
 			}
 		})
 	}

--- a/cl/caller_frame_test.go
+++ b/cl/caller_frame_test.go
@@ -368,6 +368,44 @@ func unrelated() {}
 	}
 }
 
+func TestCompileRuntimeNilCheckCondition(t *testing.T) {
+	ssapkg, files := buildCallerFrameSSAPackage(t, llssa.PkgRuntime, `package runtime
+//go:noinline
+func AssertNilDeref(b bool) { if b { for {} } }
+func ordinary(b bool) { if b { for {} } }
+`)
+	for _, target := range []*llssa.Target{
+		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "js", GOARCH: "wasm"},
+	} {
+		t.Run(target.GOARCH, func(t *testing.T) {
+			prog := newLLSSAProgForTarget(t, target)
+			pkg, err := NewPackage(prog, ssapkg, files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const barrier = `asm sideeffect "", "=r,0"`
+			for _, name := range []string{"AssertNilDeref", "ordinary"} {
+				ir := pkg.Module().NamedFunction(llssa.PkgRuntime + "." + name).String()
+				want := name == "AssertNilDeref" && target.GOARCH != "wasm"
+				if strings.Contains(ir, barrier) != want {
+					t.Fatalf("unexpected LTO condition barrier for %s:\n%s", name, ir)
+				}
+				if want {
+					for _, line := range strings.Split(ir, "\n") {
+						if strings.Contains(line, barrier) {
+							result := strings.TrimSpace(strings.Split(line, " = ")[0])
+							if !strings.Contains(ir, "br i1 "+result+",") {
+								t.Fatalf("nil helper does not branch on the opaque condition:\n%s", ir)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCompileRuntimeCallerPanicPCLineMetadata(t *testing.T) {
 	ssapkg, files := buildCallerFrameSSAPackage(t, "example.com/foo", `package foo
 import "runtime"
@@ -439,11 +477,13 @@ func pinnedPanicSite() {
 		}
 		return count
 	}
-	if got := countPCLine("example.com/foo.repeatedPanicLeaf", "repeated_panic_site.go", 345); got != 1 {
-		t.Fatalf("same-line panic sites in one basic block produced %d metadata records, want 1:\n%s", got, ir)
+	// The source block shares one anchor, while each cold nil-check block
+	// needs its own anchor in case the backend moves it after another line.
+	if got := countPCLine("example.com/foo.repeatedPanicLeaf", "repeated_panic_site.go", 345); got != 3 {
+		t.Fatalf("one source block and two nil-check blocks produced %d metadata records, want 3:\n%s", got, ir)
 	}
-	if got := countPCLine("example.com/foo.branchPanicLeaf", "branch_panic_site.go", 456); got != 2 {
-		t.Fatalf("same-line panic sites in separate basic blocks produced %d metadata records, want 2:\n%s", got, ir)
+	if got := countPCLine("example.com/foo.branchPanicLeaf", "branch_panic_site.go", 456); got != 4 {
+		t.Fatalf("two source blocks and two nil-check blocks produced %d metadata records, want 4:\n%s", got, ir)
 	}
 	if strings.Contains(ir, `!"non_recover_site.go"`) {
 		t.Fatalf("ordinary pinned function unexpectedly received implicit panic-site metadata:\n%s", ir)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -183,6 +183,7 @@ type context struct {
 	safepointEntry       bool
 	safepoints           map[ssa.Instruction]struct{}
 	pcLineSeq            uint64
+	panicSitePos         token.Pos
 	// The runtime PC-line table stores file and line, but not column. Keep the
 	// last emitted position within one SSA basic block so repeated checks for a
 	// single source line can share an anchor.
@@ -774,6 +775,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			for _, childInit := range childInits {
 				childInit()
 			}
+			p.panicSitePos = token.NoPos
 			b.EndBuild()
 		})
 	}
@@ -1032,6 +1034,7 @@ func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, do
 	// block's anchor, so deduplication must never cross a block boundary.
 	p.lastPCLineFile = ""
 	p.lastPCLineLine = 0
+	p.panicSitePos = token.NoPos
 	oldLocalBlock := p.locality.function.block
 	p.locality.function.block = block
 	defer func() { p.locality.function.block = oldLocalBlock }()
@@ -2189,6 +2192,7 @@ func (p *context) getDebugLocScope(v *ssa.Function, pos token.Pos) *types.Scope 
 }
 
 func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
+	p.panicSitePos = token.NoPos
 	if _, ok := p.staticInitInstrs[instr]; ok {
 		return
 	}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -2236,11 +2236,11 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		}
 		ptr := p.compileValue(b, va)
 		val := p.compileValue(b, v.Val)
-		// Windows access violations report the faulting store PC. Preserve that
-		// exact source site for the SEH fault bridge without adding one carrier
-		// record per potential pointer store to ELF and Mach-O binaries, whose
-		// existing fault paths do not require this Windows-specific metadata.
-		if p.prog.Target().GOOS == "windows" && !isKnownNonNilAddr(va) && !isWrapNilCheckCall(va) {
+		// Hardware faults report the store instruction itself rather than a
+		// runtime nil-check return address. Preserve its exact source site on
+		// every native target; recordPanicSite scopes the metadata to functions
+		// whose recovered panic stack can be observed.
+		if !isKnownNonNilAddr(va) && !isWrapNilCheckCall(va) {
 			p.recordPanicSite(b, v.Pos())
 		}
 		store := b.Store(ptr, val)

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1965,6 +1965,17 @@ func (p *context) recordPanicSite(b llssa.Builder, pos token.Pos) {
 	p.recordPanicLocation(b, pos)
 	if p.panicSiteFuncs[p.goFn] {
 		p.emitPCLineLabel(b, pos)
+		p.panicSitePos = pos
+		// Install once per builder, not once per instruction. Nil-check
+		// lowering invokes it after entering its separate failure block.
+		if b.PanicSite == nil {
+			b.PanicSite = func(b llssa.Builder) {
+				if p.panicSitePos.IsValid() {
+					p.lastPCLineFile = ""
+					p.emitPCLineLabel(b, p.panicSitePos)
+				}
+			}
+		}
 	}
 }
 

--- a/runtime/internal/lib/runtime/unwind_llgo.go
+++ b/runtime/internal/lib/runtime/unwind_llgo.go
@@ -23,8 +23,8 @@ func init() {
 
 // capturePanicPCs runs at panic time, before any longjmp unwinding, and
 // stores the physical pc chain for later splicing (see spliceCallers).
-func capturePanicPCs() {
-	if !fpUnwindAvailable() {
+func capturePanicPCs(v any) {
+	if !rtdebug.SavePanicCallerFrames(v) || !fpUnwindAvailable() {
 		return
 	}
 	var pcs [64]uintptr

--- a/runtime/internal/lib/runtime/weak_llgo.go
+++ b/runtime/internal/lib/runtime/weak_llgo.go
@@ -13,6 +13,7 @@ import (
 type weakHandle struct {
 	key  uintptr
 	live uint32
+	next unsafe.Pointer // next dead handle; never a pointer to the referent
 }
 
 // BDWGC conservatively treats pointer-looking uintptr values as live roots.
@@ -30,11 +31,40 @@ var weakState struct {
 	once psync.Once
 	mu   psync.Mutex
 	m    map[uintptr]*weakHandle
+	dead unsafe.Pointer
 }
 
 func initWeakState() {
 	weakState.mu.Init(nil)
 	weakState.m = make(map[uintptr]*weakHandle)
+}
+
+// retireWeakHandle runs inside a GC finalizer. Even a map lookup can allocate
+// and invoke another finalizer on the same thread, so this path must neither
+// allocate nor take weakState.mu. Each handle is published exactly once.
+func retireWeakHandle(h *weakHandle) {
+	latomic.StoreUint32(&h.live, 0)
+	for {
+		head := latomic.LoadPointer(&weakState.dead)
+		h.next = head
+		if latomic.CompareAndSwapPointer(&weakState.dead, head, unsafe.Pointer(h)) {
+			return
+		}
+	}
+}
+
+// drainWeakHandles runs during registration with weakState.mu held. Detach only
+// one batch so concurrent cleanup cannot keep a registration here indefinitely.
+func drainWeakHandles() {
+	for h := (*weakHandle)(latomic.SwapPointer(&weakState.dead, nil)); h != nil; {
+		next := (*weakHandle)(h.next)
+		h.next = nil
+		// The address may already belong to a new object with a new handle.
+		if weakState.m[h.key] == h {
+			delete(weakState.m, h.key)
+		}
+		h = next
+	}
 }
 
 func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
@@ -45,7 +75,9 @@ func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
 
 	key := encodeWeakPointer(p)
 	weakState.mu.Lock()
-	if h := weakState.m[key]; h != nil {
+	drainWeakHandles()
+	// A cleanup may mark a handle dead before publishing it to the queue.
+	if h := weakState.m[key]; h != nil && latomic.LoadUint32(&h.live) != 0 {
 		weakState.mu.Unlock()
 		return unsafe.Pointer(h)
 	}
@@ -53,15 +85,9 @@ func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
 	weakState.m[key] = h
 	weakState.mu.Unlock()
 
-	// Keep the cleanup closure limited to encoded identities. Capturing p here
-	// would turn the cleanup itself into a strong reference to the referent.
+	// Capture only the handle with its encoded identity, never the referent p.
 	llrt.AddCleanupPtr(p, func() {
-		latomic.StoreUint32(&h.live, 0)
-		weakState.mu.Lock()
-		if weakState.m[key] == h {
-			delete(weakState.m, key)
-		}
-		weakState.mu.Unlock()
+		retireWeakHandle(h)
 	})
 	return unsafe.Pointer(h)
 }

--- a/runtime/internal/lib/runtime/weak_llgo.go
+++ b/runtime/internal/lib/runtime/weak_llgo.go
@@ -10,10 +10,18 @@ import (
 	psync "github.com/xgo-dev/llgo/runtime/internal/sync"
 )
 
+// weakHandle supplies the GC-dependent identity used by GOROOT's weak package.
+// Go's collector removes weak registrations from spans during sweep. BDWGC
+// invokes our cleanup during allocation, so registry removal must be deferred.
+// Removing an entry releases the runtime's reference; a user-held weak.Pointer
+// must keep its dead handle alive to preserve identity.
 type weakHandle struct {
 	key  uintptr
 	live uint32
-	next unsafe.Pointer // next dead handle; never a pointer to the referent
+	// Written only by the producer before the head CAS publishes this handle;
+	// after the head Swap, only the drainer accesses the link. The head atomics
+	// order these ordinary accesses. Links retain handles, never referents.
+	next unsafe.Pointer
 }
 
 // BDWGC conservatively treats pointer-looking uintptr values as live roots.
@@ -55,9 +63,14 @@ func retireWeakHandle(h *weakHandle) {
 
 // drainWeakHandles runs during registration with weakState.mu held. Detach only
 // one batch so concurrent cleanup cannot keep a registration here indefinitely.
+// This bounds the captured work, not its size: a batch of n handles takes O(n)
+// time under the registry lock. Without another non-nil weak.Make, the last
+// dead batch and its map entries remain retained; neither Value nor GC drains
+// them. Reclaiming that idle batch requires a separately scheduled safe consumer.
 func drainWeakHandles() {
 	for h := (*weakHandle)(latomic.SwapPointer(&weakState.dead, nil)); h != nil; {
 		next := (*weakHandle)(h.next)
+		// A user-held dead weak.Pointer must not retain the rest of this batch.
 		h.next = nil
 		// The address may already belong to a new object with a new handle.
 		if weakState.m[h.key] == h {

--- a/runtime/internal/runtime/caller.go
+++ b/runtime/internal/runtime/caller.go
@@ -309,6 +309,8 @@ func (p *panicPCStore) rememberRecovered(v any, frame unsafe.Pointer) {
 
 func (p *panicPCStore) takeRecovered(v any) bool {
 	e := efaceOf(&v)
+	// Raw interface data identity is the panic identity: rethrowing the value
+	// returned by recover preserves both words of that interface unchanged.
 	same := p.recoveredFrame != nil && p.recoveredFrame == getg().recoverActive &&
 		e._type == p.recoveredType && e.data == p.recoveredData
 	p.clearRecovered()

--- a/runtime/internal/runtime/caller.go
+++ b/runtime/internal/runtime/caller.go
@@ -232,12 +232,20 @@ func Callers(skip int, pcs []uintptr) int {
 // splice back in.
 var PanicPCSnapshot func()
 
-func SavePanicCallerFrames() {
+func SavePanicCallerFrames(v any) {
 	// A fault handler stores the fault-site snapshot right before it
 	// panics; the regular capture here must not overwrite it.
 	p := panicPCStoreForG()
 	if p.armed != 0 {
 		p.armed = 0
+		return
+	}
+	// A recovered panic may be thrown again before its deferred activation
+	// returns. gc keeps the original _panic record in that case, so its
+	// traceback still starts at the original panic site. LLGo has already
+	// longjmp-unwound that stack; retain its snapshot when both the raw
+	// interface identity and the recovering activation still match.
+	if p.takeRecovered(v) {
 		return
 	}
 	if PanicPCSnapshot != nil {
@@ -246,12 +254,15 @@ func SavePanicCallerFrames() {
 }
 
 type panicPCStore struct {
-	n      int32
-	armed  int32
-	fault  int32
-	recFP1 uintptr
-	recFP2 uintptr
-	pcs    [64]uintptr
+	n              int32
+	armed          int32
+	fault          int32
+	recFP1         uintptr
+	recFP2         uintptr
+	recoveredType  *_type
+	recoveredData  unsafe.Pointer
+	recoveredFrame unsafe.Pointer
+	pcs            [64]uintptr
 }
 
 func panicPCStoreForG() *panicPCStore {
@@ -282,6 +293,47 @@ func storePanicPCs(pcs []uintptr, armed int32) {
 	p.fault = armed
 	p.recFP1 = 0
 	p.recFP2 = 0
+	p.clearRecovered()
+}
+
+func (p *panicPCStore) rememberRecovered(v any, frame unsafe.Pointer) {
+	if p.n == 0 || frame == nil {
+		p.clearRecovered()
+		return
+	}
+	e := efaceOf(&v)
+	p.recoveredType = e._type
+	p.recoveredData = e.data
+	p.recoveredFrame = frame
+}
+
+func (p *panicPCStore) takeRecovered(v any) bool {
+	e := efaceOf(&v)
+	same := p.recoveredFrame != nil && p.recoveredFrame == getg().recoverActive &&
+		e._type == p.recoveredType && e.data == p.recoveredData
+	p.clearRecovered()
+	if same {
+		p.recFP1 = 0
+		p.recFP2 = 0
+	}
+	return same
+}
+
+func (p *panicPCStore) clearRecovered() {
+	p.recoveredType = nil
+	p.recoveredData = nil
+	p.recoveredFrame = nil
+}
+
+func rememberRecoveredPanic(v any, frame unsafe.Pointer) {
+	panicPCStoreForG().rememberRecovered(v, frame)
+}
+
+func clearRecoveredPanic(frame unsafe.Pointer) {
+	p := panicPCStoreForG()
+	if frame != nil && frame == p.recoveredFrame {
+		p.clearRecovered()
+	}
 }
 
 // PanicPCsAreFault reports whether the stored snapshot came from a

--- a/runtime/internal/runtime/caller.go
+++ b/runtime/internal/runtime/caller.go
@@ -230,39 +230,51 @@ func Callers(skip int, pcs []uintptr) int {
 // after recover) see the panic-site frames; LLGo's longjmp unwinding
 // removes them physically, and this snapshot is what caller-info APIs
 // splice back in.
-var PanicPCSnapshot func()
+var PanicPCSnapshot func(any)
 
-func SavePanicCallerFrames(v any) {
+// SavePanicCallerFrames reports whether the public runtime should capture a
+// new snapshot. It is called by the snapshot hook so programs without that
+// hook do not link the recovered-panic bookkeeping.
+func SavePanicCallerFrames(v any) bool {
 	// A fault handler stores the fault-site snapshot right before it
 	// panics; the regular capture here must not overwrite it.
-	p := panicPCStoreForG()
+	gp := getg()
+	p := &gp.panicPCs
 	if p.armed != 0 {
 		p.armed = 0
-		return
+		return false
 	}
 	// A recovered panic may be thrown again before its deferred activation
 	// returns. gc keeps the original _panic record in that case, so its
 	// traceback still starts at the original panic site. LLGo has already
 	// longjmp-unwound that stack; retain its snapshot when both the raw
 	// interface identity and the recovering activation still match.
-	if p.takeRecovered(v) {
-		return
+	// Compare the raw interface words, not Go equality: even an uncomparable
+	// panic value retains its identity when the recovered interface is rethrown.
+	e, recovered := efaceOf(&v), efaceOf(&p.recovered.value)
+	same := p.recovered.frame != nil && p.recovered.frame == gp.recoverFrame &&
+		e._type == recovered._type && e.data == recovered.data
+	p.recovered = recoveredPanic{}
+	if same {
+		p.recFP1 = 0
+		p.recFP2 = 0
 	}
-	if PanicPCSnapshot != nil {
-		PanicPCSnapshot()
-	}
+	return !same
+}
+
+type recoveredPanic struct {
+	value any
+	frame unsafe.Pointer
 }
 
 type panicPCStore struct {
-	n              int32
-	armed          int32
-	fault          int32
-	recFP1         uintptr
-	recFP2         uintptr
-	recoveredType  *_type
-	recoveredData  unsafe.Pointer
-	recoveredFrame unsafe.Pointer
-	pcs            [64]uintptr
+	n         int32
+	armed     int32
+	fault     int32
+	recFP1    uintptr
+	recFP2    uintptr
+	recovered recoveredPanic
+	pcs       [64]uintptr
 }
 
 func panicPCStoreForG() *panicPCStore {
@@ -293,49 +305,7 @@ func storePanicPCs(pcs []uintptr, armed int32) {
 	p.fault = armed
 	p.recFP1 = 0
 	p.recFP2 = 0
-	p.clearRecovered()
-}
-
-func (p *panicPCStore) rememberRecovered(v any, frame unsafe.Pointer) {
-	if p.n == 0 || frame == nil {
-		p.clearRecovered()
-		return
-	}
-	e := efaceOf(&v)
-	p.recoveredType = e._type
-	p.recoveredData = e.data
-	p.recoveredFrame = frame
-}
-
-func (p *panicPCStore) takeRecovered(v any) bool {
-	e := efaceOf(&v)
-	// Raw interface data identity is the panic identity: rethrowing the value
-	// returned by recover preserves both words of that interface unchanged.
-	same := p.recoveredFrame != nil && p.recoveredFrame == getg().recoverActive &&
-		e._type == p.recoveredType && e.data == p.recoveredData
-	p.clearRecovered()
-	if same {
-		p.recFP1 = 0
-		p.recFP2 = 0
-	}
-	return same
-}
-
-func (p *panicPCStore) clearRecovered() {
-	p.recoveredType = nil
-	p.recoveredData = nil
-	p.recoveredFrame = nil
-}
-
-func rememberRecoveredPanic(v any, frame unsafe.Pointer) {
-	panicPCStoreForG().rememberRecovered(v, frame)
-}
-
-func clearRecoveredPanic(frame unsafe.Pointer) {
-	p := panicPCStoreForG()
-	if frame != nil && frame == p.recoveredFrame {
-		p.clearRecovered()
-	}
+	p.recovered = recoveredPanic{}
 }
 
 // PanicPCsAreFault reports whether the stored snapshot came from a

--- a/runtime/internal/runtime/runtime2.go
+++ b/runtime/internal/runtime/runtime2.go
@@ -39,12 +39,13 @@ const (
 // while the WebAssembly fiber scheduler shares one M/P across its Gs. Suspended
 // execution state is held by the backend-specific runtimeContext.
 type g struct {
-	defer_       *Defer
-	panic_       unsafe.Pointer
-	panicPCs     panicPCStore
-	recoverFrame unsafe.Pointer
-	recoverPanic unsafe.Pointer
-	m            *m
+	defer_        *Defer
+	panic_        unsafe.Pointer
+	panicPCs      panicPCStore
+	recoverFrame  unsafe.Pointer
+	recoverPanic  unsafe.Pointer
+	recoverActive unsafe.Pointer
+	m             *m
 
 	atomicstatus uint32
 	goid         uint64

--- a/runtime/internal/runtime/runtime2.go
+++ b/runtime/internal/runtime/runtime2.go
@@ -39,13 +39,12 @@ const (
 // while the WebAssembly fiber scheduler shares one M/P across its Gs. Suspended
 // execution state is held by the backend-specific runtimeContext.
 type g struct {
-	defer_        *Defer
-	panic_        unsafe.Pointer
-	panicPCs      panicPCStore
-	recoverFrame  unsafe.Pointer
-	recoverPanic  unsafe.Pointer
-	recoverActive unsafe.Pointer
-	m             *m
+	defer_       *Defer
+	panic_       unsafe.Pointer
+	panicPCs     panicPCStore
+	recoverFrame unsafe.Pointer
+	recoverPanic unsafe.Pointer
+	m            *m
 
 	atomicstatus uint32
 	goid         uint64

--- a/runtime/internal/runtime/z_rt.go
+++ b/runtime/internal/runtime/z_rt.go
@@ -37,6 +37,7 @@ type panicNode struct {
 type recoverState struct {
 	frame  unsafe.Pointer
 	panic_ unsafe.Pointer
+	active unsafe.Pointer
 }
 
 // movePanicToDefer advances a panic and the goroutine's unwind cursor to the
@@ -89,6 +90,7 @@ func Recover(token unsafe.Pointer) (ret any) {
 		if RecoverMark != nil {
 			RecoverMark()
 		}
+		rememberRecoveredPanic(ret, gp.recoverActive)
 	}
 	return
 }
@@ -101,8 +103,9 @@ func Recover(token unsafe.Pointer) (ret any) {
 // counterpart to gorecover locating the matching _panic through stack frames.
 func StartRecoverFrame(frame unsafe.Pointer) recoverState {
 	gp := getg()
-	old := recoverState{frame: gp.recoverFrame, panic_: gp.recoverPanic}
+	old := recoverState{frame: gp.recoverFrame, panic_: gp.recoverPanic, active: gp.recoverActive}
 	gp.recoverFrame = frame
+	gp.recoverActive = frame
 	gp.recoverPanic = nil
 	if ptr := gp.panic_; ptr != nil && (*panicNode)(ptr).defer_ == gp.defer_ {
 		gp.recoverPanic = ptr
@@ -113,8 +116,10 @@ func StartRecoverFrame(frame unsafe.Pointer) recoverState {
 // EndRecoverFrame restores direct recover permission after a deferred call.
 func EndRecoverFrame(state recoverState) {
 	gp := getg()
+	clearRecoveredPanic(gp.recoverActive)
 	gp.recoverFrame = state.frame
 	gp.recoverPanic = state.panic_
+	gp.recoverActive = state.active
 }
 
 // BindRecoverFrame replaces a deferred function's code token with the unique
@@ -124,6 +129,9 @@ func BindRecoverFrame(function, activation unsafe.Pointer) {
 	gp := getg()
 	if gp.recoverFrame == function {
 		gp.recoverFrame = activation
+	}
+	if gp.recoverActive == function {
+		gp.recoverActive = activation
 	}
 }
 
@@ -167,6 +175,7 @@ func (gp *g) abortPanics() {
 	}
 	gp.recoverFrame = nil
 	gp.recoverPanic = nil
+	gp.recoverActive = nil
 	if discarded && PanicRecovered != nil {
 		PanicRecovered()
 	}
@@ -190,7 +199,7 @@ func Panic(v any) {
 	if v == nil {
 		v = &PanicNilError{}
 	}
-	SavePanicCallerFrames()
+	SavePanicCallerFrames(v)
 	gp := getg()
 	ptr := (*panicNode)(c.Malloc(unsafe.Sizeof(panicNode{})))
 	ptr.prev = gp.panic_

--- a/runtime/internal/runtime/z_rt.go
+++ b/runtime/internal/runtime/z_rt.go
@@ -37,7 +37,6 @@ type panicNode struct {
 type recoverState struct {
 	frame  unsafe.Pointer
 	panic_ unsafe.Pointer
-	active unsafe.Pointer
 }
 
 // movePanicToDefer advances a panic and the goroutine's unwind cursor to the
@@ -72,7 +71,9 @@ func Recover(token unsafe.Pointer) (ret any) {
 	if ptr != nil && ptr == gp.panic_ {
 		node := (*panicNode)(ptr)
 		gp.panic_ = node.prev
-		gp.recoverFrame = nil
+		// Keep the activation token until its deferred call returns, so a
+		// same-value repanic can reuse the original snapshot. Clearing the
+		// eligible panic still prevents any subsequent recover from succeeding.
 		gp.recoverPanic = nil
 		ret = node.arg
 		c.Free(unsafe.Pointer(node))
@@ -89,8 +90,10 @@ func Recover(token unsafe.Pointer) (ret any) {
 		// to mark.
 		if RecoverMark != nil {
 			RecoverMark()
+			if gp.panicPCs.n != 0 {
+				gp.panicPCs.recovered = recoveredPanic{value: ret, frame: gp.recoverFrame}
+			}
 		}
-		rememberRecoveredPanic(ret, gp.recoverActive)
 	}
 	return
 }
@@ -103,9 +106,8 @@ func Recover(token unsafe.Pointer) (ret any) {
 // counterpart to gorecover locating the matching _panic through stack frames.
 func StartRecoverFrame(frame unsafe.Pointer) recoverState {
 	gp := getg()
-	old := recoverState{frame: gp.recoverFrame, panic_: gp.recoverPanic, active: gp.recoverActive}
+	old := recoverState{frame: gp.recoverFrame, panic_: gp.recoverPanic}
 	gp.recoverFrame = frame
-	gp.recoverActive = frame
 	gp.recoverPanic = nil
 	if ptr := gp.panic_; ptr != nil && (*panicNode)(ptr).defer_ == gp.defer_ {
 		gp.recoverPanic = ptr
@@ -116,10 +118,11 @@ func StartRecoverFrame(frame unsafe.Pointer) recoverState {
 // EndRecoverFrame restores direct recover permission after a deferred call.
 func EndRecoverFrame(state recoverState) {
 	gp := getg()
-	clearRecoveredPanic(gp.recoverActive)
+	if gp.panicPCs.recovered.frame == gp.recoverFrame {
+		gp.panicPCs.recovered = recoveredPanic{}
+	}
 	gp.recoverFrame = state.frame
 	gp.recoverPanic = state.panic_
-	gp.recoverActive = state.active
 }
 
 // BindRecoverFrame replaces a deferred function's code token with the unique
@@ -129,9 +132,6 @@ func BindRecoverFrame(function, activation unsafe.Pointer) {
 	gp := getg()
 	if gp.recoverFrame == function {
 		gp.recoverFrame = activation
-	}
-	if gp.recoverActive == function {
-		gp.recoverActive = activation
 	}
 }
 
@@ -151,7 +151,13 @@ func StartRecoverFrameAlias(from, to unsafe.Pointer) unsafe.Pointer {
 // wrappers share their caller's eligible panic rather than opening a nested
 // defer scope.
 func EndRecoverFrameAlias(frame unsafe.Pointer) {
-	getg().recoverFrame = frame
+	gp := getg()
+	// The wrapped activation has returned too; do not retain its recovered
+	// value when restoring the transparent wrapper's direct-call token.
+	if gp.recoverFrame != frame && gp.panicPCs.recovered.frame == gp.recoverFrame {
+		gp.panicPCs.recovered = recoveredPanic{}
+	}
+	gp.recoverFrame = frame
 }
 
 // panicIsSuspended reports whether ptr belongs to an outer panic whose direct
@@ -175,8 +181,7 @@ func (gp *g) abortPanics() {
 	}
 	gp.recoverFrame = nil
 	gp.recoverPanic = nil
-	gp.recoverActive = nil
-	gp.panicPCs.clearRecovered()
+	gp.panicPCs.recovered = recoveredPanic{}
 	if discarded && PanicRecovered != nil {
 		PanicRecovered()
 	}
@@ -200,7 +205,9 @@ func Panic(v any) {
 	if v == nil {
 		v = &PanicNilError{}
 	}
-	SavePanicCallerFrames(v)
+	if PanicPCSnapshot != nil {
+		PanicPCSnapshot(v)
+	}
 	gp := getg()
 	ptr := (*panicNode)(c.Malloc(unsafe.Sizeof(panicNode{})))
 	ptr.prev = gp.panic_

--- a/runtime/internal/runtime/z_rt.go
+++ b/runtime/internal/runtime/z_rt.go
@@ -176,6 +176,7 @@ func (gp *g) abortPanics() {
 	gp.recoverFrame = nil
 	gp.recoverPanic = nil
 	gp.recoverActive = nil
+	gp.panicPCs.clearRecovered()
 	if discarded && PanicRecovered != nil {
 		PanicRecovered()
 	}

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -372,15 +372,46 @@ func (b Builder) AssertNilDeref(ptr Expr) {
 	blks := b.Func.MakeBlocks(2)
 	b.If(isNil, blks[0], blks[1])
 	b.SetBlockEx(blks[0], AtEnd, false)
+	if b.PanicSite != nil {
+		b.PanicSite(b)
+	}
 	b.Call(b.Pkg.rtFunc("AssertNilDeref"), b.Prog.BoolVal(true))
-	// AssertNilDeref(true) cannot return normally, but keep a formal edge to
-	// the continuation rather than a self-looping failure terminator. The
-	// self-loop lets LLVM prove a statically nil caller does not return; its
-	// caller's saved return PC can then equal the next function entry, and
-	// panic snapshots lose that caller identity.
-	b.Jump(blks[1])
+	if b.Prog.NeedsFramePointer() {
+		// AssertNilDeref(true) never returns. A self-loop here, however, lets
+		// LLVM infer noreturn for statically nil callers and place their
+		// callers' return PCs at the next function entry. Keep a formal return
+		// so those PCs stay inside the caller. Do not join the success block:
+		// that would lose its non-nil fact and force spills around cold calls.
+		// These undefined results are never observed; this is not a Go return
+		// and must not dispatch defers or other source-level return handling.
+		ret := b.Func.impl.GlobalValueType().ReturnType()
+		if ret.TypeKind() == llvm.VoidTypeKind {
+			b.impl.CreateRetVoid()
+		} else {
+			b.impl.CreateRet(llvm.Undef(ret))
+		}
+	} else {
+		b.Jump(blks[0])
+	}
 	b.SetBlockEx(blks[1], AtEnd, false)
 	b.blk.last = blks[1].last
+}
+
+func (b Builder) preserveNilCheckCondition() {
+	if b.Func.Name() != PkgRuntime+".AssertNilDeref" || !b.Prog.NeedsFramePointer() {
+		return
+	}
+	// Keep the runtime helper potentially returning even when LTO sees that
+	// every caller passes true. A matching-register constraint preserves the
+	// condition without instructions. Put the barrier in this one noinline
+	// helper, not at every nil check: per-call barriers inhibit optimization
+	// of otherwise pure callers and increase code size substantially.
+	b.impl.SetInsertPointBefore(b.Func.impl.EntryBasicBlock().FirstInstruction())
+	param := b.Func.Param(0)
+	opaque := b.InlineAsmFull("", "=r,0", b.Prog.Bool(), []Expr{param})
+	param.impl.ReplaceAllUsesWith(opaque.impl)
+	// Replace the body's uses, not the barrier's own input.
+	opaque.impl.SetOperand(0, param.impl)
 }
 
 func (b Builder) NilDerefCheck(ptr Expr) Expr {

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -373,9 +373,11 @@ func (b Builder) AssertNilDeref(ptr Expr) {
 	b.If(isNil, blks[0], blks[1])
 	b.SetBlockEx(blks[0], AtEnd, false)
 	b.Call(b.Pkg.rtFunc("AssertNilDeref"), b.Prog.BoolVal(true))
-	// Like the bounds-check failure path, this cannot return normally. Keep
-	// a post-call instruction for panic return-address line information.
-	b.Jump(blks[0])
+	// AssertNilDeref(true) cannot return normally, but keep a formal edge to
+	// the continuation. An infinite failure loop lets LLVM prove a statically
+	// nil caller does not return; its caller's saved return PC can then equal
+	// the next function entry, and panic snapshots lose that caller identity.
+	b.Jump(blks[1])
 	b.SetBlockEx(blks[1], AtEnd, false)
 	b.blk.last = blks[1].last
 }

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -374,9 +374,10 @@ func (b Builder) AssertNilDeref(ptr Expr) {
 	b.SetBlockEx(blks[0], AtEnd, false)
 	b.Call(b.Pkg.rtFunc("AssertNilDeref"), b.Prog.BoolVal(true))
 	// AssertNilDeref(true) cannot return normally, but keep a formal edge to
-	// the continuation. An infinite failure loop lets LLVM prove a statically
-	// nil caller does not return; its caller's saved return PC can then equal
-	// the next function entry, and panic snapshots lose that caller identity.
+	// the continuation rather than a self-looping failure terminator. The
+	// self-loop lets LLVM prove a statically nil caller does not return; its
+	// caller's saved return PC can then equal the next function entry, and
+	// panic snapshots lose that caller identity.
 	b.Jump(blks[1])
 	b.SetBlockEx(blks[1], AtEnd, false)
 	b.blk.last = blks[1].last

--- a/ssa/memory_test.go
+++ b/ssa/memory_test.go
@@ -63,9 +63,10 @@ func TestAssertNilDerefColdCall(t *testing.T) {
 						}
 					}
 					failure := branch.Successor(0)
-					back := failure.LastInstruction()
-					if back.InstructionOpcode() != llvm.Br || back.SuccessorsCount() != 1 || back.Successor(0) != failure {
-						t.Fatalf("nil failure must not return to the successful path:\n%s", fn.impl.String())
+					continuation := branch.Successor(1)
+					next := failure.LastInstruction()
+					if next.InstructionOpcode() != llvm.Br || next.SuccessorsCount() != 1 || next.Successor(0) != continuation {
+						t.Fatalf("nil failure must retain a formal continuation edge:\n%s", fn.impl.String())
 					}
 				}
 			}

--- a/ssa/memory_test.go
+++ b/ssa/memory_test.go
@@ -18,6 +18,10 @@ func TestAssertNilDerefColdCall(t *testing.T) {
 	Initialize(InitAllTargets | InitAllTargetInfos | InitAllTargetMCs | InitAllAsmPrinters)
 	for _, target := range []*Target{
 		{GOOS: "linux", GOARCH: "amd64", LLVMTarget: "x86_64-unknown-linux"},
+		{GOOS: "darwin", GOARCH: "arm64", LLVMTarget: "aarch64-apple-darwin"},
+		{GOOS: "windows", GOARCH: "amd64", LLVMTarget: "x86_64-pc-windows-msvc"},
+		{GOOS: "windows", GOARCH: "386", LLVMTarget: "i686-pc-windows-msvc"},
+		{GOOS: "windows", GOARCH: "arm64", LLVMTarget: "aarch64-pc-windows-msvc"},
 		{GOOS: "js", GOARCH: "wasm", LLVMTarget: "wasm32-unknown-emscripten"},
 		{GOOS: "js", GOARCH: "wasm", LLVMTarget: "wasm64-unknown-emscripten"},
 		{GOOS: "wasip1", GOARCH: "wasm", LLVMTarget: "wasm32-unknown-wasip1"},
@@ -35,9 +39,16 @@ func TestAssertNilDerefColdCall(t *testing.T) {
 			pkg := prog.NewPackage("p", "example.com/nilcheck")
 			params := types.NewTuple(types.NewVar(token.NoPos, nil, "p", types.Typ[types.UnsafePointer]))
 			sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-			for _, name := range []string{"dynamic", "nil", "allocated", "constant"} {
-				fn := pkg.NewFunc(name, sig, InGo)
+			for _, name := range []string{"dynamic", "nil", "allocated", "constant", "value"} {
+				fnSig := sig
+				if name == "value" {
+					results := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+					fnSig = types.NewSignatureType(nil, nil, nil, params, results, false)
+				}
+				fn := pkg.NewFunc(name, fnSig, InGo)
 				b := fn.MakeBody(1)
+				var panicBlock llvm.BasicBlock
+				b.PanicSite = func(b Builder) { panicBlock = b.impl.GetInsertBlock() }
 				ptr := fn.Param(0)
 				switch name {
 				case "nil":
@@ -49,7 +60,11 @@ func TestAssertNilDerefColdCall(t *testing.T) {
 					ptr = b.Convert(prog.VoidPtr(), prog.IntVal(1, prog.Uintptr()))
 				}
 				b.AssertNilDeref(ptr)
-				b.Return()
+				if name == "value" {
+					b.Return(prog.IntVal(42, prog.Int()))
+				} else {
+					b.Return()
+				}
 				b.EndBuild()
 				if name == "dynamic" {
 					entry := fn.impl.EntryBasicBlock()
@@ -63,10 +78,16 @@ func TestAssertNilDerefColdCall(t *testing.T) {
 						}
 					}
 					failure := branch.Successor(0)
-					continuation := branch.Successor(1)
+					if panicBlock != failure {
+						t.Fatal("panic-site callback did not run in the failure block")
+					}
 					next := failure.LastInstruction()
-					if next.InstructionOpcode() != llvm.Br || next.SuccessorsCount() != 1 || next.Successor(0) != continuation {
-						t.Fatalf("nil failure must retain a formal continuation edge:\n%s", fn.impl.String())
+					if prog.NeedsFramePointer() {
+						if next.InstructionOpcode() != llvm.Ret {
+							t.Fatalf("native nil failure must retain a separate formal return:\n%s", fn.impl.String())
+						}
+					} else if next.InstructionOpcode() != llvm.Br || next.SuccessorsCount() != 1 || next.Successor(0) != failure {
+						t.Fatalf("non-native nil failure must not rejoin the success path:\n%s", fn.impl.String())
 					}
 				}
 			}
@@ -79,14 +100,52 @@ func TestAssertNilDerefColdCall(t *testing.T) {
 			if err := mod.RunPasses("function(instcombine,simplifycfg)", prog.TargetMachine(), opts); err != nil {
 				t.Fatal(err)
 			}
-			for _, name := range []string{"dynamic", "nil", "allocated", "constant"} {
+			for _, name := range []string{"dynamic", "nil", "allocated", "constant", "value"} {
 				ir := mod.NamedFunction(name).String()
-				if got := strings.Contains(ir, "AssertNilDeref"); got != (name == "dynamic" || name == "nil") {
+				if got := strings.Contains(ir, "AssertNilDeref"); got != (name == "dynamic" || name == "nil" || name == "value") {
 					t.Fatalf("unexpected optimized %s check:\n%s", name, ir)
 				}
 			}
 			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
 				t.Fatal(err)
+			}
+			if prog.NeedsFramePointer() {
+				// Model LTO seeing the helper body and all of its call sites.
+				// It must not propagate a constant true into this noinline
+				// helper and rediscover noreturn through its callers.
+				helper := mod.NamedFunction(PkgRuntime + ".AssertNilDeref")
+				helper.SetLinkage(llvm.InternalLinkage)
+				helper.AddFunctionAttr(prog.ctx.CreateEnumAttribute(llvm.AttributeKindID("noinline"), 0))
+				entry := prog.ctx.AddBasicBlock(helper, "entry")
+				failure := prog.ctx.AddBasicBlock(helper, "failure")
+				success := prog.ctx.AddBasicBlock(helper, "success")
+				hb := prog.ctx.NewBuilder()
+				hb.SetInsertPointAtEnd(entry)
+				boolTy := prog.Bool().ll
+				barrierTy := llvm.FunctionType(boolTy, []llvm.Type{boolTy}, false)
+				barrier := llvm.InlineAsm(barrierTy, "", "=r,0", true, false, llvm.InlineAsmDialectATT, false)
+				condition := hb.CreateCall(barrierTy, barrier, []llvm.Value{helper.Param(0)}, "")
+				hb.CreateCondBr(condition, failure, success)
+				hb.SetInsertPointAtEnd(failure)
+				hb.CreateBr(failure)
+				hb.SetInsertPointAtEnd(success)
+				hb.CreateRetVoid()
+				hb.Dispose()
+				if err := mod.RunPasses("default<O2>", prog.TargetMachine(), opts); err != nil {
+					t.Fatal(err)
+				}
+				fn := mod.NamedFunction("nil")
+				if attr := fn.GetEnumAttributeAtIndex(-1, llvm.AttributeKindID("noreturn")); attr.C != nil {
+					t.Fatalf("static nil caller must retain a return-PC continuation after optimization:\n%s", fn.String())
+				}
+				if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+					t.Fatal(err)
+				}
+				obj, err := prog.TargetMachine().EmitToMemoryBuffer(mod, llvm.ObjectFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				obj.Dispose()
 			}
 		})
 	}

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -64,6 +64,11 @@ type aBuilder struct {
 	Pkg  Package
 	Prog Program
 
+	// PanicSite emits source metadata at an implicit panic's cold call site.
+	// The frontend owns the current source position; the lowering owns the
+	// failure block, which machine block placement can move away from it.
+	PanicSite func(Builder)
+
 	diScopeCache map[*types.Scope]DIScope // avoid duplicated DILexicalBlock(s)
 	diFuncScope  *types.Scope
 }
@@ -78,6 +83,7 @@ func (b Builder) EndBuild() {
 	}
 	b.Func.endDefer(b)
 	b.Func.endGCRoots(b)
+	b.preserveNilCheckCondition()
 }
 
 // Dispose disposes of the builder.

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -33,6 +33,7 @@ go test -race -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/signal
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/cpuprof
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/finalizer
+/tmp/llgo-runtime-stress test -count=3 -timeout=5m ./runtime/weak
 ```
 
 The signal suite is LLGo-only and targets Unix hosts. The CPU profile suite is
@@ -66,3 +67,12 @@ regress fatal native-handler replacement windows. The finalizer suite
 repeatedly publishes large finalizer batches while many goroutines call
 `runtime.GC`, and checks that queued callbacks are neither corrupted nor
 delivered twice.
+
+The weak suite creates batches of weak pointers in a goroutine that exits,
+then performs bounded collections while retaining only the weak handles. It
+regresses cleanup callbacks recursively invoking another cleanup while
+allocating under the weak registry lock. Each batch must expire at least half
+its handles, and a separate helper process enforces a 60-second deadline even
+if the tested runtime deadlocks. It uses only public Go APIs and also runs with
+`go test` on Go 1.24 or newer. Use identical profiles before and after the fix;
+neither sleeping nor reducing allocation pressure is part of the workload.

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -71,7 +71,7 @@ delivered twice.
 The weak suite creates batches of weak pointers in a goroutine that exits,
 then performs bounded collections while retaining only the weak handles. It
 regresses cleanup callbacks recursively invoking another cleanup while
-allocating under the weak registry lock. Each batch must expire at least half
+allocating under the weak registry lock. Each batch must expire more than half
 its handles, and a separate helper process enforces a 60-second deadline even
 if the tested runtime deadlocks. It uses only public Go APIs and also runs with
 `go test` on Go 1.24 or newer. Use identical profiles before and after the fix;

--- a/test/_stress/runtime/weak/weak_stress_test.go
+++ b/test/_stress/runtime/weak/weak_stress_test.go
@@ -1,0 +1,97 @@
+//go:build go1.24 && !baremetal && !nogc && !wasm
+
+package weakstress
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+	"weak"
+)
+
+type referent struct {
+	id  int
+	pad [256]byte
+}
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		return base / 8
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+func TestWeakCleanupReentrancy(t *testing.T) {
+	if os.Getenv("LLGO_STRESS_WEAK_CHILD") != t.Name() {
+		// A GC callback can deadlock the allocating thread, including testing's
+		// own timeout machinery. Keep the hard deadline in a separate process.
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, executable, "-test.run=^"+t.Name()+"$", "-test.v", "-test.timeout=45s")
+		cmd.Env = append(os.Environ(), "LLGO_STRESS_WEAK_CHILD="+t.Name())
+		output, err := cmd.CombinedOutput()
+		t.Logf("%s", output)
+		if ctx.Err() != nil {
+			t.Fatalf("weak cleanup helper did not exit within 60s: %v", ctx.Err())
+		}
+		if err != nil {
+			t.Fatalf("weak cleanup helper failed: %v", err)
+		}
+		return
+	}
+
+	rounds, objects := stressCount(t, 16), stressCount(t, 8192)
+	t.Logf("rounds=%d objects=%d GC_MARKERS=%q", rounds, objects, os.Getenv("GC_MARKERS"))
+	for round := 0; round < rounds; round++ {
+		handles := make(chan []weak.Pointer[referent], 1)
+		go func() {
+			live := make([]*referent, objects)
+			batch := make([]weak.Pointer[referent], objects)
+			for i := range live {
+				live[i] = &referent{id: i}
+				batch[i] = weak.Make(live[i])
+			}
+			handles <- batch
+			runtime.KeepAlive(live)
+			// Exit this goroutine so conservative stack scanning does not keep
+			// the entire batch alive while another goroutine collects it.
+		}()
+		batch := <-handles
+		var expired int
+		for collection := 0; collection < 16; collection++ {
+			// Finite collections avoid mixing collector/allocator starvation
+			// from an unbounded GC loop into weak-callback reentrancy coverage.
+			runtime.GC()
+			expired = 0
+			for _, h := range batch {
+				if h.Value() == nil {
+					expired++
+				}
+			}
+			if expired > objects/2 {
+				break
+			}
+			runtime.Gosched()
+		}
+		if expired <= objects/2 {
+			t.Fatalf("round %d: only %d/%d weak handles expired", round, expired, objects)
+		}
+		t.Logf("round %d: expired %d/%d weak handles", round, expired, objects)
+		runtime.KeepAlive(batch)
+	}
+}

--- a/test/go/caller_runtime_test.go
+++ b/test/go/caller_runtime_test.go
@@ -26,7 +26,10 @@ import (
 	"testing"
 )
 
-const callerPanicChild = "LLGO_TEST_CALLER_PANIC"
+const (
+	callerPanicChild   = "LLGO_TEST_CALLER_PANIC"
+	callerRepanicChild = "LLGO_TEST_CALLER_REPANIC"
+)
 
 var (
 	callerInitFile string
@@ -77,6 +80,91 @@ func TestCallerPanicTraceback(t *testing.T) {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("panic traceback is missing %q:\n%s", want, output)
 		}
+	}
+}
+
+//go:noinline
+func callerRepanicOrigin() {
+	var pointer *int
+	_ = *pointer // REPANIC_ORIGIN_MARK
+}
+
+//go:noinline
+func callerReplacementPanic() {
+	defer func() {
+		_ = recover()
+		panic("replacement panic") // REPLACEMENT_PANIC_MARK
+	}()
+	panic("original panic")
+}
+
+//go:noinline
+func callerLaterSameValuePanic() {
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		panic("earlier panic")
+	}()
+	panic(recovered) // LATER_SAME_VALUE_PANIC_MARK
+}
+
+func TestCallerRepanicTraceback(t *testing.T) {
+	mode := os.Getenv(callerRepanicChild)
+	switch mode {
+	case "same":
+		callerRepanicOrigin()
+		return
+	case "different":
+		callerReplacementPanic()
+		return
+	case "later":
+		callerLaterSameValuePanic()
+		return
+	}
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("current source file is unavailable")
+	}
+	source, err := os.ReadFile(sourceFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(mode string) string {
+		t.Helper()
+		cmd := exec.Command(os.Args[0], "-test.run=^TestCallerRepanicTraceback$")
+		cmd.Env = append(os.Environ(), callerRepanicChild+"="+mode)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("%s repanic child unexpectedly succeeded:\n%s", mode, output)
+		}
+		return string(output)
+	}
+
+	same := run("same")
+	for _, want := range []string{
+		"callerRepanicOrigin",
+		"caller_runtime_test.go:" + strconv.Itoa(markerLine(string(source), "REPANIC_ORIGIN_MARK")),
+	} {
+		if !strings.Contains(same, want) {
+			t.Fatalf("same-value repanic traceback is missing %q:\n%s", want, same)
+		}
+	}
+
+	different := run("different")
+	for _, want := range []string{
+		"panic: replacement panic",
+		"caller_runtime_test.go:" + strconv.Itoa(markerLine(string(source), "REPLACEMENT_PANIC_MARK")),
+	} {
+		if !strings.Contains(different, want) {
+			t.Fatalf("replacement panic traceback is missing %q:\n%s", want, different)
+		}
+	}
+	later := run("later")
+	wantLater := "caller_runtime_test.go:" + strconv.Itoa(markerLine(string(source), "LATER_SAME_VALUE_PANIC_MARK"))
+	if !strings.Contains(later, wantLater) {
+		t.Fatalf("same value panicked after its recover activation returned is missing %q:\n%s", wantLater, later)
 	}
 }
 

--- a/test/go/caller_runtime_test.go
+++ b/test/go/caller_runtime_test.go
@@ -108,6 +108,38 @@ func callerLaterSameValuePanic() {
 	panic(recovered) // LATER_SAME_VALUE_PANIC_MARK
 }
 
+type callerRepanicReceiver struct{}
+
+//go:noinline
+func (callerRepanicReceiver) repanic() {
+	if v := recover(); v != nil {
+		panic(v)
+	}
+}
+
+//go:noinline
+func callerWrappedRepanic(indirect bool) {
+	// A pointer implementing this value-receiver method needs a transparent
+	// wrapper. Only the direct deferred invocation is allowed to recover.
+	var receiver interface{ repanic() } = &callerRepanicReceiver{}
+	if indirect {
+		defer func() {
+			v := recover()
+			receiver.repanic()
+			panic(v)
+		}()
+	} else {
+		defer receiver.repanic()
+	}
+	callerRepanicOrigin()
+}
+
+//go:noinline
+func callerSliceRepanic() {
+	defer func() { panic(recover()) }()
+	panic([]int{1}) // SLICE_REPANIC_ORIGIN_MARK
+}
+
 func TestCallerRepanicTraceback(t *testing.T) {
 	mode := os.Getenv(callerRepanicChild)
 	switch mode {
@@ -119,6 +151,12 @@ func TestCallerRepanicTraceback(t *testing.T) {
 		return
 	case "later":
 		callerLaterSameValuePanic()
+		return
+	case "wrapper", "indirect-wrapper":
+		callerWrappedRepanic(mode == "indirect-wrapper")
+		return
+	case "slice":
+		callerSliceRepanic()
 		return
 	}
 
@@ -142,13 +180,19 @@ func TestCallerRepanicTraceback(t *testing.T) {
 		return string(output)
 	}
 
-	same := run("same")
-	for _, want := range []string{
-		"callerRepanicOrigin",
-		"caller_runtime_test.go:" + strconv.Itoa(markerLine(string(source), "REPANIC_ORIGIN_MARK")),
-	} {
-		if !strings.Contains(same, want) {
-			t.Fatalf("same-value repanic traceback is missing %q:\n%s", want, same)
+	for _, mode := range []string{"same", "wrapper", "indirect-wrapper", "slice"} {
+		name, marker := "callerRepanicOrigin", "REPANIC_ORIGIN_MARK"
+		if mode == "slice" {
+			name, marker = "callerSliceRepanic", "SLICE_REPANIC_ORIGIN_MARK"
+		}
+		same := run(mode)
+		for _, want := range []string{
+			name,
+			"caller_runtime_test.go:" + strconv.Itoa(markerLine(string(source), marker)),
+		} {
+			if !strings.Contains(same, want) {
+				t.Fatalf("%s repanic traceback is missing %q:\n%s", mode, want, same)
+			}
 		}
 	}
 

--- a/test/go/caller_runtime_test.go
+++ b/test/go/caller_runtime_test.go
@@ -144,7 +144,8 @@ func TestCallerRepanicTraceback(t *testing.T) {
 	mode := os.Getenv(callerRepanicChild)
 	switch mode {
 	case "same":
-		callerRepanicOrigin()
+		// Match llcppg: both nested tRunner repanics must retain the nil site.
+		t.Run("origin", func(t *testing.T) { callerRepanicOrigin() })
 		return
 	case "different":
 		callerReplacementPanic()

--- a/test/go/runtime_statement_line_test.go
+++ b/test/go/runtime_statement_line_test.go
@@ -40,10 +40,9 @@ func TestRuntimeStatementLineInfo(t *testing.T) {
 	checkRuntimeClosureIndirectCaller(t)
 	checkAdjacentRuntimeStack(t)
 	checkRecoveredDebugStackBounds(t, runtimeStatementMarkerLine(t, "// BOUNDS_MARK"))
-	checkRecoveredStaticPanicLine(t)
-	if runtime.GOOS == "windows" {
-		checkRecoveredStorePanicLine(t)
-	}
+	t.Run("panic_caller", checkRuntimePanicCaller)
+	t.Run("load_panic_line", checkRecoveredStaticPanicLine)
+	t.Run("store_panic_line", checkRecoveredStorePanicLine)
 	checkRecoveredIndirectPanicLine(t)
 }
 
@@ -184,21 +183,68 @@ func checkRecoveredDebugStackBounds(t *testing.T, want int) {
 }
 
 func checkRecoveredStaticPanicLine(t *testing.T) {
-	checkRecoveredPanicLine(t, "runtimeStatementStaticNilPanic", runtimeStatementMarkerLine(t, "// STATIC_NIL_PANIC_MARK"), runtimeStatementStaticNilPanic)
+	runtimeStatementStaticNilPanic(t, nil, runtimeStatementMarkerLine(t, "// STATIC_NIL_PANIC_MARK"))
 }
 
-func runtimeStatementStaticNilPanic() {
-	var pointer *int
-	_ = *pointer // STATIC_NIL_PANIC_MARK
+var runtimeStatementPanicSink int64
+var runtimeStatementNilPointer *int
+
+// issue27201: distinguish the faulting load from the following statement.
+//
+//go:noinline
+func runtimeStatementStaticNilPanic(t *testing.T, pointer *int32, want int) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("missing nil load panic")
+		}
+		var buf [4096]byte
+		n := runtime.Stack(buf[:], false)
+		stack := string(buf[:n])
+		if got := runtimeStackLineFor(stack, "runtimeStatementStaticNilPanic"); got != want {
+			t.Fatalf("recovered nil load line = %d, want %d\n%s", got, want, stack)
+		}
+	}()
+	value := *pointer // STATIC_NIL_PANIC_MARK
+	runtimeStatementPanicSink = int64(value)
 }
 
 func checkRecoveredStorePanicLine(t *testing.T) {
 	checkRecoveredPanicLine(t, "runtimeStatementStoreNilPanic", runtimeStatementMarkerLine(t, "// STORE_NIL_PANIC_MARK"), runtimeStatementStoreNilPanic)
 }
 
+// issue34123: distinguish a faulting store from the earlier pointer load.
+//
+//go:noinline
 func runtimeStatementStoreNilPanic() {
-	var pointer *int
-	*pointer = 1 // STORE_NIL_PANIC_MARK
+	pointer := runtimeStatementNilPointer
+	runtimeStatementPanicSink = 11
+	*pointer = 12 // STORE_NIL_PANIC_MARK
+}
+
+// issue17381: a statically panicking leaf must not lose its caller's return PC.
+//
+//go:noinline
+func checkRuntimePanicCaller(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("missing nil panic")
+		}
+		var pcs [20]uintptr
+		n := runtime.Callers(1, pcs[:])
+		for _, pc := range pcs[:n] {
+			if fn := runtime.FuncForPC(pc); fn != nil && strings.HasSuffix(fn.Name(), ".checkRuntimePanicCaller") {
+				return
+			}
+		}
+		t.Fatalf("missing original caller after nil panic: %x", pcs[:n])
+	}()
+	runtimeStatementNilFrame()
+}
+
+//go:noinline
+func runtimeStatementNilFrame() {
+	var frame [1]int
+	*(*int)(nil) = frame[0]
 }
 
 func checkRecoveredIndirectPanicLine(t *testing.T) {

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -359,7 +359,6 @@ func TestObservedFailuresHaveXFailClassifications(t *testing.T) {
 		tc       testCase
 	}{
 		{version: "go1.27.0", platform: "linux/amd64", tc: testCase{RelPath: "rangegen.go", Directive: "runoutput"}},
-		{version: "go1.27.0", platform: "linux/amd64", tc: testCase{RelPath: "fixedbugs/issue34123.go", Directive: "run"}},
 		{version: "go1.27.0", platform: "linux/amd64", tc: testCase{RelPath: "heapsampling.go", Directive: "run"}},
 		{version: "go1.26.7", platform: "linux/amd64", tc: testCase{RelPath: "convert5.go", Directive: "run"}},
 		{version: "go1.26.7", platform: "windows-msvc/amd64", tc: testCase{RelPath: "linkmain_run.go", Directive: "run"}},
@@ -385,6 +384,8 @@ func TestObservedPassesDoNotHaveXFailClassifications(t *testing.T) {
 		{version: "go1.27.0", platform: "darwin/arm64", tc: testCase{RelPath: "index0.go", Directive: "runoutput"}},
 		{version: "go1.27.0", platform: "windows-mingw/386", tc: testCase{RelPath: "index0.go", Directive: "runoutput"}},
 		{version: "go1.27.0", platform: "windows-msvc/386", tc: testCase{RelPath: "rangegen.go", Directive: "runoutput"}},
+		{version: "go1.27.0", platform: "darwin/arm64", tc: testCase{RelPath: "fixedbugs/issue34123.go", Directive: "run"}},
+		{version: "go1.27.0", platform: "linux/amd64", tc: testCase{RelPath: "fixedbugs/issue34123.go", Directive: "run"}},
 		{version: "go1.27.0", platform: "windows-msvc/amd64", tc: testCase{RelPath: "fixedbugs/issue34123.go", Directive: "run"}},
 		{version: "go1.27.0", platform: "darwin/arm64", tc: testCase{RelPath: "fixedbugs/issue52612.go", Directive: "run"}},
 	}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -179,14 +179,6 @@ xfails:
     directive: runoutput
     case: rangegen.go
     reason: the current golang.org/x/tools/go/ssa dependency mishandles labeled branches in generated range-over-function code; update x/tools after https://github.com/golang/tools/pull/666 lands
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue34123.go
-    reason: LLGo reports the deferred recovery frame two source lines earlier than cmd/compile
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue34123.go
-    reason: LLGo reports the deferred recovery frame two source lines earlier than cmd/compile
   - directive: run
     case: fixedbugs/issue80196.go
     reason: LLGo overflows its native stack while repeatedly assigning the escaped named result in this test

--- a/test/std/weak/weak_test.go
+++ b/test/std/weak/weak_test.go
@@ -128,3 +128,24 @@ func TestPointerNilInput(t *testing.T) {
 		t.Errorf("Make(nil).Value() = %v, want nil", val)
 	}
 }
+
+func TestPointerIdentity(t *testing.T) {
+	x, y := new([256]byte), new([256]byte)
+	x[0], y[0] = 1, 2
+	xw, yw := weak.Make(x), weak.Make(y)
+	if xw != weak.Make(x) {
+		t.Fatal("repeated Make returned a different handle for the same object")
+	}
+	if xw == yw {
+		t.Fatal("Make returned the same handle for distinct objects")
+	}
+	runtime.GC()
+	if xw != weak.Make(x) || yw != weak.Make(y) {
+		t.Fatal("GC changed the identity of a live weak pointer")
+	}
+	if xw.Value() != x || yw.Value() != y {
+		t.Fatal("GC invalidated a live weak pointer")
+	}
+	runtime.KeepAlive(x)
+	runtime.KeepAlive(y)
+}


### PR DESCRIPTION
## Dependency and targeted CI

Rebased onto #2575 at `a7863ee05`, which independently fixes a captured weak-cleanup reentrancy deadlock in the Qiniu Linux shard-0 test. The original five panic-location commits remain patch-identical after rebase. The GitHub base remains `main` because both contributions come from a fork; the dependency's changes will drop out of this diff once #2575 is merged. The complete affected Qiniu Ubuntu 24.04 large / LLVM 22 / Go 1.27 shard-0 job passed for this stack in [run 34702086188](https://github.com/xgo-dev/llgo/actions/runs/34702086188): the first test phase completed in 136 seconds, symbol checks in 12 seconds, build-mode checks in 602 seconds, all later integration checks passed, and the new weak-runtime pressure regression passed three times in 0.16 seconds, without ptrace sampling. #2575 separately passed the same complete job plus its old-runtime negative control in [run 34703427423](https://github.com/xgo-dev/llgo/actions/runs/34703427423). The ordinary matrix for `148f3d099` completed with 64 successful checks, no failure, and only the expected tag-gated release job skipped; its normal affected Qiniu job independently passed in [22m26s](https://github.com/xgo-dev/llgo/actions/runs/34704729277/job/103582614999), and Codecov patch coverage is 100% (26/26). No diagnostic workflow or stress retry is added to this PR.

The current head `cf807ffb1` rebases those same five patches onto #2575's source-comment update. `git range-diff` reports all five patches unchanged; compared with the previously validated `148f3d099`, the source diff contains only weak-runtime comments. CI results above belong to the named earlier revisions, not a new full-matrix result for this rebased head.

## Summary

- Preserve the original panic PC snapshot when a recovering defer throws the same raw interface value again, matching the pattern used by `testing.tRunner`, while tying reuse to the still-active recover activation so a later panic of the same value gets a fresh traceback.
- Keep nil-check failure blocks separate from the call-free success path, with a formal return that preserves the caller's saved return PC. Keep the noinline runtime helper's condition opaque to LTO using one empty matching-register constraint inside the helper, not barriers at every call site. Emit the source anchor inside the cold failure block so backend block placement cannot assign it a later statement's line.
- Emit recover-observable pointer-store panic-site records on Linux and Darwin as well as Windows, and remove the now-passing `fixedbugs/issue34123.go` xfails.

Fixes #2566. Addresses the `fixedbugs/issue17381.go` and `fixedbugs/issue27201.go` regressions reported by #2564.

## Cause

LLGo longjmp-unwinds the original panic frames and reconstructs them from a per-goroutine PC snapshot. A same-value `panic(recover())` previously replaced that snapshot with the re-panic site, so `go test` failures stopped at `testing.go:2123`. Separately, the nil-check cold-block self-loop introduced by #2538 allowed LLVM to infer that a static nil-dereference caller never returns; this both exposed a return-PC/function-entry boundary misattribution in `issue17381` and moved the recovered panic line in `issue27201`. Native pointer stores also lacked the scoped PC-line carrier already emitted on Windows, leaving `issue34123` at the earlier pointer-load line.

The two recent regressions were traced to #2538 commit `cdaa60ff7`: both original GOROOT programs pass with its parent `88a698364` and fail with that commit on macOS/arm64 with Go 1.27. Same-value repanic retention is a longer-standing omission in the snapshot design introduced by #2026, not a new #2538 regression. The pointer-store metadata was added during #2405 development and then restricted to Windows before merging, leaving the existing Linux/macOS gap unresolved; the former Windows-only runtime assertion is now enabled on every platform.

## Size and performance

The original version added 80 bytes of symbol-index records to `cprintf` for five new runtime helpers and approximately 11 KiB of macOS machine code to non-LTO `fmtprintf` by joining nil-check failures back into the normal path. This revision removes those five helpers, moves snapshot bookkeeping behind the existing public-runtime hook so tiny programs do not link it, reuses the existing recover activation token, and leaves `recoverState` at its original two-pointer ABI. The snapshot retains three words of per-goroutine state without allocating a separate recovery object. Returning from a defer or transparent wrapper and `Goexit` clear the retained value.

Local paired builds of base `daada50d2270` and the updated source used the same checkout path, compiler options, and macOS/arm64 host. The code column below is the Mach-O `__text` section; file sizes include alignment and all metadata.

| Workload | File size | Change vs base | Machine-code change vs base |
|---|---:|---:|---:|
| cprintf | 84,480 B | 0 B | 0 B |
| cprintf, full LTO | 84,288 B | 0 B | 0 B |
| println | 114,848 B | -80 B | -108 B |
| println, full LTO | 118,736 B | 0 B | 0 B |
| fmtprintf | 1,473,264 B | 0 B | -1,184 B |
| fmtprintf, full LTO | 1,159,440 B | +16 B | +5,664 B |

The remaining full-LTO code increase is explicitly not zero: keeping the panic helper potentially returning prevents return-PC boundary misattribution even after whole-program optimization. The protection is confined to the helper, emits no assembly instructions itself, and adds no runtime call to successful nil checks. CI's paired benchmarks remain the cross-platform size and timing acceptance check; local timing samples were too sensitive to host load to support a speedup claim.

The [paired CI measurements for `5daef74c420b`](https://github.com/xgo-dev/llgo/pull/2567#issuecomment-5643533010) now confirm no file or Text growth for `cprintf` or `cprintf-lto` on any native platform; `println` and `println-lto` are unchanged or smaller. Non-LTO `fmtprintf` file deltas range from -3,584 B to +512 B, while full-LTO Text deltas are +3,104 B to +5,632 B and full-LTO file deltas are 0 B to +6,144 B. The report's Text metric is distinct from the local Mach-O `__text` measurement above. The broad macOS timing slowdown also affects unchanged Go timer controls, so this single run does not isolate an LLGo performance regression or establish a speedup. The LTO size cost is a limitation of this approach, not a proven lower bound.

## Validation

- Ordinary PR CI covers all four scenarios through the existing `test/go` suite, compatible with both `go test` and `llgo test`. `TestRuntimeStatementLineInfo/panic_caller` checks raw `runtime.Callers` PCs still resolve to the recovering caller after a statically panicking leaf (`issue17381`); `load_panic_line` requires the nil load's exact line rather than the following observable statement (`issue27201`); `store_panic_line` requires the pointer store's line rather than the earlier pointer load (`issue34123`) on every platform. `TestCallerRepanicTraceback` uses nested `testing.T.Run` to reproduce llcppg's same-value repanic. These extend the existing test binary without additional build-driver tests, GOROOT subprocess builds, workflow changes, nightly opt-in, or xfail allowances.
- The strengthened `test/go` cases pass with host Go and LLGo default/full LTO. A negative control using the unmodified `cdaa60ff7` compiler and its runtime fails all four scenarios: the caller is missing, the nil load is reported two lines late, the store two lines early, and the nested test panic loses `callerRepanicOrigin`. These are behavioral checks, not merely compilation checks; the added in-process subtests take less than the test logger's 0.01-second resolution locally.
- `go test ./ssa -run '^TestAssertNilDeref(ZeroExprNoPanic|ColdCall)$' -count=1`
- `go test ./cl -run '^TestCompileRuntimeCaller(StorePanicPCLineMetadataOnNativeTargets|PanicPCLineMetadata)$' -count=1`
- `go test ./test/go -run '^(TestCallerRepanicTraceback|TestCallerPanicTraceback|TestRuntimeStatementLineInfo)$' -count=1`
- `llgo test -v -run '^(TestCallerRepanicTraceback|TestCallerPanicTraceback|TestRuntimeStatementLineInfo)$' ./test/go`
- Go 1.27 GOROOT `fixedbugs/issue17381.go`, `fixedbugs/issue27201.go`, and `fixedbugs/issue34123.go` pass on macOS/arm64 with both default compilation and full LTO, without xfail allowances.
- Full `llgo test -timeout=5m ./test/go`, plus full-LTO caller/recover/statement-line tests; repanic coverage includes transparent method wrappers, indirect recover attempts, uncomparable slice values, replacement panics, and later reuse of the same value.
- `go test ./ssa ./cl -skip '^TestRunAndTestFrom' -timeout=5m -count=1`; targeted SSA tests model whole-program argument propagation and emit objects for Linux/amd64, Darwin/arm64, and Windows/amd64, 386, and arm64, while retaining the original WebAssembly failure path.
- The `goplus/llcppg@dev-panic-at` reproduction now prints the complete application stack instead of stopping at `testing.tRunner`; its innermost frame is the exact nil access at `go/ast/ast.go:520`, followed by `gogen` and llcppg `compile_test.go:49` and `compile_test.go:77`.

The open #2530 debug-location work was tested on current main and does not fix either GOROOT regression, so this PR does not depend on it.

A separate full local `go test ./cl` exceeded its five-minute whole-suite budget while advancing through native run fixtures; this is not listed as a full local pass. CI covers the complete fixture suites.

