### PR TITLE
cabi: place aggregate return conversion storage in entry

### DIFF
--- a/internal/cabi/_testdata/returns/returns.go
+++ b/internal/cabi/_testdata/returns/returns.go
@@ -1,0 +1,26 @@
+package returns
+
+type Small struct {
+	X, Y uint32
+}
+
+func Width(x, y uint32) Small {
+	if x < y {
+		return Small{x, y}
+	}
+	return Small{y, x}
+}
+
+func Pair(x uint64, y uint32) (uint64, uint32) {
+	if x < uint64(y) {
+		return x + 1, y
+	}
+	return x - 1, y + 1
+}
+
+func PairBool(x uint64, flag bool) (uint64, bool) {
+	if x < 32 {
+		return x + 1, flag
+	}
+	return x - 1, !flag
+}

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -636,6 +636,7 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 			}
 			bb = llvm.NextBasicBlock(bb)
 		}
+		var returnSlot llvm.Value
 		for _, instr := range retInstrs {
 			ret := instr.Operand(0)
 			b.SetInsertPointBefore(instr)
@@ -659,8 +660,8 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 				// See: https://github.com/xgo-dev/llgo/issues/1608
 				b.CreateStore(nativeRet, params[0])
 				rv = b.CreateRetVoid()
-			case AttrWidthType:
-				if p.optimize && !info.Return.hasNativeLayoutConversion() {
+			case AttrWidthType, AttrWidthType2:
+				if info.Return.Kind == AttrWidthType && p.optimize && !info.Return.hasNativeLayoutConversion() {
 					if load := ret.IsALoadInst(); !load.IsNil() && !load.IsVolatile() && llvm.NextInstruction(load) == instr {
 						iptr := b.CreateBitCast(ret.Operand(0), llvm.PointerType(nft.ReturnType(), 0), "")
 						value := b.CreateLoad(nft.ReturnType(), iptr, "")
@@ -669,16 +670,17 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 						break
 					}
 				}
-				// Materialize the saved SSA value. The return may be a load whose
-				// source was modified after that load but before the return.
-				ptr := llvm.CreateAlloca(b, info.Return.nativeType())
-				b.CreateStore(nativeRet, ptr)
-				iptr := b.CreateBitCast(ptr, llvm.PointerType(nft.ReturnType(), 0), "")
-				rv = b.CreateRet(b.CreateLoad(nft.ReturnType(), iptr, ""))
-			case AttrWidthType2:
-				ptr := llvm.CreateAlloca(b, info.Return.nativeType())
-				b.CreateStore(nativeRet, ptr)
-				iptr := b.CreateBitCast(ptr, llvm.PointerType(nft.ReturnType(), 0), "")
+				// A single entry-block slot lets SROA promote conversions from
+				// every return path. Only the alloca moves: materialize the saved
+				// SSA value here, since a load's source may have changed before
+				// the return. The slot never escapes and return paths are disjoint.
+				if returnSlot.IsNil() {
+					b.SetInsertPointBefore(nfn.EntryBasicBlock().FirstInstruction())
+					returnSlot = llvm.CreateAlloca(b, info.Return.nativeType())
+					b.SetInsertPointBefore(instr)
+				}
+				b.CreateStore(nativeRet, returnSlot)
+				iptr := b.CreateBitCast(returnSlot, llvm.PointerType(nft.ReturnType(), 0), "")
 				rv = b.CreateRet(b.CreateLoad(nft.ReturnType(), iptr, ""))
 			}
 			instr.ReplaceAllUsesWith(rv)

--- a/internal/cabi/return_test.go
+++ b/internal/cabi/return_test.go
@@ -1,0 +1,71 @@
+//go:build !llgo
+
+package cabi_test
+
+import (
+	"testing"
+
+	"github.com/xgo-dev/llgo/internal/build"
+	"github.com/xgo-dev/llvm"
+)
+
+// Compile Go source through the normal ABI lowering before optimizing it. A
+// return conversion temporary in each branch prevents SROA from eliminating
+// the store/load pairs and can leave dynamic stack adjustments in leaf code.
+func TestAggregateReturnStoragePromotes(t *testing.T) {
+	for _, target := range []struct{ goos, goarch string }{
+		{"linux", "amd64"},
+		{"linux", "arm64"},
+		{"linux", "386"},
+		{"linux", "arm"},
+		{"linux", "riscv64"},
+		{"windows", "amd64"},
+		{"windows", "arm64"},
+		{"windows", "386"},
+		{"wasip1", "wasm"},
+	} {
+		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
+			conf := build.NewDefaultConf(build.ModeGen)
+			conf.Goos, conf.Goarch = target.goos, target.goarch
+			pkgs, err := build.Do([]string{"./_testdata/returns/returns.go"}, conf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pkg := pkgs[0].LPkg
+			defer pkg.Prog.Dispose()
+			mod := pkg.Module()
+			mod.SetDataLayout(pkg.Prog.DataLayout())
+			mod.SetTarget(pkg.Prog.Target().Spec().Triple)
+			pbo := llvm.NewPassBuilderOptions()
+			defer pbo.Dispose()
+			pbo.SetVerifyEach(true)
+			if err := mod.RunPasses("default<O2>", pkg.Prog.TargetMachine(), pbo); err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range []string{"Width", "Pair", "PairBool"} {
+				fn := mod.NamedFunction(pkgs[0].PkgPath + "." + name)
+				if fn.IsNil() {
+					t.Fatalf("function %s not found:\n%s", name, mod.String())
+				}
+				for bb := fn.FirstBasicBlock(); !bb.IsNil(); bb = llvm.NextBasicBlock(bb) {
+					for instr := bb.FirstInstruction(); !instr.IsNil(); instr = llvm.NextInstruction(instr) {
+						if instr.IsAAllocaInst().IsNil() {
+							continue
+						}
+						// LLVM may retain a byte slot for the i1 store followed by
+						// an ABI-width load. It must be static and scalar; the
+						// integer-only returns should need no stack storage.
+						if name != "PairBool" || bb != fn.EntryBasicBlock() || instr.AllocatedType().TypeKind() != llvm.IntegerTypeKind {
+							t.Fatalf("aggregate return storage was not promoted after O2:\n%s", fn.String())
+						}
+					}
+				}
+			}
+			asm, err := pkg.Prog.TargetMachine().EmitToMemoryBuffer(mod, llvm.AssemblyFile)
+			if err != nil {
+				t.Fatalf("emit aggregate return assembly: %v", err)
+			}
+			asm.Dispose()
+		})
+	}
+}

--- a/test/go/aggregate_return_test.go
+++ b/test/go/aggregate_return_test.go
@@ -1,0 +1,59 @@
+package gotest
+
+import "testing"
+
+type aggregateReturnPair struct {
+	Value uint64
+	Flag  bool
+}
+
+//go:noinline
+func aggregateReturnSnapshot(src *aggregateReturnPair, first bool) aggregateReturnPair {
+	saved := *src
+	*src = aggregateReturnPair{99, !saved.Flag}
+	if first {
+		return saved
+	}
+	saved.Value++
+	return saved
+}
+
+//go:noinline
+func aggregateReturnIntegers(x uint64, y uint32) (uint64, uint32) {
+	if x < uint64(y) {
+		return x + 1, y
+	}
+	return x - 1, y + 1
+}
+
+func TestAggregateReturnSnapshots(t *testing.T) {
+	for _, first := range []bool{false, true} {
+		for _, flag := range []bool{false, true} {
+			for _, value := range []uint64{0, 31, 1 << 32, 1<<63 + 3, ^uint64(0)} {
+				src := aggregateReturnPair{value, flag}
+				want := src
+				if !first {
+					want.Value++
+				}
+				if got := aggregateReturnSnapshot(&src, first); got != want {
+					t.Fatalf("snapshot(%d, %v, %v) = %v, want %v", value, flag, first, got, want)
+				}
+				if src != (aggregateReturnPair{99, !flag}) {
+					t.Fatalf("source mutation lost: %v", src)
+				}
+			}
+		}
+	}
+	for _, x := range []uint64{0, 31, 1 << 32, 1<<63 + 3, ^uint64(0)} {
+		for _, y := range []uint32{0, 31, 1<<31 + 3, ^uint32(0)} {
+			gotX, gotY := aggregateReturnIntegers(x, y)
+			wantX, wantY := x+1, y
+			if x >= uint64(y) {
+				wantX, wantY = x-1, y+1
+			}
+			if gotX != wantX || gotY != wantY {
+				t.Fatalf("integer pair(%d, %d) = (%d, %d), want (%d, %d)", x, y, gotX, gotY, wantX, wantY)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Aggregate return conversions currently allocate a temporary in each return block. LLVM can merge those paths through a pointer PHI and retain the aggregate stores/loads after O2. On ARM64, a branching `(uint64, uint32)` return then requires dynamic stack adjustments even though it can return entirely in registers.

Use one non-escaping temporary in the entry block for register-width aggregate returns. Each return still stores its already evaluated native value at the original return point, preserving loaded-value snapshots and existing native-layout conversions. The adjacent-load fast path remains unchanged.

The real Go source → post-ABI → O2 → ARM64 assembly comparison removes all stack operations from the integer-pair example. Boolean results can still retain an entry-block byte slot because of LLVM's handling of an `i1` store followed by a wider ABI load; this change removes their dynamic aggregate slots without changing boolean or padding semantics. These are code-generation improvements, not end-to-end benchmark results.

Validation:

- Full `go test ./internal/cabi -count=1`, including existing snapshot and Windows/386 native-layout coverage.
- New source-to-ABI/O2/assembly regression on Linux amd64/arm64/386/arm/riscv64, Windows amd64/arm64/386, and Wasm; optimization uses verify-each.
- New snapshot and integer-pair runtime cases pass with Go and LLGo default, O2, and full LTO on macOS ARM64.
- `go vet ./internal/cabi` and the new runtime test file.

Cross-platform execution remains for CI. Before/after assembly evidence is from separate-module O2; full LTO was validated for runtime semantics, not measured for performance.
