### PR TITLE
cl: lower unsigned multiply overflow as an intrinsic

### DIFF
--- a/cl/_testlibc/umuloverflow/expect.txt
+++ b/cl/_testlibc/umuloverflow/expect.txt
@@ -1,0 +1,1 @@
+unsigned multiply overflow ok

--- a/cl/_testlibc/umuloverflow/go_baremetal.go
+++ b/cl/_testlibc/umuloverflow/go_baremetal.go
@@ -1,0 +1,7 @@
+//go:build baremetal
+
+package main
+
+// Baremetal has no thread backend for go calls. The shared test still checks
+// every unsigned width, function values, and deferred argument evaluation.
+func checkGoCall() {}

--- a/cl/_testlibc/umuloverflow/go_host.go
+++ b/cl/_testlibc/umuloverflow/go_host.go
@@ -1,0 +1,12 @@
+//go:build !baremetal
+
+package main
+
+func checkGoCall() {
+	order := 0
+	arg := func(digit int) uintptr { order = order*10 + digit; return uintptr(order) }
+	go multiply(arg(1), arg(2))
+	if order != 12 {
+		panic("goroutine multiply argument evaluation mismatch")
+	}
+}

--- a/cl/_testlibc/umuloverflow/in.go
+++ b/cl/_testlibc/umuloverflow/in.go
@@ -85,10 +85,6 @@ func main() {
 			panic("deferred multiply argument evaluation mismatch")
 		}
 	}()
-	order = 0
-	go multiply(arg(1), arg(2))
-	if order != 12 {
-		panic("goroutine multiply argument evaluation mismatch")
-	}
+	checkGoCall()
 	println("unsigned multiply overflow ok")
 }

--- a/cl/_testlibc/umuloverflow/in.go
+++ b/cl/_testlibc/umuloverflow/in.go
@@ -1,0 +1,94 @@
+// LITTEST
+// Scope: common
+package main
+
+type unsigned interface {
+	~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uint | ~uintptr
+}
+
+//llgo:link multiply llgo.umulOverflow
+func multiply[T unsigned](a, b T) (T, bool) {
+	return a * b, a != 0 && b > ^T(0)/a
+}
+
+func check[T unsigned](a, b T) {
+	product, overflow := multiply(a, b)
+	// Use division as an independent oracle for the overflow flag.
+	want := a != 0 && b > ^T(0)/a
+	if product != a*b || overflow != want {
+		panic("unsigned multiply overflow mismatch")
+	}
+}
+
+func checkWidth[T unsigned]() {
+	max := ^T(0)
+	edges := []T{0, 1, 2, 3, max, max - 1, max / 2, max/2 + 1}
+	// Include both sides of every power-of-two boundary and its exact
+	// largest non-overflowing cofactor.
+	for p := T(1); p != 0; p <<= 1 {
+		edges = append(edges, p, p-1, p+1)
+		limit := max / p
+		check(p, limit)
+		if limit < max {
+			check(p, limit+1)
+		}
+	}
+	for _, a := range edges {
+		for _, b := range edges {
+			check(a, b)
+		}
+	}
+	seed := uint64(0x123456789abcdef)
+	next := func() T {
+		seed ^= seed << 13
+		seed ^= seed >> 7
+		seed ^= seed << 17
+		return T(seed)
+	}
+	for i := 0; i < 1024; i++ {
+		check(next(), next())
+	}
+}
+
+type word uint64
+
+var multiplyValue = multiply[uintptr]
+
+// CHECK-LABEL: define void @main.main()
+// CHECK: call { i[[WIDTH:32|64]], i1 } @llvm.umul.with.overflow.i[[WIDTH]](
+// CHECK: call {{.*}} %{{[^ (]+}}(
+func main() {
+	checkWidth[uint8]()
+	checkWidth[uint16]()
+	checkWidth[uint32]()
+	checkWidth[uint64]()
+	checkWidth[uint]()
+	checkWidth[uintptr]()
+	checkWidth[word]()
+	max := ^uintptr(0)
+	// Calls must evaluate their operands once, from left to right.
+	order := 0
+	arg := func(digit int) uintptr { order = order*10 + digit; return uintptr(order) }
+	product, overflow := multiply(arg(1), arg(2))
+	if order != 12 || product != 12 || overflow {
+		panic("multiply argument evaluation mismatch")
+	}
+	// Taking an intrinsic's address must produce a callable wrapper.
+	product, overflow = multiplyValue(max, 2)
+	if product != max-1 || !overflow {
+		panic("multiply function value mismatch")
+	}
+	func() {
+		order = 0
+		defer multiply(arg(1), arg(2))
+		if order != 12 {
+			panic("deferred multiply argument evaluation mismatch")
+		}
+	}()
+	order = 0
+	go multiply(arg(1), arg(2))
+	if order != 12 {
+		panic("goroutine multiply argument evaluation mismatch")
+	}
+	println("unsigned multiply overflow ok")
+}

--- a/cl/import.go
+++ b/cl/import.go
@@ -669,6 +669,7 @@ const (
 	llgoFloat32Bits        = llgoInstrBase + 0x4a
 	llgoFloat64FromBits    = llgoInstrBase + 0x4b
 	llgoFloat64Bits        = llgoInstrBase + 0x4c
+	llgoUMulOverflow       = llgoInstrBase + 0x4d
 
 	llgoAtomicOpLast = llgoAtomicOpBase + int(llssa.OpUMin)
 )

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -669,6 +669,7 @@ var llgoInstrs = map[string]int{
 	"float32Bits":     llgoFloat32Bits,
 	"float64FromBits": llgoFloat64FromBits,
 	"float64Bits":     llgoFloat64Bits,
+	"umulOverflow":    llgoUMulOverflow,
 }
 
 // funcOf returns a function by name and set ftype = goFunc, cFunc, etc.
@@ -2664,6 +2665,17 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 		case llgoFloat64Bits:
 			args := p.compileValues(b, args, kind)
 			ret = p.bitCastIntrinsic(b, args, types.Typ[types.Uint64], "math.Float64bits")
+		case llgoUMulOverflow:
+			results := call.Signature().Results()
+			if len(args) != 2 || results.Len() != 2 ||
+				!types.Identical(results.At(0).Type(), args[0].Type()) ||
+				!types.Identical(results.At(1).Type(), types.Typ[types.Bool]) {
+				panic("umulOverflow(a, b T) (T, bool): invalid arguments")
+			}
+			args := p.compileValues(b, args, kind)
+			ret = p.emitDo(b, act, ds, false, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				return b.UMulOverflow(args[0], args[1])
+			}, args...)
 		case llgoUnreachable: // func unreachable()
 			b.Unreachable()
 		case llgoAtomicLoad:

--- a/cl/overflow_test.go
+++ b/cl/overflow_test.go
@@ -1,0 +1,79 @@
+//go:build !llgo
+
+package cl
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	llssa "github.com/xgo-dev/llgo/ssa"
+	"github.com/xgo-dev/llvm"
+)
+
+func TestUMulOverflowLowering(t *testing.T) {
+	const src = `package overflow
+type Unsigned interface { ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uint | ~uintptr }
+//llgo:link multiply llgo.umulOverflow
+func multiply[T Unsigned](a, b T) (T, bool) { panic("intrinsic") }
+type Word uint64
+func Mul8(a, b uint8) (uint8, bool) { return multiply(a, b) }
+func Mul16(a, b uint16) (uint16, bool) { return multiply(a, b) }
+func Mul32(a, b uint32) (uint32, bool) { return multiply(a, b) }
+func Mul64(a, b Word) (Word, bool) { return multiply(a, b) }
+func MulPtr(a, b uintptr) (uintptr, bool) { return multiply(a, b) }
+var multiplyValue = multiply[Word]
+func Value64(a, b Word) (Word, bool) { return multiplyValue(a, b) }
+func Defer64(a, b Word) { defer multiply(a, b) }
+`
+	for _, target := range []llssa.Target{
+		{GOOS: "linux", GOARCH: "arm64"},
+		{GOOS: "windows", GOARCH: "amd64"},
+		{GOOS: "windows", GOARCH: "386"},
+		{GOOS: "windows", GOARCH: "386", GO386: "softfloat"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "5"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "7"},
+		{GOOS: "wasip1", GOARCH: "wasm"},
+		{GOOS: "linux", GOARCH: "riscv64"},
+	} {
+		t.Run(target.GOARCH+target.GO386+target.GOARM, func(t *testing.T) {
+			ssapkg, _, files := buildGoSSAPkg(t, src)
+			prog := newLLSSAProgForTarget(t, &target)
+			defer prog.Dispose()
+			pkg, err := NewPackage(prog, ssapkg, files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mod := pkg.Module()
+			if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+			for _, suffix := range []string{"8", "16", "32", "64", "Ptr"} {
+				width := suffix
+				if suffix == "Ptr" {
+					width = strconv.Itoa(int(prog.SizeOf(prog.Uintptr())) * 8)
+				}
+				ir := mustNamedFunction(t, mod, "overflow.Mul"+suffix).String()
+				if strings.Count(ir, "@llvm.umul.with.overflow.i"+width+"(") != 1 {
+					t.Errorf("expected one unsigned multiply-with-overflow call:\n%s", ir)
+				}
+				if strings.Contains(ir, " udiv ") || strings.Contains(ir, "AssertDivideByZero") || strings.Contains(ir, "br i1") {
+					t.Errorf("unsigned overflow introduced division or a conditional branch:\n%s", ir)
+				}
+			}
+			mod.SetDataLayout(prog.DataLayout())
+			mod.SetTarget(target.Spec().Triple)
+			opts := llvm.NewPassBuilderOptions()
+			defer opts.Dispose()
+			opts.SetVerifyEach(true)
+			if err := mod.RunPasses("default<O2>", prog.TargetMachine(), opts); err != nil {
+				t.Fatal(err)
+			}
+			asm, err := prog.TargetMachine().EmitToMemoryBuffer(mod, llvm.AssemblyFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			asm.Dispose()
+		})
+	}
+}

--- a/cl/overflow_test.go
+++ b/cl/overflow_test.go
@@ -3,6 +3,7 @@
 package cl
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -74,6 +75,33 @@ func Defer64(a, b Word) { defer multiply(a, b) }
 				t.Fatal(err)
 			}
 			asm.Dispose()
+		})
+	}
+}
+
+func TestUMulOverflowInvalidDeclarations(t *testing.T) {
+	for _, tc := range []struct{ name, decl, call, want string }{
+		{"arity", "func mul(a uint) (uint, bool)", "mul(a)", "invalid arguments"},
+		{"result-count", "func mul(a, b uint) uint", "mul(a, a)", "invalid arguments"},
+		{"product-type", "func mul(a, b uint) (uint64, bool)", "mul(a, a)", "invalid arguments"},
+		{"flag-type", "func mul(a, b uint) (uint, uint)", "mul(a, a)", "invalid arguments"},
+		{"signed", "func mul(a, b int) (int, bool)", "mul(int(a), int(a))", "same unsigned integer type"},
+		{"mismatched-operands", "func mul(a uint, b uint64) (uint, bool)", "mul(a, uint64(a))", "same unsigned integer type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "package overflow\n//llgo:link mul llgo.umulOverflow\n" + tc.decl + "\nfunc bad(a uint) { " + tc.call + " }"
+			ssapkg, _, files := buildGoSSAPkg(t, src)
+			prog := newLLSSAProgForTarget(t, &llssa.Target{GOOS: "linux", GOARCH: "amd64"})
+			defer prog.Dispose()
+			defer func() {
+				if got := fmt.Sprint(recover()); !strings.Contains(got, tc.want) {
+					t.Fatalf("diagnostic = %q, want %q", got, tc.want)
+				}
+			}()
+			_, err := NewPackage(prog, ssapkg, files)
+			if err != nil {
+				panic(err)
+			}
 		})
 	}
 }

--- a/runtime/_test/codegen/muloverflow/expect.txt
+++ b/runtime/_test/codegen/muloverflow/expect.txt
@@ -1,0 +1,1 @@
+runtime multiply overflow ok

--- a/runtime/_test/codegen/muloverflow/in.go
+++ b/runtime/_test/codegen/muloverflow/in.go
@@ -1,0 +1,38 @@
+// LITTEST
+// Scope: common
+package main
+
+import "github.com/xgo-dev/llgo/runtime/internal/runtime/math"
+
+// CHECK-LABEL: define {{.*}} @main.runtimeMul(
+// CHECK: call { i[[WIDTH:32|64]], i1 } @llvm.umul.with.overflow.i[[WIDTH]](
+// CHECK-NOT: AssertDivideByZero
+// CHECK-NOT: @"{{.*}}math.MulUintptr"
+// CHECK: ret
+func runtimeMul(a, b uintptr) (uintptr, bool) {
+	return math.MulUintptr(a, b)
+}
+
+var multiplyValue = math.MulUintptr
+
+func main() {
+	max := ^uintptr(0)
+	edges := []uintptr{0, 1, 2, 3, max / 2, max/2 + 1, max - 1, max}
+	for p := uintptr(1); p != 0; p <<= 1 {
+		edges = append(edges, p-1, p, p+1)
+	}
+	for _, a := range edges {
+		for _, b := range edges {
+			product, overflow := runtimeMul(a, b)
+			want := a != 0 && b > max/a
+			if product != a*b || overflow != want {
+				panic("runtime MulUintptr mismatch")
+			}
+			product, overflow = multiplyValue(a, b)
+			if product != a*b || overflow != want {
+				panic("runtime MulUintptr function value mismatch")
+			}
+		}
+	}
+	println("runtime multiply overflow ok")
+}

--- a/runtime/internal/runtime/math/math.go
+++ b/runtime/internal/runtime/math/math.go
@@ -5,7 +5,8 @@ import "github.com/xgo-dev/llgo/runtime/internal/runtime/goarch"
 const MaxUintptr = ^uintptr(0)
 
 // MulUintptr returns a * b and whether the multiplication overflowed.
-// On supported platforms this is an intrinsic lowered by the compiler.
+//
+//llgo:link MulUintptr llgo.umulOverflow
 func MulUintptr(a, b uintptr) (uintptr, bool) {
 	if a|b < 1<<(4*goarch.PtrSize) || a == 0 {
 		return a * b, false

--- a/ssa/overflow.go
+++ b/ssa/overflow.go
@@ -1,0 +1,31 @@
+package ssa
+
+import (
+	"go/types"
+
+	"github.com/xgo-dev/llvm"
+)
+
+// UMulOverflow returns the wrapped unsigned product and an overflow flag.
+// Both operands must have the same unsigned integer type.
+func (b Builder) UMulOverflow(a, c Expr) Expr {
+	t := a.Type
+	basic, ok := t.RawType().Underlying().(*types.Basic)
+	if !ok || basic.Info()&types.IsUnsigned == 0 || !types.Identical(t.RawType(), c.Type.RawType()) {
+		panic("umulOverflow(a, b T) (T, bool): operands must have the same unsigned integer type")
+	}
+	prog := b.Prog
+	// LLVM's result has its native {integer, i1} layout, even on targets
+	// where Go aggregates use a different alignment (for example 386).
+	retTy := prog.ctx.StructType([]llvm.Type{a.impl.Type(), prog.tyInt1()}, false)
+	ret := b.impl.CreateIntrinsic(retTy, llvm.LookupIntrinsicID("llvm.umul.with.overflow"), []llvm.Value{a.impl, c.impl}, "")
+	resultType := prog.Struct(t, prog.Bool())
+	if retTy != resultType.ll {
+		// Normalize before the tuple can escape through a function-value
+		// wrapper, which returns the complete Go aggregate at once.
+		return b.aggregateValue(resultType,
+			b.impl.CreateExtractValue(ret, 0, ""),
+			b.impl.CreateExtractValue(ret, 1, ""))
+	}
+	return Expr{ret, resultType}
+}

--- a/ssa/overflow_test.go
+++ b/ssa/overflow_test.go
@@ -1,0 +1,60 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"fmt"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestUMulOverflowResultLayout(t *testing.T) {
+	for _, arch := range []string{"amd64", "386"} {
+		t.Run(arch, func(t *testing.T) {
+			prog := NewProgram(&Target{GOOS: "windows", GOARCH: arch})
+			defer prog.Dispose()
+			prog.TypeSizes(types.SizesFor("gc", arch))
+			pkg := prog.NewPackage("overflow", "overflow")
+			fn := pkg.NewFunc("test", NoArgsNoRet, InC)
+			b := fn.MakeBody(1)
+			for _, kind := range []types.BasicKind{types.Uint8, types.Uint16, types.Uint32, types.Uint64, types.Uint, types.Uintptr} {
+				typ := prog.toType(types.Typ[kind])
+				a := Expr{llvm.ConstInt(typ.ll, 3, false), typ}
+				result := b.UMulOverflow(a, a)
+				want := prog.Struct(typ, prog.Bool())
+				if result.impl.Type() != want.ll {
+					t.Fatalf("%s result LLVM type = %s, want %s", typ.RawType(), result.impl.Type(), want.ll)
+				}
+				if result.Type.ll != want.ll {
+					t.Fatal("result Go and LLVM layouts disagree")
+				}
+			}
+			b.Return()
+			if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestUMulOverflowRejectsInvalidOperands(t *testing.T) {
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	pkg := prog.NewPackage("overflow", "overflow")
+	b := pkg.NewFunc("test", NoArgsNoRet, InC).MakeBody(1)
+	for _, pair := range [][2]types.BasicKind{{types.Int, types.Int}, {types.Float64, types.Float64}, {types.Uint32, types.Uint64}} {
+		t.Run(fmt.Sprint(pair), func(t *testing.T) {
+			defer func() {
+				if got := fmt.Sprint(recover()); !strings.Contains(got, "same unsigned integer type") {
+					t.Fatalf("diagnostic = %q", got)
+				}
+			}()
+			a, c := prog.toType(types.Typ[pair[0]]), prog.toType(types.Typ[pair[1]])
+			b.UMulOverflow(Expr{llvm.Undef(a.ll), a}, Expr{llvm.Undef(c.ll), c})
+		})
+	}
+	b.Return()
+}


### PR DESCRIPTION
Runtime allocation paths use `math.MulUintptr` to compute a size and detect unsigned overflow. Per-module O2 currently retains a helper call; the helper itself keeps the small-operand branches and `AssertDivideByZero(false)`. Add a generic `llgo.umulOverflow` intrinsic and opt `MulUintptr` into it through the existing link directive, so callers directly emit `llvm.umul.with.overflow` without requiring LTO. The ordinary Go implementation remains the host-compiler reference.

The lowering supports unsigned integer widths and named types, and normalizes LLVM's native result to the Go aggregate layout when necessary. This matters for real function-value wrappers returning `(uint64, bool)` on 386, where native and Go layouts differ. Source regressions cover direct calls, global function values, and argument evaluation for ordinary calls, defer, and go statements on targets with a thread backend. Baremetal runs the arithmetic, function-value, and defer cases without attempting to create an OS thread.

Validation:
- `go test ./ssa ./cl -count=1` and `go vet ./ssa ./cl`.
- Generic and imported-runtime semantic fixtures match the Go multiplication/division oracle in default mode, native `-O2`, and native `-O2 -lto=full` on macOS ARM64.
- LLVM verification, O2, and assembly generation for ARM64, Windows AMD64, Windows 386 with SSE2/soft-float, ARMv5/v7, Wasm, and RISC-V64, including the true function-value wrapper on 386.
- ESP32-C3 and ESP32 QEMU execution of the unsigned-width semantic fixture.
- Invalid intrinsic declaration diagnostics and direct SSA result-layout tests, including 386; local statement coverage of `ssa/overflow.go` is 100%.
- A real caller's before/after post-ABI ARM64 assembly replaces the helper call with direct `umulh`/`mul`/comparison operations. Other cross-target execution is left to CI; end-to-end throughput was not benchmarked.
