### PR TITLE
WIP: investigate runtime GC starvation during MakeFunc startup

### DIFF
--- a/.github/workflows/diagnose-qiniu-shard0.yml
+++ b/.github/workflows/diagnose-qiniu-shard0.yml
@@ -19,13 +19,21 @@ jobs:
       github.event.review.state == 'commented' &&
       startsWith(github.event.review.body, 'diagnose-qiniu-shard0')
     runs-on: [qiniu, ubuntu-24.04-large]
+    name: shard0 (${{ matrix.trial }})
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - trial: previously-passed
+            revision: 40c7bf8f66b2836efbd306d02aa2c6c6b67255f5
+          - trial: repeatedly-timed-out
+            revision: 94677096ec9981665d37c506c6d4ea09a460ca86
     steps:
       - uses: actions/checkout@v7
         with:
-          # The actual merge tree checked out by all three failed attempts,
-          # not just the PR head (which lacks main's float min/max change).
-          ref: 94677096ec9981665d37c506c6d4ea09a460ca86
+          # Pin the actual CI merge trees, not the corresponding PR heads.
+          ref: ${{ matrix.revision }}
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -35,6 +43,8 @@ jobs:
           harness_dir=$(mktemp -d "$RUNNER_TEMP/shard0-harness.XXXXXX")
           mv diagnostic-harness "$harness_dir/source"
           echo "DIAGNOSTIC_HARNESS=$harness_dir/source" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/shard0-diagnostics"
+          git status --porcelain > "$RUNNER_TEMP/shard0-diagnostics/status-before-setup.txt"
       - uses: ./.github/actions/setup-deps
         with:
           llvm-version: '22'
@@ -60,15 +70,20 @@ jobs:
         with:
           path: ${{ steps.cache-profile.outputs.root }}/build
           key: ${{ steps.cache-profile.outputs.key }}
-      - name: Build the unmodified failed compiler
+      - name: Build the original CI compiler revision
         run: |
-          test -z "$(git status --porcelain)"
+          mkdir -p "$RUNNER_TEMP/shard0-diagnostics"
+          git status --porcelain > "$RUNNER_TEMP/shard0-diagnostics/status-before-build.txt"
+          git diff --stat > "$RUNNER_TEMP/shard0-diagnostics/diff-before-build.txt"
           dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
+          go version -m "$RUNNER_TEMP/llgo-bin/llgo" > "$RUNNER_TEMP/shard0-diagnostics/compiler-build-info.txt"
           echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
           sudo apt-get install -y gdb
       - name: Replay shard 0 with original arguments and external diagnostics
         timeout-minutes: 19
         env:
+          DIAGNOSTIC_TRIAL: ${{ matrix.trial }}
+          DIAGNOSTIC_REVISION: ${{ matrix.revision }}
           DIAGNOSTIC_CACHE_HIT: ${{ steps.package-cache.outputs.cache-hit }}
           DIAGNOSTIC_CACHE_KEY: ${{ steps.cache-profile.outputs.key }}
           LLGO_BUILD_CACHE: '1'
@@ -82,7 +97,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: qiniu-shard0-${{ github.run_id }}
+          name: qiniu-shard0-${{ matrix.trial }}-${{ github.run_id }}
           path: ${{ runner.temp }}/shard0-diagnostics/
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/diagnose-qiniu-shard0.yml
+++ b/.github/workflows/diagnose-qiniu-shard0.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: diagnostic-harness
+      - name: Keep diagnostic files outside the compiler checkout
+        run: |
+          harness_dir=$(mktemp -d "$RUNNER_TEMP/shard0-harness.XXXXXX")
+          mv diagnostic-harness "$harness_dir/source"
+          echo "DIAGNOSTIC_HARNESS=$harness_dir/source" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup-deps
         with:
           llvm-version: '22'
@@ -57,6 +62,7 @@ jobs:
           key: ${{ steps.cache-profile.outputs.key }}
       - name: Build the unmodified failed compiler
         run: |
+          test -z "$(git status --porcelain)"
           dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
           echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
           sudo apt-get install -y gdb
@@ -71,12 +77,12 @@ jobs:
           LLGO_TEST_STD_BUILDMODES: '1'
           SHARD_INDEX: '0'
           SHARD_TOTAL: '2'
-        run: bash diagnostic-harness/dev/diagnose_qiniu_shard0.sh
+        run: bash "$DIAGNOSTIC_HARNESS/dev/diagnose_qiniu_shard0.sh"
       - name: Preserve diagnostics before the runner's one-hour deadline
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: qiniu-shard0-${{ github.run_id }}
-          path: shard0-diagnostics/
+          path: ${{ runner.temp }}/shard0-diagnostics/
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/diagnose-qiniu-shard0.yml
+++ b/.github/workflows/diagnose-qiniu-shard0.yml
@@ -1,8 +1,8 @@
-name: Diagnose Qiniu shard-0 timeout (temporary)
+name: Validate Qiniu shard-0 runtime fix (temporary)
 
-# Temporary investigation in draft #2573, not a production fix. A comment
-# review allows one explicitly requested Linux diagnostic without scheduling
-# the unrelated macOS/Windows matrix for a [skip ci] diagnostic commit.
+# Draft #2573 is only the diagnostic entry point. Compile the two pinned
+# contribution merge trees without adding diagnostic files to either PR.
+# A comment review leaves their unrelated matrices suppressed by [skip ci].
 on:
   pull_request_review:
     types: [submitted]
@@ -20,19 +20,30 @@ jobs:
       startsWith(github.event.review.body, 'diagnose-qiniu-shard0')
     runs-on: [qiniu, ubuntu-24.04-large]
     name: shard0 (${{ matrix.trial }})
-    timeout-minutes: 25
+    # Match the original job budget. Its previously passing execution took
+    # 22m02s before the added weak-pointer regression, so a 25m whole-job limit
+    # could turn ordinary setup variance into an unrelated timeout.
+    timeout-minutes: 60
+    env:
+      DIAGNOSTIC_TRIAL: ${{ matrix.trial }}
+      DIAGNOSTIC_REVISION: ${{ matrix.revision }}
+      DIAGNOSTIC_BASE_REVISION: ${{ matrix.base_revision }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - trial: previously-passed
-            revision: 40c7bf8f66b2836efbd306d02aa2c6c6b67255f5
-          - trial: repeatedly-timed-out
-            revision: 94677096ec9981665d37c506c6d4ea09a460ca86
+          # Pin the actual CI merge trees of #2575 and its dependent #2567.
+          - trial: runtime-fix
+            revision: abe30d37b322005249f42f7052198480d232faf2
+            base_revision: b07cd12ad1ace793047dcf1c12ece8c01b139565
+          - trial: panic-on-runtime-fix
+            revision: 7c9b6079842863c6ee20e1b74cac3fef6928869d
+            base_revision: b07cd12ad1ace793047dcf1c12ece8c01b139565
     steps:
       - uses: actions/checkout@v7
         with:
-          # Pin the actual CI merge trees, not the corresponding PR heads.
+          # The review belongs to #2573, not the contribution being measured.
+          # Explicitly pin the target's real CI merge tree, never github.sha.
           ref: ${{ matrix.revision }}
       - uses: actions/checkout@v7
         with:
@@ -44,6 +55,7 @@ jobs:
           mv diagnostic-harness "$harness_dir/source"
           echo "DIAGNOSTIC_HARNESS=$harness_dir/source" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/shard0-diagnostics"
+          echo "DIAGNOSTIC_OUTPUT=$RUNNER_TEMP/shard0-diagnostics" >> "$GITHUB_ENV"
           git status --porcelain > "$RUNNER_TEMP/shard0-diagnostics/status-before-setup.txt"
       - uses: ./.github/actions/setup-deps
         with:
@@ -57,20 +69,23 @@ jobs:
         with:
           build-cache-mode: 'off'
           crosscompile-cache-mode: restore
-      - name: Resolve the original first-attempt package cache
+      - name: Resolve the target PR package cache
         id: cache-profile
         run: |
           source dev/llgo_cache_dir.sh
           echo "root=$(llgo_cache_dir)" >> "$GITHUB_OUTPUT"
           clang_version="$(clang --version | sed -nE '1s/.*version ([0-9]+([.][0-9]+)+).*/\1/p')"
-          echo "key=llgo-build-v2-Linux-X64-native-native-$(go env GOVERSION)-clang-${clang_version}-daada50d2270554c2eaea8887ce2d39acbd572c9" >> "$GITHUB_OUTPUT"
-      - name: Restore the old main cache used by the failed first attempt
+          prefix="llgo-build-v2-Linux-X64-native-native-$(go env GOVERSION)-clang-${clang_version}"
+          echo "key=$prefix-$DIAGNOSTIC_REVISION" >> "$GITHUB_OUTPUT"
+          echo "base-key=$prefix-$DIAGNOSTIC_BASE_REVISION" >> "$GITHUB_OUTPUT"
+      - name: Restore the target tree or main package cache
         id: package-cache
         uses: actions/cache/restore@v6
         with:
           path: ${{ steps.cache-profile.outputs.root }}/build
           key: ${{ steps.cache-profile.outputs.key }}
-      - name: Build the original CI compiler revision
+          restore-keys: ${{ steps.cache-profile.outputs.base-key }}
+      - name: Build the target CI compiler revision
         run: |
           mkdir -p "$RUNNER_TEMP/shard0-diagnostics"
           git status --porcelain > "$RUNNER_TEMP/shard0-diagnostics/status-before-build.txt"
@@ -78,14 +93,14 @@ jobs:
           dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
           go version -m "$RUNNER_TEMP/llgo-bin/llgo" > "$RUNNER_TEMP/shard0-diagnostics/compiler-build-info.txt"
           echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
+          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
           sudo apt-get install -y gdb
       - name: Replay shard 0 with original arguments and external diagnostics
-        timeout-minutes: 19
+        timeout-minutes: 26
         env:
-          DIAGNOSTIC_TRIAL: ${{ matrix.trial }}
-          DIAGNOSTIC_REVISION: ${{ matrix.revision }}
           DIAGNOSTIC_CACHE_HIT: ${{ steps.package-cache.outputs.cache-hit }}
           DIAGNOSTIC_CACHE_KEY: ${{ steps.cache-profile.outputs.key }}
+          DIAGNOSTIC_CACHE_MATCHED_KEY: ${{ steps.package-cache.outputs.cache-matched-key }}
           LLGO_BUILD_CACHE: '1'
           LLGO_TEST_BENCH_GO126: '1'
           LLGO_TEST_CHECK_SYMBOLS: '1'
@@ -93,6 +108,30 @@ jobs:
           SHARD_INDEX: '0'
           SHARD_TOTAL: '2'
         run: bash "$DIAGNOSTIC_HARNESS/dev/diagnose_qiniu_shard0.sh"
+      - name: Complete the original Linux job integration checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash "$DIAGNOSTIC_HARNESS/dev/diagnose_qiniu_shard0_post.sh" 2>&1 | tee "$DIAGNOSTIC_OUTPUT/post-shard0.log"
+      - name: Verify the old runtime weak-pointer deadlock signature
+        if: matrix.trial == 'runtime-fix'
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash "$DIAGNOSTIC_HARNESS/dev/diagnose_qiniu_weak_baseline.sh" 2>&1 | tee "$DIAGNOSTIC_OUTPUT/weak-baseline.log"
+      - name: Stress the fixed weak-pointer runtime three times
+        timeout-minutes: 6
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d test/_stress/runtime/weak
+          cd test/_stress
+          started=$SECONDS
+          timeout --signal=TERM --kill-after=10s 5m \
+            "$RUNNER_TEMP/llgo-bin/llgo" test -v -count=3 -timeout=3m \
+            ./runtime/weak 2>&1 | tee "$DIAGNOSTIC_OUTPUT/weak-fixed.log"
+          printf '\nWeak-pointer regression: all three iterations passed in %ss.\n' "$((SECONDS - started))" >> "$GITHUB_STEP_SUMMARY"
       - name: Preserve diagnostics before the runner's one-hour deadline
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/diagnose-qiniu-shard0.yml
+++ b/.github/workflows/diagnose-qiniu-shard0.yml
@@ -1,0 +1,82 @@
+name: Diagnose Qiniu shard-0 timeout (temporary)
+
+# Temporary investigation in draft #2573, not a production fix. A comment
+# review allows one explicitly requested Linux diagnostic without scheduling
+# the unrelated macOS/Windows matrix for a [skip ci] diagnostic commit.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  shard0:
+    if: >-
+      github.repository == 'xgo-dev/llgo' &&
+      github.event.pull_request.number == 2573 &&
+      github.event.review.user.login == 'cpunion' &&
+      github.event.review.state == 'commented' &&
+      startsWith(github.event.review.body, 'diagnose-qiniu-shard0')
+    runs-on: [qiniu, ubuntu-24.04-large]
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The actual merge tree checked out by all three failed attempts,
+          # not just the PR head (which lacks main's float min/max change).
+          ref: 94677096ec9981665d37c506c6d4ea09a460ca86
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: diagnostic-harness
+      - uses: ./.github/actions/setup-deps
+        with:
+          llvm-version: '22'
+      - uses: ./.github/actions/setup-embed-deps
+      - uses: ./.github/actions/setup-demo-deps
+        with:
+          install-lldb-python: 'true'
+      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-llgo-cache
+        with:
+          build-cache-mode: 'off'
+          crosscompile-cache-mode: restore
+      - name: Resolve the original first-attempt package cache
+        id: cache-profile
+        run: |
+          source dev/llgo_cache_dir.sh
+          echo "root=$(llgo_cache_dir)" >> "$GITHUB_OUTPUT"
+          clang_version="$(clang --version | sed -nE '1s/.*version ([0-9]+([.][0-9]+)+).*/\1/p')"
+          echo "key=llgo-build-v2-Linux-X64-native-native-$(go env GOVERSION)-clang-${clang_version}-daada50d2270554c2eaea8887ce2d39acbd572c9" >> "$GITHUB_OUTPUT"
+      - name: Restore the old main cache used by the failed first attempt
+        id: package-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ steps.cache-profile.outputs.root }}/build
+          key: ${{ steps.cache-profile.outputs.key }}
+      - name: Build the unmodified failed compiler
+        run: |
+          dev/build_ci_tools.sh "$RUNNER_TEMP/llgo-bin"
+          echo "$RUNNER_TEMP/llgo-bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y gdb
+      - name: Replay shard 0 with original arguments and external diagnostics
+        timeout-minutes: 19
+        env:
+          DIAGNOSTIC_CACHE_HIT: ${{ steps.package-cache.outputs.cache-hit }}
+          DIAGNOSTIC_CACHE_KEY: ${{ steps.cache-profile.outputs.key }}
+          LLGO_BUILD_CACHE: '1'
+          LLGO_TEST_BENCH_GO126: '1'
+          LLGO_TEST_CHECK_SYMBOLS: '1'
+          LLGO_TEST_STD_BUILDMODES: '1'
+          SHARD_INDEX: '0'
+          SHARD_TOTAL: '2'
+        run: bash diagnostic-harness/dev/diagnose_qiniu_shard0.sh
+      - name: Preserve diagnostics before the runner's one-hour deadline
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: qiniu-shard0-${{ github.run_id }}
+          path: shard0-diagnostics/
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/diagnose-qiniu-shard0.yml
+++ b/.github/workflows/diagnose-qiniu-shard0.yml
@@ -32,12 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Pin the actual CI merge trees of #2575 and its dependent #2567.
+          # Revalidate only #2575 after widening the old-runtime signature from
+          # map lookup to either allocating map operation. The dependent #2567
+          # merge passed the complete job in run 34702086188.
           - trial: runtime-fix
             revision: abe30d37b322005249f42f7052198480d232faf2
-            base_revision: b07cd12ad1ace793047dcf1c12ece8c01b139565
-          - trial: panic-on-runtime-fix
-            revision: 7c9b6079842863c6ee20e1b74cac3fef6928869d
             base_revision: b07cd12ad1ace793047dcf1c12ece8c01b139565
     steps:
       - uses: actions/checkout@v7

--- a/dev/diagnose_qiniu_llgo.sh
+++ b/dev/diagnose_qiniu_llgo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+invocation=$(mktemp -d "$DIAGNOSTIC_OUTPUT/invocation.XXXXXX")
+printf '%q ' "$@" >"$invocation/command.txt"
+printf 'pid=%s started=%s\n' "$$" "$(date -u +%FT%TZ)" >"$invocation/start.txt"
+# exec preserves the PID and the original command's arguments and exit status.
+exec "$LLGO_REAL" "$@"

--- a/dev/diagnose_qiniu_shard0.sh
+++ b/dev/diagnose_qiniu_shard0.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # This harness does not change compiler code, test arguments, or GC settings.
 export DIAGNOSTIC_OUTPUT="$RUNNER_TEMP/shard0-diagnostics"
 mkdir -p "$DIAGNOSTIC_OUTPUT"
+test "$(git rev-parse HEAD)" = "$DIAGNOSTIC_REVISION"
 export LLGO_ROOT=$PWD
 export LLGO_REAL="$RUNNER_TEMP/llgo-bin/llgo"
 export LLGO_TEST_LLGEN="$RUNNER_TEMP/llgo-bin/llgen"
@@ -13,6 +14,7 @@ chmod +x "$LLGO"
 {
   git show -s --format='commit=%H tree=%T parents=%P'
   git status --short
+  printf 'trial=%s expected_revision=%s\n' "$DIAGNOSTIC_TRIAL" "$DIAGNOSTIC_REVISION"
   uname -a
   lscpu
   free -h
@@ -45,7 +47,7 @@ kill -- "-$watchdog" 2>/dev/null || true
 wait "$watchdog" 2>/dev/null || true
 wait "$tail_pid" || true
 {
-  printf 'Exact failed merge: 94677096ec9981665d37c506c6d4ea09a460ca86. Original arguments, Qiniu Ubuntu 24.04 large, LLVM 22, Go 1.27.\n\n'
+  printf 'Trial: %s. Exact CI merge: %s. Original arguments, Qiniu Ubuntu 24.04 large, LLVM 22, Go 1.27.\n\n' "$DIAGNOSTIC_TRIAL" "$DIAGNOSTIC_REVISION"
   printf 'Package cache hit: %s. Pipeline exit: %s.\n\n' "$DIAGNOSTIC_CACHE_HIT" "$status"
   if [[ -f "$DIAGNOSTIC_OUTPUT/ptrace-sampled.txt" ]]; then
     printf 'Late ptrace diagnostics were taken: this cannot count as an unperturbed passing trial.\n\n'

--- a/dev/diagnose_qiniu_shard0.sh
+++ b/dev/diagnose_qiniu_shard0.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This harness does not change compiler code, test arguments, or GC settings.
+export DIAGNOSTIC_OUTPUT="$PWD/shard0-diagnostics"
+mkdir -p "$DIAGNOSTIC_OUTPUT"
+export LLGO_ROOT=$PWD
+export LLGO_REAL="$RUNNER_TEMP/llgo-bin/llgo"
+export LLGO_TEST_LLGEN="$RUNNER_TEMP/llgo-bin/llgen"
+export CHECK_STD_SYMBOLS="$RUNNER_TEMP/llgo-bin/check_std_symbols"
+export LLGO="$PWD/diagnostic-harness/dev/diagnose_qiniu_llgo.sh"
+chmod +x "$LLGO"
+{
+  git show -s --format='commit=%H tree=%T parents=%P'
+  git status --short
+  uname -a
+  lscpu
+  free -h
+  go version
+  clang --version
+  dpkg-query -W libgc1 libgc-dev libc6
+  printf 'cache_hit=%s cache_key=%s\n' "$DIAGNOSTIC_CACHE_HIT" "$DIAGNOSTIC_CACHE_KEY"
+  for resource in cpu.max cpuset.cpus.effective memory.max memory.events; do
+    if [[ -r "/sys/fs/cgroup/$resource" ]]; then
+      printf '%s: ' "$resource"
+      cat "/sys/fs/cgroup/$resource"
+    fi
+  done
+} >"$DIAGNOSTIC_OUTPUT/environment.txt"
+
+# An external deadline still fires if the tested runtime cannot run timers.
+# Its process group includes the compiler and nested test programs.
+setsid timeout --signal=TERM --kill-after=10s 18m bash dev/test_go_version.sh 1.27 >"$DIAGNOSTIC_OUTPUT/pipeline.log" 2>&1 &
+pipeline=$!
+export DIAGNOSTIC_PIPELINE=$pipeline
+tail --pid="$pipeline" -f "$DIAGNOSTIC_OUTPUT/pipeline.log" &
+tail_pid=$!
+setsid bash diagnostic-harness/dev/diagnose_qiniu_watchdog.sh &
+watchdog=$!
+
+status=0
+wait "$pipeline" || status=$?
+kill -- "-$watchdog" 2>/dev/null || true
+wait "$watchdog" 2>/dev/null || true
+wait "$tail_pid" || true
+{
+  printf 'Exact failed merge: 94677096ec9981665d37c506c6d4ea09a460ca86. Original arguments, Qiniu Ubuntu 24.04 large, LLVM 22, Go 1.27.\n\n'
+  printf 'Package cache hit: %s. Pipeline exit: %s.\n\n' "$DIAGNOSTIC_CACHE_HIT" "$status"
+  if [[ -f "$DIAGNOSTIC_OUTPUT/ptrace-sampled.txt" ]]; then
+    printf 'Late ptrace diagnostics were taken: this cannot count as an unperturbed passing trial.\n\n'
+  fi
+  printf 'Completed package lines: '
+  awk '$1 == "ok" && $2 ~ /^github.com\/xgo-dev\/llgo\/test/ {seen[$2]=1} END {for (p in seen) n++; print n+0}' "$DIAGNOSTIC_OUTPUT/pipeline.log"
+  printf '\nLast output:\n```text\n'
+  tail -35 "$DIAGNOSTIC_OUTPUT/pipeline.log"
+  printf '\n```\n'
+} >>"$GITHUB_STEP_SUMMARY"
+exit "$status"

--- a/dev/diagnose_qiniu_shard0.sh
+++ b/dev/diagnose_qiniu_shard0.sh
@@ -22,7 +22,7 @@ chmod +x "$LLGO"
   go version -m "$LLGO_REAL"
   clang --version
   dpkg-query -W libgc1 libgc-dev libc6
-  printf 'cache_hit=%s cache_key=%s\n' "$DIAGNOSTIC_CACHE_HIT" "$DIAGNOSTIC_CACHE_KEY"
+  printf 'cache_hit=%s cache_key=%s cache_matched_key=%s\n' "$DIAGNOSTIC_CACHE_HIT" "$DIAGNOSTIC_CACHE_KEY" "$DIAGNOSTIC_CACHE_MATCHED_KEY"
   for resource in cpu.max cpuset.cpus.effective memory.max memory.events; do
     if [[ -r "/sys/fs/cgroup/$resource" ]]; then
       printf '%s: ' "$resource"
@@ -33,7 +33,9 @@ chmod +x "$LLGO"
 
 # An external deadline still fires if the tested runtime cannot run timers.
 # Its process group includes the compiler and nested test programs.
-setsid timeout --signal=TERM --kill-after=10s 18m bash dev/test_go_version.sh 1.27 >"$DIAGNOSTIC_OUTPUT/pipeline.log" 2>&1 &
+# Keep the original per-test 20m timeout. This outer deadline also covers
+# compilation and catches a runtime that cannot service its own timeout.
+setsid timeout --signal=TERM --kill-after=10s 25m bash dev/test_go_version.sh 1.27 >"$DIAGNOSTIC_OUTPUT/pipeline.log" 2>&1 &
 pipeline=$!
 export DIAGNOSTIC_PIPELINE=$pipeline
 tail --pid="$pipeline" -f "$DIAGNOSTIC_OUTPUT/pipeline.log" &
@@ -46,6 +48,10 @@ wait "$pipeline" || status=$?
 kill -- "-$watchdog" 2>/dev/null || true
 wait "$watchdog" 2>/dev/null || true
 wait "$tail_pid" || true
+if [[ "$status" == 0 && -f "$DIAGNOSTIC_OUTPUT/ptrace-sampled.txt" ]]; then
+  echo 'A sampled trial cannot establish an unperturbed passing result.' >&2
+  status=1
+fi
 {
   printf 'Trial: %s. Exact CI merge: %s. Original arguments, Qiniu Ubuntu 24.04 large, LLVM 22, Go 1.27.\n\n' "$DIAGNOSTIC_TRIAL" "$DIAGNOSTIC_REVISION"
   printf 'Package cache hit: %s. Pipeline exit: %s.\n\n' "$DIAGNOSTIC_CACHE_HIT" "$status"

--- a/dev/diagnose_qiniu_shard0.sh
+++ b/dev/diagnose_qiniu_shard0.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # This harness does not change compiler code, test arguments, or GC settings.
-export DIAGNOSTIC_OUTPUT="$PWD/shard0-diagnostics"
+export DIAGNOSTIC_OUTPUT="$RUNNER_TEMP/shard0-diagnostics"
 mkdir -p "$DIAGNOSTIC_OUTPUT"
 export LLGO_ROOT=$PWD
 export LLGO_REAL="$RUNNER_TEMP/llgo-bin/llgo"
 export LLGO_TEST_LLGEN="$RUNNER_TEMP/llgo-bin/llgen"
 export CHECK_STD_SYMBOLS="$RUNNER_TEMP/llgo-bin/check_std_symbols"
-export LLGO="$PWD/diagnostic-harness/dev/diagnose_qiniu_llgo.sh"
+export LLGO="$DIAGNOSTIC_HARNESS/dev/diagnose_qiniu_llgo.sh"
 chmod +x "$LLGO"
 {
   git show -s --format='commit=%H tree=%T parents=%P'
@@ -17,6 +17,7 @@ chmod +x "$LLGO"
   lscpu
   free -h
   go version
+  go version -m "$LLGO_REAL"
   clang --version
   dpkg-query -W libgc1 libgc-dev libc6
   printf 'cache_hit=%s cache_key=%s\n' "$DIAGNOSTIC_CACHE_HIT" "$DIAGNOSTIC_CACHE_KEY"
@@ -35,7 +36,7 @@ pipeline=$!
 export DIAGNOSTIC_PIPELINE=$pipeline
 tail --pid="$pipeline" -f "$DIAGNOSTIC_OUTPUT/pipeline.log" &
 tail_pid=$!
-setsid bash diagnostic-harness/dev/diagnose_qiniu_watchdog.sh &
+setsid bash "$DIAGNOSTIC_HARNESS/dev/diagnose_qiniu_watchdog.sh" &
 watchdog=$!
 
 status=0

--- a/dev/diagnose_qiniu_shard0_post.sh
+++ b/dev/diagnose_qiniu_shard0_post.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Linux-only continuation of .github/workflows/llgo.yml:jobs.llgo, after
+# "Run Go 1.27 LLGo tests". Reuse the tested tree's existing scripts and keep
+# each original step in a subshell so environment/cwd changes do not leak.
+# This temporary harness belongs only to draft #2573, not either runtime PR.
+test "$(git rev-parse HEAD)" = "$DIAGNOSTIC_REVISION"
+
+run_step() {
+  local name=$1 started=$SECONDS status=0
+  shift
+  printf '::group::%s\n' "$name"
+  ( "$@" ) || status=$?
+  printf '::endgroup::\n'
+  printf '%s: exit=%s elapsed=%ss\n' "$name" "$status" "$((SECONDS - started))"
+  printf '\n%s: exit=%s, %ss.\n' "$name" "$status" "$((SECONDS - started))" >> "$GITHUB_STEP_SUMMARY"
+  return "$status"
+}
+
+# Expand mod_version in the child shell, not while constructing its command.
+# shellcheck disable=SC2016
+run_step 'Test Hello World with go.mod 1.21 through 1.26' bash -euo pipefail -c '
+  for mod_version in 1.21 1.22 1.23 1.24 1.25 1.26; do
+    LLGO_HELLO_EMBED=false dev/with_go_version.sh 1.27 dev/test_helloworld.sh "$mod_version"
+  done
+'
+run_step 'Test Hello World with go.mod 1.27' dev/with_go_version.sh 1.27 dev/test_helloworld.sh 1.27
+run_step 'Test runtime module compatibility' dev/test_runtime_go_versions.sh
+run_step 'Test demo without RPATH (expect failure)' bash -euo pipefail -c '
+  export LLGO_FULL_RPATH=false
+  pkg-config --libs cargs
+  if (cd ./_demo/c/cargs && llgo run .); then
+    echo "ERROR: cargs demo should have failed without RPATH!"
+    exit 1
+  else
+    echo "cargs demo correctly failed without RPATH"
+  fi
+'
+run_step 'Test demos' bash .github/workflows/test_demo.sh
+run_step 'Test demos (embedded target)' bash .github/workflows/test_demo.sh --embedded
+run_step 'Test C header generation' bash -euo pipefail -c '
+  cd _demo/go/export
+  chmod +x test.sh
+  ./test.sh
+'
+run_step 'Test export with different symbol names on embedded targets' bash -euo pipefail -c '
+  cd _demo/embed/export
+  chmod +x verify_export.sh
+  ./verify_export.sh
+'
+run_step 'Test ESP serial smoke' bash -euo pipefail -c '
+  cd _demo/embed
+  chmod +x test-esp-serial-startup.sh
+  ./test-esp-serial-startup.sh
+'
+run_step 'Test ESP32-C3 startup regression' bash -euo pipefail -c '
+  python -m pip install esptool==5.1.0
+  cd _demo/embed
+  chmod +x test_esp32c3_startup.sh
+  ./test_esp32c3_startup.sh
+'
+run_step '_xtool build tests' bash -euo pipefail -c '
+  cd _xtool
+  llgo build -v ./...
+'
+run_step 'Show test result' cat result.md
+run_step 'Install LLDB for integration tests' sudo apt-get install -y lldb-22
+run_step 'LLDB integration tests' bash cmd/llgo/lldbtest/runtest.sh -v
+printf '\nAll original Linux shard-0 job integration checks passed.\n' >> "$GITHUB_STEP_SUMMARY"

--- a/dev/diagnose_qiniu_watchdog.sh
+++ b/dev/diagnose_qiniu_watchdog.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 goroot=$(go env GOROOT)
-for minute in {1..17}; do
+for minute in {1..24}; do
   sleep 60
   if ! kill -0 "$DIAGNOSTIC_PIPELINE" 2>/dev/null; then exit 0; fi
   {
@@ -18,7 +18,7 @@ for minute in {1..17}; do
   } >"$DIAGNOSTIC_OUTPUT/processes-minute-$minute.txt"
   completed=$(awk '$1 == "ok" && $2 ~ /^github.com\/xgo-dev\/llgo\/test/ {n++} END {print n+0}' "$DIAGNOSTIC_OUTPUT/pipeline.log")
   printf '[diagnostic] minute=%s completed-package-lines=%s; process snapshot saved\n' "$minute" "$completed"
-  if [[ "$minute" != 14 && "$minute" != 16 ]]; then continue; fi
+  if [[ "$minute" != 22 && "$minute" != 24 ]]; then continue; fi
 
   # ptrace can change scheduling, so sample only after the ordinary pipeline
   # should have finished and label any later success as a perturbed trial.

--- a/dev/diagnose_qiniu_watchdog.sh
+++ b/dev/diagnose_qiniu_watchdog.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+goroot=$(go env GOROOT)
+for minute in {1..17}; do
+  sleep 60
+  if ! kill -0 "$DIAGNOSTIC_PIPELINE" 2>/dev/null; then exit 0; fi
+  {
+    date -u +%FT%TZ
+    ps -eo pid,ppid,pgid,pcpu,pmem,stat,wchan:32,etime,args --forest
+    free -h
+    for pid in $(pgrep -g "$DIAGNOSTIC_PIPELINE" || true); do
+      printf '\nProcess %s\n' "$pid"
+      ps -L -p "$pid" -o pid,tid,pcpu,stat,wchan:32,comm || true
+      ls -l "/proc/$pid/fd" 2>/dev/null || true
+    done
+    if [[ -r /sys/fs/cgroup/memory.events ]]; then cat /sys/fs/cgroup/memory.events; fi
+  } >"$DIAGNOSTIC_OUTPUT/processes-minute-$minute.txt"
+  completed=$(awk '$1 == "ok" && $2 ~ /^github.com\/xgo-dev\/llgo\/test/ {n++} END {print n+0}' "$DIAGNOSTIC_OUTPUT/pipeline.log")
+  printf '[diagnostic] minute=%s completed-package-lines=%s; process snapshot saved\n' "$minute" "$completed"
+  if [[ "$minute" != 14 && "$minute" != 16 ]]; then continue; fi
+
+  # ptrace can change scheduling, so sample only after the ordinary pipeline
+  # should have finished and label any later success as a perturbed trial.
+  date -u +%FT%TZ >>"$DIAGNOSTIC_OUTPUT/ptrace-sampled.txt"
+  sampled=0
+  for pid in $(pgrep -g "$DIAGNOSTIC_PIPELINE" || true); do
+    executable=$(readlink "/proc/$pid/exe" || true)
+    case "$executable" in
+      */llgo|*/runner-*|*.test)
+        # The compiler is a Go executable; native tests need native stacks.
+        # Go's own gdb helpers also expose parked compiler goroutines.
+        # shellcheck disable=SC2024
+        sudo timeout -k 2s 12s gdb --batch --nx -p "$pid" \
+          -ex 'set pagination off' \
+          -ex 'thread apply all bt 30' \
+          -ex "source $goroot/src/runtime/runtime-gdb.py" \
+          -ex 'goroutine all bt 20' -ex detach \
+          >"$DIAGNOSTIC_OUTPUT/stacks-minute-$minute-pid-$pid.txt" 2>&1 || true
+        sampled=$((sampled + 1))
+        if (( sampled >= 6 )); then break; fi
+        ;;
+    esac
+  done
+done

--- a/dev/diagnose_qiniu_weak_baseline.sh
+++ b/dev/diagnose_qiniu_weak_baseline.sh
@@ -93,7 +93,7 @@ for stack in "$DIAGNOSTIC_OUTPUT"/weak-old-stack-*.txt; do
       block = block $0 "\n"
       if ($0 ~ /llgoRegisterWeakPointer[$]1/) callbacks++
       if ($0 ~ /GC_invoke_finalizers/) collectors++
-      if ($0 ~ /MapAccess1Fast64|mapaccess1_fast64/) mapaccess = 1
+      if ($0 ~ /Map(Access1|Delete)Fast64|map(access1|delete)_fast64/) mapaccess = 1
       if ($0 ~ /pthread_mutex_lock|lll_mutex_lock|lll_lock_wait/) mutex = 1
       if ($0 ~ /weakState/) weakstate = 1
     }

--- a/dev/diagnose_qiniu_weak_baseline.sh
+++ b/dev/diagnose_qiniu_weak_baseline.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_root=$PWD
+compiler="$RUNNER_TEMP/llgo-bin/llgo"
+binary="$DIAGNOSTIC_OUTPUT/weak-old.test"
+baseline_parent=$(mktemp -d "$RUNNER_TEMP/weak-baseline.XXXXXX")
+baseline_root="$baseline_parent/source"
+test_group=
+sampler=
+cleanup() {
+  if [[ -n "$test_group" ]]; then kill -- "-$test_group" 2>/dev/null || true; fi
+  if [[ -n "$sampler" ]]; then kill "$sampler" 2>/dev/null || true; fi
+  if [[ -d "$baseline_root" ]]; then
+    git -C "$target_root" worktree remove "$baseline_root" || true
+  fi
+  rmdir "$baseline_parent" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+test "$(git rev-parse HEAD)" = "$DIAGNOSTIC_REVISION"
+git fetch --no-tags --depth=1 origin "$DIAGNOSTIC_BASE_REVISION"
+git worktree add --detach "$baseline_root" "$DIAGNOSTIC_BASE_REVISION"
+test "$(git -C "$baseline_root" rev-parse HEAD)" = "$DIAGNOSTIC_BASE_REVISION"
+printf 'Same compiler: %s\nTarget test source: %s/test/_stress/runtime/weak\nOld runtime source: %s/runtime\n' "$compiler" "$target_root" "$baseline_root"
+printf 'The compiler and public stress test stay fixed; only LLGO_ROOT selects the pinned, unmodified baseline runtime. Package cache is disabled for this baseline build.\n'
+git -C "$baseline_root" show -s --format='baseline commit=%H tree=%T'
+git hash-object "$target_root/test/_stress/runtime/weak/weak_stress_test.go"
+
+# Compile errors stop the step here. They can never satisfy the expected
+# runtime-failure check below, and the tested target checkout is not modified.
+cd "$target_root/test/_stress"
+LLGO_ROOT="$baseline_root" GOWORK=off LLGO_BUILD_CACHE=off \
+  "$compiler" test -c -o "$binary" ./runtime/weak 2>&1 | tee "$DIAGNOSTIC_OUTPUT/weak-old-build.log"
+test -x "$binary"
+binary=$(readlink -f "$binary")
+
+# The public test has a 60s subprocess guard; the 80s process-group deadline
+# also protects CI if the old runtime cannot service that parent-side guard.
+unset LLGO_STRESS_WEAK_CHILD
+setsid timeout --signal=TERM --kill-after=5s 80s \
+  "$binary" -test.v -test.count=1 -test.timeout=3m \
+  >"$DIAGNOSTIC_OUTPUT/weak-old-run.log" 2>&1 &
+test_group=$!
+(
+  sleep 10
+  sampled=0
+  for pid in $(pgrep -g "$test_group" || true); do
+    [[ "$(readlink "/proc/$pid/exe" 2>/dev/null || true)" == "$binary" ]] || continue
+    # Inspect only the explicit child marker, never log the runner environment.
+    if ! awk 'BEGIN { RS = "\0" } $0 == "LLGO_STRESS_WEAK_CHILD=TestWeakCleanupReentrancy" { found = 1 } END { exit !found }' \
+      "/proc/$pid/environ"; then continue; fi
+    ps -L -p "$pid" -o pid,tid,pcpu,stat,wchan:32,comm \
+      >"$DIAGNOSTIC_OUTPUT/weak-old-threads-$pid.txt"
+    printf 'Sampling the old-runtime stress child PID %s after 10s.\n' "$pid"
+    # This intentionally perturbs only the expected-failing baseline, never
+    # either fixed-runtime success trial. Disable remote debuginfo downloads.
+    # shellcheck disable=SC2024
+    sudo timeout --kill-after=2s 15s gdb --batch --nx -p "$pid" \
+      -ex 'set pagination off' -ex 'set debuginfod enabled off' \
+      -ex 'thread apply all bt 60' -ex detach \
+      >"$DIAGNOSTIC_OUTPUT/weak-old-stack-$pid.txt" 2>&1 || true
+    sampled=$((sampled + 1))
+  done
+  if [[ "$sampled" == 0 ]]; then
+    echo 'No old-runtime stress child remained available for the 10s native stack sample.' >&2
+    exit 1
+  fi
+) &
+sampler=$!
+status=0
+wait "$test_group" || status=$?
+sampler_status=0
+wait "$sampler" || sampler_status=$?
+sampler=
+cat "$DIAGNOSTIC_OUTPUT/weak-old-run.log"
+printf 'Old runtime exit=%s, sampler exit=%s.\n' "$status" "$sampler_status"
+
+# A timeout, compiler error, assertion failure, or arbitrary panic is not a
+# reproduction. Require the public test's guarded failure plus one native
+# thread containing the exact recursive weak cleanup / map allocation chain.
+signature=0
+for stack in "$DIAGNOSTIC_OUTPUT"/weak-old-stack-*.txt; do
+  [[ -f "$stack" ]] || continue
+  if awk '
+    function matches() { return callbacks >= 2 && collectors >= 2 && mapaccess && mutex && weakstate }
+    function finish() { if (matches()) { print block; found = 1 } }
+    /^Thread [0-9]+ / {
+      finish()
+      block = ""; callbacks = 0; collectors = 0; mapaccess = 0; mutex = 0; weakstate = 0
+    }
+    {
+      block = block $0 "\n"
+      if ($0 ~ /llgoRegisterWeakPointer[$]1/) callbacks++
+      if ($0 ~ /GC_invoke_finalizers/) collectors++
+      if ($0 ~ /MapAccess1Fast64|mapaccess1_fast64/) mapaccess = 1
+      if ($0 ~ /pthread_mutex_lock|lll_mutex_lock|lll_lock_wait/) mutex = 1
+      if ($0 ~ /weakState/) weakstate = 1
+    }
+    END { finish(); exit !found }
+  ' "$stack" >"$stack.signature.txt"; then signature=1; fi
+done
+if [[ "$status" != 1 || "$sampler_status" != 0 || "$signature" != 1 ]] || \
+  ! grep -q -- '--- FAIL: TestWeakCleanupReentrancy' "$DIAGNOSTIC_OUTPUT/weak-old-run.log" || \
+  ! grep -Eq 'weak cleanup helper (did not exit within 60s|failed)' "$DIAGNOSTIC_OUTPUT/weak-old-run.log"; then
+  echo 'Baseline did not establish the expected guarded failure and same-thread weak cleanup self-deadlock signature; this is not a passing reproduction.' >&2
+  exit 1
+fi
+printf '\nOld runtime: public weak stress failed as expected; native stack confirmed nested weak cleanup, map allocation, GC finalizer reentry, and weakState mutex self-lock on one thread.\n' >> "$GITHUB_STEP_SUMMARY"

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -33,6 +33,7 @@ go test -race -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/signal
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/cpuprof
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/finalizer
+GC_MARKERS=1 /tmp/llgo-runtime-stress test -count=3 -timeout=10m ./runtime/gc
 ```
 
 The signal suite is LLGo-only and targets Unix hosts. The CPU profile suite is
@@ -66,3 +67,13 @@ regress fatal native-handler replacement windows. The finalizer suite
 repeatedly publishes large finalizer batches while many goroutines call
 `runtime.GC`, and checks that queued callbacks are neither corrupted nor
 delivered twice.
+
+The GC progress suite runs allocations and both MakeFunc goroutine signatures
+against an unthrottled collector, with no sleeps or retries in the workload.
+It reports allocation, callback, and collection counts, fails if progress stalls
+for five seconds, and uses a separate process with a 90-second deadline because
+GC starvation can delay the tested runtime's own timeout machinery. Run the
+same test binary parameters and `LLGO_STRESS_PROFILE` before and after a runtime
+change; reducing pressure is not a fix. `GC_MARKERS=1` makes the single-marker
+case explicit; also validate with it unset for the platform default. This suite
+also runs with `go test` to check the harness independently.

--- a/test/_stress/runtime/gc/gc_stress_test.go
+++ b/test/_stress/runtime/gc/gc_stress_test.go
@@ -1,0 +1,161 @@
+//go:build !baremetal && !nogc && !wasm
+
+package gcstress
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		return base / 8
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+func TestGCAllocationProgress(t *testing.T) { testGCProgress(t, false) }
+
+func TestGCMakeFuncProgress(t *testing.T) { testGCProgress(t, true) }
+
+func testGCProgress(t *testing.T, makeFunc bool) {
+	t.Helper()
+	if os.Getenv("LLGO_STRESS_GC_CHILD") != t.Name() {
+		// A collector that starves allocations can also starve testing's alarm
+		// and its traceback. Enforce a second deadline outside that runtime.
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, executable, "-test.run=^"+t.Name()+"$", "-test.v", "-test.timeout=75s")
+		cmd.Env = append(os.Environ(), "LLGO_STRESS_GC_CHILD="+t.Name())
+		output, err := cmd.CombinedOutput()
+		t.Logf("%s", output)
+		if ctx.Err() != nil {
+			t.Fatalf("GC stress helper failed to exit within 90s: %v", ctx.Err())
+		}
+		if err != nil {
+			t.Fatalf("GC stress helper failed: %v", err)
+		}
+		return
+	}
+
+	const workers = 4
+	iterations := stressCount(t, 256)
+	var collections, allocations, callbacks atomic.Int64
+	var badArguments atomic.Int64
+	var stop atomic.Bool
+	start := make(chan struct{})
+	gcDone := make(chan struct{})
+	workDone := make(chan struct{})
+	var work sync.WaitGroup
+	work.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			defer work.Done()
+			<-start
+			var live [64]*[4096]byte
+			done := make(chan struct{}, iterations)
+			for i := 0; i < iterations; i++ {
+				p := new([4096]byte)
+				p[i%len(p)] = byte(i)
+				live[i%len(live)] = p
+				if makeFunc {
+					if i&1 == 0 {
+						f := reflect.MakeFunc(reflect.TypeOf((func(*int))(nil)), func(args []reflect.Value) []reflect.Value {
+							if len(args) != 1 || !args[0].IsNil() {
+								badArguments.Add(1)
+							}
+							callbacks.Add(1)
+							done <- struct{}{}
+							return nil
+						}).Interface().(func(*int))
+						go f(nil)
+					} else {
+						f := reflect.MakeFunc(reflect.TypeOf((func())(nil)), func(args []reflect.Value) []reflect.Value {
+							if len(args) != 0 {
+								badArguments.Add(1)
+							}
+							callbacks.Add(1)
+							done <- struct{}{}
+							return nil
+						}).Interface().(func())
+						go f()
+					}
+				}
+				allocations.Add(1)
+			}
+			if makeFunc {
+				for i := 0; i < iterations; i++ {
+					<-done
+				}
+			}
+			runtime.KeepAlive(live)
+		}()
+	}
+	go func() { work.Wait(); stop.Store(true); close(workDone) }()
+
+	// Observe from the collector itself: an allocating watchdog or a timer
+	// goroutine can be starved by the same lock. Never sleep or yield here.
+	var starved bool
+	t.Logf("workers=%d iterations=%d GC_MARKERS=%q makefunc=%v", workers, iterations, os.Getenv("GC_MARKERS"), makeFunc)
+	go func() {
+		defer close(gcDone)
+		runtime.GC()
+		collections.Add(1)
+		close(start)
+		lastProgress := time.Now()
+		var previous int64
+		for !stop.Load() {
+			runtime.GC()
+			if collections.Add(1)%64 == 0 {
+				progress := allocations.Load() + callbacks.Load()
+				if progress != previous {
+					previous = progress
+					lastProgress = time.Now()
+				} else if time.Since(lastProgress) >= 5*time.Second {
+					starved = true
+					break
+				}
+			}
+		}
+	}()
+	<-gcDone
+	// Stopping pressure after a failed observation is cleanup, never success.
+	beforeAlloc, beforeCallbacks, beforeGC := allocations.Load(), callbacks.Load(), collections.Load()
+	select {
+	case <-workDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("allocation/MakeFunc workers did not stop")
+	}
+	t.Logf("under pressure: allocations=%d callbacks=%d collections=%d", beforeAlloc, beforeCallbacks, beforeGC)
+	if starved {
+		t.Fatal("allocation/MakeFunc progress stalled for at least 5s during continuous GC")
+	}
+	if got, want := allocations.Load(), int64(workers*iterations); got != want {
+		t.Fatalf("allocations=%d, want %d", got, want)
+	}
+	if got := callbacks.Load(); makeFunc && got != int64(workers*iterations) {
+		t.Fatalf("callbacks=%d, want %d", got, workers*iterations)
+	}
+	if got := badArguments.Load(); got != 0 {
+		t.Fatalf("%d callbacks received incorrect arguments", got)
+	}
+}

--- a/test/go/reflect_makefunc_goroutine_test.go
+++ b/test/go/reflect_makefunc_goroutine_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
-	"time"
 )
 
 func TestReflectMakeFuncGoroutineStartup(t *testing.T) {
@@ -30,15 +29,11 @@ func testReflectMakeFuncGoroutineStartup(t *testing.T, withArg bool) {
 	go func() {
 		defer close(gcDone)
 		for {
-			// Collect at least once, even if the callbacks finish before we run.
-			runtime.GC()
 			select {
 			case <-stopGC:
 				return
 			default:
-				// Back-to-back collections can starve MakeFunc/startup allocations
-				// in BDWGC. Gosched is a no-op on LLGo's pthread backend.
-				time.Sleep(time.Millisecond)
+				runtime.GC()
 			}
 		}
 	}()

--- a/test/go/reflect_makefunc_goroutine_test.go
+++ b/test/go/reflect_makefunc_goroutine_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestReflectMakeFuncGoroutineStartup(t *testing.T) {
@@ -29,11 +30,15 @@ func testReflectMakeFuncGoroutineStartup(t *testing.T, withArg bool) {
 	go func() {
 		defer close(gcDone)
 		for {
+			// Collect at least once, even if the callbacks finish before we run.
+			runtime.GC()
 			select {
 			case <-stopGC:
 				return
 			default:
-				runtime.GC()
+				// Back-to-back collections can starve MakeFunc/startup allocations
+				// in BDWGC. Gosched is a no-op on LLGo's pthread backend.
+				time.Sleep(time.Millisecond)
 			}
 		}
 	}()


### PR DESCRIPTION
Draft — the allocator-starvation reproducer also fails on native Linux amd64 and still has no production fix. The separate Qiniu shard-0 investigation has now captured a different defect, a weak-cleanup self-deadlock; its production fix is isolated in #2575, not this PR. The original `Sleep(1ms)` mitigation has been removed and `test/go/reflect_makefunc_goroutine_test.go` is unchanged from main. Reducing test pressure is not an acceptable fix. The temporary Qiniu diagnostic workflow added below is investigation-only and must not ship as the production fix.

## Reproducer

Add `test/_stress/runtime/gc`, with allocation-only and MakeFunc goroutine-startup workloads competing against continuous `runtime.GC`. Four workers each perform 256 operations by default; the MakeFunc workload exercises both pointer-argument and zero-argument callbacks. The collector neither sleeps nor yields, and no failed run is retried by the test. A five-second no-progress check runs on the collector thread itself so an allocating observer cannot be starved; an independent helper-process deadline also bounds failures of the tested runtime's timeout machinery. The output reports allocation, callback, and collection counts. `LLGO_STRESS_PROFILE` scales the workload, following the existing stress-suite convention. These tests are opt-in and are not added to normal PR or daily CI.

```sh
export LLGO_ROOT=/path/to/llgo
cd "$LLGO_ROOT/test/_stress"
GC_MARKERS=1 llgo test -v -count=3 -timeout=10m ./runtime/gc
go test -race -v -count=3 -timeout=10m ./runtime/gc
```

## Controlled result

With the same test executable built from unmodified main `b07cd12ad`, identical parameters, `GC_MARKERS=1`, and the default stress profile on macOS arm64:

| Collector library | MakeFunc result, three repetitions |
| --- | --- |
| Homebrew BDWGC 8.2.12 | All failed after 5.10–5.25 s; 1,472 / 1,472 / 1,536 completed `runtime.GC` calls, zero completed allocation operations, zero callbacks |
| The same BDWGC release with a local experimental fair-share allocator mutex | All passed in 6.63 / 7.11 / 7.45 s; all 1,024 allocation operations and 1,024 callbacks completed each time |
| Official Go, `-race -count=3`, both stress tests | All passed |

A further three full-suite repetitions with the experimental library passed: allocation-only took 0.47–0.52 s, and MakeFunc took 6.88–7.27 s. The test executable was not rebuilt between the original-library and experimental-library runs. Existing unmodified `TestReflectMakeFuncGoroutineStartup` also changes from three independent 20 s external timeouts to repeated 2.86–3.12 s passes when only this mutex policy changes.

With `GC_MARKERS` unset, the same MakeFunc stress test also fails on the original library after 5.18 s (1,984 GC calls, zero operations/callbacks) and passes with the experimental library in 5.05 s (all 1,024 operations/callbacks, 1,814 GC calls). Thus the reproduction is not limited to the forced single-marker configuration.

## Cause and remaining work

Process sampling shows allocation and goroutine-startup threads blocked on BDWGC's allocator mutex while another thread repeatedly executes full collections. The fair-lock intervention strongly implicates unfair reacquisition of that lock on macOS. The experimental library patch is diagnostic only, is not included here, and is not a production fix: initialization ordering, other platforms, allocator performance, and supported dependency integration still need validation. A pure C pthread/BDWGC probe also demonstrates excessive collections during a small number of allocations without LLGo.

The Linux arm64 original startup test completes in 3.64–5.54 s. The subsequent [native Ubuntu 24.04 amd64 / LLVM 22 comparison](https://github.com/cpunion/llgo/actions/runs/34692329117) reproduced the stress failure on both unmodified main and the panic-fix branch: all six recorded MakeFunc stress trials failed, with either zero progress under `GC_MARKERS=1` or an external helper timeout with default marker settings. Native stacks show allocator/thread-registration calls waiting for BDWGC's mutex while the collector runs full collections. Official Go controls pass. The diagnostic workflow itself succeeds because it preserves each trial's failure as data; that green workflow does not mean the stress tests passed. A production fix passing the same unthrottled tests is still required before this PR is ready.

## Separate Qiniu shard-0 timeout investigation

The MakeFunc test belongs to shard 1 and is not the unfinished test in the captured shard-0 failure. In [diagnostic run 34698144515](https://github.com/xgo-dev/llgo/actions/runs/34698144515/job/103565085856), 96 of 97 tested packages completed; `crypto/ecdsa` remained blocked. Native samples at minutes 14 and 16 show the same thread holding `weakState.mu`, allocating inside `mapaccess1_fast64`, recursively invoking another weak cleanup, and waiting for its own non-recursive mutex. The compiler waits for that test child, rather than looping in LLVM compilation. The old three one-hour timeout attempts lack surviving stacks, so they cannot each be assigned this cause with certainty.

The [unperturbed Qiniu comparison](https://github.com/xgo-dev/llgo/actions/runs/34698798137) subsequently passed on both the previously green `cd6b1e5f` source tree and the later failed merge `94677096`; first test invocations took 120 and 138 seconds respectively. Both versions contain the same unsafe weak callback. Passing controls do not fix the reentrant lock or establish that its trigger frequency is unchanged.

The actual weak-runtime fix and public-API pressure regression are in #2575. On local macOS arm64, the unchanged test fails on old runtime in 3/3 executions with matching native self-deadlock stacks, and passes with the fix 53 times with default GC markers plus 20 times with one marker. This result must not be represented as fixing the separate continuous-GC allocator-starvation tests above.

This draft temporarily hosts a review-triggered Qiniu workflow to validate the exact CI merge trees of #2575 and #2567 rebased onto it. Both target PRs are initially pushed with `[skip ci]`. Each diagnostic job includes the complete original Linux shard-0 job, including symbol/build-mode checks and all later integration checks, followed by the weak pressure regression. The runtime-only lane also verifies the old-runtime failure with native stack evidence. The harness lives outside the measured source checkout; captured stacks and logs are uploaded, and a ptrace-sampled run cannot count as an unperturbed passing trial. Only after both targeted jobs pass will the target PRs' ordinary CI matrices be started. This draft's diagnostic workflow and unrelated starvation test are not included in either production contribution.

