### PR TITLE
Use native ARM64 ESP tools in Windows LLGo packages

### DIFF
--- a/.github/windows/build-release.ps1
+++ b/.github/windows/build-release.ps1
@@ -102,17 +102,23 @@ if ($Profile -eq 'mingw') {
     -Destination (Join-Path $stage 'LICENSES/windows-runtime') -Recurse
 }
 
-# Keep the existing integrated layout. ESP's Windows payload is x64 for both
-# host architectures, as in LLGo's existing Windows ARM64 download path.
+# ESP tools match the LLGo host architecture for both MSVC and MinGW packages.
 $espVersion = '22.1.4_20260905'
-$espAsset = "clang-esp-$espVersion-x86_64-w64-mingw32.tar.xz"
+$espTarget = @{ amd64 = 'x86_64-w64-mingw32'; arm64 = 'aarch64-w64-mingw32' }[$GoArch]
+$espChecksums = @{
+  amd64 = '3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3'
+}
+$espChecksum = $espChecksums[$GoArch]
+if (-not $espChecksum) { throw "Missing pinned ESP Clang checksum for windows/$GoArch" }
+$espAsset = "clang-esp-$espVersion-$espTarget.tar.xz"
 $espParent = Join-Path $env:RUNNER_TEMP ('llgo-release-esp-' + [Guid]::NewGuid())
 try {
   Expand-ReleaseXz `
-    -URL "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/$espVersion/$espAsset" `
-    -SHA256 '3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3' `
+    -URL "https://github.com/xgo-dev/espressif-llvm-project-prebuilt/releases/download/$espVersion/$espAsset" `
+    -SHA256 $espChecksum `
     -CacheDirectory (Join-Path $env:RUNNER_TOOL_CACHE 'llgo-release-downloads/esp') `
     -Destination $espParent
+  Assert-ReleaseESPPayload -Root (Join-Path $espParent 'esp-clang') -GoArch $GoArch -Version $espVersion
   $crosscompile = Join-Path $stage 'crosscompile'
   New-Item -ItemType Directory $crosscompile | Out-Null
   Move-Item -LiteralPath (Join-Path $espParent 'esp-clang') -Destination (Join-Path $crosscompile 'clang')
@@ -130,7 +136,8 @@ Copy-Item -LiteralPath (Join-Path $root 'LICENSES/XGo-LLVM-Apache-2.0-WITH-LLVM-
   abi = $Profile
   llvm_version = $llvmVersion
   esp_clang_version = $espVersion
-  esp_clang_host = 'windows/amd64'
+  esp_clang_host = "windows/$GoArch"
+  esp_clang_sha256 = $espChecksum
 } | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $stage 'release.json')
 
 # Directory records must be STORE for WinGet compatibility.

--- a/.github/windows/build-release.ps1
+++ b/.github/windows/build-release.ps1
@@ -103,10 +103,11 @@ if ($Profile -eq 'mingw') {
 }
 
 # ESP tools match the LLGo host architecture for both MSVC and MinGW packages.
-$espVersion = '22.1.4_20260905'
+$espVersion = '22.1.4_20260912'
 $espTarget = @{ amd64 = 'x86_64-w64-mingw32'; arm64 = 'aarch64-w64-mingw32' }[$GoArch]
 $espChecksums = @{
-  amd64 = '3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3'
+  amd64 = '49ba5159967f1f3cdc11b51d902595baaf0f94bf6c73fb4b880940f30a2d6f4f'
+  arm64 = '02521d03911dadbd84ecfb27903e59dae1d9f12c45245982caea7dad6e6d4188'
 }
 $espChecksum = $espChecksums[$GoArch]
 if (-not $espChecksum) { throw "Missing pinned ESP Clang checksum for windows/$GoArch" }

--- a/.github/windows/release-lib.ps1
+++ b/.github/windows/release-lib.ps1
@@ -153,3 +153,47 @@ function Expand-ReleaseXz {
     Remove-Item -LiteralPath $temporary -Recurse -Force
   }
 }
+
+function Assert-ReleaseESPPayload {
+  param([string]$Root, [string]$GoArch, [string]$Version)
+
+  $target = @{ amd64 = 'x86_64-w64-mingw32'; arm64 = 'aarch64-w64-mingw32' }[$GoArch]
+  $want = @{ amd64 = 'AMD64'; arm64 = 'ARM64' }[$GoArch]
+  $manifest = Get-Content -LiteralPath (Join-Path $Root 'LLGO-LLVM-MANIFEST.txt')
+  if (-not $target -or $manifest -notcontains "host_target=$target") {
+    throw "The ESP payload manifest does not match windows/$GoArch"
+  }
+  if (-not $Version -or $manifest -notcontains "payload_version=$Version") {
+    throw "The ESP payload manifest does not match version $Version"
+  }
+  $bin = Join-Path $Root 'bin'
+  $readObj = Join-Path $bin 'llvm-readobj.exe'
+  $binaries = @(Get-ChildItem -LiteralPath $bin -File |
+    Where-Object { $_.Extension -in @('.exe', '.dll') })
+  if (-not $binaries.Count) { throw 'The ESP payload contains no PE binaries' }
+  foreach ($binary in $binaries) {
+    # ESP tools execute in separate processes and carry their own MinGW DLLs,
+    # independently of the LLGo compiler's MSVC or MinGW runtime profile.
+    $pe = Get-ReleasePE -ReadObj $readObj -Path $binary.FullName
+    if ($pe.Machine -ne $want) {
+      throw "$($binary.Name) has PE machine $($pe.Machine), expected ESP host $want"
+    }
+    foreach ($dll in $pe.Imports) {
+      if ($dll -match '^(api-ms-|ext-ms-)') { continue }
+      if (-not (Test-Path -LiteralPath (Join-Path $bin $dll)) -and
+          -not (Test-Path -LiteralPath (Join-Path $env:SystemRoot "System32/$dll"))) {
+        throw "$($binary.Name) imports $dll, which is absent from the ESP payload and Windows"
+      }
+    }
+  }
+  $savedPath = $env:PATH
+  try {
+    $env:PATH = "$bin;$env:SystemRoot/System32;$env:SystemRoot"
+    foreach ($tool in @('clang', 'clang++', 'ld.lld', 'llc', 'opt', 'llvm-config')) {
+      $null = Invoke-ReleaseCapture (Join-Path $bin "$tool.exe") @('--version')
+    }
+  } finally {
+    $env:PATH = $savedPath
+  }
+  Write-Host "Validated native ESP tools and DLLs for windows/$GoArch"
+}

--- a/.github/windows/test-release.ps1
+++ b/.github/windows/test-release.ps1
@@ -35,6 +35,11 @@ if ($metadata.goos -ne 'windows' -or $metadata.goarch -ne $GoArch -or $metadata.
 $commit = (& git rev-parse HEAD).Trim()
 if ($LASTEXITCODE -ne 0 -or $metadata.commit -ne $commit) { throw 'The release belongs to a different commit' }
 
+if ($metadata.esp_clang_host -ne "windows/$GoArch") {
+  throw 'The ESP toolchain host does not match the LLGo release host'
+}
+Assert-ReleaseESPPayload -Root (Join-Path $releaseRoot 'crosscompile/clang') -GoArch $GoArch -Version $metadata.esp_clang_version
+
 $llgo = Join-Path $releaseRoot 'bin/llgo.exe'
 $readObj = Join-Path $releaseRoot 'crosscompile/clang/bin/llvm-readobj.exe'
 Copy-ReleaseDLLs -ReadObj $readObj -Executable $llgo -GoArch $GoArch -Profile $Profile -CheckOnly

--- a/.github/workflows/download_esp_clang.sh
+++ b/.github/workflows/download_esp_clang.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-ESP_CLANG_VERSION="22.1.4_20260905"
-BASE_URL="https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/${ESP_CLANG_VERSION}"
+ESP_CLANG_VERSION="22.1.4_20260912"
+BASE_URL="https://github.com/xgo-dev/espressif-llvm-project-prebuilt/releases/download/${ESP_CLANG_VERSION}"
 LLVM_LICENSE="LICENSES/XGo-LLVM-Apache-2.0-WITH-LLVM-exception.txt"
 
 get_esp_clang_platform() {

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -184,7 +184,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ runner.tool_cache }}/llgo-release-downloads/esp
-          key: llgo-release-esp-archive-v1-3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3
+          key: llgo-release-esp-archive-v2-${{ matrix.goarch }}-${{ hashFiles('.github/windows/build-release.ps1') }}
           enableCrossOsArchive: true
       - name: Download release metadata
         uses: actions/download-artifact@v8

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ The release workflow builds four integrated Windows variants, each as a ZIP: `ll
 
 See [Windows release dependencies and PowerShell setup](WINDOWS.md) for the external tools, ABI-specific libraries, and pkg-config configuration needed to compile native programs. The document is included in every Windows ZIP.
 
-Use the archive matching your native architecture and toolchain profile. Native programs still need the corresponding SDK/CRT, Clang, and dependencies described below: Visual Studio's C++ developer environment for MSVC, or MSYS2 `CLANG64` (`amd64`) / `CLANGARM64` (`arm64`) for MinGW. The bundled ESP Clang remains the upstream x64 Windows payload, including in ARM64 archives, and runs through Windows' x64 emulation there; `llgo.exe` itself is native ARM64 in those archives.
+Use the archive matching your native architecture and toolchain profile. Native programs still need the corresponding SDK/CRT, Clang, and dependencies described below: Visual Studio's C++ developer environment for MSVC, or MSYS2 `CLANG64` (`amd64`) / `CLANGARM64` (`arm64`) for MinGW. The bundled ESP Clang matches the host architecture: ARM64 archives contain native ARM64 ESP tools and DLLs for both MSVC and MinGW variants.
 
 The recommended GNU-hosted setup is an MSYS2 `CLANG64` shell. Install the LLVM 22 stack and LLGo's native dependencies, then provide the versioned pkg-config metadata used by the Go/C++ bindings:
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -10,7 +10,7 @@ The integrated package contains LLGo, its own DLL dependencies, `runtime`, `targ
 | Compile native Windows programs | Go, native Clang/Clang++ and a linker, matching SDK/CRT and native libraries, and pkg-config. |
 | Compile ESP firmware | Go and the bundled ESP toolchain. The first build may download and compile target libraries such as newlib and compiler-rt. |
 
-Do not use `crosscompile/clang` as your native Windows Clang. The ESP payload is x64, including in the ARM64 release, where it uses Windows x64 emulation. Use one native ABI profile at a time; mixing MSVC and MinGW headers, libraries, DLLs, or pkg-config metadata can break builds.
+Do not use `crosscompile/clang` as your native Windows Clang. The ESP tools and their DLLs match the release host architecture; ARM64 packages run them natively. Use one native ABI profile at a time; mixing MSVC and MinGW headers, libraries, DLLs, or pkg-config metadata can break builds.
 
 ## Versions and shared dependencies
 

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -226,7 +226,7 @@ func nativeDebugInfoPolicy(toolchain NativeToolchain) DebugInfoPolicy {
 var (
 	wasiSdkUrl      = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-macos.tar.gz"
 	wasiMacosSubdir = "wasi-sdk-25.0-x86_64-macos"
-	espClangBaseUrl = "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/" + espClangVersion
+	espClangBaseUrl = "https://github.com/xgo-dev/espressif-llvm-project-prebuilt/releases/download/" + espClangVersion
 	espClangSHA256  = map[string]string{
 		"aarch64-apple-darwin": "fcd3f70db3b05a8815ea156b09778de017a4a3f2d5ba11cbc5fbb205b1daa3fc",
 		"aarch64-linux-gnu":    "628a7f94ac8f392506ee59034525d05db8cc466c15a01f089df229a2a7c661cb",
@@ -236,10 +236,7 @@ var (
 	}
 )
 
-const (
-	espClangVersion         = "22.1.4_20260905"
-	espClangWindowsPlatform = "x86_64-w64-mingw32"
-)
+const espClangVersion = "22.1.4_20260905"
 
 // cacheRoot can be overridden for testing
 var cacheRoot = env.LLGoCacheDir
@@ -315,7 +312,7 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 			err = fmt.Errorf("missing ESP Clang checksum for %s", platformSuffix)
 			return
 		}
-		cacheClangDir := filepath.Join(cacheRoot(), "crosscompile", "esp-clang-"+espClangVersion)
+		cacheClangDir := espClangCacheDir(platformSuffix)
 		if _, err = os.Stat(cacheClangDir); err != nil {
 			if !errors.Is(err, fs.ErrNotExist) {
 				return
@@ -331,6 +328,12 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 
 	err = fmt.Errorf("ESP Clang not found in LLGoROOT and platform %s/%s is not supported for download", runtime.GOOS, runtime.GOARCH)
 	return
+}
+
+// Include the tool host in the cache key: x64 and ARM64 LLGo installations
+// can share a Windows user cache, but cannot share a native ESP payload.
+func espClangCacheDir(platform string) string {
+	return filepath.Join(cacheDir(), "esp-clang-"+espClangVersion+"-"+platform)
 }
 
 // getESPClangPlatform returns the platform suffix for ESP Clang downloads
@@ -352,11 +355,11 @@ func getESPClangPlatform(goos, goarch string) string {
 		}
 	case "windows":
 		switch goarch {
-		case "386", "amd64", "arm64":
-			// The Windows payload is x86-64 hosted. Windows on ARM64 runs it
-			// through the system's x64 emulation layer; 32-bit LLGo hosts run
-			// it as a separate 64-bit process.
-			return espClangWindowsPlatform
+		case "386", "amd64":
+			// 32-bit LLGo hosts run the x64 tools as separate processes.
+			return "x86_64-w64-mingw32"
+		case "arm64":
+			return "aarch64-w64-mingw32"
 		}
 	}
 	return ""

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -228,15 +228,16 @@ var (
 	wasiMacosSubdir = "wasi-sdk-25.0-x86_64-macos"
 	espClangBaseUrl = "https://github.com/xgo-dev/espressif-llvm-project-prebuilt/releases/download/" + espClangVersion
 	espClangSHA256  = map[string]string{
-		"aarch64-apple-darwin": "fcd3f70db3b05a8815ea156b09778de017a4a3f2d5ba11cbc5fbb205b1daa3fc",
-		"aarch64-linux-gnu":    "628a7f94ac8f392506ee59034525d05db8cc466c15a01f089df229a2a7c661cb",
-		"x86_64-apple-darwin":  "06018f283b3af1ba38523823c633a3517f1580571c48bfb46d53f5bfc0056ff7",
-		"x86_64-linux-gnu":     "0fc09b634fcbc00f91f1a1d3d023e6491f213de941939c374590e40f69961ecc",
-		"x86_64-w64-mingw32":   "3d32533daec8be08e608496eff817798eb7d3c25f07a02de1f1c94c0a0bbb8b3",
+		"aarch64-apple-darwin": "31cb1b87c84531bd777a4d7493a5a35070e6dd860e4c600b63937f5b449c3064",
+		"aarch64-linux-gnu":    "4a88902abe7977c0cbdecb239ac1a4d24185557e451a3e1f59aebbd56371124d",
+		"aarch64-w64-mingw32":  "02521d03911dadbd84ecfb27903e59dae1d9f12c45245982caea7dad6e6d4188",
+		"x86_64-apple-darwin":  "c31d127230d87bc468e6ea5e709db20d0729ecf6407222ef33f2378e2f847416",
+		"x86_64-linux-gnu":     "735f9d343863e5693179908acd946a0e85468463246f11210f2aa690b47784ab",
+		"x86_64-w64-mingw32":   "49ba5159967f1f3cdc11b51d902595baaf0f94bf6c73fb4b880940f30a2d6f4f",
 	}
 )
 
-const espClangVersion = "22.1.4_20260905"
+const espClangVersion = "22.1.4_20260912"
 
 // cacheRoot can be overridden for testing
 var cacheRoot = env.LLGoCacheDir

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -33,10 +33,12 @@ func TestESPClangHostDownload(t *testing.T) {
 		wantPlatform string
 	}{
 		{"darwin", "arm64", "aarch64-apple-darwin"},
+		{"darwin", "amd64", "x86_64-apple-darwin"},
+		{"linux", "arm64", "aarch64-linux-gnu"},
 		{"linux", "amd64", "x86_64-linux-gnu"},
 		{"windows", "386", "x86_64-w64-mingw32"},
 		{"windows", "amd64", "x86_64-w64-mingw32"},
-		{"windows", "arm64", "x86_64-w64-mingw32"},
+		{"windows", "arm64", "aarch64-w64-mingw32"},
 	}
 	for _, test := range tests {
 		platform := getESPClangPlatform(test.goos, test.goarch)
@@ -47,6 +49,36 @@ func TestESPClangHostDownload(t *testing.T) {
 		if espClangSHA256[platform] == "" {
 			t.Errorf("ESP Clang %s %s has no checksum", espClangVersion, platform)
 		}
+	}
+}
+
+func TestESPClangCacheSeparatesHosts(t *testing.T) {
+	legacy := filepath.Join(cacheDir(), "esp-clang-"+espClangVersion)
+	x64 := espClangCacheDir(getESPClangPlatform("windows", "amd64"))
+	arm64 := espClangCacheDir(getESPClangPlatform("windows", "arm64"))
+	if x64 == arm64 || x64 == legacy || arm64 == legacy {
+		t.Fatalf("ESP payload caches overlap: x64=%q arm64=%q legacy=%q", x64, arm64, legacy)
+	}
+}
+
+func TestESPClangDoesNotReuseLegacyCache(t *testing.T) {
+	writeWasmTargetFixture(t, "", "")
+	originalCacheRoot, originalBaseURL := cacheRoot, espClangBaseUrl
+	root := t.TempDir()
+	cacheRoot = func() string { return root }
+	server := httptest.NewServer(http.NotFoundHandler())
+	espClangBaseUrl = server.URL
+	t.Cleanup(func() {
+		cacheRoot, espClangBaseUrl = originalCacheRoot, originalBaseURL
+		server.Close()
+	})
+	legacy := filepath.Join(cacheDir(), "esp-clang-"+espClangVersion)
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := getESPClangRoot(true)
+	if got != "" || err == nil || !strings.Contains(err.Error(), "404 Not Found") {
+		t.Fatalf("getESPClangRoot() = %q, %v; want a fresh download instead of legacy cache %q", got, err, legacy)
 	}
 }
 


### PR DESCRIPTION
Windows ARM64 releases currently run x64 ESP tools through emulation. Select native ARM64 MinGW ESP tools for both ARM64 LLGo ABI variants and separate downloaded ESP caches by host platform, so x64 and ARM64 installations cannot reuse the same cache entry.

Pin ESP Clang 22.1.4_20260912 in the Go downloader and Windows/Unix release builders, with all six Go download hashes and both Windows archive hashes taken from verified official release bytes. The LLVM libraries linked into llgo.exe remain unchanged.

The Windows release builder and extracted-ZIP tests check the ESP manifest version/host, every packaged EXE/DLL architecture and dependency, and tool startup. Release metadata records the ESP host and archive checksum. The existing four Windows artifact jobs then compile and run native Go/C/C++ and build ESP firmware using the extracted toolchain.

Validation:
- Official prebuilt tag resolves to merged commit cc8f8d187df28763ee8d0679bc0e74370cc25f66; its release workflow passed all six builds and both native Windows execution checks: https://github.com/xgo-dev/espressif-llvm-project-prebuilt/actions/runs/34694706857. Post-merge main CI also passed.
- Downloaded all six official archives, checked SHA-256 against the published checksum file and GitHub asset digests, and checked embedded manifests for the pinned source, version and host.
- ESP host-selection, cache-isolation, legacy-cache rejection, missing-checksum and download-integrity Go tests pass. The original ARM64 selection regression failed before the change.
- Existing PowerShell PE/DLL closure, relocation, missing-dependency, architecture and ABI checks pass for both architectures using real COFF binaries. Shell syntax and git diff checks pass.
- All applicable PR checks passed at bca7b171a86882375c192fa709071814c7dcb3f6. Release Build passed all four Windows builds and all four extracted-artifact tests, each executing native Go/C/C++ and compiling ESP firmware with the bundled tools: https://github.com/xgo-dev/llgo/actions/runs/34708308625. Both ARM64 ABI variants ran on native Windows ARM64 runners. Codecov patch coverage is 100%.
