### PR TITLE
fix(runtime): avoid reentrant weak cleanup deadlocks

### DIFF
--- a/runtime/internal/lib/runtime/weak_llgo.go
+++ b/runtime/internal/lib/runtime/weak_llgo.go
@@ -13,6 +13,7 @@ import (
 type weakHandle struct {
 	key  uintptr
 	live uint32
+	next unsafe.Pointer // next dead handle; never a pointer to the referent
 }
 
 // BDWGC conservatively treats pointer-looking uintptr values as live roots.
@@ -30,11 +31,40 @@ var weakState struct {
 	once psync.Once
 	mu   psync.Mutex
 	m    map[uintptr]*weakHandle
+	dead unsafe.Pointer
 }
 
 func initWeakState() {
 	weakState.mu.Init(nil)
 	weakState.m = make(map[uintptr]*weakHandle)
+}
+
+// retireWeakHandle runs inside a GC finalizer. Even a map lookup can allocate
+// and invoke another finalizer on the same thread, so this path must neither
+// allocate nor take weakState.mu. Each handle is published exactly once.
+func retireWeakHandle(h *weakHandle) {
+	latomic.StoreUint32(&h.live, 0)
+	for {
+		head := latomic.LoadPointer(&weakState.dead)
+		h.next = head
+		if latomic.CompareAndSwapPointer(&weakState.dead, head, unsafe.Pointer(h)) {
+			return
+		}
+	}
+}
+
+// drainWeakHandles runs during registration with weakState.mu held. Detach only
+// one batch so concurrent cleanup cannot keep a registration here indefinitely.
+func drainWeakHandles() {
+	for h := (*weakHandle)(latomic.SwapPointer(&weakState.dead, nil)); h != nil; {
+		next := (*weakHandle)(h.next)
+		h.next = nil
+		// The address may already belong to a new object with a new handle.
+		if weakState.m[h.key] == h {
+			delete(weakState.m, h.key)
+		}
+		h = next
+	}
 }
 
 func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
@@ -45,7 +75,9 @@ func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
 
 	key := encodeWeakPointer(p)
 	weakState.mu.Lock()
-	if h := weakState.m[key]; h != nil {
+	drainWeakHandles()
+	// A cleanup may mark a handle dead before publishing it to the queue.
+	if h := weakState.m[key]; h != nil && latomic.LoadUint32(&h.live) != 0 {
 		weakState.mu.Unlock()
 		return unsafe.Pointer(h)
 	}
@@ -53,15 +85,9 @@ func llgoRegisterWeakPointer(p unsafe.Pointer) unsafe.Pointer {
 	weakState.m[key] = h
 	weakState.mu.Unlock()
 
-	// Keep the cleanup closure limited to encoded identities. Capturing p here
-	// would turn the cleanup itself into a strong reference to the referent.
+	// Capture only the handle with its encoded identity, never the referent p.
 	llrt.AddCleanupPtr(p, func() {
-		latomic.StoreUint32(&h.live, 0)
-		weakState.mu.Lock()
-		if weakState.m[key] == h {
-			delete(weakState.m, key)
-		}
-		weakState.mu.Unlock()
+		retireWeakHandle(h)
 	})
 	return unsafe.Pointer(h)
 }

--- a/runtime/internal/lib/runtime/weak_llgo.go
+++ b/runtime/internal/lib/runtime/weak_llgo.go
@@ -10,10 +10,18 @@ import (
 	psync "github.com/xgo-dev/llgo/runtime/internal/sync"
 )
 
+// weakHandle supplies the GC-dependent identity used by GOROOT's weak package.
+// Go's collector removes weak registrations from spans during sweep. BDWGC
+// invokes our cleanup during allocation, so registry removal must be deferred.
+// Removing an entry releases the runtime's reference; a user-held weak.Pointer
+// must keep its dead handle alive to preserve identity.
 type weakHandle struct {
 	key  uintptr
 	live uint32
-	next unsafe.Pointer // next dead handle; never a pointer to the referent
+	// Written only by the producer before the head CAS publishes this handle;
+	// after the head Swap, only the drainer accesses the link. The head atomics
+	// order these ordinary accesses. Links retain handles, never referents.
+	next unsafe.Pointer
 }
 
 // BDWGC conservatively treats pointer-looking uintptr values as live roots.
@@ -55,9 +63,14 @@ func retireWeakHandle(h *weakHandle) {
 
 // drainWeakHandles runs during registration with weakState.mu held. Detach only
 // one batch so concurrent cleanup cannot keep a registration here indefinitely.
+// This bounds the captured work, not its size: a batch of n handles takes O(n)
+// time under the registry lock. Without another non-nil weak.Make, the last
+// dead batch and its map entries remain retained; neither Value nor GC drains
+// them. Reclaiming that idle batch requires a separately scheduled safe consumer.
 func drainWeakHandles() {
 	for h := (*weakHandle)(latomic.SwapPointer(&weakState.dead, nil)); h != nil; {
 		next := (*weakHandle)(h.next)
+		// A user-held dead weak.Pointer must not retain the rest of this batch.
 		h.next = nil
 		// The address may already belong to a new object with a new handle.
 		if weakState.m[h.key] == h {

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -33,6 +33,7 @@ go test -race -count=3 -timeout=20m ./runtime/timer
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/signal
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/cpuprof
 /tmp/llgo-runtime-stress test -count=3 -timeout=30m ./runtime/finalizer
+/tmp/llgo-runtime-stress test -count=3 -timeout=5m ./runtime/weak
 ```
 
 The signal suite is LLGo-only and targets Unix hosts. The CPU profile suite is
@@ -66,3 +67,12 @@ regress fatal native-handler replacement windows. The finalizer suite
 repeatedly publishes large finalizer batches while many goroutines call
 `runtime.GC`, and checks that queued callbacks are neither corrupted nor
 delivered twice.
+
+The weak suite creates batches of weak pointers in a goroutine that exits,
+then performs bounded collections while retaining only the weak handles. It
+regresses cleanup callbacks recursively invoking another cleanup while
+allocating under the weak registry lock. Each batch must expire at least half
+its handles, and a separate helper process enforces a 60-second deadline even
+if the tested runtime deadlocks. It uses only public Go APIs and also runs with
+`go test` on Go 1.24 or newer. Use identical profiles before and after the fix;
+neither sleeping nor reducing allocation pressure is part of the workload.

--- a/test/_stress/README.md
+++ b/test/_stress/README.md
@@ -71,7 +71,7 @@ delivered twice.
 The weak suite creates batches of weak pointers in a goroutine that exits,
 then performs bounded collections while retaining only the weak handles. It
 regresses cleanup callbacks recursively invoking another cleanup while
-allocating under the weak registry lock. Each batch must expire at least half
+allocating under the weak registry lock. Each batch must expire more than half
 its handles, and a separate helper process enforces a 60-second deadline even
 if the tested runtime deadlocks. It uses only public Go APIs and also runs with
 `go test` on Go 1.24 or newer. Use identical profiles before and after the fix;

--- a/test/_stress/runtime/weak/weak_stress_test.go
+++ b/test/_stress/runtime/weak/weak_stress_test.go
@@ -1,0 +1,97 @@
+//go:build go1.24 && !baremetal && !nogc && !wasm
+
+package weakstress
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+	"weak"
+)
+
+type referent struct {
+	id  int
+	pad [256]byte
+}
+
+func stressCount(t *testing.T, base int) int {
+	t.Helper()
+	switch profile := os.Getenv("LLGO_STRESS_PROFILE"); profile {
+	case "", "default":
+		return base
+	case "quick":
+		return base / 8
+	case "heavy":
+		return base * 2
+	default:
+		t.Fatalf("unknown LLGO_STRESS_PROFILE %q", profile)
+		return 0
+	}
+}
+
+func TestWeakCleanupReentrancy(t *testing.T) {
+	if os.Getenv("LLGO_STRESS_WEAK_CHILD") != t.Name() {
+		// A GC callback can deadlock the allocating thread, including testing's
+		// own timeout machinery. Keep the hard deadline in a separate process.
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, executable, "-test.run=^"+t.Name()+"$", "-test.v", "-test.timeout=45s")
+		cmd.Env = append(os.Environ(), "LLGO_STRESS_WEAK_CHILD="+t.Name())
+		output, err := cmd.CombinedOutput()
+		t.Logf("%s", output)
+		if ctx.Err() != nil {
+			t.Fatalf("weak cleanup helper did not exit within 60s: %v", ctx.Err())
+		}
+		if err != nil {
+			t.Fatalf("weak cleanup helper failed: %v", err)
+		}
+		return
+	}
+
+	rounds, objects := stressCount(t, 16), stressCount(t, 8192)
+	t.Logf("rounds=%d objects=%d GC_MARKERS=%q", rounds, objects, os.Getenv("GC_MARKERS"))
+	for round := 0; round < rounds; round++ {
+		handles := make(chan []weak.Pointer[referent], 1)
+		go func() {
+			live := make([]*referent, objects)
+			batch := make([]weak.Pointer[referent], objects)
+			for i := range live {
+				live[i] = &referent{id: i}
+				batch[i] = weak.Make(live[i])
+			}
+			handles <- batch
+			runtime.KeepAlive(live)
+			// Exit this goroutine so conservative stack scanning does not keep
+			// the entire batch alive while another goroutine collects it.
+		}()
+		batch := <-handles
+		var expired int
+		for collection := 0; collection < 16; collection++ {
+			// Finite collections avoid mixing collector/allocator starvation
+			// from an unbounded GC loop into weak-callback reentrancy coverage.
+			runtime.GC()
+			expired = 0
+			for _, h := range batch {
+				if h.Value() == nil {
+					expired++
+				}
+			}
+			if expired > objects/2 {
+				break
+			}
+			runtime.Gosched()
+		}
+		if expired <= objects/2 {
+			t.Fatalf("round %d: only %d/%d weak handles expired", round, expired, objects)
+		}
+		t.Logf("round %d: expired %d/%d weak handles", round, expired, objects)
+		runtime.KeepAlive(batch)
+	}
+}

--- a/test/std/weak/weak_test.go
+++ b/test/std/weak/weak_test.go
@@ -128,3 +128,24 @@ func TestPointerNilInput(t *testing.T) {
 		t.Errorf("Make(nil).Value() = %v, want nil", val)
 	}
 }
+
+func TestPointerIdentity(t *testing.T) {
+	x, y := new([256]byte), new([256]byte)
+	x[0], y[0] = 1, 2
+	xw, yw := weak.Make(x), weak.Make(y)
+	if xw != weak.Make(x) {
+		t.Fatal("repeated Make returned a different handle for the same object")
+	}
+	if xw == yw {
+		t.Fatal("Make returned the same handle for distinct objects")
+	}
+	runtime.GC()
+	if xw != weak.Make(x) || yw != weak.Make(y) {
+		t.Fatal("GC changed the identity of a live weak pointer")
+	}
+	if xw.Value() != x || yw.Value() != y {
+		t.Fatal("GC invalidated a live weak pointer")
+	}
+	runtime.KeepAlive(x)
+	runtime.KeepAlive(y)
+}


### PR DESCRIPTION
## Problem

Fix a real weak-cleanup self-deadlock captured in the Qiniu Linux amd64 / LLVM 22 / Go 1.27 shard-0 investigation for #2567. In [the failing diagnostic job](https://github.com/xgo-dev/llgo/actions/runs/34698144515/job/103565085856), `crypto/ecdsa` was the only unfinished package. Native stacks taken two minutes apart show the same thread holding `weakState.mu` inside a weak cleanup, allocating during `mapaccess1_fast64`, recursively entering `GC_invoke_finalizers`, and then blocking in another weak cleanup on that same non-recursive mutex. The parent LLGo process is waiting for the test child, not looping in compilation. This weak callback code predates #2567 and is unchanged between its previously passing and subsequently timed-out revisions. The earlier timeout attempts have no surviving native stacks, so this PR does not claim each had the same cause.

## Change

Weak cleanup now only atomically marks its handle dead and publishes it to an intrusive pending list. Registration detaches one batch and removes matching map entries while holding the existing registry lock. Each producer initializes its private node's ordinary `next` link before the sequentially consistent head CAS publishes it, stops accessing the node after publication, and the head Swap transfers the detached batch to the sole drainer; the head atomics therefore order the ordinary link accesses without redundant per-link atomics. A live-state check handles the interval between invalidation and publication; an identity check prevents a delayed old cleanup from deleting a new handle after address reuse. The pending list keeps handles reachable, but retains only the existing encoded referent identity. Weak-pointer reads are unchanged, and no background goroutine or collector policy change is introduced. Clearing each detached node's `next` prevents a user-held dead weak pointer from retaining the rest of the batch. Reclamation is registration-gated, with the explicit limits below.

Add regular weak-identity coverage and the opt-in `test/_stress/runtime/weak` regression. It uses only public `weak.Make` and `runtime.GC` APIs, keeps referents alive until a whole batch is registered, releases them from an exiting goroutine, and checks bounded collection progress. A helper-process deadline turns the old runtime deadlock into a finite test failure. There are no production test hooks, retries, sleeps, or reduced-pressure success conditions.

## Standard-library reuse and reclamation limits

LLGo already compiles GOROOT's [public `weak.Pointer`, `Make`, and `Value` implementation](https://github.com/golang/go/blob/go1.27.0/src/weak/pointer.go). This file provides the two collector-dependent runtime hooks. In [Go 1.27's runtime](https://github.com/golang/go/blob/go1.27.0/src/runtime/mheap.go#L2389), a registration node is attached to the referent's GC span; sweep removes that node, zeros the heap-allocated handle, and returns the node to the runtime allocator. A user-held weak pointer still retains the dead handle to preserve identity; the handle itself becomes collectible when no roots retain it. Those runtime routines depend on Go's span metadata, marking/sweeping synchronization, write barriers, and scheduler, so they cannot be directly reused with LLGo's BDWGC heap.

This PR removes dead registry entries only during the next non-nil `weak.Make`. If registration stops, the last dead batch and its map entries remain retained; neither `Pointer.Value` nor `runtime.GC` directly drains them. They retain handles, not the referents. The batch has no fixed size bound, so this is a real metadata-retention tradeoff, not a guarantee of bounded memory relative to currently live weak pointers. Continued registrations detach pending batches instead of accumulating all historical dead handles. Deleting entries also does not shrink the map's backing capacity or guarantee an immediate RSS reduction.

Each non-nil registration adds one atomic head exchange, including existing-handle lookups. A captured batch of D handles requires O(D) work under the registry mutex: taking one batch prevents cleanup arrivals from indefinitely extending that batch, but does not cap a single registration's latency. Each handle gains one pointer; the reduced closure allocation described below must not be interpreted as a whole-process memory saving. `Pointer.Value` keeps its existing allocation-free, lock-free path.

Complete reclamation after automatic GC with no subsequent registration needs a separately scheduled safe consumer or deeper collector integration. Adding a drain only to explicit `runtime.GC` would not cover automatic collection and would still require reentrancy analysis. A consumer must use an allocation-safe notification path; an ordinary channel is not automatically suitable because LLGo's channel receive can allocate while holding its own lock. Native LLGo goroutines currently use OS threads, so a dedicated worker also adds thread/stack and lifecycle costs. This PR does not add that mechanism or claim to solve idle metadata retention. The source comments document the ownership handoff, retained-identity distinction, and reclamation limits.

## Local verification

| Same stress test and default parameters, macOS arm64 | Result |
| --- | --- |
| Unmodified main `b07cd12ad`, 3 independent executions | 3/3 fail at the first batch with the helper's 60-second deadline; native samples reproduce the CI weak-callback/map-allocation/reentrant-lock stack |
| Fixed runtime, default GC marker configuration | 53/53 pass, approximately 0.12 seconds per execution |
| Fixed runtime, `GC_MARKERS=1` | 20/20 pass |
| Official Go, `-race -count=10` | Pass |

`llgo test -count=3 ./test/std/weak`, `go test -race -count=3 ./test/std/weak`, and the selected wasm/atomic source-patch type-check tests also pass. Native disassembly confirms that the valid-handle cleanup path contains only loads/stores and atomic operations, with no lock, map, or allocator calls. Although a handle gains one pointer, the cleanup closure no longer captures a separate key: this arm64 build reduces direct registration allocation requests from four allocations totaling 48 bytes to three totaling 40 bytes, excluding map/cleanup internals and allocator size-class rounding. This is code-generation evidence, not a whole-process memory benchmark.

The standard-Go `-race` runs validate the public test harness against Go's runtime; they are not race-detector coverage of LLGo's runtime implementation.

## Targeted CI verification

The complete previously failing Qiniu Ubuntu 24.04 large / LLVM 22 / Go 1.27 shard-0 job passed for this fix in [run 34703427423](https://github.com/xgo-dev/llgo/actions/runs/34703427423), including all later integration checks. The original test, symbol, and build-mode phases completed in 136, 12, and 615 seconds; the job completed in 23m37s without ptrace sampling. The same target compiler and public stress source were then compiled against unmodified main runtime `b07cd12ad`: the helper hit its 60-second deadline, and the native stack validator confirmed on one thread two weak cleanup callbacks, two `GC_invoke_finalizers` frames, allocating `mapaccess1_fast64`, and the `weakState` mutex self-lock. Recompiled against the fixed runtime, the same 16-round/8,192-object stress test passed three times in 0.14–0.16 seconds per run.

The ordinary PR matrix for `50409da6e` also completed with 64 successful checks, no failure, and only the expected tag-gated release job skipped. Its normal Qiniu shard-0 job independently passed in [22m26s](https://github.com/xgo-dev/llgo/actions/runs/34704707491/job/103582554898), and Codecov reports all modified coverable lines covered. The subsequent `a7863ee05` commit adds source comments only; the full-matrix results cited here are for `50409da6e`, not a new CI run on the documentation commit.

#2567 was rebased onto this fix without changing its five panic-location patches. Its complete targeted Qiniu job independently passed in [run 34702086188](https://github.com/xgo-dev/llgo/actions/runs/34702086188), including a 136-second first test phase, 12-second symbol check, 602-second build-mode checks, all later integration checks, and three 0.16-second weak-stress runs, again without ptrace sampling. The temporary diagnostic workflow in draft #2573 and its unrelated MakeFunc/continuous-GC starvation reproducer are not included in either production PR.
